### PR TITLE
Update ansible build conditions for docker

### DIFF
--- a/build/ansible/pmm2/post-build-actions.yml
+++ b/build/ansible/pmm2/post-build-actions.yml
@@ -11,7 +11,7 @@
   tasks:
     # pmm-managed checks that if /srv/pmm-distribution exist, it contains "docker", "ovf", or "ami" (all lowercase)
     - name: Detect distribution        | Create '/srv/pmm-distribution' file for Docker
-      when: ansible_virtualization_type == "docker"
+      when: ansible_facts.virtualization_type | default('') in ['docker', 'container', 'containerd', 'kvm']
       copy:
         content: "docker"
         dest: /srv/pmm-distribution
@@ -80,11 +80,11 @@
       ignore_errors: True
 
     - name: Supervisord stop           | Stop supervisord service for AMI/OVF
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       service: name=supervisord state=stopped enabled=yes
 
     - name: Supervisord stop           | Stop supervisord service for docker
-      when: ansible_virtualization_type == "docker"
+      when: ansible_facts.virtualization_type | default('') in ['docker', 'container', 'containerd', 'kvm']
       shell: supervisorctl shutdown
 
     - name: Cleanup yum cache          | Cleanup yum cache

--- a/build/ansible/roles/pmm2-images/tasks/main.yml
+++ b/build/ansible/roles/pmm2-images/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+    - name: show virtualization_type
+      debug:
+        var: ansible_facts.virtualization_type
+
     - name: Packages                   | Add PMM2 Server YUM repository
       yum_repository:
         name: pmm2-server
@@ -10,7 +14,7 @@
 
     # local yum repo for building of pmm server docker image in autobuild jobs
     - name: PMM                        | Add local YUM repository
-      when: ansible_virtualization_type == "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       yum_repository:
         name: local
         description: Local YUM repository - x86_64
@@ -40,7 +44,7 @@
     - name: Create users for non-docker images          | Create users
       user:
         name: "pmm"
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
 
     - name: Create users and groups in docker container
       block:
@@ -69,7 +73,7 @@
             - { name: grafana, uid: 998, comment: "Grafana Dashboard", shell: "/sbin/nologin", home: "/etc/grafana", group: grafana }
             - { name: clickhouse, uid: 997, comment: "Clickhouse server", shell: "/sbin/nologin", home: "/var/lib/clickhouse", group: clickhouse }
             - { name: pmm-agent, uid: 996, comment: "pmm-agent", shell: "/bin/false", home: "/usr/local/percona/", group: pmm-agent }
-      when: ansible_virtualization_type == "docker"
+      when: ansible_facts.virtualization_type | default('') in ['docker', 'container', 'containerd', 'kvm']
 
     - name: Create directories        | Create dirs
       file: path={{ item }} state=directory owner=pmm group=pmm
@@ -87,7 +91,7 @@
         mode: '0775'
 
     - name: Create dirs                | Create dirs
-      when: ansible_virtualization_type == "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       file: path={{ item }} state=directory
       with_items:
         - /var/lib/cloud/scripts/per-once
@@ -125,11 +129,11 @@
         enablerepo: "{{ pmm_client_repo_name }}"
 
     - name: Disable pmm-agent service | Disable pmm-agent
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       service: name=pmm-agent state=stopped enabled=no
 
     - name: Create tmp dirs           | Create tmp dirs
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       command: /usr/bin/systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
 
     - name: Copy grafana.ini file for the first run

--- a/build/ansible/roles/pmm2-images/tasks/main.yml
+++ b/build/ansible/roles/pmm2-images/tasks/main.yml
@@ -91,7 +91,7 @@
         mode: '0775'
 
     - name: Create dirs                | Create dirs
-      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
+      when: ansible_facts.virtualization_type | default('') in ['docker', 'container', 'containerd', 'kvm']
       file: path={{ item }} state=directory
       with_items:
         - /var/lib/cloud/scripts/per-once

--- a/build/ansible/roles/pmm2-images/tasks/main.yml
+++ b/build/ansible/roles/pmm2-images/tasks/main.yml
@@ -14,7 +14,7 @@
 
     # local yum repo for building of pmm server docker image in autobuild jobs
     - name: PMM                        | Add local YUM repository
-      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
+      when: ansible_facts.virtualization_type | default('') in ['docker', 'container', 'containerd', 'kvm']
       yum_repository:
         name: local
         description: Local YUM repository - x86_64

--- a/build/ansible/roles/supervisord-init/tasks/main.yml
+++ b/build/ansible/roles/supervisord-init/tasks/main.yml
@@ -54,7 +54,7 @@
         state: directory
 
     - name: Configure supervisor       | Add /etc/tmpfiles.d/supervisor.conf config
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       copy:
         content: |
           D /var/run/supervisor 0775 root root -
@@ -76,7 +76,7 @@
         value: dummy
 
     - name: Configure supervisor       | Increase number of open files for jobs
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       ini_file:
         dest: /etc/supervisord.conf
         section: supervisord
@@ -84,7 +84,7 @@
         value: "800000"
 
     - name: Configure supervisor       | Add supervisord.service
-      when: ansible_virtualization_type != "docker"
+      when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'kvm']
       copy:
         src: supervisord.service
         dest: /usr/lib/systemd/system/


### PR DESCRIPTION
This is a improvement proposal for the pmm-server docker image so it can be built on different container / virt environments under some different linux distros.

Our problem is/was that with the current ansible virtualized docker environments will not be recognized under some circumstances. we tested this with a current ubuntu and docker-ce, manjaro with docker-ce and also macOS Monterey with Rancher-Desktop installed.

There will be eventually a follow up PR with a slightly modified docker image for local builds. 

Build: [verification-build](https://github.com/Percona-Lab/pmm-submodules/pull/2749)
