### PR TITLE
PMM-7 remove old hash for quick-install script

### DIFF
--- a/.sha256-oneline
+++ b/.sha256-oneline
@@ -1,1 +1,0 @@
-926e1bfd95ebd349f99b4dbb09565d6c9fcd85c46e312e18b19f3e2133f9dab8  get-pmm.sh


### PR DESCRIPTION
We don't use this file for quick install script anymore.

PMM-7

- [ ] Links to other linked pull requests (optional).