### PR TITLE
PMM-4010 travis go 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ branches:
   except:
     - /^PMM\-\d{4}/
 
+go_import_path: github.com/percona/pmm
+
 cache:
   directories:
     - /home/travis/.cache/go-build


### PR DESCRIPTION
- Made it skip non-trunk PMM-XXXX branch builds, but still build pull requests.