### PR TITLE
PMM-11517 resync local storage before restore

### DIFF
--- a/agent/runner/jobs/mongodb_backup_job.go
+++ b/agent/runner/jobs/mongodb_backup_job.go
@@ -115,7 +115,7 @@ func (j *MongoDBBackupJob) Run(ctx context.Context, send Send) error {
 	}
 	defer os.Remove(confFile) //nolint:errcheck
 
-	if err := pbmConfigure(ctx, j.l, j.dbURL, confFile); err != nil {
+	if err := pbmConfigure(ctx, j.l, j.dbURL, false, confFile); err != nil {
 		return errors.Wrap(err, "failed to configure pbm")
 	}
 


### PR DESCRIPTION
PMM-11517

With local storage, backup artifacts goes missing before after we restart pbm/pbm-agents (i.e., after a physical restore). This causes subsequent restores to fail as `pbm` cannot correctly detect such artifact.

This adds the `--force-resync` option to pbm config before restoring to update the artifact list.

Build: SUBMODULES-0

- [ ] Links to other linked pull requests (optional).