### PR TITLE
PMM-7 fix the use of deprecated `RdsServiceID` constant

### DIFF
--- a/managed/services/management/rds.go
+++ b/managed/services/management/rds.go
@@ -120,7 +120,7 @@ func listRegions(partitions []string) []string {
 				continue
 			}
 
-			for r := range partition.Services()[endpoints.RdsServiceID].Regions() {
+			for r := range partition.Services()[rds.EndpointsID].Regions() {
 				set[r] = struct{}{}
 			}
 			break


### PR DESCRIPTION
PMM-7

Why:
It was showing up in every PR as a linter warning, too annoying...
