### PR TITLE
PMM-7 install yum prior to installing NodeJS

### DIFF
--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -29,8 +29,8 @@ ENV GO_VERSION 1.22.0
 ENV GO_RELEASER_VERSION 1.24.0
 
 RUN if [ `uname -i` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \
-    wget --progress=dot:giga https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz -O /tmp/golang.tar.gz && \
-    wget --progress=dot:giga https://github.com/goreleaser/goreleaser/releases/download/v${GO_RELEASER_VERSION}/goreleaser-${GO_RELEASER_VERSION}-1.`uname -i`.rpm -O /tmp/goreleaser.rpm && \
+    curl -fSL -o /tmp/golang.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    curl -fSL -o /tmp/goreleaser.rpm https://github.com/goreleaser/goreleaser/releases/download/v${GO_RELEASER_VERSION}/goreleaser-${GO_RELEASER_VERSION}-1.`uname -i`.rpm && \
     tar -C /usr/local -xzf /tmp/golang.tar.gz && \
     yum install -y /tmp/goreleaser.rpm && \
     rm /tmp/golang.tar.gz /tmp/goreleaser.rpm

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -1,9 +1,9 @@
 FROM oraclelinux:9-slim
 
-# enable nodesource repo for nodejs
-RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
-RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 RUN microdnf install -y yum
+# enable nodesource repo for nodejs
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
 RUN yum update -y && \
     yum install -y --setopt=skip_missing_names_on_install=False \

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -29,8 +29,8 @@ ENV GO_VERSION 1.22.0
 ENV GO_RELEASER_VERSION 1.24.0
 
 RUN if [ `uname -i` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \
-    curl -fSL -o /tmp/golang.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz && \
-    curl -fSL -o /tmp/goreleaser.rpm https://github.com/goreleaser/goreleaser/releases/download/v${GO_RELEASER_VERSION}/goreleaser-${GO_RELEASER_VERSION}-1.`uname -i`.rpm && \
+    curl -fSsL -o /tmp/golang.tar.gz https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz && \
+    curl -fSsL -o /tmp/goreleaser.rpm https://github.com/goreleaser/goreleaser/releases/download/v${GO_RELEASER_VERSION}/goreleaser-${GO_RELEASER_VERSION}-1.`uname -i`.rpm && \
     tar -C /usr/local -xzf /tmp/golang.tar.gz && \
     yum install -y /tmp/goreleaser.rpm && \
     rm /tmp/golang.tar.gz /tmp/goreleaser.rpm

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -2,7 +2,7 @@ FROM oraclelinux:9-slim
 
 RUN microdnf install -y yum
 # enable nodesource repo for nodejs
-RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
 RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
 
 RUN yum update -y && \


### PR DESCRIPTION
PMM-7

This patch fixes the problem where NodeJS install script requires either `dnf` or `yum` as a package manager. If those can't be found, the script fails. It seems like the behavior must have changed in the recent versions of the script.

Tested: https://pmm.cd.percona.com/job/rpm-build-3/4/console
