### PR TITLE
PMM-12641 Fix the dashboard upgrade

### DIFF
--- a/build/ansible/roles/initialization/tasks/main.yml
+++ b/build/ansible/roles/initialization/tasks/main.yml
@@ -27,56 +27,61 @@
 
 - name: Set need_upgrade fact
   set_fact:
-    need_upgrade: not pmm_current_version is version(pmm_image_version, '>=')
+    need_upgrade: "{{ pmm_current_version is version(pmm_image_version, '<') }}"
 
 - name: Print current PMM and image versions
   debug:
     msg: "Current version: {{ pmm_current_version }} Image Version: {{ pmm_image_version }}"
 
-- name: Enable maintenance mode before upgrade
-  copy:
-    src: maintenance.html
-    dest: /usr/share/pmm-server/maintenance/
-    owner: pmm
-    group: pmm
-    mode: 0644
+- name: Print need_upgrade fact
+  debug:
+    msg: "Need upgrade: {{ need_upgrade }}"
 
-- name: Upgrade dashboards
-  include_role:
-    name: dashboards
+- name: Perform upgrade tasks
+  block:
+    - name: Enable maintenance mode before upgrade
+      copy:
+        src: maintenance.html
+        dest: /usr/share/pmm-server/maintenance/
+        owner: pmm
+        group: pmm
+        mode: 0644
+    
+    - name: Upgrade dashboards
+      include_role:
+        name: dashboards
+    
+    - name: Copy file with image version
+      copy:
+        src: /usr/share/percona-dashboards/VERSION
+        dest: /srv/grafana/PERCONA_DASHBOARDS_VERSION
+        owner: pmm
+        group: pmm
+        mode: 0644
+        remote_src: yes
+    
+    - name: Create a backup directory
+      file:
+        path: /srv/backup
+        state: directory
+        owner: pmm
+        group: pmm
+        mode: 0775
+
+    - name: Wait for PMM to be ready
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:7772/v1/readyz"
+        status_code: 200
+        method: GET
+      retries: 20
+      delay: 5
+    
+    - name: Disable maintenance mode
+      file:
+        state: absent
+        path: /usr/share/pmm-server/maintenance/maintenance.html
   when: need_upgrade
-
-- name: Copy file with image version
-  copy:
-    src: /usr/share/percona-dashboards/VERSION
-    dest: /srv/grafana/PERCONA_DASHBOARDS_VERSION
-    owner: pmm
-    group: pmm
-    mode: 0644
-    remote_src: yes
-  when: need_upgrade
-
-- name: Create a backup directory
-  file:
-    path: /srv/backup
-    state: directory
-    owner: pmm
-    group: pmm
-    mode: 0775
 
 # Note: we want to leave this for some time until we achieve stable builds
 - name: Output pmm-managed logs
   shell: sleep 10 && tail -n 300 /srv/logs/pmm-managed.log
-
-- name: Wait for PMM to be ready
-  ansible.builtin.uri:
-    url: "http://127.0.0.1:7772/v1/readyz"
-    status_code: 200
-    method: GET
-  retries: 20
-  delay: 5
-
-- name: Disable maintenance mode
-  file:
-    state: absent
-    path: /usr/share/pmm-server/maintenance/maintenance.html

--- a/build/ansible/roles/initialization/tasks/main.yml
+++ b/build/ansible/roles/initialization/tasks/main.yml
@@ -68,6 +68,10 @@
         group: pmm
         mode: 0775
 
+    # Note: we want to leave this for some time until we achieve stable builds
+    - name: Output pmm-managed logs
+      shell: sleep 10 && tail -n 300 /srv/logs/pmm-managed.log
+
     - name: Wait for PMM to be ready
       ansible.builtin.uri:
         url: "http://127.0.0.1:7772/v1/readyz"
@@ -81,7 +85,3 @@
         state: absent
         path: /usr/share/pmm-server/maintenance/maintenance.html
   when: need_upgrade
-
-# Note: we want to leave this for some time until we achieve stable builds
-- name: Output pmm-managed logs
-  shell: sleep 10 && tail -n 300 /srv/logs/pmm-managed.log


### PR DESCRIPTION
This fixes a bug where, due to a wrong ansible formula, PMM would upgrade the dashboards no matter what :)

PMM-12641

Link to the Feature Build: SUBMODULES-3599

<details><summary>Faulty logs</summary>
<p>
[ec2-user@ip-10-178-1-214 ~]$ docker exec pmm-server cat /srv/logs/pmm-update-perform-init.log
ProjectName: pmm-update
Version: 3.0.0
PMMVersion: 3.0.0
Timestamp: 2024-03-21 00:22:05 (UTC)
FullCommit: f9fd3a773f757c4cdfedc86681093eabdf6095d3
Starting "ansible-playbook --flush-cache /opt/ansible/pmm-docker/init.yml" ...
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [initialization : Get current version] ************************************
ok: [localhost]

TASK [initialization : Get image version] **************************************
ok: [localhost]

TASK [initialization : Set current version if VERSION doesn't exist] ***********
skipping: [localhost]

TASK [initialization : Setting current PMM version] ****************************
ok: [localhost]

TASK [initialization : Setting current PMM image version] **********************
ok: [localhost]

TASK [initialization : Set need_upgrade fact] **********************************
ok: [localhost]

TASK [initialization : Print current PMM and image versions] *******************
ok: [localhost] => {
    "msg": "Current version: 3.0.0 Image Version: 3.0.0"
}

TASK [initialization : Enable maintenance mode before upgrade] *****************
ok: [localhost]

TASK [Upgrade dashboards] ******************************************************

TASK [dashboards : Get plugin list] ********************************************
ok: [localhost]

TASK [dashboards : Delete older plugins] ***************************************
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/grafana-clickhouse-datasource', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 230, 'inode': 38952651, 'dev': 39, 'nlink': 4, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/grafana-piechart-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 277, 'inode': 50424402, 'dev': 39, 'nlink': 4, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/grafana-polystat-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 255, 'inode': 1117878, 'dev': 39, 'nlink': 5, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/grafana-worldmap-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 188, 'inode': 17361044, 'dev': 39, 'nlink': 6, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/jdbranham-diagram-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 175, 'inode': 38952661, 'dev': 39, 'nlink': 3, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/natel-discrete-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 191, 'inode': 46595502, 'dev': 39, 'nlink': 4, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/petrslavotinek-carpetplot-panel', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 4096, 'inode': 58998806, 'dev': 39, 'nlink': 7, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [localhost] => (item={'path': '/usr/share/percona-dashboards/panels/pmm-app', 'mode': '0755', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 18, 'inode': 42566029, 'dev': 39, 'nlink': 3, 'atime': 0.0, 'mtime': 1711028062.0, 'ctime': 1711222397.6157818, 'gr_name': 'pmm', 'pw_name': 'pmm', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})

TASK [dashboards : Copy plugins to the plugin directory] ***********************
changed: [localhost]

TASK [dashboards : Set permissions for the plugin directory] *******************
changed: [localhost]

TASK [dashboards : Restart grafana with new plugins] ***************************
changed: [localhost] => (item=stop)
changed: [localhost] => (item=remove)
changed: [localhost] => (item=add)

TASK [initialization : Copy file with image version] ***************************
ok: [localhost]

TASK [initialization : Create a backup directory] ******************************
ok: [localhost]

TASK [initialization : Output pmm-managed logs] ********************************
changed: [localhost]

TASK [initialization : Wait for PMM to be ready] *******************************
ok: [localhost]

TASK [initialization : Disable maintenance mode] *******************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=18   changed=6    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0

</p>
</details> 

The fix has been tested on the feature build instance. ✅ 
<details><summary>Logs (cat /srv/logs/pmm-update-perform-init.log)</summary>
<p>
Starting "ansible-playbook --flush-cache /opt/ansible/pmm-docker/init.yml" ...
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [initialization : Get current version] ************************************
ok: [localhost]

TASK [initialization : Get image version] **************************************
ok: [localhost]

TASK [initialization : Set current version if VERSION doesn't exist] ***********
skipping: [localhost]

TASK [initialization : Setting current PMM version] ****************************
ok: [localhost]

TASK [initialization : Setting current PMM image version] **********************
ok: [localhost]

TASK [initialization : Set need_upgrade fact] **********************************
ok: [localhost]

TASK [initialization : Print current PMM and image versions] *******************
ok: [localhost] => {
    "msg": "Current version: 3.0.0 Image Version: 3.0.0"
}

TASK [initialization : Print need_upgrade fact] ********************************
ok: [localhost] => {
    "msg": "Need upgrade: False"
}

TASK [initialization : Enable maintenance mode before upgrade] *****************
skipping: [localhost]

TASK [Upgrade dashboards] ******************************************************
skipping: [localhost]

TASK [initialization : Copy file with image version] ***************************
skipping: [localhost]

TASK [initialization : Create a backup directory] ******************************
skipping: [localhost]

TASK [initialization : Wait for PMM to be ready] *******************************
skipping: [localhost]

TASK [initialization : Disable maintenance mode] *******************************
skipping: [localhost]

TASK [initialization : Output pmm-managed logs] ********************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=9    changed=1    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0

</p>
</details> 

NOTE: PMM v2 is not affected.
