### PR TITLE
PMM-3763 Adding DockerFile for Sphinx doc build

### DIFF
--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -1,0 +1,8 @@
+FROM ddidier/sphinx-doc
+
+RUN apt-get update
+RUN apt-get install wget
+RUN python -m pip install sphinx==1.6.7
+
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -4,4 +4,5 @@ RUN apt-get update
 RUN apt-get install wget
 RUN python -m pip install sphinx==1.6.7
 
+
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/doc/Dockerfile
+++ b/doc/Dockerfile
@@ -4,5 +4,4 @@ RUN apt-get update
 RUN apt-get install wget
 RUN python -m pip install sphinx==1.6.7
 
-
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]


### PR DESCRIPTION
Needs to be a specific version of Sphinx 1.6.7, Wget is missing from most of the Docker images, that needs to be installed 