### PR TITLE
PMM-7 enable `nestif` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,9 @@ linters-settings:
     line-length: 170
     tab-width: 4
 
+  nestif:
+    min-complexity: 7
+
   tagliatelle:
     # Check the struck tag name case.
     case:
@@ -107,7 +110,6 @@ linters:
     - ireturn
     - gocognit
     - maintidx
-    - nestif
     - errorlint
     - nonamedreturns
     - execinquery

--- a/admin/commands/base/setup.go
+++ b/admin/commands/base/setup.go
@@ -53,6 +53,7 @@ var (
 
 // SetupClients configures local and PMM Server API clients.
 func SetupClients(ctx context.Context, globalFlags *flags.GlobalFlags) {
+	//nolint:nestif
 	if globalFlags.ServerURL == nil || globalFlags.ServerURL.String() == "" {
 		status, err := agentlocal.GetStatus(agentlocal.DoNotRequestNetworkInfo)
 		if err != nil {

--- a/agent/agents/mysql/perfschema/perfschema.go
+++ b/agent/agents/mysql/perfschema/perfschema.go
@@ -326,6 +326,7 @@ func (m *PerfSchema) getNewBuckets(periodStart time.Time, periodLengthSecs uint3
 		b.Common.PeriodStartUnixSecs = startS
 		b.Common.PeriodLengthSecs = periodLengthSecs
 
+		//nolint:nestif
 		if esh := history[b.Common.Queryid]; esh != nil {
 			// TODO test if we really need that
 			// If we don't need it, we can avoid polling events_statements_history completely

--- a/agent/agents/postgres/pgstatmonitor/stat_monitor_cache.go
+++ b/agent/agents/postgres/pgstatmonitor/stat_monitor_cache.go
@@ -154,6 +154,7 @@ func (ssc *statMonitorCache) getStatMonitorExtended(ctx context.Context, q *refo
 			}
 		}
 
+		//nolint:nestif
 		if c.Fingerprint == "" {
 			newN++
 			fingerprint := c.Query

--- a/agent/cmd/pmm-agent-entrypoint/main.go
+++ b/agent/cmd/pmm-agent-entrypoint/main.go
@@ -179,7 +179,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *pmmAgentSetup {
+	if *pmmAgentSetup { //nolint:nestif
 		var agent *exec.Cmd
 		restartPolicy := doNotRestart
 		if *pmmAgentSidecar {
@@ -204,7 +204,7 @@ func main() {
 	}
 
 	status = 0
-	if *pmmAgentPrerunFile != "" || *pmmAgentPrerunScript != "" {
+	if *pmmAgentPrerunFile != "" || *pmmAgentPrerunScript != "" { //nolint:nestif
 		l.Info("Starting pmm-agent for prerun...")
 		agent := commandPmmAgent([]string{"run"})
 		err := agent.Start()

--- a/agent/runner/actions/postgresql_show_create_table_action.go
+++ b/agent/runner/actions/postgresql_show_create_table_action.go
@@ -299,6 +299,7 @@ ORDER BY i.indisprimary DESC, i.indisunique DESC, c2.relname`, tableID)
 		}
 		fmt.Fprintf(bw, "\t%q", info.Relname)
 
+		//nolint:nestif
 		if pointer.GetString(info.Contype) == "x" {
 			fmt.Fprintf(bw, " %s", pointer.GetString(info.PgGetConstraintDef))
 		} else {

--- a/managed/services/dbaas/kubernetes/types.go
+++ b/managed/services/dbaas/kubernetes/types.go
@@ -608,6 +608,7 @@ func UpdatePatchForPSMDB(dbCluster *dbaasv1.DatabaseCluster, updateRequest *dbaa
 	if updateRequest.Params.Image != "" {
 		dbCluster.Spec.DatabaseImage = updateRequest.Params.Image
 	}
+	//nolint:nestif
 	if updateRequest.Params.Replicaset != nil {
 		if updateRequest.Params.Replicaset.ComputeResources != nil {
 			if updateRequest.Params.Replicaset.ComputeResources.CpuM > 0 {

--- a/managed/services/management/backup/locations_service_test.go
+++ b/managed/services/management/backup/locations_service_test.go
@@ -137,6 +137,7 @@ func TestListBackupLocations(t *testing.T) {
 		checkLocation := func(id string, req *backuppb.AddLocationRequest) func() bool {
 			return func() bool {
 				for _, loc := range res.Locations {
+					//nolint:nestif
 					if loc.LocationId == id {
 						if loc.Name != req.Name || loc.Description != req.Description {
 							return false

--- a/managed/services/management/dbaas/dbaas_initializer.go
+++ b/managed/services/management/dbaas/dbaas_initializer.go
@@ -104,6 +104,7 @@ func (in *Initializer) Enable(ctx context.Context) error {
 // registerIncluster automatically adds k8s cluster to dbaas when PMM is running inside k8s cluster
 func (in *Initializer) registerInCluster(ctx context.Context) error {
 	kubeConfig, err := in.dbaasClient.GetKubeConfig(ctx, &dbaascontrollerv1beta1.GetKubeconfigRequest{})
+	//nolint:nestif
 	if err == nil {
 		// If err is not equal to nil, dont' register cluster and fail silently
 		err := in.db.InTransaction(func(t *reform.TX) error {

--- a/managed/services/management/dbaas/version_service_client_test.go
+++ b/managed/services/management/dbaas/version_service_client_test.go
@@ -78,6 +78,7 @@ func (f fakeLatestVersionServer) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			break
 		}
 	}
+	//nolint:nestif
 	if certainVersionRequested {
 		segments := strings.Split(r.URL.Path, "/")
 		version := segments[len(segments)-2]


### PR DESCRIPTION
Ref: issue https://github.com/percona/pmm/issues/1541

Changes:
1/ enable the rule, set the min-complexity to 7
2/ fix linter warnings

Note: setting min-complexity to 7 seems to be a balance between too strict (default is 5) and too lax. Please comment if we want a different setting.
