### PR TITLE
PMM-7 enable the `nakedret` lint rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,7 @@ linters:
     - varnamelen       # useless
     - wrapcheck        # we do not use wrapping everywhere
     - wsl              # too annoying
+    - staticcheck
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
@@ -115,7 +116,7 @@ linters:
     - interfacebloat
     - gosimple
     - contextcheck
-    - nakedret
+    # - nakedret
     - forbidigo
     - errcheck
     - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,6 @@ linters:
     - varnamelen       # useless
     - wrapcheck        # we do not use wrapping everywhere
     - wsl              # too annoying
-    - staticcheck
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
@@ -116,7 +115,6 @@ linters:
     - interfacebloat
     - gosimple
     - contextcheck
-    # - nakedret
     - forbidigo
     - errcheck
     - dupl

--- a/agent/agents/mysql/slowlog/slowlog.go
+++ b/agent/agents/mysql/slowlog/slowlog.go
@@ -375,7 +375,7 @@ func (s *SlowLog) processFile(ctx context.Context, file string, outlierTime floa
 		case <-t.C:
 			lengthS := uint32(math.Round(wait.Seconds())) // round 59.9s/60.1s to 60s
 			res := aggregator.Finalize()
-			buckets := makeBuckets(s.params.AgentID, res, start, lengthS, s.params.DisableQueryExamples, s.params.MaxQueryLength, s.l)
+			buckets := makeBuckets(s.params.AgentID, res, start, lengthS, s.params.DisableQueryExamples, s.params.MaxQueryLength)
 			s.l.Debugf("Made %d buckets out of %d classes in %s+%d interval. Wait time: %s.",
 				len(buckets), len(res.Class), start.Format("15:04:05"), lengthS, time.Since(start))
 
@@ -400,7 +400,6 @@ func makeBuckets(
 	periodLengthSecs uint32,
 	disableQueryExamples bool,
 	maxQueryLength int32,
-	l *logrus.Entry,
 ) []*agentpb.MetricsBucket {
 	buckets := make([]*agentpb.MetricsBucket, 0, len(res.Class))
 

--- a/agent/agents/mysql/slowlog/slowlog_test.go
+++ b/agent/agents/mysql/slowlog/slowlog_test.go
@@ -62,7 +62,7 @@ func TestSlowLogMakeBucketsInvalidUTF8(t *testing.T) {
 		},
 	}
 
-	actualBuckets := makeBuckets(agentID, parsingResult, periodStart, 60, false, truncate.GetDefaultMaxQueryLength(), logrus.NewEntry(logrus.New()))
+	actualBuckets := makeBuckets(agentID, parsingResult, periodStart, 60, false, truncate.GetDefaultMaxQueryLength())
 	expectedBuckets := []*agentpb.MetricsBucket{
 		{
 			Common: &agentpb.MetricsBucket_Common{
@@ -94,7 +94,7 @@ func TestSlowLogMakeBuckets(t *testing.T) {
 	parsingResult := event.Result{}
 	getDataFromFile(t, "slowlog_fixture.json", &parsingResult)
 
-	actualBuckets := makeBuckets(agentID, parsingResult, periodStart, 60, false, truncate.GetDefaultMaxQueryLength(), logrus.NewEntry(logrus.New()))
+	actualBuckets := makeBuckets(agentID, parsingResult, periodStart, 60, false, truncate.GetDefaultMaxQueryLength())
 
 	var expectedBuckets []*agentpb.MetricsBucket
 	getDataFromFile(t, "slowlog_expected.json", &expectedBuckets)

--- a/agent/agents/postgres/pgstatmonitor/pgstatmonitor.go
+++ b/agent/agents/postgres/pgstatmonitor/pgstatmonitor.go
@@ -399,7 +399,7 @@ func (m *PGStatMonitorQAN) getSettings() (settings, error) {
 	}
 
 	result := make(settings)
-	if settingsValuesAreText {
+	if settingsValuesAreText { //nolint:nestif
 		if pgsmVersion >= pgStatMonitorVersion20PG12 {
 			result, err = getPGSM20Settings(m.q)
 			if err != nil {

--- a/managed/services/management/dbaas/version_service_client.go
+++ b/managed/services/management/dbaas/version_service_client.go
@@ -389,7 +389,7 @@ func (c *VersionServiceClient) NextOperatorVersion(
 	installedVersion string,
 ) (*goversion.Version, error) {
 	if installedVersion == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 	// Get all operator versions
 	params := componentsParams{
@@ -400,7 +400,7 @@ func (c *VersionServiceClient) NextOperatorVersion(
 		return nil, err
 	}
 	if len(matrix.Versions) == 0 {
-		return nil, nil
+		return nil, nil //nolint:nilnil
 	}
 
 	// Convert slice of version structs to slice of strings so it can be used in generic function next.
@@ -413,7 +413,7 @@ func (c *VersionServiceClient) NextOperatorVersion(
 	if installedVersion != "" {
 		return next(versions, installedVersion)
 	}
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 // next direct successor of given installed version, returns nil if there is none.

--- a/managed/services/management/dbaas/version_service_client.go
+++ b/managed/services/management/dbaas/version_service_client.go
@@ -383,13 +383,13 @@ func (c *VersionServiceClient) GetVersionServiceURL() string {
 // It returns nil if update is not available or error occurred. It does not take PMM version into consideration.
 // We need to upgrade to current + 1 version for upgrade to be successful. So even if dbaas-controller does not support the
 // operator, we need to upgrade to it on our way to supported one.
-func (c *VersionServiceClient) NextOperatorVersion( //nolint:nonamedreturns
+func (c *VersionServiceClient) NextOperatorVersion(
 	ctx context.Context,
 	operatorType,
 	installedVersion string,
-) (nextOperatorVersion *goversion.Version, err error) {
+) (*goversion.Version, error) {
 	if installedVersion == "" {
-		return
+		return nil, nil
 	}
 	// Get all operator versions
 	params := componentsParams{
@@ -397,10 +397,10 @@ func (c *VersionServiceClient) NextOperatorVersion( //nolint:nonamedreturns
 	}
 	matrix, err := c.Matrix(ctx, params)
 	if err != nil {
-		return
+		return nil, err
 	}
 	if len(matrix.Versions) == 0 {
-		return
+		return nil, nil
 	}
 
 	// Convert slice of version structs to slice of strings so it can be used in generic function next.
@@ -413,7 +413,7 @@ func (c *VersionServiceClient) NextOperatorVersion( //nolint:nonamedreturns
 	if installedVersion != "" {
 		return next(versions, installedVersion)
 	}
-	return
+	return nil, nil
 }
 
 // next direct successor of given installed version, returns nil if there is none.


### PR DESCRIPTION
Ref: issue #1541 

Changes:
* enabled the rule
* fixed a couple of other linter errors

Note: `nakedret` was mostly fixed along with `nonamedreturns `, so there was only one left.
