### PR TITLE
PMM-11387 Fixed calculation for gcache setting depending on memory size available 

### DIFF
--- a/managed/services/dbaas/kubernetes/types.go
+++ b/managed/services/dbaas/kubernetes/types.go
@@ -101,12 +101,12 @@ func DatabaseClusterForPXC(cluster *dbaasv1beta1.CreatePXCClusterRequest, cluste
 	}
 	memory := cluster.Params.Pxc.ComputeResources.MemoryBytes
 	gCacheSize := "600M"
-	diskSize := resource.NewQuantity(cluster.Params.Pxc.DiskSize, resource.DecimalSI)
+	diskSize := resource.NewQuantity(cluster.Params.Pxc.DiskSize, resource.BinarySI)
 	cpu, err := resource.ParseQuantity(fmt.Sprintf("%dm", cluster.Params.Pxc.ComputeResources.CpuM))
 	if err != nil {
 		return nil, err
 	}
-	clusterMemory := resource.NewQuantity(cluster.Params.Pxc.ComputeResources.MemoryBytes, resource.DecimalSI)
+	clusterMemory := resource.NewQuantity(cluster.Params.Pxc.ComputeResources.MemoryBytes, resource.BinarySI)
 	if cluster.Params.Pxc.Configuration == "" {
 		if memory > memorySmallSize && memory <= memoryMediumSize {
 			gCacheSize = "2.4G"
@@ -202,12 +202,12 @@ func DatabaseClusterForPSMDB(cluster *dbaasv1beta1.CreatePSMDBClusterRequest, cl
 	if cluster.Params.Replicaset.Configuration == "" {
 		cluster.Params.Replicaset.Configuration = psmdbDefaultConfigurationTemplate
 	}
-	diskSize := resource.NewQuantity(cluster.Params.Replicaset.DiskSize, resource.DecimalSI)
+	diskSize := resource.NewQuantity(cluster.Params.Replicaset.DiskSize, resource.BinarySI)
 	cpu, err := resource.ParseQuantity(fmt.Sprintf("%dm", cluster.Params.Replicaset.ComputeResources.CpuM))
 	if err != nil {
 		return nil, err
 	}
-	clusterMemory := resource.NewQuantity(cluster.Params.Replicaset.ComputeResources.MemoryBytes, resource.DecimalSI)
+	clusterMemory := resource.NewQuantity(cluster.Params.Replicaset.ComputeResources.MemoryBytes, resource.BinarySI)
 	dbCluster := &dbaasv1.DatabaseCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cluster.Name,
@@ -290,7 +290,7 @@ func UpdatePatchForPSMDB(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaa
 				dbCluster.Spec.DBInstance.CPU = cpu
 			}
 			if updateRequest.Params.Replicaset.ComputeResources.MemoryBytes > 0 {
-				clusterMemory := resource.NewQuantity(updateRequest.Params.Replicaset.ComputeResources.MemoryBytes, resource.DecimalSI)
+				clusterMemory := resource.NewQuantity(updateRequest.Params.Replicaset.ComputeResources.MemoryBytes, resource.BinarySI)
 				dbCluster.Spec.DBInstance.Memory = *clusterMemory
 			}
 		}
@@ -344,7 +344,7 @@ func UpdatePatchForPXC(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaasv
 			dbCluster.Spec.DBInstance.CPU = cpu
 		}
 		if updateRequest.Params.Pxc.ComputeResources.MemoryBytes > 0 {
-			clusterMemory := resource.NewQuantity(updateRequest.Params.Pxc.ComputeResources.MemoryBytes, resource.DecimalSI)
+			clusterMemory := resource.NewQuantity(updateRequest.Params.Pxc.ComputeResources.MemoryBytes, resource.BinarySI)
 			dbCluster.Spec.DBInstance.Memory = *clusterMemory
 		}
 	}

--- a/managed/services/dbaas/kubernetes/types.go
+++ b/managed/services/dbaas/kubernetes/types.go
@@ -101,12 +101,12 @@ func DatabaseClusterForPXC(cluster *dbaasv1beta1.CreatePXCClusterRequest, cluste
 	}
 	memory := cluster.Params.Pxc.ComputeResources.MemoryBytes
 	gCacheSize := "600M"
-	diskSize := resource.NewQuantity(cluster.Params.Pxc.DiskSize, resource.BinarySI)
+	diskSize := resource.NewQuantity(cluster.Params.Pxc.DiskSize, resource.DecimalSI)
 	cpu, err := resource.ParseQuantity(fmt.Sprintf("%dm", cluster.Params.Pxc.ComputeResources.CpuM))
 	if err != nil {
 		return nil, err
 	}
-	clusterMemory := resource.NewQuantity(cluster.Params.Pxc.ComputeResources.MemoryBytes, resource.BinarySI)
+	clusterMemory := resource.NewQuantity(cluster.Params.Pxc.ComputeResources.MemoryBytes, resource.DecimalSI)
 	if cluster.Params.Pxc.Configuration == "" {
 		if memory > memorySmallSize && memory <= memoryMediumSize {
 			gCacheSize = "2.4G"
@@ -202,12 +202,12 @@ func DatabaseClusterForPSMDB(cluster *dbaasv1beta1.CreatePSMDBClusterRequest, cl
 	if cluster.Params.Replicaset.Configuration == "" {
 		cluster.Params.Replicaset.Configuration = psmdbDefaultConfigurationTemplate
 	}
-	diskSize := resource.NewQuantity(cluster.Params.Replicaset.DiskSize, resource.BinarySI)
+	diskSize := resource.NewQuantity(cluster.Params.Replicaset.DiskSize, resource.DecimalSI)
 	cpu, err := resource.ParseQuantity(fmt.Sprintf("%dm", cluster.Params.Replicaset.ComputeResources.CpuM))
 	if err != nil {
 		return nil, err
 	}
-	clusterMemory := resource.NewQuantity(cluster.Params.Replicaset.ComputeResources.MemoryBytes, resource.BinarySI)
+	clusterMemory := resource.NewQuantity(cluster.Params.Replicaset.ComputeResources.MemoryBytes, resource.DecimalSI)
 	dbCluster := &dbaasv1.DatabaseCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: cluster.Name,
@@ -290,7 +290,7 @@ func UpdatePatchForPSMDB(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaa
 				dbCluster.Spec.DBInstance.CPU = cpu
 			}
 			if updateRequest.Params.Replicaset.ComputeResources.MemoryBytes > 0 {
-				clusterMemory := resource.NewQuantity(updateRequest.Params.Replicaset.ComputeResources.MemoryBytes, resource.BinarySI)
+				clusterMemory := resource.NewQuantity(updateRequest.Params.Replicaset.ComputeResources.MemoryBytes, resource.DecimalSI)
 				dbCluster.Spec.DBInstance.Memory = *clusterMemory
 			}
 		}
@@ -344,7 +344,7 @@ func UpdatePatchForPXC(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaasv
 			dbCluster.Spec.DBInstance.CPU = cpu
 		}
 		if updateRequest.Params.Pxc.ComputeResources.MemoryBytes > 0 {
-			clusterMemory := resource.NewQuantity(updateRequest.Params.Pxc.ComputeResources.MemoryBytes, resource.BinarySI)
+			clusterMemory := resource.NewQuantity(updateRequest.Params.Pxc.ComputeResources.MemoryBytes, resource.DecimalSI)
 			dbCluster.Spec.DBInstance.Memory = *clusterMemory
 		}
 	}

--- a/managed/services/dbaas/kubernetes/types.go
+++ b/managed/services/dbaas/kubernetes/types.go
@@ -109,13 +109,13 @@ func DatabaseClusterForPXC(cluster *dbaasv1beta1.CreatePXCClusterRequest, cluste
 	clusterMemory := resource.NewQuantity(cluster.Params.Pxc.ComputeResources.MemoryBytes, resource.DecimalSI)
 	if cluster.Params.Pxc.Configuration == "" {
 		if memory > memorySmallSize && memory <= memoryMediumSize {
-			gCacheSize = "2.4G"
+			gCacheSize = "2457M"
 		}
 		if memory > memoryMediumSize && memory <= memoryLargeSize {
-			gCacheSize = "9.6G"
+			gCacheSize = "9830M"
 		}
 		if memory > memoryLargeSize {
-			gCacheSize = "9.6G"
+			gCacheSize = "9830M"
 		}
 		cluster.Params.Pxc.Configuration = fmt.Sprintf(pxcDefaultConfigurationTemplate, gCacheSize)
 	}


### PR DESCRIPTION
DecimalSI calculation does not work for PXC clusters with fraction values. PXC gives the calculated "2.4G" is not valid and if I manually override that to 3G it is working fine.

PMM-0

Build: SUBMODULES-0

- [ ] Links to other linked pull requests (optional).