### PR TITLE
PMM-7 re-enable the `predeclared` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,7 +111,6 @@ linters:
     - golint
     - nonamedreturns
     - execinquery
-    - predeclared
     - interfacebloat
     - gosimple
     - contextcheck

--- a/agent/agents/supervisor/supervisor.go
+++ b/agent/agents/supervisor/supervisor.go
@@ -384,16 +384,16 @@ func (s *Supervisor) setBuiltinAgents(builtinAgents map[string]*agentpb.SetState
 
 // filter extracts IDs of the Agents that should be started, restarted with new parameters, or stopped,
 // and filters out IDs of the Agents that should not be changed.
-func filter(existing, new map[string]agentpb.AgentParams) (toStart, toRestart, toStop []string) {
+func filter(existing, ap map[string]agentpb.AgentParams) (toStart, toRestart, toStop []string) {
 	// existing agents not present in the new requested state should be stopped
 	for existingID := range existing {
-		if new[existingID] == nil {
+		if ap[existingID] == nil {
 			toStop = append(toStop, existingID)
 		}
 	}
 
 	// detect new and changed agents
-	for newID, newParams := range new {
+	for newID, newParams := range ap {
 		existingParams := existing[newID]
 		if existingParams == nil {
 			toStart = append(toStart, newID)


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

This PR re-enables the `predeclared` linter rule and fixes the warnings thereof.
