### PR TITLE
return common test for docs

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
-    paths-ignore:
-      - "docs/**"
 
 jobs:
   check:


### PR DESCRIPTION
Common tests are required to pass, and it is hard to workaround this report in Actions.
