### PR TITLE
PMM-5939 ParseEnvVars notifies about proxy variables

### DIFF
--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -64,6 +64,8 @@ func (e InvalidDurationError) Error() string { return string(e) }
 //   - ENABLE_AZUREDISCOVER enables Azure Discover;
 //   - ENABLE_DBAAS enables Database as a Service feature, it's a replacement for deprecated PERCONA_TEST_DBAAS which still works but will be removed eventually;
 //   - the environment variables prefixed with GF_ passed as related to Grafana.
+//   - the environment variables relating to proxies
+//   - the environment variable set by podman
 func ParseEnvVars(envs []string) (envSettings *models.ChangeSettingsParams, errs []error, warns []string) { //nolint:cyclop
 	envSettings = &models.ChangeSettingsParams{}
 
@@ -151,6 +153,12 @@ func ParseEnvVars(envs []string) (envSettings *models.ChangeSettingsParams, errs
 
 		case "PMM_PUBLIC_ADDRESS":
 			envSettings.PMMPublicAddress = v
+
+		case "NO_PROXY", "HTTP_PROXY", "HTTPS_PROXY":
+			continue
+
+		case "CONTAINER":
+			continue
 
 		case envEnableDbaas, envTestDbaas:
 			envSettings.EnableDBaaS, err = strconv.ParseBool(v)

--- a/managed/utils/envvars/parser_test.go
+++ b/managed/utils/envvars/parser_test.go
@@ -91,6 +91,26 @@ func TestEnvVarValidator(t *testing.T) {
 		assert.Nil(t, gotWarns)
 	})
 
+	t.Run("Optional env vars", func(t *testing.T) {
+		t.Parallel()
+
+		envs := []string{
+			"container=podman",
+			"no_proxy=localhost",
+			"http_proxy=http://localhost",
+			"https_proxy=http://localhost",
+			"NO_PROXY=localhost",
+			"HTTP_PROXY=http://localhost",
+			"HTTPS_PROXY=http://localhost",
+		}
+		expectedEnvVars := &models.ChangeSettingsParams{}
+
+		gotEnvVars, gotErrs, gotWarns := ParseEnvVars(envs)
+		assert.Equal(t, gotEnvVars, expectedEnvVars)
+		assert.Nil(t, gotErrs)
+		assert.Nil(t, gotWarns)
+	})
+
 	t.Run("Invalid env variables values", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
When the host system has a proxy configured, warnings are emitted in the pmm-managed log due to their absence in the validation of environment variables.

Similarly, when PMM Server is running in a container via podman then the `container` environment variable triggers a warning too.

* Updated parsing to allow `NO_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY` and the respective lowercase versions, along with the special podman variable, `container`
* Added test case for optional environment variables, where optional means that they may exist with or without direct specification by the user

[PMM-5939](https://jira.percona.com/browse/PMM-5939)

Build: [SUBMODULES-2798](https://github.com/Percona-Lab/pmm-submodules/pull/2798)
