### PR TITLE
PMM-7 upgrade Go to v1.22

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - version: 1.21.x
+          - version: 1.22.x
             may-fail: false
           - version: tip
             may-fail: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used only for API tests.
 
-FROM golang:1.21
+FROM golang:1.22
 
 RUN export GOPATH=$(go env GOPATH) && \
     mkdir -p $GOPATH/src/github.com/percona/pmm

--- a/build/docker/rpmbuild/Dockerfile
+++ b/build/docker/rpmbuild/Dockerfile
@@ -23,7 +23,7 @@ RUN yum update -y && \
     yum clean all && rm -rf /var/cache/yum
 
 # keep that format for easier search
-ENV GO_VERSION 1.21.7
+ENV GO_VERSION 1.22.2
 ENV GO_RELEASER_VERSION 1.24.0
 
 RUN if [ `uname -i` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -25,7 +25,7 @@ RUN yum update -y && \
     yum clean all && rm -rf /var/cache/yum
 
 # keep that format for easier search
-ENV GO_VERSION 1.21.7
+ENV GO_VERSION 1.22.2
 ENV GO_RELEASER_VERSION 1.24.0
 
 RUN if [ `uname -i` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \

--- a/devcontainer.Dockerfile
+++ b/devcontainer.Dockerfile
@@ -2,7 +2,7 @@ ARG PMM_SERVER_IMAGE="perconalab/pmm-server:dev-latest"
 FROM $PMM_SERVER_IMAGE
 
 ARG PMM_SERVER_IMAGE
-ARG GO_VERSION="1.21.x"
+ARG GO_VERSION="1.22.x"
 
 RUN echo "Building with: GO: $GO_VERSION, PMM: $PMM_SERVER_IMAGE"
 ENV GOPATH=/root/go

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,8 @@
 module github.com/percona/pmm/tools
 
-go 1.21
+go 1.22
+
+toolchain go1.22.2
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.20.5-percona
 
@@ -20,7 +22,7 @@ require (
 	github.com/quasilyte/go-consistent v0.6.0
 	github.com/reviewdog/reviewdog v0.17.0
 	github.com/vburenin/ifacemaker v1.2.1
-	github.com/vektra/mockery/v2 v2.40.2
+	github.com/vektra/mockery/v2 v2.43.0
 	golang.org/x/perf v0.0.0-20230717203022-1ba3a21238c9
 	golang.org/x/tools v0.21.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -682,8 +682,8 @@ github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinC
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/vburenin/ifacemaker v1.2.1 h1:3Vq8B/bfBgjWTkv+jDg4dVL1KHt3k1K4lO7XRxYA2sk=
 github.com/vburenin/ifacemaker v1.2.1/go.mod h1:5WqrzX2aD7/hi+okBjcaEQJMg4lDGrpuEX3B8L4Wgrs=
-github.com/vektra/mockery/v2 v2.40.2 h1:JKuQ74IXibMCGKG6F0yvH/s2sNs1CHy/nGBP0We5DJ8=
-github.com/vektra/mockery/v2 v2.40.2/go.mod h1:KYBZF/7sqOa86BaOZPYsoCZWEWLS90a5oBLg2pVudxY=
+github.com/vektra/mockery/v2 v2.43.0 h1:9jgLwYbFIKPwWJUeK6Y+0s9oLRIGXLfW4FWlmF9R8c0=
+github.com/vektra/mockery/v2 v2.43.0/go.mod h1:XNTE9RIu3deGAGQRVjP1VZxGpQNm0YedZx4oDs3prr8=
 github.com/vvakame/sdlog v1.2.0 h1:gwZRXZ0EmhJQJN/Do/+PTQigcmFiSqZ07aDjxqGOLT8=
 github.com/vvakame/sdlog v1.2.0/go.mod h1:gFYv2g/iR3pJSxkJz0YnkNmhNbXT5R3PzWsfZKGQADY=
 github.com/xanzy/go-gitlab v0.96.0 h1:LGkZ+wSNMRtHIBaYE4Hq3dZVjprwHv3Y1+rhKU3WETs=

--- a/update/.devcontainer/install-dev-tools.sh
+++ b/update/.devcontainer/install-dev-tools.sh
@@ -8,7 +8,7 @@ set -o errexit
 set -o xtrace
 
 # download (in the background) the same verison as used by PMM build process
-curl -sS https://dl.google.com/go/go1.21.7.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
+curl -sS https://dl.google.com/go/go1.22.2.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
 
 # to install man pages
 sed -i '/nodocs/d' /etc/yum.conf

--- a/update/docker-compose.yml
+++ b/update/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       # for tests
       - PMM_SERVER_IMAGE=${PMM_SERVER_IMAGE:-percona/pmm-server:2}
-      - GO_VERSION=${GO_VERSION:-1.21.x}
+      - GO_VERSION=${GO_VERSION:-1.22.x}
       - PATH=/root/go/bin:$PATH
       - REVIEWDOG_GITHUB_API_TOKEN=${REVIEWDOG_GITHUB_API_TOKEN}
     volumes:


### PR DESCRIPTION
PMM-7

This PR should aid in making [dependabot](https://github.com/percona/pmm/pull/2985) PRs pass.

TODO: publish the `rpmbuild` containers before merging

