### PR TITLE
PMM-7: extract test env workaround

### DIFF
--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -61,9 +61,14 @@ jobs:
           pushd tools && go mod download -x
           popd        && go mod download -x
 
-      - name: Initialize CI environment
-        run: make env-compose-up # the container workdir is /root/go/src/github.com/percona/pmm
-
+      - name: Launch PMM Server (see docker-compose.yml)
+        run: |
+          # Note: launching the container with --wait fails for an unknown reason.
+          # A temporary workaround is to run it manually. To be reverted once the issue is resolved.
+          # make env-compose-up # the container workdir is /root/go/src/github.com/percona/pmm
+          docker compose --profile pmm up -d
+          sleep 100s
+          docker logs pmm-server
       - name: Restore Go build cache
         if: ${{ fromJSON(env.DEVCONTAINER_CACHE_ENABLED) }}
         continue-on-error: true

--- a/managed/services/grafana/client_test.go
+++ b/managed/services/grafana/client_test.go
@@ -65,7 +65,7 @@ func TestClient(t *testing.T) {
 			body := clientError.Body
 			body = strings.ReplaceAll(body, "\n", "") // different grafana versions format response differently
 			body = strings.ReplaceAll(body, " ", "")  // so we cleanup response from spaces and newlines to get unified result
-			assert.Equal(t, "{\"message\":\"Unauthorized\"}", body)
+			assert.Equal(t, "{\"extra\":null,\"message\":\"Unauthorized\",\"messageId\":\"auth.unauthorized\",\"statusCode\":401,\"traceID\":\"\"}", body)
 			assert.Equal(t, `Unauthorized`, clientError.ErrorMessage)
 			assert.Equal(t, none, role)
 			assert.Equal(t, "None", role.String())

--- a/managed/services/grafana/client_test.go
+++ b/managed/services/grafana/client_test.go
@@ -211,7 +211,7 @@ func TestClient(t *testing.T) {
 			authorization := req.Header.Get("Authorization")
 			_, err = c.CreateAnnotation(ctx, nil, time.Now(), "", authorization)
 			require.ErrorContains(t, err, "failed to create annotation: clientError: POST http://127.0.0.1:3000/api/annotations -> 401")
-			require.ErrorContains(t, err, "invalid username or password")
+			require.ErrorContains(t, err, "Invalid username or password")
 		})
 	})
 


### PR DESCRIPTION
PMM-7
CI currently fails because the health checks for pmm-server container is failing. This applies a workaround copied from https://github.com/percona/pmm/pull/2777 as a temporary workaround.

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
