### PR TITLE
Improve pmm readme documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Before submitting code or documentation contributions, you should first complete
 
 ### 1. Sign the CLA
 
-Before you can contribute, we kindly ask you to sign our [Contributor License Agreement](https://cla-assistant.percona.com/<linktoCLA>) (CLA). You can do this using your GitHub account and one click.
+Before you can contribute, we kindly ask you to sign our [Contributor License Agreement](https://cla-assistant.percona.com/percona/grafana-dashboards) (CLA). You can do this using your GitHub account and one click.
 
 ### 2. Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Before submitting code or documentation contributions, you should first complete
 
 ### 1. Sign the CLA
 
-Before you can contribute, we kindly ask you to sign our [Contributor License Agreement](https://cla-assistant.percona.com/percona/grafana-dashboards) (CLA). You can do this using your GitHub account and one click.
+Before you can contribute, we kindly ask you to sign our [Contributor License Agreement](https://cla-assistant.percona.com/percona/pmm) (CLA). You can do this using your GitHub account and one click.
 
 ### 2. Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ percona/pmm-server:2
 
 <img src="https://docs.percona.com/percona-monitoring-and-management/_images/PMM_Login.jpg" width="280">
 
-Enter the username and password given to you by your system administrator. The defaults are username: **admin** and password: **admim**
+Enter the username and password. The defaults are username: **admin** and password: **admim**
 
 ## Submitting Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -43,20 +43,29 @@ Please check our [Documentation](https://docs.percona.com/percona-monitoring-and
 There are numbers of installation methods, please check our [Setting Up](https://docs.percona.com/percona-monitoring-and-management/setting-up/index.html) documentation page.
 
 But in a nutshell:
+1. Download PMM server Docker image
 ```bash
 $ docker pull percona/pmm-server:2
-
+```
+2. Create the data volume container
+```bash
 $ docker create --volume /srv \
 --name pmm-data \
 percona/pmm-server:2 /bin/true
-
+```
+3. Run PMM server container
+```bash
 $ docker run --detach --restart always \
 --publish 443:443 \
 --volumes-from pmm-data \
 --name pmm-server \
 percona/pmm-server:2
-
 ```
+4. Start a web browser and in the address bar enter the server name or IP address of the PMM server host.
+
+<img src="https://docs.percona.com/percona-monitoring-and-management/_images/PMM_Login.jpg" width="280">
+
+Enter the username and password given to you by your system administrator. The defaults are username: **admin** and password: **admim**
 
 ## Submitting Bug Reports
 


### PR DESCRIPTION
Improving PMM Readme

1. Added comments to the docker commands, I think it will be better to let the user know what these commands are doing in general and how to open the dashboard.

2. CLA link fixed, it was giving "the page does not exist" so, I added this **https://cla-assistant.percona.com/percona/grafana-dashboards** (correct me if this link is wrong) instead of **https://cla-assistant.percona.com/<linktoCLA>**

Any feedback is appreciated!