### PR TITLE
PMM-7 re-enable the `nilnil` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,7 +115,6 @@ linters:
     - execinquery
     - predeclared
     - nosprintfhostport
-    - nilnil
     - nilerr
     - interfacebloat
     - gosimple

--- a/admin/commands/inventory/inventory.go
+++ b/admin/commands/inventory/inventory.go
@@ -92,7 +92,7 @@ type RemoveCommand struct {
 // Values comparison is case-insensitive.
 func formatTypeValue(acceptableTypeValues map[string][]string, input string) (*string, error) {
 	if input == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	for value, variations := range acceptableTypeValues {

--- a/managed/models/models.go
+++ b/managed/models/models.go
@@ -135,7 +135,7 @@ func prepareLabels(m map[string]string, removeEmptyValues bool) error {
 // getLabels deserializes model's Prometheus labels.
 func getLabels(b []byte) (map[string]string, error) {
 	if len(b) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 	m := make(map[string]string)
 	if err := json.Unmarshal(b, &m); err != nil {

--- a/managed/models/node_helpers.go
+++ b/managed/models/node_helpers.go
@@ -60,13 +60,13 @@ func checkUniqueNodeName(q *reform.Querier, name string) error {
 }
 
 // CheckUniqueNodeInstanceRegion checks for uniqueness of instance address and region.
-// This function not only return an error in case of finding an existing node with those paramenters but
+// This function not only returns an error in case of finding an existing node with those paramenters but
 // also returns the Node itself if there is any, because if we are recreating the instance (--force in pmm-admin)
 // we need to know the Node.ID to remove it and its dependencies.
-// This check only applies is region is not empty.
+// This check only applies if region is not empty.
 func CheckUniqueNodeInstanceRegion(q *reform.Querier, instance string, region *string) (*Node, error) {
 	if pointer.GetString(region) == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	if instance == "" {
@@ -79,7 +79,7 @@ func CheckUniqueNodeInstanceRegion(q *reform.Querier, instance string, region *s
 	case nil:
 		return &node, status.Errorf(codes.AlreadyExists, "Node with instance %q and region %q already exists.", instance, *region)
 	case reform.ErrNoRows:
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	default:
 		return nil, errors.WithStack(err)
 	}

--- a/managed/services/checks/funcs.go
+++ b/managed/services/checks/funcs.go
@@ -111,7 +111,7 @@ func GetAdditionalContext() map[string]starlark.GoFunc {
 }
 
 // ipIsPrivate accepts a single string argument (IP address or a network) and
-// returns true for a private address, otherwise false. In case of an invalid argument nil.
+// returns true for a private address, otherwise false. It returns nil in case of an invalid argument.
 func ipIsPrivate(args ...interface{}) (interface{}, error) {
 	log := logrus.WithField("component", "checks")
 

--- a/managed/services/checks/funcs.go
+++ b/managed/services/checks/funcs.go
@@ -130,7 +130,7 @@ func ipIsPrivate(args ...interface{}) (interface{}, error) {
 		_, net, err := net.ParseCIDR(ip)
 		if err != nil {
 			log.Errorf("invalid ip/network address: %q", ip)
-			return nil, nil
+			return nil, errors.Errorf("invalid ip/network address: %q", ip)
 		}
 		for _, network := range privateNetworks {
 			// check if the two networks intersect

--- a/managed/services/checks/funcs.go
+++ b/managed/services/checks/funcs.go
@@ -130,7 +130,7 @@ func ipIsPrivate(args ...interface{}) (interface{}, error) {
 		_, net, err := net.ParseCIDR(ip)
 		if err != nil {
 			log.Errorf("invalid ip/network address: %q", ip)
-			return nil, errors.Errorf("invalid ip/network address: %q", ip)
+			return nil, nil //nolint:nilnil
 		}
 		for _, network := range privateNetworks {
 			// check if the two networks intersect

--- a/managed/services/management/dbaas/psmdb_cluster_service.go
+++ b/managed/services/management/dbaas/psmdb_cluster_service.go
@@ -322,7 +322,7 @@ func (s PSMDBClusterService) getBackupLocation(req *dbaasv1beta1.CreatePSMDBClus
 	if req.Params != nil && req.Params.Restore != nil && req.Params.Restore.LocationId != "" {
 		return models.FindBackupLocationByID(s.db.Querier, req.Params.Restore.LocationId)
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 // GetPSMDBClusterResources returns expected resources to be consumed by the cluster.

--- a/managed/services/management/dbaas/pxc_cluster_service.go
+++ b/managed/services/management/dbaas/pxc_cluster_service.go
@@ -404,5 +404,5 @@ func (s PXCClustersService) getBackupLocation(req *dbaasv1beta1.CreatePXCCluster
 	if req.Params != nil && req.Params.Restore != nil && req.Params.Restore.LocationId != "" {
 		return models.FindBackupLocationByID(s.db.Querier, req.Params.Restore.LocationId)
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

Note: this PR re-enables the `ninil` linter rule and fixes the warnings thereof. Even though I mostly had to resort to disabling all warnings with `nolint`, IMO it is still a good rule to follow for the sake of more semantic code. 

Fixing this rule in the code would have required us to re-test the code in a number of components, which wasn't the gole of this PR.