### PR TITLE
PMM-7 temporarily disable PMM CLI tests

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -82,6 +82,7 @@ jobs:
 
   cli-test:
     name: CLI Tests
+    if: false
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
PMM-7

PMM CLI is not a GA feature yet. Since its tests are not stable, we want to temporarily disable them.