### PR TITLE
PMM-7 enable `gosimple` linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -92,6 +92,7 @@ linters:
     - interfacer       # deprecated
     - maligned         # deprecated
     - nlreturn         # too annoying
+    - nosnakecase      # deprecated
     - scopelint        # too many false positives
     - varnamelen       # useless
     - wrapcheck        # we do not use wrapping everywhere
@@ -106,13 +107,11 @@ linters:
     - godot
     - godox
     - revive
-    - nosnakecase
     - paralleltest
     - ireturn
     - gocognit
     - maintidx
     - interfacebloat
-    - gosimple
     - forbidigo
     - errcheck
     # ENDTODO

--- a/agent/agents/mongodb/mongodb.go
+++ b/agent/agents/mongodb/mongodb.go
@@ -91,7 +91,6 @@ func (m *MongoDB) Run(ctx context.Context) {
 
 	<-ctx.Done()
 	m.changes <- agents.Change{Status: inventorypb.AgentStatus_STOPPING}
-	return
 }
 
 // Changes returns channel that should be read until it is closed.

--- a/managed/services/dbaas/kubernetes/kubernetes.go
+++ b/managed/services/dbaas/kubernetes/kubernetes.go
@@ -901,7 +901,7 @@ func (k *Kubernetes) UpgradeOperator(ctx context.Context, namespace, name string
 		return errors.Wrapf(err, "cannot get install plan to upgrade %q", name)
 	}
 
-	if ip.Spec.Approved == true {
+	if ip.Spec.Approved {
 		return nil // There are no upgrades.
 	}
 

--- a/managed/services/grafana/auth_server.go
+++ b/managed/services/grafana/auth_server.go
@@ -298,7 +298,7 @@ func (s *AuthServer) maybeAddVMProxyFilters(ctx context.Context, rw http.Respons
 		return err
 	}
 
-	if filters == nil || len(filters) == 0 {
+	if filters == nil || len(filters) == 0 { //nolint:gosimple
 		return nil
 	}
 

--- a/managed/services/supervisord/pmm_config.go
+++ b/managed/services/supervisord/pmm_config.go
@@ -56,7 +56,7 @@ func saveConfig(path string, cfg []byte) (err error) {
 	}
 
 	// compare with new config
-	if bytes.Compare(cfg, oldCfg) == 0 {
+	if bytes.Equal(cfg, oldCfg) {
 		// nothing to change
 		return nil
 	}

--- a/vmproxy/proxy/proxy.go
+++ b/vmproxy/proxy/proxy.go
@@ -88,12 +88,9 @@ func director(target *url.URL, headerName string) func(*http.Request) {
 			q := req.URL.Query()
 			q.Del("extra_filters[]")
 
-			parsed, err := parseFilters(filters)
-			if err != nil {
-				logrus.Error(err)
-			}
+			parsed, _ := parseFilters(filters)
 
-			if parsed != nil {
+			if parsed != nil { //nolint:gosimple
 				for _, f := range parsed {
 					q.Add("extra_filters[]", f)
 				}


### PR DESCRIPTION
PMM-7

Ref: #1541 

Ref: https://golangci-lint.run/usage/linters/#gosimple

This PR:
- disabled the `nosnakecase` rule, since it's deprecated
- enables the `gosimple` rule and addresses some of the warnings
