### PR TITLE
PMM-0 fix data race

### DIFF
--- a/managed/services/agents/registry.go
+++ b/managed/services/agents/registry.go
@@ -123,15 +123,20 @@ func NewRegistry(db *reform.DB) *Registry {
 			Help:       "Clock drift.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		}),
-		mAgents: prom.NewGaugeFunc(prom.GaugeOpts{
-			Namespace: prometheusNamespace,
-			Subsystem: prometheusSubsystem,
-			Name:      "connected",
-			Help:      "The current number of connected pmm-agents.",
-		}, func() float64 {
-			return float64(len(agents))
-		}),
 	}
+
+	r.mAgents = prom.NewGaugeFunc(prom.GaugeOpts{
+		Namespace: prometheusNamespace,
+		Subsystem: prometheusSubsystem,
+		Name:      "connected",
+		Help:      "The current number of connected pmm-agents.",
+	}, func() float64 {
+		r.rw.Lock()
+		defer r.rw.Unlock()
+
+		return float64(len(agents))
+	})
+
 	// initialize metrics with labels
 	r.mDisconnects.WithLabelValues("unknown")
 


### PR DESCRIPTION
PMM-0

Build: SUBMODULES-0

Catch this data race when work on PMM-11154

```go
package pmm

import (
	"sync"
	"testing"
)

func BenchmarkMapRaceLenUnsafe(b *testing.B) {
	var (
		data = make(map[int]bool, b.N)
		wg   sync.WaitGroup
		mu   sync.Mutex
	)

	wg.Add(1)
	go func() {
		defer wg.Done()

		for i := 0; i < b.N; i++ {
			mu.Lock()
			data[i] = true
			mu.Unlock()
		}
	}()

	wg.Add(1)
	go func() {
		defer wg.Done()

		for i := 0; i < b.N; i++ {
			// PANIC
			_ = len(data)
		}
	}()

	wg.Wait()
}

func BenchmarkMapLenSafe(b *testing.B) {
	var (
		data = make(map[int]bool, b.N)
		wg   sync.WaitGroup
		mu   sync.Mutex
	)

	wg.Add(1)
	go func() {
		defer wg.Done()

		for i := 0; i < b.N; i++ {
			mu.Lock()
			data[i] = true
			mu.Unlock()
		}
	}()

	wg.Add(1)
	go func() {
		defer wg.Done()

		for i := 0; i < b.N; i++ {
			mu.Lock()
			_ = len(data)
			mu.Unlock()
		}
	}()

	wg.Wait()
}
```