### PR TITLE
PMM-7 fix the branch names containing forward slashes

### DIFF
--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -16,6 +16,8 @@ pmm_branch=$(git rev-parse --abbrev-ref HEAD)
 
 pmm_base_version=$(cat ${root_dir}/VERSION)
 full_pmm_version=${pmm_base_version}-${pmm_branch}-$(git rev-parse --short HEAD)
+# Replace '/' with '-' to prevent sed from failing on dependabot-authored PRs
+full_pmm_version=${full_pmm_version//\//-}
 
 # TODO Maybe it makes sense to use variable from job here
 if [[ ${pmm_branch} =~ release-* || \


### PR DESCRIPTION
PMM-7

Link to the Feature Build: SUBMODULES-3550

Dependabot is very likely to create branch names that contain forward slashes. This breaks the `sed -e` command in `build-server-rpm` script. This PR fixes the bug by replacing `/` with `-`.
