### PR TITLE
Improvements to get-pmm.sh script for readability and Mac users

### DIFF
--- a/get-pmm.sh
+++ b/get-pmm.sh
@@ -162,11 +162,29 @@ run_root() {
 }
 
 #######################################
+# Check if MacOS 
+#######################################
+is_darwin() {
+   case "$(uname -s)" in
+   *darwin* ) true ;;
+   *Darwin* ) true ;;
+   * ) false;;
+   esac
+}
+
+#######################################
 # Installs docker if needed.
 #######################################
 install_docker() {
   printf "Checking docker installation"
   if ! check_command docker; then
+    if is_darwin; then
+      echo
+      echo "ERROR: Cannot auto-install components on macOS"
+      echo "Please get Docker Desktop from https://www.docker.com/products/docker-desktop and rerun installer after starting"
+      echo
+      exit 1
+    fi
     printf " - not installed. Installing...\n\n"
     curl -fsSL get.docker.com -o /tmp/get-docker.sh ||
       wget -qO /tmp/get-docker.sh get.docker.com
@@ -179,7 +197,13 @@ install_docker() {
   if ! docker ps 1>/dev/null; then
     root_is_needed='yes'
     if ! run_root 'docker ps > /dev/null'; then
-      die "${RED}ERROR: cannot run "docker ps" command${NOFORMAT}"
+      if is_darwin; then
+        open --background -a Docker
+        echo "Giving docker desktop time to start"
+        sleep 30
+      else
+        die "${RED}ERROR: cannot run "docker ps" command${NOFORMAT}"
+      fi
     fi
   fi
 }

--- a/get-pmm.sh
+++ b/get-pmm.sh
@@ -198,7 +198,7 @@ install_docker() {
     root_is_needed='yes'
     if ! run_root 'docker ps > /dev/null'; then
       if is_darwin; then
-        open --background -a Docker
+        run_root 'open --background -a Docker'
         echo "Giving docker desktop time to start"
         sleep 30
       else

--- a/get-pmm.sh
+++ b/get-pmm.sh
@@ -239,7 +239,7 @@ show_message() {
 
   msg "You can access your new server using the one of following web addresses:"
   for ip in $ips; do
-    msg "\t${BLUE}https://$ip:$port/${NOFORMAT}"
+    msg "\t${GREEN}https://$ip:$port/${NOFORMAT}"
   done
   msg "\nThe default username is '${PURPLE}admin${NOFORMAT}' and the password is '${PURPLE}admin${NOFORMAT}' :)"
   msg "Note: Some browsers may not trust the default SSL certificate when you first open one of the urls above."

--- a/get-pmm.sh
+++ b/get-pmm.sh
@@ -166,9 +166,8 @@ run_root() {
 #######################################
 is_darwin() {
    case "$(uname -s)" in
-   *darwin* ) true ;;
-   *Darwin* ) true ;;
-   * ) false;;
+     *darwin* | *Darwin* ) true ;;
+     * ) false;;
    esac
 }
 


### PR DESCRIPTION
The default terminal window for a fresh ubuntu install makes the URL's unreadable with the blue on black...changing to green but feel free to choose a different color.