### PR TITLE
PMM-7 re-enable `containedctx` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,7 +121,6 @@ linters:
     - forbidigo
     - errcheck
     - dupl
-    - containedctx
     # ENDTODO
 
 run:

--- a/agent/agents/supervisor/supervisor.go
+++ b/agent/agents/supervisor/supervisor.go
@@ -54,7 +54,8 @@ type configGetter interface {
 
 // Supervisor manages all Agents, both processes and built-in.
 type Supervisor struct {
-	ctx            context.Context
+	// TODO: refactor to move context outside of struct
+	ctx            context.Context //nolint:containedctx
 	agentVersioner agentVersioner
 	cfg            configGetter
 	portsRegistry  *portsRegistry

--- a/qan-api2/services/analytics/filters_test.go
+++ b/qan-api2/services/analytics/filters_test.go
@@ -54,26 +54,19 @@ func TestService_GetFilters(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.FiltersRequest
-	}
 	tests := []struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.FiltersRequest
 		want    *qanpb.FiltersReply
 		wantErr bool
 	}{
 		{
 			"success",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-				},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
 			},
 			&want,
 			false,
@@ -81,14 +74,11 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"success_with_dimensions_username",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					Labels: []*qanpb.MapFieldEntry{
-						{Key: "username", Value: []string{"user1", "user2"}},
-					},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				Labels: []*qanpb.MapFieldEntry{
+					{Key: "username", Value: []string{"user1", "user2"}},
 				},
 			},
 			&want,
@@ -97,16 +87,13 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"success_with_dimensions_client_host_schema_service_name",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					Labels: []*qanpb.MapFieldEntry{
-						{Key: "client_host", Value: []string{"10.11.12.1", "10.11.12.2", "10.11.12.3", "10.11.12.4", "10.11.12.5", "10.11.12.6", "10.11.12.7", "10.11.12.8", "10.11.12.9", "10.11.12.10", "10.11.12.11", "10.11.12.12", "10.11.12.13"}},
-						{Key: "schema", Value: []string{"schema65", "schema6", "schema42", "schema76", "schema90", "schema39", "schema1", "schema17", "schema79", "schema10"}},
-						{Key: "service_name", Value: []string{"server5", "server8", "server6", "server3", "server4", "server2", "server1"}},
-					},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				Labels: []*qanpb.MapFieldEntry{
+					{Key: "client_host", Value: []string{"10.11.12.1", "10.11.12.2", "10.11.12.3", "10.11.12.4", "10.11.12.5", "10.11.12.6", "10.11.12.7", "10.11.12.8", "10.11.12.9", "10.11.12.10", "10.11.12.11", "10.11.12.12", "10.11.12.13"}},
+					{Key: "schema", Value: []string{"schema65", "schema6", "schema42", "schema76", "schema90", "schema39", "schema1", "schema17", "schema79", "schema10"}},
+					{Key: "service_name", Value: []string{"server5", "server8", "server6", "server3", "server4", "server2", "server1"}},
 				},
 			},
 			&want,
@@ -115,29 +102,26 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"success_with_dimensions_multiple",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					Labels: []*qanpb.MapFieldEntry{
-						{Key: "container_id", Value: []string{"container_id"}},
-						{Key: "container_name", Value: []string{"container_name1"}},
-						{Key: "machine_id", Value: []string{"machine_id1"}},
-						{Key: "node_type", Value: []string{"node_type1"}},
-						{Key: "node_name", Value: []string{"node_name1"}},
-						{Key: "node_id", Value: []string{"node_id1"}},
-						{Key: "node_model", Value: []string{"node_model1"}},
-						{Key: "region", Value: []string{"region1"}},
-						{Key: "az", Value: []string{"az1"}},
-						{Key: "environment", Value: []string{"environment1"}},
-						{Key: "service_id", Value: []string{"service_id1"}},
-						{Key: "service_type", Value: []string{"service_type1"}},
-						{Key: "cmd_type", Value: []string{"1"}},
-						{Key: "top_queryid", Value: []string{"top_queryid1"}},
-						{Key: "application_name", Value: []string{"psql"}},
-						{Key: "planid", Value: []string{"planid1"}},
-					},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				Labels: []*qanpb.MapFieldEntry{
+					{Key: "container_id", Value: []string{"container_id"}},
+					{Key: "container_name", Value: []string{"container_name1"}},
+					{Key: "machine_id", Value: []string{"machine_id1"}},
+					{Key: "node_type", Value: []string{"node_type1"}},
+					{Key: "node_name", Value: []string{"node_name1"}},
+					{Key: "node_id", Value: []string{"node_id1"}},
+					{Key: "node_model", Value: []string{"node_model1"}},
+					{Key: "region", Value: []string{"region1"}},
+					{Key: "az", Value: []string{"az1"}},
+					{Key: "environment", Value: []string{"environment1"}},
+					{Key: "service_id", Value: []string{"service_id1"}},
+					{Key: "service_type", Value: []string{"service_type1"}},
+					{Key: "cmd_type", Value: []string{"1"}},
+					{Key: "top_queryid", Value: []string{"top_queryid1"}},
+					{Key: "application_name", Value: []string{"psql"}},
+					{Key: "planid", Value: []string{"planid1"}},
 				},
 			},
 			&want,
@@ -146,14 +130,11 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"success_with_labels",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					Labels: []*qanpb.MapFieldEntry{
-						{Key: "label0", Value: []string{"value1"}},
-					},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				Labels: []*qanpb.MapFieldEntry{
+					{Key: "label0", Value: []string{"value1"}},
 				},
 			},
 			&want,
@@ -162,12 +143,9 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"fail",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t2.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t1.Unix()},
-				},
+			&qanpb.FiltersRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t2.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t1.Unix()},
 			},
 			nil,
 			true,
@@ -175,10 +153,7 @@ func TestService_GetFilters(t *testing.T) {
 		{
 			"fail",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.FiltersRequest{},
-			},
+			&qanpb.FiltersRequest{},
 			nil,
 			true,
 		},
@@ -189,7 +164,7 @@ func TestService_GetFilters(t *testing.T) {
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
 			}
-			got, err := s.Get(tt.args.ctx, tt.args.in)
+			got, err := s.Get(context.TODO(), tt.in)
 			if (err != nil) != tt.wantErr {
 				assert.Errorf(t, err, "Service.GetFilters() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/qan-api2/services/analytics/metrics_names_test.go
+++ b/qan-api2/services/analytics/metrics_names_test.go
@@ -30,21 +30,17 @@ func TestService_GetMetricsNames(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.MetricsNamesRequest
-	}
 	tests := []struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.MetricsNamesRequest
 		want    *qanpb.MetricsNamesReply
 		wantErr bool
 	}{
 		{
 			name:    "success",
 			fields:  fields{},
-			args:    args{},
+			in:      &qanpb.MetricsNamesRequest{},
 			want:    &qanpb.MetricsNamesReply{Data: metricsNames},
 			wantErr: false,
 		},
@@ -55,7 +51,7 @@ func TestService_GetMetricsNames(t *testing.T) {
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
 			}
-			got, err := s.GetMetricsNames(tt.args.ctx, tt.args.in)
+			got, err := s.GetMetricsNames(context.TODO(), tt.in)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Service.GetMetricsNames() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/qan-api2/services/analytics/object_details_test.go
+++ b/qan-api2/services/analytics/object_details_test.go
@@ -43,28 +43,21 @@ func TestService_GetQueryExample(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.QueryExampleRequest
-	}
 	tests := []struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.QueryExampleRequest
 		want    *qanpb.QueryExampleReply
 		wantErr bool
 	}{
 		{
 			"no_period_start_from",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartTo: &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:       "queryid",
-					FilterBy:      "B305F6354FA21F2A",
-					Limit:         5,
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartTo: &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:       "queryid",
+				FilterBy:      "B305F6354FA21F2A",
+				Limit:         5,
 			},
 			nil,
 			true,
@@ -72,14 +65,11 @@ func TestService_GetQueryExample(t *testing.T) {
 		{
 			"no_period_start_to",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					GroupBy:         "queryid",
-					FilterBy:        "B305F6354FA21F2A",
-					Limit:           5,
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				GroupBy:         "queryid",
+				FilterBy:        "B305F6354FA21F2A",
+				Limit:           5,
 			},
 			nil,
 			true,
@@ -87,14 +77,11 @@ func TestService_GetQueryExample(t *testing.T) {
 		{
 			"no_group",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					FilterBy:        "B305F6354FA21F2A",
-					Limit:           5,
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				FilterBy:        "B305F6354FA21F2A",
+				Limit:           5,
 			},
 			&want,
 			false,
@@ -102,14 +89,11 @@ func TestService_GetQueryExample(t *testing.T) {
 		{
 			"no_limit",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "queryid",
-					FilterBy:        "B305F6354FA21F2A",
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "queryid",
+				FilterBy:        "B305F6354FA21F2A",
 			},
 			&want,
 			false,
@@ -117,14 +101,11 @@ func TestService_GetQueryExample(t *testing.T) {
 		{
 			"invalid_group_name",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "invalid_group_name",
-					FilterBy:        "B305F6354FA21F2A",
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "invalid_group_name",
+				FilterBy:        "B305F6354FA21F2A",
 			},
 			nil,
 			true,
@@ -132,14 +113,11 @@ func TestService_GetQueryExample(t *testing.T) {
 		{
 			"not_found",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.QueryExampleRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "queryid",
-					FilterBy:        "unexist",
-				},
+			&qanpb.QueryExampleRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "queryid",
+				FilterBy:        "unexist",
 			},
 			&want,
 			false,
@@ -151,7 +129,7 @@ func TestService_GetQueryExample(t *testing.T) {
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
 			}
-			got, err := s.GetQueryExample(tt.args.ctx, tt.args.in)
+			got, err := s.GetQueryExample(context.TODO(), tt.in)
 			if (err != nil) != tt.wantErr {
 				assert.Errorf(t, err, "Service.GetQueryExample() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -182,28 +160,21 @@ func TestService_GetMetricsError(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.MetricsRequest
-	}
 	tests := []struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.MetricsRequest
 		want    *qanpb.MetricsReply
 		wantErr bool
 	}{
 		{
 			"not_found",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.MetricsRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "queryid",
-					FilterBy:        "unexist",
-				},
+			&qanpb.MetricsRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "queryid",
+				FilterBy:        "unexist",
 			},
 			nil,
 			true,
@@ -211,13 +182,10 @@ func TestService_GetMetricsError(t *testing.T) {
 		{
 			"no_period_start_from",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.MetricsRequest{
-					PeriodStartTo: &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:       "queryid",
-					FilterBy:      "B305F6354FA21F2A",
-				},
+			&qanpb.MetricsRequest{
+				PeriodStartTo: &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:       "queryid",
+				FilterBy:      "B305F6354FA21F2A",
 			},
 			nil,
 			true,
@@ -225,13 +193,10 @@ func TestService_GetMetricsError(t *testing.T) {
 		{
 			"no_period_start_to",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.MetricsRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					GroupBy:         "queryid",
-					FilterBy:        "B305F6354FA21F2A",
-				},
+			&qanpb.MetricsRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				GroupBy:         "queryid",
+				FilterBy:        "B305F6354FA21F2A",
 			},
 			nil,
 			true,
@@ -239,14 +204,11 @@ func TestService_GetMetricsError(t *testing.T) {
 		{
 			"invalid_group_name",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.MetricsRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "no_group_name",
-					FilterBy:        "B305F6354FA21F2A",
-				},
+			&qanpb.MetricsRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "no_group_name",
+				FilterBy:        "B305F6354FA21F2A",
 			},
 			nil,
 			true,
@@ -254,45 +216,43 @@ func TestService_GetMetricsError(t *testing.T) {
 		{
 			"not_found_labels",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.MetricsRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "no_group_name",
-					FilterBy:        "B305F6354FA21F2A",
-					Labels: []*qanpb.MapFieldEntry{
-						{
-							Key:   "label1",
-							Value: []string{"value1", "value2"},
-						},
-						{
-							Key:   "server",
-							Value: []string{"server1", "server2", "server3", "server4", "server5", "server6", "server7"},
-						},
-						{
-							Key:   "client_host",
-							Value: []string{"localhost"},
-						},
-						{
-							Key:   "username",
-							Value: []string{"john"},
-						},
-						{
-							Key:   "schema",
-							Value: []string{"my_schema"},
-						},
-						{
-							Key:   "database",
-							Value: []string{"test_database"},
-						},
-						{
-							Key:   "queryid",
-							Value: []string{"some_query_id"},
-						},
+			&qanpb.MetricsRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "no_group_name",
+				FilterBy:        "B305F6354FA21F2A",
+				Labels: []*qanpb.MapFieldEntry{
+					{
+						Key:   "label1",
+						Value: []string{"value1", "value2"},
+					},
+					{
+						Key:   "server",
+						Value: []string{"server1", "server2", "server3", "server4", "server5", "server6", "server7"},
+					},
+					{
+						Key:   "client_host",
+						Value: []string{"localhost"},
+					},
+					{
+						Key:   "username",
+						Value: []string{"john"},
+					},
+					{
+						Key:   "schema",
+						Value: []string{"my_schema"},
+					},
+					{
+						Key:   "database",
+						Value: []string{"test_database"},
+					},
+					{
+						Key:   "queryid",
+						Value: []string{"some_query_id"},
 					},
 				},
 			},
+
 			nil,
 			true,
 		},
@@ -303,7 +263,7 @@ func TestService_GetMetricsError(t *testing.T) {
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
 			}
-			_, err := s.GetMetrics(tt.args.ctx, tt.args.in)
+			_, err := s.GetMetrics(context.TODO(), tt.in)
 			if (err != nil) != tt.wantErr {
 				assert.Errorf(t, err, "Service.GetMetrics() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -402,14 +362,10 @@ func TestService_GetLabels(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.ObjectDetailsLabelsRequest
-	}
 	type testCase struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.ObjectDetailsLabelsRequest
 		want    *qanpb.ObjectDetailsLabelsReply
 		wantErr error
 	}
@@ -417,14 +373,11 @@ func TestService_GetLabels(t *testing.T) {
 	tt := testCase{
 		"success",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			&qanpb.ObjectDetailsLabelsRequest{
-				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-				GroupBy:         "queryid",
-				FilterBy:        "1D410B4BE5060972",
-			},
+		&qanpb.ObjectDetailsLabelsRequest{
+			PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+			PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+			GroupBy:         "queryid",
+			FilterBy:        "1D410B4BE5060972",
 		},
 		&want,
 		nil,
@@ -435,7 +388,7 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		got, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		got, err := s.GetLabels(context.TODO(), tt.in)
 		require.Equal(t, tt.wantErr, err)
 		expectedJSON := getExpectedJSON(t, got, "../../test_data/GetLabels"+tt.name+".json")
 
@@ -450,14 +403,11 @@ func TestService_GetLabels(t *testing.T) {
 	tt = testCase{
 		"required from",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			&qanpb.ObjectDetailsLabelsRequest{
-				PeriodStartFrom: nil,
-				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-				GroupBy:         "queryid",
-				FilterBy:        "1D410B4BE5060972",
-			},
+		&qanpb.ObjectDetailsLabelsRequest{
+			PeriodStartFrom: nil,
+			PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+			GroupBy:         "queryid",
+			FilterBy:        "1D410B4BE5060972",
 		},
 		nil,
 		fmt.Errorf("period_start_from is required: %v", nil),
@@ -468,21 +418,18 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		_, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		_, err := s.GetLabels(context.TODO(), tt.in)
 		require.EqualError(t, err, tt.wantErr.Error())
 	})
 
 	tt = testCase{
 		"required to",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			&qanpb.ObjectDetailsLabelsRequest{
-				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-				PeriodStartTo:   nil,
-				GroupBy:         "queryid",
-				FilterBy:        "1D410B4BE5060972",
-			},
+		&qanpb.ObjectDetailsLabelsRequest{
+			PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+			PeriodStartTo:   nil,
+			GroupBy:         "queryid",
+			FilterBy:        "1D410B4BE5060972",
 		},
 		nil,
 		fmt.Errorf("period_start_to is required: %v", nil),
@@ -493,7 +440,7 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		_, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		_, err := s.GetLabels(context.TODO(), tt.in)
 		require.EqualError(t, err, tt.wantErr.Error())
 	})
 
@@ -506,10 +453,7 @@ func TestService_GetLabels(t *testing.T) {
 	tt = testCase{
 		"required group_by",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			request,
-		},
+		request,
 		nil,
 		fmt.Errorf("group_by is required if filter_by is not empty %v = %v", request.GroupBy, request.FilterBy),
 	}
@@ -519,7 +463,7 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		_, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		_, err := s.GetLabels(context.TODO(), tt.in)
 		require.EqualError(t, err, tt.wantErr.Error())
 	})
 
@@ -532,10 +476,7 @@ func TestService_GetLabels(t *testing.T) {
 	tt = testCase{
 		"required_filter_by",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			request,
-		},
+		request,
 		nil,
 		nil,
 	}
@@ -545,7 +486,7 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		got, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		got, err := s.GetLabels(context.TODO(), tt.in)
 		require.Equal(t, tt.wantErr, err)
 		expectedJSON := getExpectedJSON(t, got, "../../test_data/GetLabels_"+tt.name+".json")
 
@@ -566,10 +507,7 @@ func TestService_GetLabels(t *testing.T) {
 	tt = testCase{
 		"invalid time range",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			request,
-		},
+		request,
 		nil,
 		fmt.Errorf("from time (%s) cannot be after to (%s)", request.PeriodStartFrom, request.PeriodStartTo),
 	}
@@ -579,11 +517,9 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		_, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		_, err := s.GetLabels(context.TODO(), tt.in)
 		require.EqualError(t, err, tt.wantErr.Error())
 	})
-
-	const selectError = `cannot select object details labels`
 
 	request = &qanpb.ObjectDetailsLabelsRequest{
 		PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
@@ -594,10 +530,7 @@ func TestService_GetLabels(t *testing.T) {
 	tt = testCase{
 		"select error",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			request,
-		},
+		request,
 		nil,
 		fmt.Errorf("error in selecting object details labels:cannot select object details labels"),
 	}
@@ -607,7 +540,7 @@ func TestService_GetLabels(t *testing.T) {
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
 		}
-		_, err := s.GetLabels(tt.args.ctx, tt.args.in)
+		_, err := s.GetLabels(context.TODO(), tt.in)
 		// errors start with same text.
 		require.Regexp(t, "^error in selecting object details labels:cannot select object details labels.*", err.Error())
 	})

--- a/qan-api2/services/analytics/profile_test.go
+++ b/qan-api2/services/analytics/profile_test.go
@@ -81,31 +81,24 @@ func TestService_GetReport(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.ReportRequest
-	}
 	tests := []struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.ReportRequest
 		want    *qanpb.ReportReply
 		wantErr bool
 	}{
 		{
 			"success",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.ReportRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "queryid",
-					Columns:         []string{"query_time", "lock_time", "sort_scan"},
-					OrderBy:         "query_time",
-					Offset:          0,
-					Limit:           10,
-				},
+			&qanpb.ReportRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "queryid",
+				Columns:         []string{"query_time", "lock_time", "sort_scan"},
+				OrderBy:         "query_time",
+				Offset:          0,
+				Limit:           10,
 			},
 			&want,
 			false,
@@ -113,17 +106,14 @@ func TestService_GetReport(t *testing.T) {
 		{
 			"load without query_time",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.ReportRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-					GroupBy:         "queryid",
-					Columns:         []string{"load", "lock_time", "sort_scan"},
-					OrderBy:         "-load",
-					Offset:          0,
-					Limit:           10,
-				},
+			&qanpb.ReportRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+				GroupBy:         "queryid",
+				Columns:         []string{"load", "lock_time", "sort_scan"},
+				OrderBy:         "-load",
+				Offset:          0,
+				Limit:           10,
 			},
 			&want,
 			false,
@@ -131,12 +121,9 @@ func TestService_GetReport(t *testing.T) {
 		{
 			"wrong_time_range",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.ReportRequest{
-					PeriodStartFrom: &timestamp.Timestamp{Seconds: t2.Unix()},
-					PeriodStartTo:   &timestamp.Timestamp{Seconds: t1.Unix()},
-				},
+			&qanpb.ReportRequest{
+				PeriodStartFrom: &timestamp.Timestamp{Seconds: t2.Unix()},
+				PeriodStartTo:   &timestamp.Timestamp{Seconds: t1.Unix()},
 			},
 			nil,
 			true,
@@ -144,10 +131,7 @@ func TestService_GetReport(t *testing.T) {
 		{
 			"empty_fail",
 			fields{rm: rm, mm: mm},
-			args{
-				context.TODO(),
-				&qanpb.ReportRequest{},
-			},
+			&qanpb.ReportRequest{},
 			nil,
 			true,
 		},
@@ -159,7 +143,7 @@ func TestService_GetReport(t *testing.T) {
 				mm: tt.fields.mm,
 			}
 
-			got, err := s.GetReport(tt.args.ctx, tt.args.in)
+			got, err := s.GetReport(context.TODO(), tt.in)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Service.GetReport() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -190,38 +174,31 @@ func TestService_GetReport_Mix(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.ReportRequest
-	}
 	test := struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.ReportRequest
 		want    *qanpb.ReportReply
 		wantErr bool
 	}{
 		"reverce_order",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			&qanpb.ReportRequest{
-				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-				GroupBy:         "queryid",
-				Columns:         []string{"query_time", "lock_time", "sort_scan"},
-				OrderBy:         "-query_time",
-				Offset:          10,
-				Limit:           10,
-				Labels: []*qanpb.ReportMapFieldEntry{
-					{
-						Key:   "label1",
-						Value: []string{"value1", "value2"},
-					},
-					{
-						Key:   "service_name",
-						Value: []string{"server1", "server2", "server3", "server4", "server5", "server6", "server7"},
-					},
+		&qanpb.ReportRequest{
+			PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+			PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+			GroupBy:         "queryid",
+			Columns:         []string{"query_time", "lock_time", "sort_scan"},
+			OrderBy:         "-query_time",
+			Offset:          10,
+			Limit:           10,
+			Labels: []*qanpb.ReportMapFieldEntry{
+				{
+					Key:   "label1",
+					Value: []string{"value1", "value2"},
+				},
+				{
+					Key:   "service_name",
+					Value: []string{"server1", "server2", "server3", "server4", "server5", "server6", "server7"},
 				},
 			},
 		},
@@ -234,7 +211,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 			mm: test.fields.mm,
 		}
 
-		got, err := s.GetReport(test.args.ctx, test.args.in)
+		got, err := s.GetReport(context.TODO(), test.in)
 		if (err != nil) != test.wantErr {
 			t.Errorf("Service.GetReport() error = %v, wantErr %v", err, test.wantErr)
 			return
@@ -254,7 +231,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 			rm: test.fields.rm,
 			mm: test.fields.mm,
 		}
-		got, err := s.GetReport(test.args.ctx, test.args.in)
+		got, err := s.GetReport(context.TODO(), test.in)
 		if (err != nil) != test.wantErr {
 			t.Errorf("Service.GetReport() error = %v, wantErr %v", err, test.wantErr)
 			return
@@ -275,7 +252,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 			mm: test.fields.mm,
 		}
 
-		got, err := s.GetReport(test.args.ctx, test.args.in)
+		got, err := s.GetReport(context.TODO(), test.in)
 		if (err != nil) != test.wantErr {
 			t.Errorf("Service.GetReport() error = %v, wantErr %v", err, test.wantErr)
 			return
@@ -295,8 +272,8 @@ func TestService_GetReport_Mix(t *testing.T) {
 			mm: test.fields.mm,
 		}
 
-		test.args.in.Limit = 0
-		_, err := s.GetReport(test.args.ctx, test.args.in)
+		test.in.Limit = 0
+		_, err := s.GetReport(context.TODO(), test.in)
 		if err != nil {
 			t.Errorf("Service.GetReport() error = %v, wantErr %v", err, test.wantErr)
 			return
@@ -309,9 +286,9 @@ func TestService_GetReport_Mix(t *testing.T) {
 			mm: test.fields.mm,
 		}
 
-		test.args.in.GroupBy = "unknown dimension"
+		test.in.GroupBy = "unknown dimension"
 		expectedErr := fmt.Errorf("unknown group dimension: %s", "unknown dimension")
-		_, err := s.GetReport(test.args.ctx, test.args.in)
+		_, err := s.GetReport(context.TODO(), test.in)
 		if err.Error() != expectedErr.Error() {
 			t.Errorf("Service.GetReport() unexpected error = %v, wantErr %v", err, expectedErr)
 			return
@@ -565,10 +542,6 @@ func TestService_GetReport_AllLabels(t *testing.T) {
 		rm models.Reporter
 		mm models.Metrics
 	}
-	type args struct {
-		ctx context.Context
-		in  *qanpb.ReportRequest
-	}
 
 	genDimensionvalues := func(dimKey string, amount int) []string {
 		arr := []string{}
@@ -580,78 +553,75 @@ func TestService_GetReport_AllLabels(t *testing.T) {
 	test := struct {
 		name    string
 		fields  fields
-		args    args
+		in      *qanpb.ReportRequest
 		wantErr bool
 	}{
 		"",
 		fields{rm: rm, mm: mm},
-		args{
-			context.TODO(),
-			&qanpb.ReportRequest{
-				PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
-				PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
-				GroupBy:         "queryid",
-				Columns:         []string{"query_time", "lock_time", "sort_scan"},
-				OrderBy:         "-query_time",
-				Offset:          10,
-				Limit:           10,
-				Labels: []*qanpb.ReportMapFieldEntry{
-					{
-						Key:   "label1",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label2",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label3",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label4",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label5",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label6",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label7",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label8",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "label9",
-						Value: genDimensionvalues("value", 100),
-					},
-					{
-						Key:   "service_name",
-						Value: genDimensionvalues("server", 10),
-					},
-					{
-						Key:   "database",
-						Value: []string{},
-					},
-					{
-						Key:   "schema",
-						Value: genDimensionvalues("schema", 100),
-					},
-					{
-						Key:   "username",
-						Value: genDimensionvalues("user", 100),
-					},
-					{
-						Key:   "client_host",
-						Value: genDimensionvalues("10.11.12.", 100),
-					},
+		&qanpb.ReportRequest{
+			PeriodStartFrom: &timestamp.Timestamp{Seconds: t1.Unix()},
+			PeriodStartTo:   &timestamp.Timestamp{Seconds: t2.Unix()},
+			GroupBy:         "queryid",
+			Columns:         []string{"query_time", "lock_time", "sort_scan"},
+			OrderBy:         "-query_time",
+			Offset:          10,
+			Limit:           10,
+			Labels: []*qanpb.ReportMapFieldEntry{
+				{
+					Key:   "label1",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label2",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label3",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label4",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label5",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label6",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label7",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label8",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "label9",
+					Value: genDimensionvalues("value", 100),
+				},
+				{
+					Key:   "service_name",
+					Value: genDimensionvalues("server", 10),
+				},
+				{
+					Key:   "database",
+					Value: []string{},
+				},
+				{
+					Key:   "schema",
+					Value: genDimensionvalues("schema", 100),
+				},
+				{
+					Key:   "username",
+					Value: genDimensionvalues("user", 100),
+				},
+				{
+					Key:   "client_host",
+					Value: genDimensionvalues("10.11.12.", 100),
 				},
 			},
 		},
@@ -662,7 +632,7 @@ func TestService_GetReport_AllLabels(t *testing.T) {
 			rm: test.fields.rm,
 			mm: test.fields.mm,
 		}
-		got, err := s.GetReport(test.args.ctx, test.args.in)
+		got, err := s.GetReport(context.TODO(), test.in)
 		if (err != nil) != test.wantErr {
 			t.Errorf("Service.GetReport() error = %v, wantErr %v", err, test.wantErr)
 			return


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

This PR re-enables the `containedctx` linter rule and fixes linter warnings thereof.
