### PR TITLE
PMM-7 fix action-slack-notify

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
 
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@v2.2.1
 
   workflow_failure:
     if: ${{ failure() }}
@@ -169,4 +169,4 @@ jobs:
 
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@v2.2.1


### PR DESCRIPTION
They not only bumped up the version. This action now calls a [third-party action](https://github.com/rtCamp/action-slack-notify/compare/v2.2.1...v2.3.0#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R10), which is not listed with us. I was afraid it may leak secrets, so we'd better pin the version we know.

PMM-7

