### PR TITLE
PMM-9998 Re-applying PR #386 from pmm-agent repo

### DIFF
--- a/agent/utils/version/mysql.go
+++ b/agent/utils/version/mysql.go
@@ -48,6 +48,8 @@ func GetMySQLVersion(q *reform.Querier) (string, string, error) {
 		vendor = "percona"
 	case strings.Contains(strings.ToLower(ven), "mariadb"):
 		vendor = "mariadb"
+	case strings.Contains(strings.ToLower(ven), "debian") && strings.Contains(strings.ToLower(ver), "mariadb"):
+		vendor = "mariadb"
 	default:
 		vendor = "oracle"
 	}

--- a/agent/utils/version/mysql_test.go
+++ b/agent/utils/version/mysql_test.go
@@ -91,6 +91,21 @@ func TestGetMySQLVersion(t *testing.T) {
 			wantVendor:  "mariadb",
 			wantVersion: "10.2",
 		},
+		{
+			name: "MariaDB-Debian",
+			mockedData: []mockedVariables{
+				{
+					variable: "version",
+					value:    "10.1.48-MariaDB-0+deb9u2",
+				},
+				{
+					variable: "version_comment",
+					value:    "Debian 9.13",
+				},
+			},
+			wantVendor:  "mariadb",
+			wantVersion: "10.1",
+		},
 	}
 
 	//nolint:paralleltest


### PR DESCRIPTION
Since the repos were joined, I am re-applying https://github.com/percona/pmm-agent/pull/386/files here.

[PMM-9998](https://jira.percona.com/browse/PMM-9998) Again: Error 1054: Unknown column 'performance_schema.events_statements_summary_by_digest.QUERY_SAMPLE_TEXT' in 'field list'