### PR TITLE
Revert "PMM-7 enable `tparallel` linter rule"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -99,7 +99,9 @@ linters:
 
     # TODO: carefully review all the rules below and either fix the code
     # or leave disabled and provide a reason why
+    - paralleltest
     - tagliatelle
+    - tparallel
     - gocritic
     - godot
     - godox

--- a/agent/agents/cache/cache_test.go
+++ b/agent/agents/cache/cache_test.go
@@ -34,7 +34,6 @@ type someType struct {
 type innerStruct struct{ float64 }
 
 func TestCache(t *testing.T) {
-	t.Parallel()
 	set1 := map[int64]*someType{
 		1: {},
 		2: {},
@@ -141,7 +140,6 @@ func TestCache(t *testing.T) {
 }
 
 func TestCacheErrors(t *testing.T) {
-	t.Parallel()
 	t.Run("WrongTypeOnNew", func(t *testing.T) {
 		t.Parallel()
 		var err error

--- a/agent/agents/mysql/slowlog/parser/continuous_file_reader_test.go
+++ b/agent/agents/mysql/slowlog/parser/continuous_file_reader_test.go
@@ -32,7 +32,6 @@ func cleanup(t *testing.T, files []string) {
 }
 
 func TestContinuousFileReader(t *testing.T) {
-	t.Parallel()
 	t.Run("Normal", func(t *testing.T) {
 		t.Parallel()
 

--- a/agent/agents/mysql/slowlog/parser/parser_test.go
+++ b/agent/agents/mysql/slowlog/parser/parser_test.go
@@ -66,7 +66,6 @@ func TestParserGolden(t *testing.T) {
 		goldenFile := strings.TrimSuffix(file, ".log") + ".json"
 		name := strings.TrimSuffix(filepath.Base(file), ".log")
 		t.Run(name, func(t *testing.T) {
-			t.Parallel()
 			opts := log.Options{
 				DefaultLocation: time.UTC,
 			}

--- a/agent/agents/mysql/slowlog/slowlog_test.go
+++ b/agent/agents/mysql/slowlog/slowlog_test.go
@@ -113,9 +113,8 @@ func TestSlowLogMakeBuckets(t *testing.T) {
 }
 
 func TestSlowLog(t *testing.T) {
-	t.Parallel()
 	sqlDB := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { sqlDB.Close() }) //nolint:errcheck
+	defer sqlDB.Close() //nolint:errcheck
 
 	q := reform.NewDB(sqlDB, mysql.Dialect, reform.NewPrintfLogger(t.Logf)).WithTag(queryTag)
 	ctx := context.Background()

--- a/agent/agents/process/process_test.go
+++ b/agent/agents/process/process_test.go
@@ -62,6 +62,7 @@ func build(t *testing.T, tag string, fileName string, outputFile string) *exec.C
 
 func setup(t *testing.T) (context.Context, context.CancelFunc, *logrus.Entry) {
 	t.Helper()
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	l := logrus.WithField("test", t.Name())

--- a/agent/agents/supervisor/supervisor_test.go
+++ b/agent/agents/supervisor/supervisor_test.go
@@ -280,7 +280,6 @@ func TestFilter(t *testing.T) {
 }
 
 func TestSupervisorProcessParams(t *testing.T) {
-	t.Parallel()
 	setup := func(t *testing.T) (*Supervisor, func()) {
 		t.Helper()
 

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -76,8 +76,6 @@ func setup(t *testing.T, connect func(agentpb.Agent_ConnectServer) error) (port 
 }
 
 func TestClient(t *testing.T) {
-	t.Parallel()
-
 	t.Run("NoAddress", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())

--- a/agent/connectionuptime/service_test.go
+++ b/agent/connectionuptime/service_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestConnectionUpTime(t *testing.T) {
-	t.Parallel()
 	now := time.Now()
 	tests := []struct {
 		name             string
@@ -176,7 +175,6 @@ func TestConnectionUpTime(t *testing.T) {
 }
 
 func TestConnectionUpTimeWithUpdatingConnectionUptime(t *testing.T) {
-	t.Parallel()
 	now := time.Now()
 	tests := []struct {
 		name             string
@@ -271,7 +269,6 @@ func compareFloatWithTolerance(a, b float32) bool {
 }
 
 func TestCalculationConnectionUpTimeWhenCleanupMethodIsNotCalled(t *testing.T) {
-	t.Parallel()
 	now := time.Now()
 	tests := []struct {
 		name             string

--- a/agent/runner/actions/mysql_explain_action_test.go
+++ b/agent/runner/actions/mysql_explain_action_test.go
@@ -37,7 +37,7 @@ func TestMySQLExplain(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	sqlDB := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { sqlDB.Close() }) //nolint:errcheck
+	defer sqlDB.Close() //nolint:errcheck
 
 	q := reform.NewDB(sqlDB, mysql.Dialect, reform.NewPrintfLogger(t.Logf)).WithTag(queryTag)
 	ctx := context.Background()
@@ -46,7 +46,6 @@ func TestMySQLExplain(t *testing.T) {
 	const query = "SELECT * FROM city ORDER BY Population"
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLExplainParams{
 			Dsn:          dsn,
 			Query:        query,
@@ -73,7 +72,6 @@ func TestMySQLExplain(t *testing.T) {
 	})
 
 	t.Run("JSON", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLExplainParams{
 			Dsn:          dsn,
 			Query:        query,
@@ -118,8 +116,6 @@ func TestMySQLExplain(t *testing.T) {
 	})
 
 	t.Run("TraditionalJSON", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLExplainParams{
 			Dsn:          dsn,
 			Query:        query,
@@ -161,8 +157,6 @@ func TestMySQLExplain(t *testing.T) {
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLExplainParams{
 			Dsn:          "pmm-agent:pmm-agent-wrong-password@tcp(127.0.0.1:3306)/world",
 			OutputFormat: agentpb.MysqlExplainOutputFormat_MYSQL_EXPLAIN_OUTPUT_FORMAT_DEFAULT,
@@ -177,8 +171,6 @@ func TestMySQLExplain(t *testing.T) {
 	})
 
 	t.Run("DML Query Insert", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLExplainParams{
 			Dsn:          dsn,
 			Query:        `INSERT INTO city (Name) VALUES ('Rosario')`,
@@ -198,8 +190,6 @@ func TestMySQLExplain(t *testing.T) {
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
-
 		checkCity := func(t *testing.T) {
 			t.Helper()
 
@@ -210,8 +200,6 @@ func TestMySQLExplain(t *testing.T) {
 		}
 
 		t.Run("Drop", func(t *testing.T) {
-			t.Parallel()
-
 			params := &agentpb.StartActionRequest_MySQLExplainParams{
 				Dsn:          dsn,
 				Query:        `SELECT 1; DROP TABLE city; --`,
@@ -230,8 +218,6 @@ func TestMySQLExplain(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			t.Parallel()
-
 			params := &agentpb.StartActionRequest_MySQLExplainParams{
 				Dsn:          dsn,
 				Query:        `DELETE FROM city`,

--- a/agent/runner/actions/mysql_query_select_action_test.go
+++ b/agent/runner/actions/mysql_query_select_action_test.go
@@ -32,11 +32,9 @@ func TestMySQLQuerySelect(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	db := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: "COUNT(*) AS count FROM mysql.user WHERE plugin NOT IN ('caching_sha2_password')",
@@ -57,8 +55,6 @@ func TestMySQLQuerySelect(t *testing.T) {
 	})
 
 	t.Run("Binary", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: `x'0001feff' AS bytes`,
@@ -82,8 +78,6 @@ func TestMySQLQuerySelect(t *testing.T) {
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_MySQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: "* FROM city; DROP TABLE city; --",

--- a/agent/runner/actions/mysql_query_show_action_test.go
+++ b/agent/runner/actions/mysql_query_show_action_test.go
@@ -32,10 +32,9 @@ func TestMySQLQueryShow(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	db := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLQueryShowParams{
 			Dsn:   dsn,
 			Query: "VARIABLES",

--- a/agent/runner/actions/mysql_show_create_table_action_test.go
+++ b/agent/runner/actions/mysql_show_create_table_action_test.go
@@ -35,7 +35,7 @@ func TestMySQLShowCreateTable(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	sqlDB := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { sqlDB.Close() }) //nolint:errcheck
+	defer sqlDB.Close() //nolint:errcheck
 
 	q := reform.NewDB(sqlDB, mysql.Dialect, reform.NewPrintfLogger(t.Logf)).WithTag(queryTag)
 	ctx := context.Background()
@@ -43,7 +43,6 @@ func TestMySQLShowCreateTable(t *testing.T) {
 	t.Logf("version = %q, vendor = %q", mySQLVersion, mySQLVendor)
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: "city",
@@ -122,7 +121,6 @@ CREATE TABLE "city" (
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: "no_such_table",
@@ -136,7 +134,6 @@ CREATE TABLE "city" (
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: `city"; DROP TABLE city; --`,

--- a/agent/runner/actions/mysql_show_index_action_test.go
+++ b/agent/runner/actions/mysql_show_index_action_test.go
@@ -35,14 +35,13 @@ func TestMySQLShowIndex(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	sqlDB := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { sqlDB.Close() }) //nolint:errcheck
+	defer sqlDB.Close() //nolint:errcheck
 
 	q := reform.NewDB(sqlDB, mysql.Dialect, reform.NewPrintfLogger(t.Logf)).WithTag(queryTag)
 	ctx := context.Background()
 	mySQLVersion, mySQLVendor, _ := version.GetMySQLVersion(ctx, q)
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowIndexParams{
 			Dsn:   dsn,
 			Table: "city",
@@ -103,7 +102,6 @@ func TestMySQLShowIndex(t *testing.T) {
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowIndexParams{
 			Dsn:   dsn,
 			Table: "no_such_table",
@@ -117,7 +115,6 @@ func TestMySQLShowIndex(t *testing.T) {
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowIndexParams{
 			Dsn:   dsn,
 			Table: `city"; DROP TABLE city; --`,

--- a/agent/runner/actions/mysql_show_table_status_action_test.go
+++ b/agent/runner/actions/mysql_show_table_status_action_test.go
@@ -32,10 +32,9 @@ func TestShowTableStatus(t *testing.T) {
 
 	dsn := tests.GetTestMySQLDSN(t)
 	db := tests.OpenTestMySQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowTableStatusParams{
 			Dsn:   dsn,
 			Table: "city",
@@ -80,7 +79,6 @@ func TestShowTableStatus(t *testing.T) {
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowTableStatusParams{
 			Dsn:   dsn,
 			Table: "no_such_table",
@@ -94,7 +92,6 @@ func TestShowTableStatus(t *testing.T) {
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_MySQLShowTableStatusParams{
 			Dsn:   dsn,
 			Table: `city"; DROP TABLE city; --`,

--- a/agent/runner/actions/postgresql_query_select_action_test.go
+++ b/agent/runner/actions/postgresql_query_select_action_test.go
@@ -33,10 +33,9 @@ func TestPostgreSQLQuerySelect(t *testing.T) {
 
 	dsn := tests.GetTestPostgreSQLDSN(t)
 	db := tests.OpenTestPostgreSQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: "* FROM pg_extension",
@@ -69,7 +68,6 @@ func TestPostgreSQLQuerySelect(t *testing.T) {
 	})
 
 	t.Run("Binary", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: `'\x0001feff'::bytea AS bytes`,
@@ -93,7 +91,6 @@ func TestPostgreSQLQuerySelect(t *testing.T) {
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLQuerySelectParams{
 			Dsn:   dsn,
 			Query: "* FROM city; DROP TABLE city CASCADE; --",

--- a/agent/runner/actions/postgresql_query_show_action_test.go
+++ b/agent/runner/actions/postgresql_query_show_action_test.go
@@ -33,10 +33,9 @@ func TestPostgreSQLQueryShow(t *testing.T) {
 
 	dsn := tests.GetTestPostgreSQLDSN(t)
 	db := tests.OpenTestPostgreSQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLQueryShowParams{
 			Dsn: dsn,
 		}

--- a/agent/runner/actions/postgresql_show_create_table_action_test.go
+++ b/agent/runner/actions/postgresql_show_create_table_action_test.go
@@ -32,10 +32,9 @@ func TestPostgreSQLShowCreateTable(t *testing.T) {
 
 	dsn := tests.GetTestPostgreSQLDSN(t)
 	db := tests.OpenTestPostgreSQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("With Schema Name", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: "public.country",
@@ -78,7 +77,6 @@ Referenced by:
 	})
 
 	t.Run("Without constraints", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: "city",
@@ -107,7 +105,6 @@ Referenced by:
 	})
 
 	t.Run("Without references", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: "countrylanguage",
@@ -135,7 +132,6 @@ Foreign-key constraints:
 	})
 
 	t.Run("LittleBobbyTables", func(t *testing.T) {
-		t.Parallel()
 		params := &agentpb.StartActionRequest_PostgreSQLShowCreateTableParams{
 			Dsn:   dsn,
 			Table: `city; DROP TABLE city; --`,

--- a/agent/runner/actions/postgresql_show_index_action_test.go
+++ b/agent/runner/actions/postgresql_show_index_action_test.go
@@ -33,11 +33,9 @@ func TestPostgreSQLShowIndex(t *testing.T) {
 
 	dsn := tests.GetTestPostgreSQLDSN(t)
 	db := tests.OpenTestPostgreSQL(t)
-	t.Cleanup(func() { db.Close() }) //nolint:errcheck
+	defer db.Close() //nolint:errcheck
 
 	t.Run("Default", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_PostgreSQLShowIndexParams{
 			Dsn:   dsn,
 			Table: "city",
@@ -62,8 +60,6 @@ func TestPostgreSQLShowIndex(t *testing.T) {
 	})
 
 	t.Run("WithSchemaName", func(t *testing.T) {
-		t.Parallel()
-
 		params := &agentpb.StartActionRequest_PostgreSQLShowIndexParams{
 			Dsn:   dsn,
 			Table: "public.city",

--- a/api-tests/inventory/agents_azure_database_exporter_test.go
+++ b/api-tests/inventory/agents_azure_database_exporter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestAzureDatabaseExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_external_exporter_test.go
+++ b/api-tests/inventory/agents_external_exporter_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestExternalExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_mongodb_exporter_test.go
+++ b/api-tests/inventory/agents_mongodb_exporter_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestMongoDBExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_mysqld_exporter_test.go
+++ b/api-tests/inventory/agents_mysqld_exporter_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestMySQLdExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_node_exporter_test.go
+++ b/api-tests/inventory/agents_node_exporter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestNodeExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_postgres_exporter_test.go
+++ b/api-tests/inventory/agents_postgres_exporter_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestPostgresExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_proxysql_exporter_test.go
+++ b/api-tests/inventory/agents_proxysql_exporter_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestProxySQLExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_rds_exporter_test.go
+++ b/api-tests/inventory/agents_rds_exporter_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestRDSExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/agents_test.go
+++ b/api-tests/inventory/agents_test.go
@@ -36,7 +36,6 @@ import (
 var AgentStatusUnknown = inventorypb.AgentStatus_name[int32(inventorypb.AgentStatus_UNKNOWN)]
 
 func TestAgents(t *testing.T) {
-	t.Parallel()
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 
@@ -236,7 +235,6 @@ func TestAgents(t *testing.T) {
 }
 
 func TestPMMAgent(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -448,7 +446,6 @@ func TestPMMAgent(t *testing.T) {
 }
 
 func TestQanAgentExporter(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -678,7 +675,6 @@ func TestQanAgentExporter(t *testing.T) {
 }
 
 func TestPGStatStatementsQanAgent(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -908,7 +904,6 @@ func TestPGStatStatementsQanAgent(t *testing.T) {
 }
 
 func TestPGStatMonitorQanAgent(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/nodes_test.go
+++ b/api-tests/inventory/nodes_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestNodes(t *testing.T) {
-	t.Parallel()
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 
@@ -92,7 +91,6 @@ func TestNodes(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -146,7 +144,6 @@ func TestGetNode(t *testing.T) {
 }
 
 func TestGenericNode(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -206,7 +203,6 @@ func TestGenericNode(t *testing.T) {
 }
 
 func TestContainerNode(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -271,7 +267,6 @@ func TestContainerNode(t *testing.T) {
 }
 
 func TestRemoteNode(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -336,7 +331,6 @@ func TestRemoteNode(t *testing.T) {
 }
 
 func TestRemoveNode(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/inventory/services_test.go
+++ b/api-tests/inventory/services_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestServices(t *testing.T) {
-	t.Parallel()
 	t.Run("List", func(t *testing.T) {
 		t.Parallel()
 
@@ -173,7 +172,6 @@ func TestServices(t *testing.T) {
 }
 
 func TestGetService(t *testing.T) {
-	t.Parallel()
 	t.Run("NotFound", func(t *testing.T) {
 		t.Parallel()
 
@@ -200,7 +198,6 @@ func TestGetService(t *testing.T) {
 }
 
 func TestRemoveService(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -322,7 +319,6 @@ func TestRemoveService(t *testing.T) {
 }
 
 func TestMySQLService(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -525,7 +521,6 @@ func TestMySQLService(t *testing.T) {
 }
 
 func TestMongoDBService(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -737,7 +732,6 @@ func TestMongoDBService(t *testing.T) {
 }
 
 func TestPostgreSQLService(t *testing.T) {
-	t.Parallel()
 	const defaultPostgresDBName = "postgres"
 
 	t.Run("Basic", func(t *testing.T) {
@@ -943,7 +937,6 @@ func TestPostgreSQLService(t *testing.T) {
 }
 
 func TestProxySQLService(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 
@@ -1146,7 +1139,6 @@ func TestProxySQLService(t *testing.T) {
 }
 
 func TestExternalService(t *testing.T) {
-	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
 		t.Parallel()
 

--- a/api-tests/management/alerting/alerting_test.go
+++ b/api-tests/management/alerting/alerting_test.go
@@ -118,7 +118,6 @@ func assertTemplate(t *testing.T, expectedTemplate alert.Template, listTemplates
 }
 
 func TestTemplatesAPI(t *testing.T) {
-	t.Parallel()
 	client := alertingClient.Default.Alerting
 
 	templateData, err := os.ReadFile("../../testdata/ia/template.yaml")

--- a/api-tests/management/ia/channels_test.go
+++ b/api-tests/management/ia/channels_test.go
@@ -35,7 +35,6 @@ import (
 // ENABLE_ALERTING env var.
 
 func TestChannelsAPI(t *testing.T) {
-	t.Parallel()
 	client := channelsClient.Default.Channels
 
 	t.Run("add", func(t *testing.T) {

--- a/api-tests/management/ia/rules_test.go
+++ b/api-tests/management/ia/rules_test.go
@@ -39,7 +39,6 @@ import (
 // we don't enable or disable IA explicit in our tests since it is enabled by default through
 // ENABLE_ALERTING env var.
 func TestRulesAPI(t *testing.T) {
-	t.Parallel()
 	rulesClient := client.Default.Rules
 	templatesClient := alertingClient.Default.Alerting
 	channelsClient := client.Default.Channels

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -94,7 +94,6 @@ func TestAuth(t *testing.T) {
 }
 
 func TestSetup(t *testing.T) {
-	t.Parallel()
 	// make a BaseURL without authentication
 	baseURL, err := url.Parse(pmmapitests.BaseURL.String())
 	require.NoError(t, err)
@@ -126,7 +125,6 @@ func TestSetup(t *testing.T) {
 	})
 
 	t.Run("Redirect", func(t *testing.T) {
-		t.Parallel()
 		paths := map[string]int{
 			"graph":       303,
 			"graph/":      303,
@@ -187,7 +185,6 @@ func TestSetup(t *testing.T) {
 }
 
 func TestSwagger(t *testing.T) {
-	t.Parallel()
 	for _, path := range []string{
 		"swagger",
 		"swagger/",
@@ -197,7 +194,6 @@ func TestSwagger(t *testing.T) {
 		path := path
 
 		t.Run(path, func(t *testing.T) {
-			t.Parallel()
 			t.Run("NoAuth", func(t *testing.T) {
 				t.Parallel()
 

--- a/api-tests/server/panics_test.go
+++ b/api-tests/server/panics_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestPanics(t *testing.T) {
-	t.Parallel()
 	for _, mode := range []string{"panic-error", "panic-fmterror", "panic-string"} {
 		mode := mode
 		t.Run(mode, func(t *testing.T) {

--- a/api-tests/server/readyz_test.go
+++ b/api-tests/server/readyz_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestReadyz(t *testing.T) {
-	t.Parallel()
 	paths := []string{
 		"ping",
 		"v1/readyz",

--- a/api-tests/server/version_test.go
+++ b/api-tests/server/version_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	t.Parallel()
 	paths := []string{
 		"managed/v1/version",
 		"v1/version",

--- a/managed/cmd/pmm-managed-starlark/main_test.go
+++ b/managed/cmd/pmm-managed-starlark/main_test.go
@@ -47,7 +47,7 @@ var validQueryActionResult = []map[string]interface{}{
 	{"Value": "-log", "Variable_name": "version_suffix"},
 }
 
-func TestStarlarkSandbox(t *testing.T) { //nolint:tparallel
+func TestStarlarkSandbox(t *testing.T) {
 	testCases := []struct {
 		name         string
 		script       string

--- a/managed/models/check_settings_helper_test.go
+++ b/managed/models/check_settings_helper_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/percona/pmm/managed/utils/testdb"
 )
 
-func TestChecksSettings(t *testing.T) { //nolint:tparallel
+func TestChecksSettings(t *testing.T) {
 	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
-	t.Cleanup(func() {
+	defer func() {
 		require.NoError(t, sqlDB.Close())
-	})
+	}()
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("create", func(t *testing.T) {

--- a/managed/models/models_json_test.go
+++ b/managed/models/models_json_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/percona/pmm/managed/utils/testdb"
 )
 
-func TestJSON(t *testing.T) { //nolint:tparallel
+func TestJSON(t *testing.T) {
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 

--- a/managed/models/postgresql_version_test.go
+++ b/managed/models/postgresql_version_test.go
@@ -30,7 +30,7 @@ func TestGetPostgreSQLVersion(t *testing.T) {
 	t.Parallel()
 	sqlDB, mock, err := sqlmock.New()
 	require.NoError(t, err)
-	t.Cleanup(func() { sqlDB.Close() }) //nolint:errcheck
+	defer sqlDB.Close() //nolint:errcheck
 
 	q := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf)).WithTag("pmm-agent:postgresqlversion")
 	ctx := context.Background()
@@ -78,7 +78,6 @@ func TestGetPostgreSQLVersion(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			for _, version := range tc.mockedData {
 				mock.ExpectQuery("SELECT").
 					WillReturnRows(sqlmock.NewRows(column).AddRow(version))

--- a/managed/models/restore_history_helpers_test.go
+++ b/managed/models/restore_history_helpers_test.go
@@ -238,7 +238,6 @@ func TestRestoreHistory(t *testing.T) {
 }
 
 func TestRestoreHistoryValidation(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		name     string
 		params   models.CreateRestoreHistoryItemParams

--- a/managed/services/agents/agentversion_test.go
+++ b/managed/services/agents/agentversion_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestPMMAgentSupported(t *testing.T) {
-	t.Parallel()
 	prefix := "testing prefix"
 	minVersion := version.Must(version.NewVersion("2.30.5"))
 

--- a/managed/services/agents/jobs.go
+++ b/managed/services/agents/jobs.go
@@ -164,7 +164,7 @@ func (s *JobsService) RestartJob(ctx context.Context, jobID string) error {
 	return nil
 }
 
-func (s *JobsService) handleJobResult(_ context.Context, l *logrus.Entry, result *agentpb.JobResult) { //nolint:cyclop
+func (s *JobsService) handleJobResult(_ context.Context, l *logrus.Entry, result *agentpb.JobResult) {
 	var scheduleID string
 	if errTx := s.db.InTransaction(func(t *reform.TX) error {
 		job, err := models.FindJobByID(t.Querier, result.JobId)

--- a/managed/services/agents/proxysql_test.go
+++ b/managed/services/agents/proxysql_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestProxySQLExporterConfig(t *testing.T) {
-	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.18.0")
 	proxysql := &models.Service{
 		Address: pointer.ToString("1.2.3.4"),

--- a/managed/services/agents/versioner_test.go
+++ b/managed/services/agents/versioner_test.go
@@ -40,9 +40,7 @@ func TestSoftwareName(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(string(tc.name), func(t *testing.T) {
-			t.Parallel()
 			res := tc.sw.Name()
 			assert.Equal(t, tc.name, res)
 		})
@@ -66,9 +64,7 @@ func TestGetVersionRequest(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			res := tc.sw.GetVersionRequest()
 			assert.Equal(t, tc.request, res)
 		})

--- a/managed/services/backup/compatibility_service_test.go
+++ b/managed/services/backup/compatibility_service_test.go
@@ -183,9 +183,7 @@ func TestCheckCompatibility(t *testing.T) {
 			expectedError: ErrIncompatibleService,
 		},
 	} {
-		tc := tc
 		t.Run(string(tc.serviceType)+"_"+tc.name, func(t *testing.T) {
-			t.Parallel()
 			var sw []agents.Software
 			switch tc.serviceType {
 			case models.MySQLServiceType:
@@ -288,22 +286,18 @@ func TestFindCompatibleServiceIDs(t *testing.T) {
 	}
 
 	t.Run("empty db version", func(t *testing.T) {
-		t.Parallel()
 		res := cSvc.findCompatibleServiceIDs(&models.Artifact{DBVersion: ""}, testSet)
 		assert.Equal(t, 0, len(res))
 	})
 	t.Run("matches several", func(t *testing.T) {
-		t.Parallel()
 		res := cSvc.findCompatibleServiceIDs(&models.Artifact{DBVersion: "8.0.25"}, testSet)
 		assert.ElementsMatch(t, []string{"5", "8"}, res)
 	})
 	t.Run("matches one", func(t *testing.T) {
-		t.Parallel()
 		res := cSvc.findCompatibleServiceIDs(&models.Artifact{DBVersion: "8.0.24"}, testSet)
 		assert.ElementsMatch(t, []string{"7"}, res)
 	})
 	t.Run("artifact version greater then existing services", func(t *testing.T) {
-		t.Parallel()
 		res := cSvc.findCompatibleServiceIDs(&models.Artifact{DBVersion: "8.0.30"}, testSet)
 		assert.Equal(t, 0, len(res))
 	})
@@ -638,9 +632,7 @@ func TestArtifactCompatibility(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			err := cSvc.artifactCompatibility(tc.artifact, tc.service, tc.targetDBVersion)
 
 			if tc.expectedErr == nil {

--- a/managed/services/backup/removal_service_test.go
+++ b/managed/services/backup/removal_service_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/percona/pmm/managed/utils/testdb"
 )
 
-const endpoint = "https://s3.us-west-2.amazonaws.com/"
-
 func TestDeleteArtifact(t *testing.T) {
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
@@ -45,7 +43,8 @@ func TestDeleteArtifact(t *testing.T) {
 	removalService := NewRemovalService(db, mockedPbmPITRService)
 
 	agent := setup(t, db.Querier, models.MySQLServiceType, "test-service")
-	accessKey, secretKey, bucketName, bucketRegion := "access_key", "secret_key", "example_bucket", "us-east-2" //nolint:goconst
+	endpoint := "https://s3.us-west-2.amazonaws.com/"
+	accessKey, secretKey, bucketName, bucketRegion := "access_key", "secret_key", "example_bucket", "us-east-2"
 
 	s3Config := &models.S3LocationConfig{
 		Endpoint:     endpoint,
@@ -249,6 +248,7 @@ func TestTrimPITRArtifact(t *testing.T) {
 
 	agent := setup(t, db.Querier, models.MongoDBServiceType, "test-service2")
 
+	endpoint := "https://s3.us-west-2.amazonaws.com/"
 	accessKey, secretKey, bucketName, bucketRegion := "access_key", "secret_key", "example_bucket", "us-east-2"
 
 	s3Config := &models.S3LocationConfig{

--- a/managed/services/checks/checks_test.go
+++ b/managed/services/checks/checks_test.go
@@ -618,7 +618,6 @@ func setupClients(t *testing.T) {
 }
 
 func TestFindTargets(t *testing.T) {
-	t.Parallel()
 	sqlDB := testdb.Open(t, models.SetupFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -704,6 +703,8 @@ func TestFilterChecksByInterval(t *testing.T) {
 }
 
 func TestGetFailedChecks(t *testing.T) {
+	t.Parallel()
+
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())

--- a/managed/services/checks/funcs_test.go
+++ b/managed/services/checks/funcs_test.go
@@ -98,7 +98,6 @@ Traceback (most recent call last):
 }
 
 func TestAdditionalContext(t *testing.T) {
-	t.Parallel()
 	predeclaredFuncs, err := GetFuncsForVersion(1)
 	require.NoError(t, err)
 	contextFuncs := GetAdditionalContext()

--- a/managed/services/grafana/auth_server_test.go
+++ b/managed/services/grafana/auth_server_test.go
@@ -160,12 +160,11 @@ func TestAuthServerMustSetup(t *testing.T) {
 }
 
 func TestAuthServerAuthenticate(t *testing.T) {
-	t.Parallel()
 	// logrus.SetLevel(logrus.TraceLevel)
 
 	checker := &mockAwsInstanceChecker{}
 	checker.Test(t)
-	t.Cleanup(func() { checker.AssertExpectations(t) })
+	defer checker.AssertExpectations(t)
 
 	ctx := context.Background()
 	c := NewClient("127.0.0.1:3000")
@@ -243,8 +242,8 @@ func TestAuthServerAuthenticate(t *testing.T) {
 			role := role
 
 			t.Run(fmt.Sprintf("uri=%s,minRole=%s,role=%s", uri, minRole, role), func(t *testing.T) {
-				// This test couldn't run in parallel on sqlite3 - they locked Grafana's sqlite3 database
-				t.Parallel()
+				// do not run this test in parallel - they lock Grafana's sqlite3 database
+				// t.Parallel()
 
 				login := fmt.Sprintf("%s-%s-%d", minRole, role, time.Now().Nanosecond())
 				userID, err := c.testCreateUser(ctx, login, role, authHeaders)

--- a/managed/services/management/alerting/service_test.go
+++ b/managed/services/management/alerting/service_test.go
@@ -42,7 +42,6 @@ const (
 )
 
 func TestCollect(t *testing.T) {
-	t.Parallel()
 	clientID, clientSecret := os.Getenv("OAUTH_PMM_CLIENT_ID"), os.Getenv("OAUTH_PMM_CLIENT_SECRET")
 	if clientID == "" || clientSecret == "" {
 		t.Skip("Environment variables OAUTH_PMM_CLIENT_ID / OAUTH_PMM_CLIENT_SECRET are not defined, skipping test")
@@ -161,7 +160,6 @@ func TestDownloadTemplates(t *testing.T) {
 }
 
 func TestTemplateValidation(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))

--- a/managed/services/management/dbaas/components_service_test.go
+++ b/managed/services/management/dbaas/components_service_test.go
@@ -670,6 +670,7 @@ func TestInstallOperator(t *testing.T) {
 }
 
 func TestCheckForOperatorUpdate(t *testing.T) {
+	t.Parallel()
 	response := &VersionServiceResponse{
 		Versions: []Version{
 			{

--- a/managed/services/management/dbaas/kubernetes_server_test.go
+++ b/managed/services/management/dbaas/kubernetes_server_test.go
@@ -689,7 +689,7 @@ users:
       provideClusterInfo: false
 `
 
-func TestUseIAMAuthenticator(t *testing.T) { //nolint:tparallel
+func TestUseIAMAuthenticator(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name              string

--- a/managed/services/management/dbaas/pxc_cluster_service_test.go
+++ b/managed/services/management/dbaas/pxc_cluster_service_test.go
@@ -80,7 +80,7 @@ const pxcKubeconfigTest = `
 `
 const pxcKubernetesClusterNameTest = "test-k8s-cluster-name"
 
-func TestPXCClusterService(t *testing.T) { //nolint:tparallel
+func TestPXCClusterService(t *testing.T) {
 	// This is for local testing. When running local tests, if pmmversion.PMMVersion is empty
 	// these lines in kubernetes_server.go will throw an error and tests won't finish.
 	//
@@ -117,7 +117,7 @@ func TestPXCClusterService(t *testing.T) { //nolint:tparallel
 	}
 
 	ctx, db, dbaasClient, grafanaClient, componentsClient, kubeClient, teardown := setup(t)
-	t.Cleanup(func() { teardown(t) })
+	defer teardown(t)
 
 	versionService := &mockVersionService{}
 	v1120, _ := goversion.NewVersion("1.12.0")

--- a/managed/services/management/dbaas/version_service_client_test.go
+++ b/managed/services/management/dbaas/version_service_client_test.go
@@ -261,7 +261,7 @@ const (
 	psmdbImage = "percona/percona-server-mongodb"
 )
 
-func TestGetNextDatabaseVersion(t *testing.T) { //nolint:tparallel
+func TestGetNextDatabaseVersion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
 	response := &VersionServiceResponse{
 		Versions: []Version{

--- a/managed/services/server/server_test.go
+++ b/managed/services/server/server_test.go
@@ -426,9 +426,7 @@ func TestServer_TestEmailAlertingSettings(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
-			t.Parallel()
 			if tc.mock != nil {
 				tc.mock()
 			}

--- a/managed/services/supervisord/maintail_test.go
+++ b/managed/services/supervisord/maintail_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestParseEvent(t *testing.T) {
-	t.Parallel()
 	t.Run("Normal", func(t *testing.T) {
 		t.Parallel()
 

--- a/managed/services/supervisord/supervisord_test.go
+++ b/managed/services/supervisord/supervisord_test.go
@@ -52,7 +52,6 @@ func TestConfig(t *testing.T) {
 
 		tmpl := tmpl
 		t.Run(tmpl.Name(), func(t *testing.T) {
-			t.Parallel()
 			expected, err := os.ReadFile(filepath.Join(configDir, tmpl.Name()+".ini")) //nolint:gosec
 			require.NoError(t, err)
 			actual, err := s.marshalConfig(tmpl, settings, nil)
@@ -126,7 +125,6 @@ func TestAddAlertManagerParam(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty alertmanager url", func(t *testing.T) {
-		t.Parallel()
 		params := make(map[string]interface{})
 		err := addAlertManagerParams("", params)
 		require.NoError(t, err)
@@ -134,7 +132,6 @@ func TestAddAlertManagerParam(t *testing.T) {
 	})
 
 	t.Run("simple alertmanager url", func(t *testing.T) {
-		t.Parallel()
 		params := make(map[string]interface{})
 		err := addAlertManagerParams("https://some-alertmanager", params)
 		require.NoError(t, err)
@@ -142,7 +139,6 @@ func TestAddAlertManagerParam(t *testing.T) {
 	})
 
 	t.Run("extract username and password from alertmanager url", func(t *testing.T) {
-		t.Parallel()
 		params := make(map[string]interface{})
 		err := addAlertManagerParams("https://username1:PAsds!234@some-alertmanager", params)
 		require.NoError(t, err)
@@ -152,7 +148,6 @@ func TestAddAlertManagerParam(t *testing.T) {
 	})
 
 	t.Run("incorrect alertmanager url", func(t *testing.T) {
-		t.Parallel()
 		params := make(map[string]interface{})
 		err := addAlertManagerParams("*:9095", params)
 		require.EqualError(t, err, `cannot parse AlertManagerURL: parse "*:9095": first path segment in URL cannot contain colon`)
@@ -180,9 +175,7 @@ func TestSavePMMConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
-			t.Parallel()
 			expected, err := os.ReadFile(filepath.Join(configDir, test.file+".ini")) //nolint:gosec
 			require.NoError(t, err)
 			actual, err := marshalConfig(test.params)

--- a/managed/services/telemetry/distribution_util_test.go
+++ b/managed/services/telemetry/distribution_util_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func Test_distributionUtilServiceImpl_getDistributionMethodAndOS(t *testing.T) {
-	t.Parallel()
 	const (
 		ami          = "ami"
 		ovf          = "ovf"
@@ -161,7 +160,6 @@ func writeToTmpFile(t *testing.T, tmpDistributionFile string, s string) (*os.Fil
 }
 
 func Test_distributionUtilServiceImpl_getLinuxDistribution(t *testing.T) {
-	t.Parallel()
 	const (
 		tmpDistributionFile = "/tmp/distribution"
 		tmpOsInfoFilePath   = "/tmp/version"

--- a/managed/services/telemetry/telemetry_test.go
+++ b/managed/services/telemetry/telemetry_test.go
@@ -46,7 +46,6 @@ const (
 )
 
 func TestRunTelemetryService(t *testing.T) {
-	t.Parallel()
 	pgHostPort := "127.0.0.1:5432"
 	pgHostPortFromEnv, ok := os.LookupEnv(envPGHostPort)
 	if ok {

--- a/managed/utils/pprof/pprof_test.go
+++ b/managed/utils/pprof/pprof_test.go
@@ -29,7 +29,6 @@ import (
 func TestHeap(t *testing.T) {
 	t.Parallel()
 	t.Run("Heap test", func(t *testing.T) {
-		t.Parallel()
 		heapBytes, err := Heap(true)
 		assert.NoError(t, err)
 
@@ -66,7 +65,6 @@ func TestProfile(t *testing.T) {
 	})
 
 	t.Run("Profile break test", func(t *testing.T) {
-		t.Parallel()
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 		go func() {
 			profileBytes, err := Profile(ctx, 30*time.Second)
@@ -93,7 +91,6 @@ func TestTrace(t *testing.T) {
 	})
 
 	t.Run("Trace break test", func(t *testing.T) {
-		t.Parallel()
 		// Create a new context
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 		go func() {

--- a/vmproxy/main_test.go
+++ b/vmproxy/main_test.go
@@ -27,7 +27,6 @@ func TestProxy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("shall run proxy with no error", func(t *testing.T) {
-		t.Parallel()
 		err := runProxy(flags{}, func(cfg proxy.Config) error {
 			return nil
 		})


### PR DESCRIPTION
Reverts percona/pmm#2196
Will revert it until we manage to fix the API [tests](https://pmm.cd.percona.com/job/pmm2-api-tests/13648/console)