### PR TITLE
PMM-7 disable `golint` rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,11 +50,6 @@ linters-settings:
     line-length: 170
     tab-width: 4
 
-  staticcheck:
-    checks:
-      - all
-      - "-SA1019"
-
   tagliatelle:
     # Check the struck tag name case.
     case:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
+
   cyclop:
     max-complexity: 30
 
@@ -49,6 +50,11 @@ linters-settings:
     line-length: 170
     tab-width: 4
 
+  staticcheck:
+    checks:
+      - all
+      - "-SA1019"
+
   tagliatelle:
     # Check the struck tag name case.
     case:
@@ -79,6 +85,7 @@ linters:
     - gochecknoinits   # we use init functions
     - gocyclo          # using cyclop with the max 30 instead
     - goerr113         # extra work & poor benefit
+    - golint           # unmaintained, replaced by revive
     - gomnd            # we are using numbers in many cases
     - gomoddirectives  # we use replace directives
     - ifshort          # a lot of false positives
@@ -108,7 +115,6 @@ linters:
     - nestif
     - errorlint
     - forcetypeassert
-    - golint
     - nonamedreturns
     - execinquery
     - interfacebloat
@@ -144,7 +150,6 @@ issues:
         - funlen           # tests may be long
         - gocognit         # triggered by subtests
         - gomnd            # tests are full of magic numbers
+        - lll              # tests often require long lines
         - testpackage      # senseless
         - unused           # very annoying false positive: https://github.com/golangci/golangci-lint/issues/791
-        - lll              # tests often require long lines
-

--- a/Makefile.include
+++ b/Makefile.include
@@ -147,7 +147,7 @@ check:                ## Run required checkers and linters
 check-license:          ## Run license header checks against source files
 	bin/license-eye -c .licenserc.yaml header check
 
-check-all: check-license check    ## Run golangci linter to check for changes agains main
+check-all: check-license check    ## Run golangci linter to check for changes against main
 	bin/golangci-lint run -c=.golangci.yml --new-from-rev=main
 
 FILES = $(shell find . -type f -name '*.go')

--- a/Makefile.include
+++ b/Makefile.include
@@ -147,7 +147,7 @@ check:                ## Run required checkers and linters
 check-license:          ## Run license header checks against source files
 	bin/license-eye -c .licenserc.yaml header check
 
-check-all: check-license check    ## Run golang ci linter to check new changes from main
+check-all: check-license check    ## Run golangci linter to check for changes agains main
 	bin/golangci-lint run -c=.golangci.yml --new-from-rev=main
 
 FILES = $(shell find . -type f -name '*.go')

--- a/agent/utils/mongo_fix/mongo_fix.go
+++ b/agent/utils/mongo_fix/mongo_fix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ClientOptionsForDSN applies URI to Client.
-func ClientOptionsForDSN(dsn string) (*options.ClientOptions, error) { //nolint:unparam
+func ClientOptionsForDSN(dsn string) (*options.ClientOptions, error) {
 	clientOptions := options.Client().ApplyURI(dsn)
 	if e := clientOptions.Validate(); e != nil {
 		return nil, e

--- a/managed/Makefile
+++ b/managed/Makefile
@@ -46,12 +46,13 @@ release-dev:										## Build pmm-managed binaries for development
 
 PMM_TEST_FLAGS ?= -timeout=180s
 PMM_TEST_RUN_UPDATE ?= 0
+PMM_TEST_FILES ?= ./...
 
 test:                           ## Run tests
-	go test $(PMM_TEST_FLAGS) -p 1 -race ./...
+	go test $(PMM_TEST_FLAGS) -p 1 -race $(PMM_TEST_FILES)
 
 test-cover:                     ## Run tests and collect per-package coverage information
-	go test $(PMM_TEST_FLAGS) -p 1 -race -coverprofile=cover.out -covermode=atomic -coverpkg=./... ./...
+	go test $(PMM_TEST_FLAGS) -p 1 -race -coverprofile=cover.out -covermode=atomic -coverpkg=$(PMM_TEST_FILES) $(PMM_TEST_FILES)
 
 test-update:                   ## Run pmm update test
 	PMM_TEST_RUN_UPDATE=1 go test -timeout=600s -v -p 1 -race ./services/supervisord -run ^TestDevContainer/Update$$

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -662,7 +662,7 @@ func newClickhouseDB(dsn string, maxIdleConns, maxOpenConns int) (*sql.DB, error
 	return db, nil
 }
 
-func main() {
+func main() { //nolint:cyclop
 	// empty version breaks much of pmm-managed logic
 	if version.Version == "" {
 		panic("pmm-managed version is not set during build.")


### PR DESCRIPTION
PMM-7

Ref: issue #1541 

Changes:
- disable the `golint` rule as [unmaintained](https://github.com/golang/lint)
- fix a couple of lint warnings that are present in `main` branch
- add a possibility to pass arbitrary files to managed's `make test ...` command
