### PR TITLE
PMM-11372: add vmproxy to update task

### DIFF
--- a/update/ansible/playbook/tasks/update.yml
+++ b/update/ansible/playbook/tasks/update.yml
@@ -14,6 +14,7 @@
       - dbaas-tools
       - pmm2-client
       - pmm-dump
+      - vmproxy
   pre_tasks:
     - name: detect /srv/pmm-distribution
       stat:


### PR DESCRIPTION
PMM-11372

Build: SUBMODULES-0

Fixes issue with a broken update due to missing `vmproxy` binary.