### PR TITLE
PMM-7 Upgrade codecov-action

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -70,6 +70,7 @@ jobs:
           file: cover.out
           flags: admin
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run debug commands on failure
         if: ${{ failure() }}

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -65,7 +65,7 @@ jobs:
         run: make test-cover
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: cover.out
           flags: admin

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -163,3 +163,4 @@ jobs:
           env | sort
           go env | sort
           git status
+          node --version

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -75,10 +75,8 @@ jobs:
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |
-          env
-          go version
-          go env
-          pwd
+          env | sort
+          go env | sort
           git status
 
   cli-test:
@@ -162,9 +160,6 @@ jobs:
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |
-          env
-          go version
-          go env
-          node --version
-          pwd
+          env | sort
+          go env | sort
           git status

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -164,3 +164,5 @@ jobs:
           go env | sort
           git status
           node --version
+          npx --version
+          npx playwright --version

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -102,7 +102,7 @@ jobs:
         run: make test-cover
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: cover.out
           flags: agent

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -108,6 +108,7 @@ jobs:
           flags: agent
           env_vars: MYSQL_IMAGE,MONGO_IMAGE,POSTGRES_IMAGE,PMM_SERVER_IMAGE
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run debug commands on failure
         if: ${{ failure() }}

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -88,7 +88,7 @@ jobs:
         run: docker exec -i pmm-server make -C managed test-update
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: managed/cover.out
           flags: managed

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -94,6 +94,7 @@ jobs:
           flags: managed
           env_vars: PMM_SERVER_IMAGE
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Cache
         if: ${{ fromJSON(env.DEVCONTAINER_CACHE_ENABLED) }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -68,3 +68,5 @@ jobs:
           file: cover.out
           flags: update
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -63,7 +63,7 @@ jobs:
         run: docker exec pmm-update-server make -C /root/go/src/github.com/percona/pmm/update run-race-cover RUN_FLAGS='-debug -check'
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: cover.out
           flags: update

--- a/.github/workflows/vmproxy.yml
+++ b/.github/workflows/vmproxy.yml
@@ -72,6 +72,7 @@ jobs:
           file: cover.out
           flags: vmproxy
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run debug commands on failure
         if: ${{ failure() }}

--- a/.github/workflows/vmproxy.yml
+++ b/.github/workflows/vmproxy.yml
@@ -67,7 +67,7 @@ jobs:
         run: make test-cover
 
       - name: Upload coverage results
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: cover.out
           flags: vmproxy
@@ -76,8 +76,6 @@ jobs:
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |
-          env
-          go version
-          go env
-          pwd
+          env | sort
+          go env | sort
           git status


### PR DESCRIPTION
**Background**

We lost codecov.io uploads for some reason. Maybe because of `CODECOV_TOKEN`, which wasn't being passed.

This PR is to rectify that and upgrade codecov's action to the latest.