### PR TITLE
PMM-7 disable `deadcode` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ linters:
     # keep the rules sorted alpahbetically
     - exhaustivestruct # too annoying
     - exhaustruct      # too many files to fix/nolint
+    - deadcode         # unmaintained, we leverage `unused`
     - funlen           # useless
     - gochecknoglobals # mostly useless
     - gochecknoinits   # we use init functions
@@ -108,7 +109,6 @@ linters:
     - errorlint
     - forcetypeassert
     - golint
-    - deadcode
     - nonamedreturns
     - usestdlibvars
     - execinquery

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -88,6 +88,5 @@ func TestImports(t *testing.T) {
 				}
 			}
 		}
-
 	}
 }

--- a/managed/services/dbaas/kubernetes/types.go
+++ b/managed/services/dbaas/kubernetes/types.go
@@ -199,7 +199,6 @@ func DatabaseClusterForPXC(cluster *dbaasv1beta1.CreatePXCClusterRequest, cluste
 				StorageName: backupLocation.Name,
 			},
 		}
-
 	}
 	if cluster.Expose {
 		exposeType, ok := exposeTypeMap[clusterType]
@@ -215,7 +214,6 @@ func DatabaseClusterForPXC(cluster *dbaasv1beta1.CreatePXCClusterRequest, cluste
 		if cluster.InternetFacing && clusterType == ClusterTypeEKS {
 			dbCluster.Spec.LoadBalancer.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "external"
 		}
-
 	}
 	var sourceRanges []string
 	for _, sourceRange := range cluster.SourceRanges {
@@ -358,7 +356,6 @@ func DatabaseClusterForPSMDB(cluster *dbaasv1beta1.CreatePSMDBClusterRequest, cl
 				StorageName: backupLocation.Name,
 			},
 		}
-
 	}
 	var sourceRanges []string
 	for _, sourceRange := range cluster.SourceRanges {
@@ -504,7 +501,6 @@ func UpdatePatchForPXC(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaasv
 			return err
 		}
 		dbCluster.Spec.LoadBalancer.Resources = resources
-
 	}
 	if updateRequest.Params.Proxysql != nil && updateRequest.Params.Proxysql.ComputeResources != nil {
 		resources, err := convertComputeResource(updateRequest.Params.Proxysql.ComputeResources)

--- a/managed/services/management/backup/locations_service_test.go
+++ b/managed/services/management/backup/locations_service_test.go
@@ -149,7 +149,6 @@ func TestListBackupLocations(t *testing.T) {
 								req.S3Config.BucketName != cfg.S3Config.BucketName {
 								return false
 							}
-
 						}
 						if req.FilesystemConfig != nil {
 							cfg := loc.Config.(*backuppb.Location_FilesystemConfig)


### PR DESCRIPTION
PMM-7

Refer to: https://github.com/percona/pmm/issues/1541

This PR:
1/ disables the linter rule `deadcode`, since `unused` does the same
2/ fixes the remaining `whitespace` warnings