### PR TITLE
fix issue in get config

### DIFF
--- a/docs/api/dbaas.md
+++ b/docs/api/dbaas.md
@@ -65,7 +65,7 @@ API endpoint used in this step: [Change settings](ref:changesettings).
 
 Once kubernetes cluster is created it should be registered in PMM where `my_cluster` is a name of kubernetes cluster which will be used later. `sed` command is used to remove newlines, otherwise this script doesn’t work.
 ```bash
-KUBECONFIG=$(kubectl -- config view --flatten --minify | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g')
+KUBECONFIG=$(kubectl config view --flatten --minify | sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\\n/g')
 
 curl -X POST "http://localhost/v1/management/DBaaS/Kubernetes/Register" \ 
      -H "accept: application/json" \


### PR DESCRIPTION
this is a small fix for kubeconfig generation.

don't know why it has `--` maybe if minikube aliased as `alias kubectl='minikube kubectl'` when it should be `alias kubectl='minikube kubectl --'`.

Anyway it should be fixed, doesn't work in current form.