### PR TITLE
PMM-7: update test to check that intervals remain unchanged

### DIFF
--- a/api-tests/server/advisors_test.go
+++ b/api-tests/server/advisors_test.go
@@ -163,7 +163,7 @@ func TestChangeSecurityChecks(t *testing.T) {
 			}
 		})
 
-		t.Run("change interval error", func(t *testing.T) {
+		t.Run("unrecognized interval is ignored", func(t *testing.T) {
 			t.Cleanup(func() { restoreCheckIntervalDefaults(t) })
 
 			resp, err := managementClient.Default.SecurityChecks.ListSecurityChecks(nil)
@@ -185,7 +185,7 @@ func TestChangeSecurityChecks(t *testing.T) {
 			}
 
 			_, err = managementClient.Default.SecurityChecks.ChangeSecurityChecks(params)
-			pmmapitests.AssertAPIErrorf(t, err, 400, codes.InvalidArgument, "invalid value for enum type: \"unknown_interval\"")
+			require.NoError(t, err)
 
 			resp, err = managementClient.Default.SecurityChecks.ListSecurityChecks(nil)
 			require.NoError(t, err)


### PR DESCRIPTION
PMM-7

Following this protobuf change, unknown enums no longer returns an error for us, this caused the previous grpc error check to fail (since the test was expecting an error).

This change drops the error check, and now the test just confirms that the check intervals remain unchanged.

Link to the Feature Build: 
SUBMODULES-3600
