### PR TITLE
PMM-12248 Fix supervisorctl path on EL-9.

### DIFF
--- a/build/ansible/roles/ami-ovf/tasks/main.yml
+++ b/build/ansible/roles/ami-ovf/tasks/main.yml
@@ -48,6 +48,17 @@
     dest: /var/lib/cloud/scripts/per-boot/show-pmm-url
     mode: 0755
 
+# PMM-12248 - Add /usr/local/bin to secure_path in /etc/sudoers so
+# that we can use supervisorctl command without the absolute path
+- name: PMM                        | Update secure_path in /etc/sudoers EL9
+  replace:
+    dest: /etc/sudoers
+    regexp: "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin"
+    replace: "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin"
+  when:
+    - ansible_distribution == 'OracleLinux' or ansible_distribution == 'AlmaLinux'
+    - ansible_distribution_major_version == '9'
+
 - name: PMM                        | Delete centos EL7
   shell: cd /tmp; nohup sh -c "trap 'userdel -r centos' EXIT; sleep 600" </dev/null >/dev/null 2>&1 &
   when:


### PR DESCRIPTION
PMM-12248

AMI (EL9) with the fix can be found at: 
https://pmm.cd.percona.com/blue/organizations/jenkins/pmm2-ami/detail/pmm2-ami/5080/pipeline/41/