### PR TITLE
PMM-7 fix GOPATH env variable in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 FROM golang:1.20
 
-RUN mkdir -p $GOPATH/src/github.com/percona/pmm
+RUN export GOPATH=$(go env GOPATH) && \
+    mkdir -p $GOPATH/src/github.com/percona/pmm
 
 COPY . $GOPATH/src/github.com/percona/pmm/
 WORKDIR $GOPATH/src/github.com/percona/pmm/api-tests/


### PR DESCRIPTION
PMM-7

**Why**:
The GOPATH envvar does not exist by default, which is why we end up having two similar directories in the devcontainer:
```
[root@pmm-managed-server pmm]# find / -name ".git" -type d
/root/go/src/github.com/percona/pmm/.git
/src/github.com/percona/pmm/.git
```
