### PR TITLE
PMM-10082 Remove ssh-keygen dependency

### DIFF
--- a/api-tests/server/updates_test.go
+++ b/api-tests/server/updates_test.go
@@ -37,6 +37,10 @@ func TestCheckUpdates(t *testing.T) {
 
 	const fast, slow = 5 * time.Second, 60 * time.Second
 
+	if !pmmapitests.RunUpdateTest {
+		t.Skip("skipping PMM Server check update test")
+	}
+
 	// that call should always be fast
 	version, err := serverClient.Default.Server.Version(server.NewVersionParamsWithTimeout(fast))
 	require.NoError(t, err)


### PR DESCRIPTION
PMM-10082

Build: SUBMODULES-2601

This PR fixes failing API Tests on SSH key validation.
The `ssh-keygen` utility has been removed from the Docker image and is no longer available.
