### PR TITLE
PMM-12986: `PostgreSQL connections in use` alert rule template not wo…

### DIFF
--- a/managed/data/iatemplates/postgresql_too_many_connections.yml
+++ b/managed/data/iatemplates/postgresql_too_many_connections.yml
@@ -4,8 +4,12 @@ templates:
     version: 1
     summary: PostgreSQL connections in use
     expr: |-
-      sum(pg_stat_activity_count{datname!~"template.*|postgres"})
-      > bool pg_settings_max_connections * [[ .threshold ]] / 100
+      sum by(agent_id, agent_type, instance, node_id, node_name) 
+      (pg_stat_activity_count{datname!~"template.*|postgres"}) 
+      /
+      on(agent_id, agent_type, instance, node_id, node_name) 
+      pg_settings_max_connections * 100 
+      > [[ .threshold ]]
     params:
       - name: threshold
         summary: A percentage from configured maximum


### PR DESCRIPTION
…rking

The expression used for alerting iterates over `pg_settings_max_connections` and compares the results to the sum of *all connections from all instances*.

This commit changes that behaviour to work per instance.

FB: https://github.com/Percona-Lab/pmm-submodules/pull/3577
https://perconadev.atlassian.net/browse/PMM-12986
