### PR TITLE
PMM-7 fix update test for RHEL9

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 *                                       @percona/pmm-review-be
 /build/                                 @atymchuk @percona/pmm-review-be
-/admin/                                 @michal-kralik @percona/pmm-review-be
+/admin/                                 @percona/pmm-review-be
 /agent/agents/postgres/                 @JiriCtvrtka @percona/pmm-review-be
 /agent/runner/                          @artemgavrilov @percona/pmm-review-be
 /api/                                   @BupycHuk @percona/pmm-review-be
 /docs/api/                              @atymchuk @percona/pmm-review-be
 /managed/services/checks/               @idoqo @percona/pmm-review-be
 /managed/                               @percona/pmm-review-be
-/managed/services/dbaas                 @gen1us2k @percona-csalguero @recharte @percona/pmm-review-be
-/managed/services/management/dbaas      @gen1us2k @percona-csalguero @recharte @percona/pmm-review-be
+/managed/services/dbaas                 @gen1us2k @recharte @percona/pmm-review-be
+/managed/services/management/dbaas      @gen1us2k @recharte @percona/pmm-review-be
 /update/                                @BupycHuk @talhabinrizwan @percona/pmm-review-be
 /api-tests/                             @percona/pmm-review-be
 **/go.mod                               @percona/pmm-review-dependency @percona/pmm-review-be

--- a/update/.devcontainer/install-dev-tools.sh
+++ b/update/.devcontainer/install-dev-tools.sh
@@ -29,6 +29,8 @@ yum install -y gcc git make pkgconfig \
 
 if [ $(rpm --eval '%{rhel}') = '7' ]; then
     yum install -y glibc-static bash-completion-extras
+else
+    yum install -y --enablerepo=ol9_codeready_builder glibc-static
 fi
 
 fg || true

--- a/update/.devcontainer/install-dev-tools.sh
+++ b/update/.devcontainer/install-dev-tools.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o xtrace
 
 # download (in the background) the same verison as used by PMM build process
-curl -sS https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
+curl -sS https://dl.google.com/go/go1.20.4.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
 
 # to install man pages
 sed -i '/nodocs/d' /etc/yum.conf
@@ -21,11 +21,15 @@ percona-release enable original testing
 yum install -y yum rpm
 yum reinstall -y yum rpm
 
-yum install -y gcc git make pkgconfig glibc-static \
+yum install -y gcc git make pkgconfig \
     ansible-lint ansible \
     mc tmux psmisc lsof which iproute \
-    bash-completion bash-completion-extras \
+    bash-completion \
     man man-pages
+
+if [ $(rpm --eval '%{rhel}') = '7' ]; then
+    yum install -y glibc-static bash-completion-extras
+fi
 
 fg || true
 tar -C /usr/local -xzf /tmp/golang.tar.gz


### PR DESCRIPTION
PMM-7

This PR fixes the failing update tests, where we use the `dev-latest` image, which is already RHEL9 based.
