### PR TITLE
PMM-5680 fix API tests

### DIFF
--- a/api-tests/server/logs_test.go
+++ b/api-tests/server/logs_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,7 @@ func TestDownloadLogs(t *testing.T) {
 		"client/pmm-admin-version.txt",
 		"client/pmm-agent-config.yaml",
 		"client/pmm-agent-version.txt",
+		"client/pmm-agent/pmm-agent.log",
 		"client/status.json",
 		"grafana.log",
 		"installed.json",
@@ -86,9 +88,14 @@ func TestDownloadLogs(t *testing.T) {
 		sort.Strings(expected)
 	}
 
-	actual := make([]string, len(zipR.File))
-	for i, file := range zipR.File {
-		actual[i] = file.Name
+	actual := make([]string, 0, len(zipR.File))
+	for _, file := range zipR.File {
+		// skip with dynamic IDs now @TODO use regex to match ~ "client/pmm-agent/NODE_EXPORTER 297b465c-a767-4bc5-809d-d394a83c7086.log"
+		if strings.Contains(file.Name, "client/pmm-agent/") && file.Name != "client/pmm-agent/pmm-agent.log" {
+			continue
+		}
+
+		actual = append(actual, file.Name)
 	}
 
 	sort.Strings(actual)

--- a/managed/services/supervisord/logs_test.go
+++ b/managed/services/supervisord/logs_test.go
@@ -182,7 +182,7 @@ func TestZip(t *testing.T) {
 			continue
 		}
 
-		// skip with dynamic IDs now
+		// skip with dynamic IDs now @TODO use regex to match ~ "client/pmm-agent/NODE_EXPORTER 297b465c-a767-4bc5-809d-d394a83c7086.log"
 		if strings.Contains(f.Name, "client/pmm-agent/") && f.Name != "client/pmm-agent/pmm-agent.log" {
 			continue
 		}


### PR DESCRIPTION
PMM-5680

Build: SUBMODULES-2683

- [ ] https://github.com/percona/pmm/pull/926
- [ ] https://github.com/percona/pmm/pull/1113

Update test **TestDownloadLogs** https://pmm.cd.percona.com/job/pmm2-api-tests/10821/consoleFull (SUBMODULES-2679)
TestDownloadLogs: https://github.com/percona/pmm/blob/fad149453944960b7a1373b3c039485dbc4d02ef/api-tests/server/logs_test.go#L95
