### PR TITLE
PMM-7 fix API tests

### DIFF
--- a/update/ansible/playbook/tasks/roles/clickhouse/files/config.xml
+++ b/update/ansible/playbook/tasks/roles/clickhouse/files/config.xml
@@ -24,7 +24,6 @@
         <level>information</level>
         <console>1</console>
         <log>/srv/logs/clickhouse-server.log</log>
-        <errorlog>/srv/logs/clickhouse-server.err.log</errorlog>
         <!-- Rotation policy
              See https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/FileChannel.h#L54-L85
           -->

--- a/update/ansible/playbook/tasks/roles/clickhouse/files/config.xml
+++ b/update/ansible/playbook/tasks/roles/clickhouse/files/config.xml
@@ -26,9 +26,9 @@
         <log>/srv/logs/clickhouse-server.log</log>
         <!-- Rotation policy
              See https://github.com/pocoproject/poco/blob/poco-1.9.4-release/Foundation/include/Poco/FileChannel.h#L54-L85
-          -->
         <size>1000M</size>
         <count>10</count>
+          -->
         <!-- <console>1</console> --> <!-- Default behavior is autodetection (log to console if not daemon mode and is tty) -->
 
         <!-- Per level overrides (legacy):


### PR DESCRIPTION
Ref: PMM-12223
Ref: [failing API test run](https://pmm.cd.percona.com/job/pmm2-api-tests/14311/consoleFull)

**Why**:
PMM API tests currently fail. Namely, `TestDownloadLogs` fails with the following diff:


```
12:38:56          	            	Diff:
12:38:56          	            	--- Expected
12:38:56          	            	+++ Actual
12:38:56          	            	@@ -1,2 +1,2 @@
12:38:56          	            	-([]string) (len=38) {
12:38:56          	            	+([]string) (len=39) {
12:38:56          	            	  (string) (len=21) "alertmanager.base.yml",
12:38:56          	            	@@ -5,2 +5,3 @@
12:38:56          	            	  (string) (len=16) "alertmanager.yml",
12:38:56          	            	+ (string) (len=25) "clickhouse-server.err.log",
12:38:56          	            	  (string) (len=21) "clickhouse-server.log",
12:38:56          	Test:       	TestDownloadLogs
12:38:56  --- FAIL: TestDownloadLogs (0.56s)
```

So far, we have been redirecting all components' error logs to stdout (supervisord has this in each config - `redirect_stderr = true`), which is convenient and which also helps writing API tests that won't fail.


**What**:
This PR:
- removes that additional error log configuration, since clickhouse errors already show up in `clickhouse-server.log`;
- removes the rotation configuration, since it is fully controlled by supervisord (example below)
```
stdout_logfile = /srv/logs/clickhouse-server.log
stdout_logfile_maxbytes = 50MB
stdout_logfile_backups = 2
```
