### PR TITLE
PMM-11991 disabled upgrade tests temporary

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ pmm-common, pmm-server-install, pmm-server-update, pmm-docker-test ]
+        test-type: [ pmm-common, pmm-server-install, pmm-docker-test ]
 
     defaults:
       run:


### PR DESCRIPTION
Temporary disabled upgrade tests by pmm-bin as it hangs forever.