### PR TITLE
PMM-7 Update gpg key to fix percona-release package installation.

### DIFF
--- a/build/ansible/roles/pmm2-images/tasks/main.yml
+++ b/build/ansible/roles/pmm2-images/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Install the GPG key for repo.percona.com
   rpm_key:
     state: present
-    key: https://downloads.percona.com/downloads/RPM-GPG-KEY-percona
+    key: https://repo.percona.com/yum/PERCONA-PACKAGING-KEY
 
 - name: Packages                   | Add PMM2 Server YUM repository for EL7
   when:


### PR DESCRIPTION
PMM-7 Update gpg key to fix percona-release package installation.

Link to the Feature Build: SUBMODULES-3657