### PR TITLE
PMM-7 fix bodyclose linter warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,22 +72,22 @@ linters:
   disable:
     # keep the rules sorted alpahbetically
     - exhaustivestruct # too annoying
-    - exhaustruct      # too many files to fix/nolint
-    - funlen           # useless
+    - exhaustruct # too many files to fix/nolint
+    - funlen # useless
     - gochecknoglobals # mostly useless
-    - gochecknoinits   # we use init functions
-    - gocyclo          # using cyclop with the max 30 instead
-    - goerr113         # extra work & poor benefit
-    - gomnd            # we are using numbers in many cases
-    - gomoddirectives  # we use replace directives
-    - ifshort          # a lot of false positives
-    - interfacer       # deprecated
-    - maligned         # deprecated
-    - nlreturn         # too annoying
-    - scopelint        # too many false positives
-    - varnamelen       # useless
-    - wrapcheck        # we do not use wrapping everywhere
-    - wsl              # too annoying
+    - gochecknoinits # we use init functions
+    - gocyclo # using cyclop with the max 30 instead
+    - goerr113 # extra work & poor benefit
+    - gomnd # we are using numbers in many cases
+    - gomoddirectives # we use replace directives
+    - ifshort # a lot of false positives
+    - interfacer # deprecated
+    - maligned # deprecated
+    - nlreturn # too annoying
+    - scopelint # too many false positives
+    - varnamelen # useless
+    - wrapcheck # we do not use wrapping everywhere
+    - wsl # too annoying
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
@@ -120,7 +120,7 @@ linters:
     - interfacebloat
     - gosimple
     - contextcheck
-    - bodyclose
+    # - bodyclose
     - prealloc
     - nakedret
     - forbidigo
@@ -150,10 +150,10 @@ issues:
       linters:
         # keep sorted
         - exhaustivestruct # very annoying
-        - funlen           # tests may be long
-        - gocognit         # triggered by subtests
-        - gomnd            # tests are full of magic numbers
-        - testpackage      # senseless
-        - unused           # very annoying false positive: https://github.com/golangci/golangci-lint/issues/791
-        - lll              # tests often require long lines
+        - funlen # tests may be long
+        - gocognit # triggered by subtests
+        - gomnd # tests are full of magic numbers
+        - testpackage # senseless
+        - unused # very annoying false positive: https://github.com/golangci/golangci-lint/issues/791
+        - lll # tests often require long lines
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,22 +72,22 @@ linters:
   disable:
     # keep the rules sorted alpahbetically
     - exhaustivestruct # too annoying
-    - exhaustruct # too many files to fix/nolint
-    - funlen # useless
+    - exhaustruct      # too many files to fix/nolint
+    - funlen           # useless
     - gochecknoglobals # mostly useless
-    - gochecknoinits # we use init functions
-    - gocyclo # using cyclop with the max 30 instead
-    - goerr113 # extra work & poor benefit
-    - gomnd # we are using numbers in many cases
-    - gomoddirectives # we use replace directives
-    - ifshort # a lot of false positives
-    - interfacer # deprecated
-    - maligned # deprecated
-    - nlreturn # too annoying
-    - scopelint # too many false positives
-    - varnamelen # useless
-    - wrapcheck # we do not use wrapping everywhere
-    - wsl # too annoying
+    - gochecknoinits   # we use init functions
+    - gocyclo          # using cyclop with the max 30 instead
+    - goerr113         # extra work & poor benefit
+    - gomnd            # we are using numbers in many cases
+    - gomoddirectives  # we use replace directives
+    - ifshort          # a lot of false positives
+    - interfacer       # deprecated
+    - maligned         # deprecated
+    - nlreturn         # too annoying
+    - scopelint        # too many false positives
+    - varnamelen       # useless
+    - wrapcheck        # we do not use wrapping everywhere
+    - wsl              # too annoying
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
@@ -120,7 +120,6 @@ linters:
     - interfacebloat
     - gosimple
     - contextcheck
-    # - bodyclose
     - prealloc
     - nakedret
     - forbidigo
@@ -150,10 +149,10 @@ issues:
       linters:
         # keep sorted
         - exhaustivestruct # very annoying
-        - funlen # tests may be long
-        - gocognit # triggered by subtests
-        - gomnd # tests are full of magic numbers
-        - testpackage # senseless
-        - unused # very annoying false positive: https://github.com/golangci/golangci-lint/issues/791
-        - lll # tests often require long lines
+        - funlen           # tests may be long
+        - gocognit         # triggered by subtests
+        - gomnd            # tests are full of magic numbers
+        - testpackage      # senseless
+        - unused           # very annoying false positive: https://github.com/golangci/golangci-lint/issues/791
+        - lll              # tests often require long lines
 

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -118,6 +118,8 @@ func TestSetup(t *testing.T) {
 		req.Header.Set("X-Test-Must-Setup", "1")
 
 		resp, b := doRequest(t, client, req)
+		defer resp.Body.Close()
+
 		assert.Equal(t, 200, resp.StatusCode, "response:\n%s", b)
 		assert.True(t, strings.HasPrefix(string(b), `<!doctype html>`), string(b))
 	})
@@ -149,6 +151,8 @@ func TestSetup(t *testing.T) {
 				req.Header.Set("X-Test-Must-Setup", "1")
 
 				resp, b := doRequest(t, client, req)
+				defer resp.Body.Close()
+
 				assert.Equal(t, code, resp.StatusCode, "response:\n%s", b)
 				if code == 303 {
 					assert.Equal(t, "/setup", resp.Header.Get("Location"))
@@ -173,6 +177,8 @@ func TestSetup(t *testing.T) {
 		req.Header.Set("X-Test-Must-Setup", "1")
 
 		resp, b := doRequest(t, client, req)
+		defer resp.Body.Close()
+
 		assert.Equal(t, 200, resp.StatusCode, "response:\n%s", b)
 		assert.Equal(t, "{}", string(b), "response:\n%s", b)
 	})
@@ -204,6 +210,8 @@ func TestSwagger(t *testing.T) {
 				require.NoError(t, err)
 
 				resp, _ := doRequest(t, http.DefaultClient, req)
+				defer resp.Body.Close()
+
 				require.NoError(t, err)
 				assert.Equal(t, 200, resp.StatusCode)
 			})
@@ -219,6 +227,8 @@ func TestSwagger(t *testing.T) {
 				require.NoError(t, err)
 
 				resp, _ := doRequest(t, http.DefaultClient, req)
+				defer resp.Body.Close()
+
 				require.NoError(t, err)
 				assert.Equal(t, 200, resp.StatusCode)
 			})
@@ -383,6 +393,8 @@ func deleteUser(t *testing.T, userID int) {
 	require.NoError(t, err)
 
 	resp, b := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
+
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to delete user, status code: %d, response: %s", resp.StatusCode, b)
 }
 
@@ -406,6 +418,7 @@ func createUser(t *testing.T, login string) int {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	resp, b := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to create user, status code: %d, response: %s", resp.StatusCode, b)
 
 	var m map[string]interface{}
@@ -431,6 +444,7 @@ func setRole(t *testing.T, userID int, role string) {
 
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	resp, b := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
 
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to set role for user, response: %s", b)
 }
@@ -445,6 +459,8 @@ func deleteAPIKey(t *testing.T, apiKeyID int) {
 	require.NoError(t, err)
 
 	resp, b := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
+
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to delete API Key, status code: %d, response: %s", resp.StatusCode, b)
 }
 
@@ -466,6 +482,8 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	resp, b := doRequest(t, http.DefaultClient, req)
+	resp.Body.Close()
+
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to create API key, status code: %d, response: %s", resp.StatusCode, b)
 
 	var m map[string]interface{}
@@ -480,6 +498,8 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 
 	resp, b = doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
+
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to get API key, status code: %d, response: %s", resp.StatusCode, b)
 
 	var k map[string]interface{}

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -482,7 +482,6 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	resp, b := doRequest(t, http.DefaultClient, req)
-	resp.Body.Close()
 
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to create API key, status code: %d, response: %s", resp.StatusCode, b)
 
@@ -490,6 +489,7 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	err = json.Unmarshal(b, &m)
 	require.NoError(t, err)
 	apiKey := m["key"].(string)
+	resp.Body.Close()
 
 	u.User = nil
 	u.Path = "/graph/api/auth/key"

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -482,6 +482,7 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	resp, b := doRequest(t, http.DefaultClient, req)
+	defer resp.Body.Close()
 
 	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to create API key, status code: %d, response: %s", resp.StatusCode, b)
 
@@ -489,7 +490,6 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	err = json.Unmarshal(b, &m)
 	require.NoError(t, err)
 	apiKey := m["key"].(string)
-	resp.Body.Close()
 
 	u.User = nil
 	u.Path = "/graph/api/auth/key"
@@ -497,10 +497,10 @@ func createAPIKeyWithRole(t *testing.T, name, role string) (int, string) {
 	require.NoError(t, err)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 
-	resp, b = doRequest(t, http.DefaultClient, req)
-	defer resp.Body.Close()
+	resp1, b := doRequest(t, http.DefaultClient, req)
+	defer resp1.Body.Close()
 
-	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to get API key, status code: %d, response: %s", resp.StatusCode, b)
+	require.Equalf(t, http.StatusOK, resp1.StatusCode, "failed to get API key, status code: %d, response: %s", resp1.StatusCode, b)
 
 	var k map[string]interface{}
 	err = json.Unmarshal(b, &k)

--- a/vmproxy/proxy/proxy_test.go
+++ b/vmproxy/proxy/proxy_test.go
@@ -64,7 +64,10 @@ func TestProxy(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, targetURL, nil)
 
 		handler.ServeHTTP(rec, req)
-		require.Equal(t, rec.Result().StatusCode, http.StatusOK)
+		resp := rec.Result()
+		defer resp.Body.Close()
+
+		require.Equal(t, resp.StatusCode, http.StatusOK)
 	})
 
 	t.Run("shall properly handle filters", func(t *testing.T) {
@@ -134,7 +137,10 @@ func TestProxy(t *testing.T) {
 				req.Header.Set(headerName, tc.headerContent)
 
 				handler.ServeHTTP(rec, req)
-				require.Equal(t, tc.expectedStatus, rec.Result().StatusCode)
+				resp := rec.Result()
+				defer resp.Body.Close()
+
+				require.Equal(t, tc.expectedStatus, resp.StatusCode)
 			})
 		}
 	})


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

Note: this PR re-enables the `bodyclose` linter rule and fixes the warnings.