### PR TITLE
PMM-1899: Add size to determine if query got truncated.

### DIFF
--- a/proto/query/query.go
+++ b/proto/query/query.go
@@ -52,4 +52,5 @@ type Example struct {
 	Db           string
 	QueryTime    float64
 	Query        string
+	Size         int // Original size of the Query, before any truncation.
 }


### PR DESCRIPTION
Add original size of the Query, before any truncation.

Related PRs:
* https://github.com/percona/qan-api/pull/52
* https://github.com/percona/go-mysql/pull/28
* https://github.com/percona/qan-app/pull/79
* https://github.com/percona/pmm/pull/135
