### PR TITLE
Revert "PMM-9769 update all components"

### DIFF
--- a/build/ansible/pmm2/main.yml
+++ b/build/ansible/pmm2/main.yml
@@ -5,8 +5,6 @@
 - hosts: all
   become: yes
   gather_facts: yes
-  vars:
-    ansible_python_interpreter: /usr/bin/python3.9
   roles:
     - cloud-node
     - lvm-init

--- a/build/ansible/roles/cloud-node/tasks/main.yml
+++ b/build/ansible/roles/cloud-node/tasks/main.yml
@@ -38,8 +38,8 @@
       - yum-utils
       - cloud-init
       - firewalld
-      - python3-libselinux
-      - python3-firewall
+      - python3-pip
+      - ansible
 
 - name: Firewalld                  | Start
   when: ansible_os_family == 'RedHat'

--- a/build/ansible/roles/pmm2-images/tasks/main.yml
+++ b/build/ansible/roles/pmm2-images/tasks/main.yml
@@ -51,6 +51,7 @@
   yum:
     name: "*"
     state: latest
+    exclude: "ansible*"
     disablerepo: percona-release-x86_64
 
 - name: Packages                   | Install OS tools for EL7
@@ -69,6 +70,7 @@
     name:
       - python3-pip
       - python3.11-pip
+      - python3.11
       - python3.11-psycopg2
       - rsync
       - libsqlite3x-devel # package does not come pre-installed on EL9

--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -18,14 +18,19 @@ EXPOSE 80 443
 
 WORKDIR /opt
 
-RUN microdnf -y install epel-release && \
-    microdnf -y install ansible-core \
-                        ansible-collection-community-general \
-                        ansible-collection-community-postgresql \
-                        ansible-collection-ansible-posix \
-                        glibc-langpack-en \
-                        yum \
-                        vi
+# NOTE: Ansible should NOT be installed via yum/dnf
+# Read more: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#pip-install
+# RUN microdnf -y install yum && yum -y install python3-pip && \
+#     yum -y install oracle-epel-release-el9 ansible-core && \
+#     python3 -m pip install ansible && \
+#     python3 -m pip install setuptools && \
+#     yum -y install epel-release
+
+RUN microdnf -y install yum && yum -y install python3-pip && \
+  yum -y install oracle-epel-release-el9 ansible-core && \
+  yum -y install epel-release && \
+  yum -y install glibc-langpack-en && \
+  yum -y install ansible vi
 
 COPY RPMS /tmp/RPMS
 COPY gitCommit /tmp/gitCommit

--- a/build/packer/pmm2.el9.json
+++ b/build/packer/pmm2.el9.json
@@ -114,8 +114,7 @@
       "inline": [
         "sudo yum -y update",
         "sudo yum -y install epel-release",
-        "sudo yum -y install ansible-core",
-        "sudo yum -y install ansible-collection-community-general ansible-collection-community-postgresql ansible-collection-ansible-posix"
+        "sudo yum -y install ansible"
       ]
     },
     {

--- a/update/ansible/playbook/tasks/update.yml
+++ b/update/ansible/playbook/tasks/update.yml
@@ -243,8 +243,20 @@
       yum:
         name: "*"
         state: latest
+        security: yes
         exclude:
           - nginx*
+
+    - name: Updating only select packages
+      yum:
+        name: "{{ item }}"
+        state: latest
+      loop:
+        - nss
+        - tzdata
+        - libssh2
+        - sshpass
+        - vi
 
     - name: Install nginx
       include_role:


### PR DESCRIPTION
Reverts percona/pmm#2446

Following the merge of (https://github.com/percona/pmm/pull/2446), we’ve encountered some CI failures, such as in this example: https://github.com/percona/pmm/actions/runs/6084707881/job/16507204096

_**TASK [Update system packages] **************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occurred: \n Problem: package ansible-5.4.0-2.el9.noarch requires (python3.9dist(ansible-core) >= 2.12.2 with python3.9dist(ansible-core) < 2.13), but none of the providers can be installed\n  - cannot install both ansible-core-2.14.2-5.el9_2.x86_64 and ansible-core-2.12.2-2.el9_0.x86_64\n  - cannot install both ansible-core-2.14.2-5.el9_2.x86_64 and ansible-core-2.12.2-1.el9.x86_64\n  - cannot install the best update candidate for package ansible-core-2.12.2-2.el9_0.x86_64\n  - cannot install the best update candidate for package ansible-5.4.0-2.el9.noarch", "rc": 1, "results": []}**_

Initially, this problem arose when the security: yes option was removed from the Ansible task to update everything in update/ansible/playbook/tasks/update.yml:
      **_yum:
        name: "*"
        state: latest
        security: yes
        exclude:
          - nginx*_**

To resolve this issue, we switched to installing the ansible-core instead of the ansible package.

However, a new challenge has surfaced with the older images, such as percona/pmm-server:2 or percona/pmm-server:dev-latest, which have already been released. These images contain the ansible package instead of ansible-core. Consequently, when attempting to update these images, we encounter failures.

We need to devise a strategy for handling these older images.