### PR TITLE
PMM-7 re-enable the `prealloc` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,7 +115,6 @@ linters:
     - interfacebloat
     - gosimple
     - contextcheck
-    - prealloc
     - nakedret
     - forbidigo
     - errcheck

--- a/admin/commands/inventory/list_agents.go
+++ b/admin/commands/inventory/list_agents.go
@@ -123,7 +123,7 @@ func (cmd *ListAgentsCommand) RunCmd() (commands.Result, error) {
 		return nil, err
 	}
 
-	var agentsList []listResultAgent
+	var agentsList []listResultAgent //nolint:prealloc
 	for _, a := range agentsRes.Payload.PMMAgent {
 		status := "disconnected"
 		if a.Connected {

--- a/admin/commands/inventory/list_nodes.go
+++ b/admin/commands/inventory/list_nodes.go
@@ -78,7 +78,8 @@ func (cmd *ListNodesCommand) RunCmd() (commands.Result, error) {
 		return nil, err
 	}
 
-	var nodesList []listResultNode
+	l := len(result.Payload.Generic) + len(result.Payload.Container) + len(result.Payload.Remote) + len(result.Payload.RemoteRDS)
+	nodesList := make([]listResultNode, 0, l)
 	for _, n := range result.Payload.Generic {
 		nodesList = append(nodesList, listResultNode{
 			NodeType: types.NodeTypeGenericNode,

--- a/admin/commands/inventory/list_services.go
+++ b/admin/commands/inventory/list_services.go
@@ -106,7 +106,7 @@ func (cmd *ListServicesCommand) RunCmd() (commands.Result, error) {
 		return net.JoinHostPort(address, strconv.FormatInt(port, 10))
 	}
 
-	var servicesList []listResultService
+	var servicesList []listResultService //nolint:prealloc
 	for _, s := range result.Payload.Mysql {
 		servicesList = append(servicesList, listResultService{
 			ServiceType: types.ServiceTypeMySQLService,

--- a/admin/commands/list.go
+++ b/admin/commands/list.go
@@ -142,20 +142,22 @@ func (cmd *ListCommand) RunCmd() (Result, error) { //nolint:cyclop
 		return nil, err
 	}
 
-	getAddressPort := func(socket, address string, port int64) string {
+	getSocketOrHost := func(socket, address string, port int64) string {
 		if socket != "" {
 			return socket
 		}
 		return net.JoinHostPort(address, strconv.FormatInt(port, 10))
 	}
 
-	var servicesList []listResultService
+	l := len(servicesRes.Payload.Mysql) + len(servicesRes.Payload.Mongodb) + len(servicesRes.Payload.Postgresql)
+	l += len(servicesRes.Payload.Proxysql) + len(servicesRes.Payload.Haproxy) + len(servicesRes.Payload.External)
+	servicesList := make([]listResultService, 0, l)
 	for _, s := range servicesRes.Payload.Mysql {
 		servicesList = append(servicesList, listResultService{
 			ServiceType: types.ServiceTypeMySQLService,
 			ServiceID:   s.ServiceID,
 			ServiceName: s.ServiceName,
-			AddressPort: getAddressPort(s.Socket, s.Address, s.Port),
+			AddressPort: getSocketOrHost(s.Socket, s.Address, s.Port),
 		})
 	}
 	for _, s := range servicesRes.Payload.Mongodb {
@@ -163,7 +165,7 @@ func (cmd *ListCommand) RunCmd() (Result, error) { //nolint:cyclop
 			ServiceType: types.ServiceTypeMongoDBService,
 			ServiceID:   s.ServiceID,
 			ServiceName: s.ServiceName,
-			AddressPort: getAddressPort(s.Socket, s.Address, s.Port),
+			AddressPort: getSocketOrHost(s.Socket, s.Address, s.Port),
 		})
 	}
 	for _, s := range servicesRes.Payload.Postgresql {
@@ -171,7 +173,7 @@ func (cmd *ListCommand) RunCmd() (Result, error) { //nolint:cyclop
 			ServiceType: types.ServiceTypePostgreSQLService,
 			ServiceID:   s.ServiceID,
 			ServiceName: s.ServiceName,
-			AddressPort: getAddressPort(s.Socket, s.Address, s.Port),
+			AddressPort: getSocketOrHost(s.Socket, s.Address, s.Port),
 		})
 	}
 	for _, s := range servicesRes.Payload.Proxysql {
@@ -179,7 +181,7 @@ func (cmd *ListCommand) RunCmd() (Result, error) { //nolint:cyclop
 			ServiceType: types.ServiceTypeProxySQLService,
 			ServiceID:   s.ServiceID,
 			ServiceName: s.ServiceName,
-			AddressPort: getAddressPort(s.Socket, s.Address, s.Port),
+			AddressPort: getSocketOrHost(s.Socket, s.Address, s.Port),
 		})
 	}
 	for _, s := range servicesRes.Payload.Haproxy {

--- a/agent/agents/postgres/parser/parser.go
+++ b/agent/agents/postgres/parser/parser.go
@@ -75,8 +75,8 @@ func extract(query, pre, post string) ([]string, error) {
 		return nil, err
 	}
 
-	var tables []string
 	match := re.FindAll([]byte(query), -1)
+	tables := make([]string, 0, len(match))
 	for _, v := range match {
 		tables = append(tables, parseValue(string(v), pre, post))
 	}

--- a/api-tests/management/helpers.go
+++ b/api-tests/management/helpers.go
@@ -152,7 +152,7 @@ func removeAllAgentsInList(t pmmapitests.TestingT, listAgentsOK *agents.ListAgen
 	require.NotNil(t, listAgentsOK)
 	require.NotNil(t, listAgentsOK.Payload)
 
-	var agentIDs []string
+	var agentIDs []string //nolint:prealloc
 	for _, agent := range listAgentsOK.Payload.NodeExporter {
 		agentIDs = append(agentIDs, agent.AgentID)
 	}

--- a/managed/services/alertmanager/alertmanager.go
+++ b/managed/services/alertmanager/alertmanager.go
@@ -769,7 +769,7 @@ func (svc *Service) GetAlerts(ctx context.Context, fp *services.FilterParams) ([
 func (svc *Service) FindAlertsByID(ctx context.Context, params *services.FilterParams, ids []string) ([]*ammodels.GettableAlert, error) {
 	alerts, err := svc.GetAlerts(ctx, params)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get alerts form alertmanager")
+		return nil, errors.Wrapf(err, "failed to get alerts from alertmanager")
 	}
 
 	l := len(ids)

--- a/managed/services/management/dbaas/db_cluster_service.go
+++ b/managed/services/management/dbaas/db_cluster_service.go
@@ -426,7 +426,7 @@ func (s DBClusterService) ListSecrets(ctx context.Context, req *dbaasv1beta1.Lis
 	if err != nil {
 		return nil, errors.Wrap(err, "failed listing database clusters")
 	}
-	var secrets []*dbaasv1beta1.Secret
+	secrets := make([]*dbaasv1beta1.Secret, 0, len(secretsList.Items))
 	for _, secret := range secretsList.Items {
 		secrets = append(secrets, &dbaasv1beta1.Secret{
 			Name: secret.Name,

--- a/managed/services/management/ia/alerts_service.go
+++ b/managed/services/management/ia/alerts_service.go
@@ -74,7 +74,7 @@ func (s *AlertsService) ListAlerts(ctx context.Context, req *iav1beta1.ListAlert
 	}
 	alerts, err := s.alertManager.GetAlerts(ctx, filter)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get alerts form alertmanager")
+		return nil, errors.Wrap(err, "failed to get alerts from alertmanager")
 	}
 
 	var res []*iav1beta1.Alert //nolint:prealloc

--- a/managed/services/management/ia/alerts_service.go
+++ b/managed/services/management/ia/alerts_service.go
@@ -77,7 +77,7 @@ func (s *AlertsService) ListAlerts(ctx context.Context, req *iav1beta1.ListAlert
 		return nil, errors.Wrap(err, "failed to get alerts form alertmanager")
 	}
 
-	var res []*iav1beta1.Alert
+	var res []*iav1beta1.Alert //nolint:prealloc
 	for _, alert := range alerts {
 		updatedAt := timestamppb.New(time.Time(*alert.UpdatedAt))
 		if err := updatedAt.CheckValid(); err != nil {

--- a/managed/services/telemetry/config.go
+++ b/managed/services/telemetry/config.go
@@ -210,7 +210,7 @@ func (c *ServiceConfig) Init(l *logrus.Entry) error { //nolint:gocognit
 }
 
 func (c *ServiceConfig) loadMetricsConfig(configFile string) ([]Config, error) {
-	var fileConfigs []FileConfig //nolint:prealloc
+	var fileConfigs []FileConfig
 	var fileCfg FileConfig
 
 	var config []byte

--- a/qan-api2/services/analytics/profile.go
+++ b/qan-api2/services/analytics/profile.go
@@ -60,7 +60,7 @@ func (s *Service) GetReport(ctx context.Context, in *qanpb.ReportRequest) (*qanp
 		labels[label.Key] = label.Value
 	}
 
-	var columns []string
+	var columns []string //nolint:prealloc
 	for _, col := range in.Columns {
 		// TODO: remove when UI will use num_queries instead.
 		if col == "count" {
@@ -88,7 +88,7 @@ func (s *Service) GetReport(ctx context.Context, in *qanpb.ReportRequest) (*qanp
 		}
 	}
 
-	var uniqColumns []string
+	uniqColumns := make([]string, 0, len(uniqColumnsMap))
 	for key := range uniqColumnsMap {
 		uniqColumns = append(uniqColumns, key)
 	}


### PR DESCRIPTION
PMM-7

Refers to: https://github.com/percona/pmm/issues/1541

This PR re-enables the `prealloc` linter rule and fixes the warnings thereof. We suppress the rule in tests and in cases where it's impractical to calculate the array length.
