### PR TITLE
Added basic steps (without confirmation)

### DIFF
--- a/doc/source/security.rst
+++ b/doc/source/security.rst
@@ -9,6 +9,7 @@ features:
 - SSL encryption secures traffic between |pmm-client| and |pmm-server|
 - HTTP password protection adds authentication when accessing the |pmm-server|
   web interface
+- Keep PMM Server isolated from the internet, where possible.
 
 |chapter.toc|
 

--- a/doc/source/security.rst
+++ b/doc/source/security.rst
@@ -146,7 +146,9 @@ The following assumes you are using a Docker container for PMM Server.
 
 3. Restart Grafana: ``supervisorctl restart grafana``
 
+.. seealso::
 
+  https://grafana.com/docs/grafana/latest/administration/configuration/#cookie_secure
 
 
 .. include:: .res/replace.txt

--- a/doc/source/security.rst
+++ b/doc/source/security.rst
@@ -108,7 +108,7 @@ a PMM Client to a PMM Server <deploy-pmm.client_server.connecting>`:
 .. include:: .res/code/pmm-admin.config.server.server-user.server-password.txt
 
 .. _pmm.security.combining:
-		
+
 `Combining Security Features <security.html#pmm-security-combining>`_
 ================================================================================
 
@@ -119,7 +119,7 @@ The following example shows how you might :ref:`run the PMM Server container
 <server-container>`:
 
 .. include:: .res/code/docker.run.example.txt
-		 
+
 The following example shows how you might :ref:`connect to PMM Server
 <deploy-pmm.client_server.connecting>`:
 
@@ -130,5 +130,22 @@ To see which security features are enabled, run either |pmm-admin.ping|,
 address field. For example:
 
 .. include:: .res/code/pmm-admin.ping.txt
-	     
+
+
+
+
+Enable HTTPS secure cookies in Grafana
+======================================
+
+The following assumes you are using a Docker container for PMM Server.
+
+1. Edit ``/etc/grafana/grafana.ini``
+
+2. Enable ``cookie_secure`` and set the value to ``true``
+
+3. Restart Grafana: ``supervisorctl restart grafana``
+
+
+
+
 .. include:: .res/replace.txt


### PR DESCRIPTION
Left out how to confirm secure cookies as it involves opening dev tools in a browser and searching for a named cookie.