### PR TITLE
Fix duplicate command execution

### DIFF
--- a/build/scripts/build-server
+++ b/build/scripts/build-server
@@ -16,9 +16,6 @@ cp ${root_dir}/results/rpm/*.rpm ${rpms_dir}/
 # install all rpms
 ${bin_dir}/build-server-rpm-all
 
-# 3rd-party
-${bin_dir}/build-server-rpm grafana-db-migrator
-
 # build pmm-server
 ${bin_dir}/build-server-docker
 


### PR DESCRIPTION
Fix duplicate execution "${bin_dir}/build-server-rpm grafana-db-migrator". It already executed in build-server-rpm-all

PMM-0

Build: SUBMODULES-0

- Links to related pull requests (optional).
