### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/agent/agents/mongodb/internal/profiler/profiler_test.go
+++ b/agent/agents/mongodb/internal/profiler/profiler_test.go
@@ -65,8 +65,7 @@ func TestProfiler(t *testing.T) {
 	defer logrus.SetLevel(logrus.InfoLevel)
 
 	sslDSNTemplate, files := tests.GetTestMongoDBWithSSLDSN(t, "../../../../")
-	tempDir, err := os.MkdirTemp("", "pmm-agent-mongodb-")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	sslDSN, err := templates.RenderDSN(sslDSNTemplate, files, tempDir)
 	require.NoError(t, err)
 	for _, url := range []string{

--- a/agent/agents/mongodb/mongodb_test.go
+++ b/agent/agents/mongodb/mongodb_test.go
@@ -16,7 +16,6 @@ package mongodb
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -31,8 +30,7 @@ import (
 
 func TestMongoRun(t *testing.T) {
 	sslDSNTemplate, files := tests.GetTestMongoDBWithSSLDSN(t, "../../")
-	tempDir, err := os.MkdirTemp("", "pmm-agent-mongodb-")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	sslDSN, err := templates.RenderDSN(sslDSNTemplate, files, tempDir)
 	require.NoError(t, err)
 	for _, params := range []*Params{

--- a/agent/agents/supervisor/supervisor_test.go
+++ b/agent/agents/supervisor/supervisor_test.go
@@ -47,8 +47,7 @@ func assertChanges(t *testing.T, s *Supervisor, expected ...*agentpb.StateChange
 
 func TestSupervisor(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	tempDir, err := os.MkdirTemp("", "pmm-agent-")
-	require.NoError(t, err)
+	tempDir := t.TempDir()
 	s := NewSupervisor(ctx, &config.Paths{TempDir: tempDir}, &config.Ports{Min: 65000, Max: 65099}, &config.Server{Address: "localhost:443"})
 
 	t.Run("Start13", func(t *testing.T) {

--- a/agent/connectionchecker/connection_checker_test.go
+++ b/agent/connectionchecker/connection_checker_test.go
@@ -17,7 +17,6 @@ package connectionchecker
 import (
 	"context"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -215,11 +214,8 @@ func TestConnectionChecker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			temp, err := os.MkdirTemp("", "pmm-agent-")
-			require.NoError(t, err)
-
 			c := New(&config.Paths{
-				TempDir: temp,
+				TempDir: t.TempDir(),
 			})
 
 			if tt.panic {
@@ -241,11 +237,8 @@ func TestConnectionChecker(t *testing.T) {
 	}
 
 	t.Run("TableCount", func(t *testing.T) {
-		temp, err := os.MkdirTemp("", "pmm-agent-")
-		require.NoError(t, err)
-
 		c := New(&config.Paths{
-			TempDir: temp,
+			TempDir: t.TempDir(),
 		})
 		resp := c.Check(context.Background(), &agentpb.CheckConnectionRequest{
 			Dsn:  "root:root-password@tcp(127.0.0.1:3306)/?clientFoundRows=true&parseTime=true&timeout=1s",
@@ -257,11 +250,9 @@ func TestConnectionChecker(t *testing.T) {
 
 	t.Run("MongoDBWithSSL", func(t *testing.T) {
 		mongoDBDSNWithSSL, mongoDBTextFiles := tests.GetTestMongoDBWithSSLDSN(t, "../")
-		temp, err := os.MkdirTemp("", "pmm-agent-")
-		require.NoError(t, err)
 
 		c := New(&config.Paths{
-			TempDir: temp,
+			TempDir: t.TempDir(),
 		})
 		resp := c.Check(context.Background(), &agentpb.CheckConnectionRequest{
 			Dsn:       mongoDBDSNWithSSL,

--- a/agent/runner/actions/mongodb_query_admincommand_action_test.go
+++ b/agent/runner/actions/mongodb_query_admincommand_action_test.go
@@ -16,7 +16,6 @@ package actions
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,30 +38,30 @@ func TestMongoDBActions(t *testing.T) {
 
 	t.Run("getParameter", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getParameter", "*", createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getParameter", "*", t.TempDir())
 		getParameterAssertions(t, b)
 	})
 
 	t.Run("buildInfo", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "buildInfo", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "buildInfo", 1, t.TempDir())
 		buildInfoAssertions(t, b)
 	})
 
 	t.Run("getCmdLineOpts", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getCmdLineOpts", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getCmdLineOpts", 1, t.TempDir())
 		getCmdLineOptsAssertionsWithAuth(t, b)
 	})
 
 	t.Run("replSetGetStatus", func(t *testing.T) {
 		t.Parallel()
-		replSetGetStatusAssertionsStandalone(t, "", 0, dsn, nil, "replSetGetStatus", 1, createTempDir(t))
+		replSetGetStatusAssertionsStandalone(t, "", 0, dsn, nil, "replSetGetStatus", 1, t.TempDir())
 	})
 
 	t.Run("getDiagnosticData", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getDiagnosticData", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getDiagnosticData", 1, t.TempDir())
 		getDiagnosticDataAssertions(t, b)
 	})
 }
@@ -74,30 +73,30 @@ func TestMongoDBActionsWithSSL(t *testing.T) {
 
 	t.Run("getParameter", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getParameter", "*", createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getParameter", "*", t.TempDir())
 		getParameterAssertions(t, b)
 	})
 
 	t.Run("buildInfo", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "buildInfo", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "buildInfo", 1, t.TempDir())
 		buildInfoAssertions(t, b)
 	})
 
 	t.Run("getCmdLineOpts", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getCmdLineOpts", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getCmdLineOpts", 1, t.TempDir())
 		getCmdLineOptsAssertionsWithSSL(t, b)
 	})
 
 	t.Run("replSetGetStatus", func(t *testing.T) {
 		t.Parallel()
-		replSetGetStatusAssertionsStandalone(t, "", 0, dsn, files, "replSetGetStatus", 1, createTempDir(t))
+		replSetGetStatusAssertionsStandalone(t, "", 0, dsn, files, "replSetGetStatus", 1, t.TempDir())
 	})
 
 	t.Run("getDiagnosticData", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getDiagnosticData", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getDiagnosticData", 1, t.TempDir())
 		getDiagnosticDataAssertions(t, b)
 	})
 }
@@ -109,31 +108,31 @@ func TestMongoDBActionsReplNoAuth(t *testing.T) {
 
 	t.Run("getParameter", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getParameter", "*", createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getParameter", "*", t.TempDir())
 		getParameterAssertions(t, b)
 	})
 
 	t.Run("buildInfo", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "buildInfo", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "buildInfo", 1, t.TempDir())
 		buildInfoAssertions(t, b)
 	})
 
 	t.Run("getCmdLineOpts", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getCmdLineOpts", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getCmdLineOpts", 1, t.TempDir())
 		getCmdLineOptsAssertionsWithoutAuth(t, b)
 	})
 
 	t.Run("replSetGetStatus", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "replSetGetStatus", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "replSetGetStatus", 1, t.TempDir())
 		replSetGetStatusAssertionsReplicated(t, b)
 	})
 
 	t.Run("getDiagnosticData", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, nil, "getDiagnosticData", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, nil, "getDiagnosticData", 1, t.TempDir())
 		getDiagnosticDataAssertions(t, b)
 	})
 }
@@ -145,31 +144,31 @@ func TestMongoDBActionsReplWithSSL(t *testing.T) {
 
 	t.Run("getParameter", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getParameter", "*", createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getParameter", "*", t.TempDir())
 		getParameterAssertions(t, b)
 	})
 
 	t.Run("buildInfo", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "buildInfo", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "buildInfo", 1, t.TempDir())
 		buildInfoAssertions(t, b)
 	})
 
 	t.Run("getCmdLineOpts", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getCmdLineOpts", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getCmdLineOpts", 1, t.TempDir())
 		getCmdLineOptsAssertionsWithSSL(t, b)
 	})
 
 	t.Run("replSetGetStatus", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "replSetGetStatus", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "replSetGetStatus", 1, t.TempDir())
 		replSetGetStatusAssertionsReplicated(t, b)
 	})
 
 	t.Run("getDiagnosticData", func(t *testing.T) {
 		t.Parallel()
-		b := runAction(t, "", 0, dsn, files, "getDiagnosticData", 1, createTempDir(t))
+		b := runAction(t, "", 0, dsn, files, "getDiagnosticData", 1, t.TempDir())
 		getDiagnosticDataAssertions(t, b)
 	})
 }
@@ -300,11 +299,4 @@ func getCmdLineOptsAssertionsWithSSL(t *testing.T, b []byte) { //nolint:thelper
 		expected = []interface{}{"mongod", "--tlsMode", "requireTLS", "--tlsCertificateKeyFile", "/etc/ssl/certificates/server.pem"}
 	}
 	assert.Subset(t, argv, expected)
-}
-
-func createTempDir(t *testing.T) string {
-	t.Helper()
-	tempDir, err := os.MkdirTemp("", "pmm-agent-")
-	require.NoError(t, err)
-	return tempDir
 }

--- a/managed/services/management/ia/rules_service_test.go
+++ b/managed/services/management/ia/rules_service_test.go
@@ -78,12 +78,7 @@ func TestCreateAlertRule(t *testing.T) {
 	templates.CollectTemplates(ctx)
 
 	t.Run("normal", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -161,12 +156,7 @@ groups:
 	})
 
 	t.Run("wrong parameter value", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -202,12 +192,7 @@ groups:
 	})
 
 	t.Run("wrong parameter", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -243,12 +228,7 @@ groups:
 	})
 
 	t.Run("missing parameter", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -280,12 +260,7 @@ groups:
 	})
 
 	t.Run("wrong parameter type", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -322,12 +297,7 @@ groups:
 	})
 
 	t.Run("missing template", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		// Create test rule
 		rules := NewRulesService(db, templates, &vmAlert, &alertManager)
@@ -359,12 +329,7 @@ groups:
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		testDir, err := ioutil.TempDir("", "")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			err = os.RemoveAll(testDir)
-			require.NoError(t, err)
-		})
+		testDir := t.TempDir()
 
 		vmAlert = mockVmAlert{}
 		vmAlert.On("RequestConfigurationUpdate").Return()


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` and `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```