### PR TITLE
PMM-7 re-enable `whitespace` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -105,7 +105,6 @@ linters:
     - gocognit
     - maintidx
     - nestif
-    - whitespace
     - errorlint
     - forcetypeassert
     - golint

--- a/api-tests/management/alerting/alerting_test.go
+++ b/api-tests/management/alerting/alerting_test.go
@@ -108,7 +108,6 @@ func assertTemplate(t *testing.T, expectedTemplate alert.Template, listTemplates
 			assert.Nil(t, param.String)
 		default:
 		}
-
 	}
 
 	assert.Equal(t, expectedTemplate.Labels, tmpl.Labels)

--- a/managed/services/management/dbaas/kubernetes_server.go
+++ b/managed/services/management/dbaas/kubernetes_server.go
@@ -487,7 +487,6 @@ func (k kubernetesServer) installDefaultOperators(operatorsToInstall map[string]
 			retval["psmdb"] = err
 			k.l.Errorf("cannot approve the PSMDB install plan: %s", err)
 		}
-
 	}
 	if _, ok := operatorsToInstall["dbaas"]; ok {
 		operator := "dbaas-operator"

--- a/managed/services/management/dbaas/psmdb_cluster_service.go
+++ b/managed/services/management/dbaas/psmdb_cluster_service.go
@@ -110,7 +110,6 @@ func (s PSMDBClusterService) GetPSMDBClusterCredentials(ctx context.Context, req
 //
 //nolint:dupl
 func (s PSMDBClusterService) CreatePSMDBCluster(ctx context.Context, req *dbaasv1beta1.CreatePSMDBClusterRequest) (*dbaasv1beta1.CreatePSMDBClusterResponse, error) { //nolint:lll
-
 	settings, err := models.GetSettings(s.db.Querier)
 	if err != nil {
 		return nil, err

--- a/managed/services/management/dbaas/pxc_cluster_service.go
+++ b/managed/services/management/dbaas/pxc_cluster_service.go
@@ -328,7 +328,6 @@ func (s PXCClustersService) fillDefaults(ctx context.Context, kubernetesClusterN
 				req.Name = req.Name[:21]
 			}
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

This PR re-enables the `whitespace` rule and fixes the warnings thereof.