### PR TITLE
Add exhaustiveness checks on our "sum types".

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+---
+linters-settings:
+  # prevent import of "errors" instead of "github.com/pkg/errors"
+  depguard:
+    list-type: blacklist
+    include-go-root: true
+    packages:
+      - errors
+
+  goimports:
+    local-prefixes: github.com/percona/pmm
+
+  lll:
+    line-length: 170
+    tab-width: 4
+
+  unused:
+    check-exported: false
+
+  unparam:
+    check-exported: true
+
+linters:
+  enable-all: true
+  disable:
+    - scopelint         # too many false positives
+    - gochecknoglobals  # mostly useless
+
+issues:
+  exclude-use-default: false
+  exclude:
+    # gas: Duplicated errcheck checks
+    - 'G104: Errors unhandled'
+    # golint: Methods for implementing interfaces are not documented
+    - 'exported method `.+` should have comment or be unexported'
+    - 'comment on exported method `.+` should be of the form `.+ ...`'
+    # golint: We have to return unexported types due to oneof implementation
+    - 'exported method .+ returns unexported type .+, which can be annoying to use'

--- a/api/Gopkg.lock
+++ b/api/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  branch = "master"
+  digest = "1:168cba3de63a4b749755aa9407c36dcffd348167023ed37ba6e350a932a9c57b"
+  name = "github.com/BurntSushi/go-sumtype"
+  packages = ["."]
+  pruneopts = "T"
+  revision = "fcb4a6205bdc6ce526f359ae5eae5fb6ded53916"
+
+[[projects]]
   digest = "1:bd3632deea7c224314b504dc51fbd244a59163e89c0cb730877d51bb13f5f74a"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
@@ -527,6 +535,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/BurntSushi/go-sumtype",
     "github.com/go-openapi/errors",
     "github.com/go-openapi/runtime",
     "github.com/go-openapi/runtime/client",

--- a/api/Gopkg.toml
+++ b/api/Gopkg.toml
@@ -4,7 +4,8 @@ required = [
   "github.com/mwitkow/go-proto-validators/protoc-gen-govalidators",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
-  "github.com/go-swagger/go-swagger/cmd/swagger"
+  "github.com/go-swagger/go-swagger/cmd/swagger",
+  "github.com/BurntSushi/go-sumtype"
 ]
 
 [prune]

--- a/api/Makefile
+++ b/api/Makefile
@@ -18,7 +18,8 @@ gen: clean            ## Generate files.
 					./vendor/github.com/mwitkow/go-proto-validators/protoc-gen-govalidators \
 					./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway \
 					./vendor/github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger \
-					./vendor/github.com/go-swagger/go-swagger/cmd/swagger
+					./vendor/github.com/go-swagger/go-swagger/cmd/swagger \
+					./vendor/github.com/BurntSushi/go-sumtype
 
 	./prototool all
 
@@ -41,6 +42,7 @@ gen: clean            ## Generate files.
 
 	make clean_swagger
 	go fmt ./...
+	go-sumtype ./...
 	go install -v ./...
 
 clean_swagger:

--- a/api/agentpb/agent.go
+++ b/api/agentpb/agent.go
@@ -6,17 +6,6 @@ import (
 
 //go-sumtype:decl isAgentMessage_Payload
 //go-sumtype:decl isServerMessage_Payload
-//go-sumtype:decl AgentMessagePayload
-//go-sumtype:decl ServerMessagePayload
-
-// Workaround for https://github.com/golang/protobuf/issues/261.
-// Useful for helper functions.
-// TODO Remove it.
-// Deprecated: use AgentRequestPayload, AgentResponsePayload, ServerResponsePayload, ServerRequestPayload instead.
-type (
-	AgentMessagePayload  = isAgentMessage_Payload
-	ServerMessagePayload = isServerMessage_Payload
-)
 
 // code below uses the same order as definitions in agent.proto
 

--- a/api/agentpb/agent.go
+++ b/api/agentpb/agent.go
@@ -4,71 +4,114 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-//go-sumtype:decl isServerMessage_Payload
 //go-sumtype:decl isAgentMessage_Payload
+//go-sumtype:decl isServerMessage_Payload
+//go-sumtype:decl AgentMessagePayload
+//go-sumtype:decl ServerMessagePayload
 
 // Workaround for https://github.com/golang/protobuf/issues/261.
 // Useful for helper functions.
 // TODO Refactor code to use
-// ServerRequestPayload, ServerResponsePayload, AgentRequestPayload, AgentResponsePayload instead.
+// AgentRequestPayload, AgentResponsePayload, ServerResponsePayload, ServerRequestPayload instead.
 type (
-	ServerMessagePayload = isServerMessage_Payload
 	AgentMessagePayload  = isAgentMessage_Payload
+	ServerMessagePayload = isServerMessage_Payload
 )
 
-//go-sumtype:decl ServerRequestPayload
-//go-sumtype:decl ServerResponsePayload
+// code below uses the same order as definitions in agent.proto
+
 //go-sumtype:decl AgentRequestPayload
 //go-sumtype:decl AgentResponsePayload
-
-type ServerRequestPayload interface {
-	server()
-	request()
-}
-
-type ServerResponsePayload interface {
-	server()
-	response()
-}
+//go-sumtype:decl ServerResponsePayload
+//go-sumtype:decl ServerRequestPayload
 
 type AgentRequestPayload interface {
-	agent()
-	request()
+	AgentMessageRequestPayload() isAgentMessage_Payload
+	sealed()
 }
 
 type AgentResponsePayload interface {
-	agent()
-	response()
+	AgentMessageResponsePayload() isAgentMessage_Payload
+	sealed()
 }
 
-// code below uses the same order as definitions in agent.proto (except ping/pong)
+type ServerResponsePayload interface {
+	ServerMessageResponsePayload() isServerMessage_Payload
+	sealed()
+}
 
-func (*Ping) agent()    {}
-func (*Ping) server()   {}
-func (*Ping) request()  {}
-func (*Pong) agent()    {}
-func (*Pong) server()   {}
-func (*Pong) response() {}
+type ServerRequestPayload interface {
+	ServerMessageRequestPayload() isServerMessage_Payload
+	sealed()
+}
 
 // AgentMessage request payloads
-func (*StateChangedRequest) agent()   {}
-func (*StateChangedRequest) request() {}
-func (*QANCollectRequest) agent()     {}
-func (*QANCollectRequest) request()   {}
+func (m *Ping) AgentMessageRequestPayload() isAgentMessage_Payload {
+	return &AgentMessage_Ping{Ping: m}
+}
+func (m *StateChangedRequest) AgentMessageRequestPayload() isAgentMessage_Payload {
+	return &AgentMessage_StateChanged{StateChanged: m}
+}
+func (m *QANCollectRequest) AgentMessageRequestPayload() isAgentMessage_Payload {
+	return &AgentMessage_QanCollect{QanCollect: m}
+}
 
 // AgentMessage response payloads
-func (*SetStateResponse) agent()    {}
-func (*SetStateResponse) response() {}
+func (m *Pong) AgentMessageResponsePayload() isAgentMessage_Payload {
+	return &AgentMessage_Pong{Pong: m}
+}
+func (m *SetStateResponse) AgentMessageResponsePayload() isAgentMessage_Payload {
+	return &AgentMessage_SetState{SetState: m}
+}
 
 // ServerMessage response payloads
-func (*StateChangedResponse) server()   {}
-func (*StateChangedResponse) response() {}
-func (*QANCollectResponse) server()     {}
-func (*QANCollectResponse) response()   {}
+func (m *Pong) ServerMessageResponsePayload() isServerMessage_Payload {
+	return &ServerMessage_Pong{Pong: m}
+}
+func (m *StateChangedResponse) ServerMessageResponsePayload() isServerMessage_Payload {
+	return &ServerMessage_StateChanged{StateChanged: m}
+}
+func (m *QANCollectResponse) ServerMessageResponsePayload() isServerMessage_Payload {
+	return &ServerMessage_QanCollect{QanCollect: m}
+}
 
 // ServerMessage request payloads
-func (*SetStateRequest) server()  {}
-func (*SetStateRequest) request() {}
+func (m *Ping) ServerMessageRequestPayload() isServerMessage_Payload {
+	return &ServerMessage_Ping{Ping: m}
+}
+func (m *SetStateRequest) ServerMessageRequestPayload() isServerMessage_Payload {
+	return &ServerMessage_SetState{SetState: m}
+}
+
+func (*Ping) sealed()                   {}
+func (m *StateChangedRequest) sealed()  {}
+func (m *QANCollectRequest) sealed()    {}
+func (*Pong) sealed()                   {}
+func (m *SetStateResponse) sealed()     {}
+func (m *StateChangedResponse) sealed() {}
+func (m *QANCollectResponse) sealed()   {}
+func (m *SetStateRequest) sealed()      {}
+
+// check interfaces
+var (
+	// AgentMessage request payloads
+	_ AgentRequestPayload = (*Ping)(nil)
+	_ AgentRequestPayload = (*StateChangedRequest)(nil)
+	_ AgentRequestPayload = (*QANCollectRequest)(nil)
+
+	// AgentMessage response payloads
+	_ AgentResponsePayload = (*Pong)(nil)
+	_ AgentResponsePayload = (*SetStateResponse)(nil)
+
+	// ServerMessage response payloads
+	_ ServerResponsePayload = (*Pong)(nil)
+	_ ServerResponsePayload = (*StateChangedResponse)(nil)
+	_ ServerResponsePayload = (*QANCollectResponse)(nil)
+
+	// ServerMessage request payloads
+	_ ServerRequestPayload = (*Ping)(nil)
+	_ ServerRequestPayload = (*SetStateRequest)(nil)
+)
 
 //go-sumtype:decl AgentParams
 

--- a/api/agentpb/agent.go
+++ b/api/agentpb/agent.go
@@ -1,40 +1,74 @@
 package agentpb
 
 import (
-	"context"
-
 	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 //go-sumtype:decl isServerMessage_Payload
 //go-sumtype:decl isAgentMessage_Payload
-//go-sumtype:decl ServerMessagePayload
-//go-sumtype:decl AgentMessagePayload
 
 // Workaround for https://github.com/golang/protobuf/issues/261.
 // Useful for helper functions.
+// TODO Refactor code to use
+// ServerRequestPayload, ServerResponsePayload, AgentRequestPayload, AgentResponsePayload instead.
 type (
 	ServerMessagePayload = isServerMessage_Payload
 	AgentMessagePayload  = isAgentMessage_Payload
 )
 
-//go-sumtype:decl RequestPayload
-//go-sumtype:decl ResponsePayload
+//go-sumtype:decl ServerRequestPayload
+//go-sumtype:decl ServerResponsePayload
+//go-sumtype:decl AgentRequestPayload
+//go-sumtype:decl AgentResponsePayload
 
-type RequestPayload interface{ request() }
-type ResponsePayload interface{ response() }
+type ServerRequestPayload interface {
+	server()
+	request()
+}
 
-func (*Ping) request()                {}
-func (*QANCollectRequest) request()   {}
+type ServerResponsePayload interface {
+	server()
+	response()
+}
+
+type AgentRequestPayload interface {
+	agent()
+	request()
+}
+
+type AgentResponsePayload interface {
+	agent()
+	response()
+}
+
+// code below uses the same order as definitions in agent.proto (except ping/pong)
+
+func (*Ping) agent()    {}
+func (*Ping) server()   {}
+func (*Ping) request()  {}
+func (*Pong) agent()    {}
+func (*Pong) server()   {}
+func (*Pong) response() {}
+
+// AgentMessage request payloads
+func (*StateChangedRequest) agent()   {}
 func (*StateChangedRequest) request() {}
-func (*SetStateRequest) request()     {}
+func (*QANCollectRequest) agent()     {}
+func (*QANCollectRequest) request()   {}
 
-func (*Pong) response()                 {}
-func (*QANCollectResponse) response()   {}
+// AgentMessage response payloads
+func (*SetStateResponse) agent()    {}
+func (*SetStateResponse) response() {}
+
+// ServerMessage response payloads
+func (*StateChangedResponse) server()   {}
 func (*StateChangedResponse) response() {}
-func (*SetStateResponse) response()     {}
+func (*QANCollectResponse) server()     {}
+func (*QANCollectResponse) response()   {}
+
+// ServerMessage request payloads
+func (*SetStateRequest) server()  {}
+func (*SetStateRequest) request() {}
 
 //go-sumtype:decl AgentParams
 
@@ -46,75 +80,3 @@ type AgentParams interface {
 
 func (*SetStateRequest_AgentProcess) agentParams() {}
 func (*SetStateRequest_BuiltinAgent) agentParams() {}
-
-const (
-	mdAgentID       = "pmm-agent-id"
-	mdAgentVersion  = "pmm-agent-version"
-	mdAgentNodeID   = "pmm-agent-node-id"
-	mdServerVersion = "pmm-server-version"
-)
-
-// AgentConnectMetadata represents metadata sent by pmm-agent with Connect RPC method.
-type AgentConnectMetadata struct {
-	ID      string
-	Version string
-}
-
-// AgentServerMetadata represents metadata sent by pmm-managed to pmm-agent.
-type AgentServerMetadata struct {
-	AgentRunsOnNodeID string
-	ServerVersion     string
-}
-
-func getValue(md metadata.MD, key string) string {
-	vs := md.Get(key)
-	if len(vs) == 1 {
-		return vs[0]
-	}
-	return ""
-}
-
-// AddAgentConnectMetadata adds metadata to pmm-agent's Connect RPC call.
-// Used by pmm-agent.
-func AddAgentConnectMetadata(ctx context.Context, md *AgentConnectMetadata) context.Context {
-	return metadata.AppendToOutgoingContext(ctx, mdAgentID, md.ID, mdAgentVersion, md.Version)
-}
-
-// GetAgentConnectMetadata returns pmm-agent's metadata.
-// Used by pmm-managed.
-func GetAgentConnectMetadata(ctx context.Context) AgentConnectMetadata {
-	var res AgentConnectMetadata
-	md, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		res.ID = getValue(md, mdAgentID)
-		res.Version = getValue(md, mdAgentVersion)
-	}
-	return res
-}
-
-// SendAgentServerMetadata sends metadata to pmm-agent.
-// Used by pmm-managed.
-func SendAgentServerMetadata(stream grpc.ServerStream, md *AgentServerMetadata) error {
-	header := metadata.Pairs(
-		mdAgentNodeID, md.AgentRunsOnNodeID,
-		mdServerVersion, md.ServerVersion,
-	)
-	if err := stream.SendHeader(header); err != nil {
-		return err
-	}
-	return nil
-}
-
-// GetAgentServerMetadata receives metadata from pmm-managed.
-// Used by pmm-agent.
-func GetAgentServerMetadata(stream grpc.ClientStream) (AgentServerMetadata, error) {
-	var res AgentServerMetadata
-	md, err := stream.Header()
-	if err != nil {
-		return res, err
-	}
-
-	res.AgentRunsOnNodeID = getValue(md, mdAgentNodeID)
-	res.ServerVersion = getValue(md, mdServerVersion)
-	return res, nil
-}

--- a/api/agentpb/agent.go
+++ b/api/agentpb/agent.go
@@ -11,8 +11,8 @@ import (
 
 // Workaround for https://github.com/golang/protobuf/issues/261.
 // Useful for helper functions.
-// TODO Refactor code to use
-// AgentRequestPayload, AgentResponsePayload, ServerResponsePayload, ServerRequestPayload instead.
+// TODO Remove it.
+// Deprecated: use AgentRequestPayload, AgentResponsePayload, ServerResponsePayload, ServerRequestPayload instead.
 type (
 	AgentMessagePayload  = isAgentMessage_Payload
 	ServerMessagePayload = isServerMessage_Payload
@@ -25,21 +25,25 @@ type (
 //go-sumtype:decl ServerResponsePayload
 //go-sumtype:decl ServerRequestPayload
 
+// AgentRequestPayload represents agent's request payload.
 type AgentRequestPayload interface {
 	AgentMessageRequestPayload() isAgentMessage_Payload
 	sealed()
 }
 
+// AgentResponsePayload represents agent's response payload.
 type AgentResponsePayload interface {
 	AgentMessageResponsePayload() isAgentMessage_Payload
 	sealed()
 }
 
+// ServerResponsePayload represents server's response payload.
 type ServerResponsePayload interface {
 	ServerMessageResponsePayload() isServerMessage_Payload
 	sealed()
 }
 
+// ServerRequestPayload represents server's request payload.
 type ServerRequestPayload interface {
 	ServerMessageRequestPayload() isServerMessage_Payload
 	sealed()
@@ -118,8 +122,8 @@ var (
 // AgentParams is a common interface for AgentProcess and BuiltinAgent parameters.
 type AgentParams interface {
 	proto.Message
-	agentParams()
+	sealedAgentParams() //nolint:unused
 }
 
-func (*SetStateRequest_AgentProcess) agentParams() {}
-func (*SetStateRequest_BuiltinAgent) agentParams() {}
+func (*SetStateRequest_AgentProcess) sealedAgentParams() {}
+func (*SetStateRequest_BuiltinAgent) sealedAgentParams() {}

--- a/api/agentpb/agent.go
+++ b/api/agentpb/agent.go
@@ -8,12 +8,20 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+//go-sumtype:decl isServerMessage_Payload
+//go-sumtype:decl isAgentMessage_Payload
+//go-sumtype:decl ServerMessagePayload
+//go-sumtype:decl AgentMessagePayload
+
 // Workaround for https://github.com/golang/protobuf/issues/261.
 // Useful for helper functions.
 type (
 	ServerMessagePayload = isServerMessage_Payload
 	AgentMessagePayload  = isAgentMessage_Payload
 )
+
+//go-sumtype:decl RequestPayload
+//go-sumtype:decl ResponsePayload
 
 type RequestPayload interface{ request() }
 type ResponsePayload interface{ response() }
@@ -27,6 +35,8 @@ func (*Pong) response()                 {}
 func (*QANCollectResponse) response()   {}
 func (*StateChangedResponse) response() {}
 func (*SetStateResponse) response()     {}
+
+//go-sumtype:decl AgentParams
 
 // AgentParams is a common interface for AgentProcess and BuiltinAgent parameters.
 type AgentParams interface {

--- a/api/agentpb/metadata.go
+++ b/api/agentpb/metadata.go
@@ -1,0 +1,80 @@
+package agentpb
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	mdAgentID       = "pmm-agent-id"
+	mdAgentVersion  = "pmm-agent-version"
+	mdAgentNodeID   = "pmm-agent-node-id"
+	mdServerVersion = "pmm-server-version"
+)
+
+// AgentConnectMetadata represents metadata sent by pmm-agent with Connect RPC method.
+type AgentConnectMetadata struct {
+	ID      string
+	Version string
+}
+
+// AgentServerMetadata represents metadata sent by pmm-managed to pmm-agent.
+type AgentServerMetadata struct {
+	AgentRunsOnNodeID string
+	ServerVersion     string
+}
+
+func getValue(md metadata.MD, key string) string {
+	vs := md.Get(key)
+	if len(vs) == 1 {
+		return vs[0]
+	}
+	return ""
+}
+
+// AddAgentConnectMetadata adds metadata to pmm-agent's Connect RPC call.
+// Used by pmm-agent.
+func AddAgentConnectMetadata(ctx context.Context, md *AgentConnectMetadata) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, mdAgentID, md.ID, mdAgentVersion, md.Version)
+}
+
+// GetAgentConnectMetadata returns pmm-agent's metadata.
+// Used by pmm-managed.
+func GetAgentConnectMetadata(ctx context.Context) AgentConnectMetadata {
+	var res AgentConnectMetadata
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		res.ID = getValue(md, mdAgentID)
+		res.Version = getValue(md, mdAgentVersion)
+	}
+	return res
+}
+
+// SendAgentServerMetadata sends metadata to pmm-agent.
+// Used by pmm-managed.
+func SendAgentServerMetadata(stream grpc.ServerStream, md *AgentServerMetadata) error {
+	header := metadata.Pairs(
+		mdAgentNodeID, md.AgentRunsOnNodeID,
+		mdServerVersion, md.ServerVersion,
+	)
+	if err := stream.SendHeader(header); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetAgentServerMetadata receives metadata from pmm-managed.
+// Used by pmm-agent.
+func GetAgentServerMetadata(stream grpc.ClientStream) (AgentServerMetadata, error) {
+	var res AgentServerMetadata
+	md, err := stream.Header()
+	if err != nil {
+		return res, err
+	}
+
+	res.AgentRunsOnNodeID = getValue(md, mdAgentNodeID)
+	res.ServerVersion = getValue(md, mdServerVersion)
+	return res, nil
+}

--- a/api/inventorypb/agents.go
+++ b/api/inventorypb/agents.go
@@ -5,30 +5,17 @@ package inventorypb
 // Agent is a common interface for all types of Agents.
 type Agent interface {
 	sealedAgent() //nolint:unused
-
-	// TODO Remove it.
-	// Deprecated: use AgentId field instead.
-	ID() string
 }
+
+// in order of AgentType enum
 
 func (*PMMAgent) sealedAgent()                {}
 func (*NodeExporter) sealedAgent()            {}
 func (*MySQLdExporter) sealedAgent()          {}
+func (*MongoDBExporter) sealedAgent()         {}
+func (*PostgresExporter) sealedAgent()        {}
+func (*QANMySQLPerfSchemaAgent) sealedAgent() {}
+func (*QANMySQLSlowlogAgent) sealedAgent()    {}
+func (*QANMongoDBProfilerAgent) sealedAgent() {}
 func (*RDSExporter) sealedAgent()             {}
 func (*ExternalExporter) sealedAgent()        {}
-func (*MongoDBExporter) sealedAgent()         {}
-func (*QANMySQLPerfSchemaAgent) sealedAgent() {}
-func (*QANMongoDBProfilerAgent) sealedAgent() {}
-func (*QANMySQLSlowlogAgent) sealedAgent()    {}
-func (*PostgresExporter) sealedAgent()        {}
-
-func (m *PMMAgent) ID() string                { return m.AgentId }
-func (m *NodeExporter) ID() string            { return m.AgentId }
-func (m *MySQLdExporter) ID() string          { return m.AgentId }
-func (m *RDSExporter) ID() string             { return m.AgentId }
-func (m *ExternalExporter) ID() string        { return m.AgentId }
-func (m *MongoDBExporter) ID() string         { return m.AgentId }
-func (m *QANMySQLPerfSchemaAgent) ID() string { return m.AgentId }
-func (m *QANMongoDBProfilerAgent) ID() string { return m.AgentId }
-func (m *QANMySQLSlowlogAgent) ID() string    { return m.AgentId }
-func (m *PostgresExporter) ID() string        { return m.AgentId }

--- a/api/inventorypb/agents.go
+++ b/api/inventorypb/agents.go
@@ -1,5 +1,7 @@
 package inventorypb
 
+//go-sumtype:decl Agent
+
 // Agent is a common interface for all types of Agents.
 type Agent interface {
 	agent()

--- a/api/inventorypb/agents.go
+++ b/api/inventorypb/agents.go
@@ -4,29 +4,31 @@ package inventorypb
 
 // Agent is a common interface for all types of Agents.
 type Agent interface {
-	agent()
+	sealedAgent() //nolint:unused
 
+	// TODO Remove it.
+	// Deprecated: use AgentId field instead.
 	ID() string
 }
 
-func (*PMMAgent) agent()                {}
-func (*NodeExporter) agent()            {}
-func (*MySQLdExporter) agent()          {}
-func (*RDSExporter) agent()             {}
-func (*ExternalExporter) agent()        {}
-func (*MongoDBExporter) agent()         {}
-func (*QANMySQLPerfSchemaAgent) agent() {}
-func (*QANMongoDBProfilerAgent) agent() {}
-func (*QANMySQLSlowlogAgent) agent()    {}
-func (*PostgresExporter) agent()        {}
+func (*PMMAgent) sealedAgent()                {}
+func (*NodeExporter) sealedAgent()            {}
+func (*MySQLdExporter) sealedAgent()          {}
+func (*RDSExporter) sealedAgent()             {}
+func (*ExternalExporter) sealedAgent()        {}
+func (*MongoDBExporter) sealedAgent()         {}
+func (*QANMySQLPerfSchemaAgent) sealedAgent() {}
+func (*QANMongoDBProfilerAgent) sealedAgent() {}
+func (*QANMySQLSlowlogAgent) sealedAgent()    {}
+func (*PostgresExporter) sealedAgent()        {}
 
-func (a *PMMAgent) ID() string                { return a.AgentId }
-func (a *NodeExporter) ID() string            { return a.AgentId }
-func (a *MySQLdExporter) ID() string          { return a.AgentId }
-func (a *RDSExporter) ID() string             { return a.AgentId }
-func (a *ExternalExporter) ID() string        { return a.AgentId }
-func (a *MongoDBExporter) ID() string         { return a.AgentId }
-func (a *QANMySQLPerfSchemaAgent) ID() string { return a.AgentId }
-func (a *QANMongoDBProfilerAgent) ID() string { return a.AgentId }
-func (a *QANMySQLSlowlogAgent) ID() string    { return a.AgentId }
-func (a *PostgresExporter) ID() string        { return a.AgentId }
+func (m *PMMAgent) ID() string                { return m.AgentId }
+func (m *NodeExporter) ID() string            { return m.AgentId }
+func (m *MySQLdExporter) ID() string          { return m.AgentId }
+func (m *RDSExporter) ID() string             { return m.AgentId }
+func (m *ExternalExporter) ID() string        { return m.AgentId }
+func (m *MongoDBExporter) ID() string         { return m.AgentId }
+func (m *QANMySQLPerfSchemaAgent) ID() string { return m.AgentId }
+func (m *QANMongoDBProfilerAgent) ID() string { return m.AgentId }
+func (m *QANMySQLSlowlogAgent) ID() string    { return m.AgentId }
+func (m *PostgresExporter) ID() string        { return m.AgentId }

--- a/api/inventorypb/nodes.go
+++ b/api/inventorypb/nodes.go
@@ -5,18 +5,11 @@ package inventorypb
 // Node is a common interface for all types of Nodes.
 type Node interface {
 	sealedNode() //nolint:unused
-
-	// TODO Remove it.
-	// Deprecated: use NodeId field instead.
-	ID() string
 }
+
+// in order of NodeType enum
 
 func (*GenericNode) sealedNode()         {}
 func (*ContainerNode) sealedNode()       {}
 func (*RemoteNode) sealedNode()          {}
 func (*RemoteAmazonRDSNode) sealedNode() {}
-
-func (m *GenericNode) ID() string         { return m.NodeId }
-func (m *ContainerNode) ID() string       { return m.NodeId }
-func (m *RemoteNode) ID() string          { return m.NodeId }
-func (m *RemoteAmazonRDSNode) ID() string { return m.NodeId }

--- a/api/inventorypb/nodes.go
+++ b/api/inventorypb/nodes.go
@@ -4,32 +4,19 @@ package inventorypb
 
 // Node is a common interface for all types of Nodes.
 type Node interface {
-	node()
+	sealedNode() //nolint:unused
 
+	// TODO Remove it.
+	// Deprecated: use NodeId field instead.
 	ID() string
-	Name() string
-
-	// Remote returns true if Node is remote.
-	// Agents can't run on Remote Nodes.
-	Remote() bool
 }
 
-func (*GenericNode) node()         {}
-func (*ContainerNode) node()       {}
-func (*RemoteNode) node()          {}
-func (*RemoteAmazonRDSNode) node() {}
+func (*GenericNode) sealedNode()         {}
+func (*ContainerNode) sealedNode()       {}
+func (*RemoteNode) sealedNode()          {}
+func (*RemoteAmazonRDSNode) sealedNode() {}
 
-func (n *GenericNode) ID() string         { return n.NodeId }
-func (n *ContainerNode) ID() string       { return n.NodeId }
-func (n *RemoteNode) ID() string          { return n.NodeId }
-func (n *RemoteAmazonRDSNode) ID() string { return n.NodeId }
-
-func (n *GenericNode) Name() string         { return n.NodeName }
-func (n *ContainerNode) Name() string       { return n.NodeName }
-func (n *RemoteNode) Name() string          { return n.NodeName }
-func (n *RemoteAmazonRDSNode) Name() string { return n.NodeName }
-
-func (*GenericNode) Remote() bool         { return false }
-func (*ContainerNode) Remote() bool       { return false }
-func (*RemoteNode) Remote() bool          { return true }
-func (*RemoteAmazonRDSNode) Remote() bool { return true }
+func (m *GenericNode) ID() string         { return m.NodeId }
+func (m *ContainerNode) ID() string       { return m.NodeId }
+func (m *RemoteNode) ID() string          { return m.NodeId }
+func (m *RemoteAmazonRDSNode) ID() string { return m.NodeId }

--- a/api/inventorypb/nodes.go
+++ b/api/inventorypb/nodes.go
@@ -1,5 +1,7 @@
 package inventorypb
 
+//go-sumtype:decl Node
+
 // Node is a common interface for all types of Nodes.
 type Node interface {
 	node()

--- a/api/inventorypb/services.go
+++ b/api/inventorypb/services.go
@@ -11,6 +11,8 @@ type Service interface {
 	ID() string
 }
 
+// in order of ServiceType enum
+
 func (*MySQLService) sealedService()          {}
 func (*AmazonRDSMySQLService) sealedService() {}
 func (*MongoDBService) sealedService()        {}

--- a/api/inventorypb/services.go
+++ b/api/inventorypb/services.go
@@ -1,5 +1,7 @@
 package inventorypb
 
+//go-sumtype:decl Service
+
 // Service is a common interface for all types of Services.
 type Service interface {
 	service()

--- a/api/inventorypb/services.go
+++ b/api/inventorypb/services.go
@@ -4,23 +4,19 @@ package inventorypb
 
 // Service is a common interface for all types of Services.
 type Service interface {
-	service()
+	sealedService() //nolint:unused
 
+	// TODO Remove it.
+	// Deprecated: use ServiceId field instead.
 	ID() string
-	Name() string
 }
 
-func (*MySQLService) service()          {}
-func (*AmazonRDSMySQLService) service() {}
-func (*MongoDBService) service()        {}
-func (*PostgreSQLService) service()     {}
+func (*MySQLService) sealedService()          {}
+func (*AmazonRDSMySQLService) sealedService() {}
+func (*MongoDBService) sealedService()        {}
+func (*PostgreSQLService) sealedService()     {}
 
-func (s *MySQLService) ID() string          { return s.ServiceId }
-func (s *AmazonRDSMySQLService) ID() string { return s.ServiceId }
-func (s *MongoDBService) ID() string        { return s.ServiceId }
-func (s *PostgreSQLService) ID() string     { return s.ServiceId }
-
-func (s *MySQLService) Name() string          { return s.ServiceName }
-func (s *AmazonRDSMySQLService) Name() string { return s.ServiceName }
-func (s *MongoDBService) Name() string        { return s.ServiceName }
-func (s *PostgreSQLService) Name() string     { return s.ServiceName }
+func (m *MySQLService) ID() string          { return m.ServiceId }
+func (m *AmazonRDSMySQLService) ID() string { return m.ServiceId }
+func (m *MongoDBService) ID() string        { return m.ServiceId }
+func (m *PostgreSQLService) ID() string     { return m.ServiceId }


### PR DESCRIPTION
One of the major pain points mentioned by @DexterHD recently was that we don't have a linter for problems like [that](https://github.com/percona/pmm-managed/commit/aa725f7698564d0d77847b2b5dba435990080a08). Those problems are also not obvious during code reviews. Now they are.

Previously, I tried to use https://github.com/haya14busa/gosum, but it did not really work. Last week I found https://github.com/BurntSushi/go-sumtype. It covers some of our problems and does not have false positives, so that should be an improvement. Please read its README to understand how it works.

While working on it, I also simplified some code in pmm-agent and pmm-managed to use new interfaces. For example, instead of
```go
SendResponse(&agentpb.AgentMessage{
    Id: serverMessage.Id,
    Payload: &agentpb.AgentMessage_Pong{
        Pong: &agentpb.Pong{
            CurrentTime: ptypes.TimestampNow(),
        },
    },
})
```
we now write
```go
SendResponse(&channel.Response{
    ID:      req.ID,
    Payload: &agentpb.Pong{
        CurrentTime: ptypes.TimestampNow(),
    },
})
```