### PR TITLE
Missing settings to use keepalive in some locations

### DIFF
--- a/update/ansible/playbook/tasks/roles/nginx/files/conf.d/pmm.conf
+++ b/update/ansible/playbook/tasks/roles/nginx/files/conf.d/pmm.conf
@@ -145,16 +145,22 @@
     location /prometheus {
       proxy_pass http://127.0.0.1:9090;
       proxy_read_timeout 600;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
     location /prometheus/api/v1 {
       proxy_pass http://vmproxy;
       proxy_read_timeout 600;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
     
     # VictoriaMetrics
     location /victoriametrics/ {
       proxy_pass http://127.0.0.1:9090/prometheus/;
       proxy_read_timeout 600;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
       client_body_buffer_size 10m;
     }
 
@@ -162,15 +168,21 @@
     location /prometheus/rules {
       proxy_pass http://127.0.0.1:8880/api/v1/rules;
       proxy_read_timeout 600;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
     location /prometheus/alerts {
       proxy_pass http://127.0.0.1:8880/api/v1/alerts;
       proxy_read_timeout 600;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
 
     # Alertmanager
     location /alertmanager {
       proxy_pass http://127.0.0.1:9093;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
     }
 
     # Swagger UI


### PR DESCRIPTION
We have keepalives enabled in upstream blocks, but some of the locations are missing the proxy changes required to use it. 
[10 top nginx configuration mistakes](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#no-keepalives)

This is contributed as part of Percona support case **CS0040376**.