### PR TITLE
PMM-7 disable `dupl` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
     - exhaustivestruct # too annoying
     - exhaustruct      # too many files to fix/nolint
     - deadcode         # unmaintained, we leverage `unused`
+    - dupl             # we can't avoid duplicating code
     - funlen           # useless
     - gochecknoglobals # mostly useless
     - gochecknoinits   # we use init functions
@@ -98,7 +99,6 @@ linters:
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
-    - paralleltest
     - tagliatelle
     - tparallel
     - gocritic
@@ -115,7 +115,6 @@ linters:
     - contextcheck
     - forbidigo
     - errcheck
-    - dupl
     # ENDTODO
 
 run:

--- a/update/.devcontainer/install-dev-tools.sh
+++ b/update/.devcontainer/install-dev-tools.sh
@@ -17,6 +17,10 @@ sed -i '/nodocs/d' /etc/yum.conf
 sed -i'' -e 's^/release/^/experimental/^' /etc/yum.repos.d/pmm2-server.repo
 percona-release enable original testing
 
+# this mirror always fails, on both AWS and github
+echo "exclude=mirror.es.its.nyu.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf
+yum clean plugins
+
 # reinstall with man pages
 yum install -y yum rpm
 yum reinstall -y yum rpm


### PR DESCRIPTION
PMM-7

Ref: #1541 
Ref: https://github.com/mibk/dupl

This PR disables the rule since we can't really avoid code duplication between different services of a component as well as between different components of this monorepo.




