### PR TITLE
PMM-13197 Fix update.yml workflow

### DIFF
--- a/update/.devcontainer/install-dev-tools.sh
+++ b/update/.devcontainer/install-dev-tools.sh
@@ -8,38 +8,54 @@ set -o errexit
 set -o xtrace
 
 # download (in the background) the same verison as used by PMM build process
-curl -sS https://dl.google.com/go/go1.22.2.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
+curl -sSL https://dl.google.com/go/go1.22.5.linux-amd64.tar.gz -o /tmp/golang.tar.gz &
 
 # to install man pages
 sed -i '/nodocs/d' /etc/yum.conf
 
 # enable experimental repository with latest development packages
 sed -i'' -e 's^/release/^/experimental/^' /etc/yum.repos.d/pmm2-server.repo
-percona-release enable original testing
 
 RHEL=$(rpm --eval '%{rhel}')
 if [ "$RHEL" = "7" ]; then
-    # this mirror always fails, on both AWS and github
-    echo "exclude=mirror.es.its.nyu.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf
-    yum clean plugins
-    # https://stackoverflow.com/questions/26734777/yum-error-cannot-retrieve-metalink-for-repository-epel-please-verify-its-path
-    sed -i "s/metalink=https/metalink=http/" /etc/yum.repos.d/epel.repo
+    # disable fastestmirror plugin, which mostly fails due to CentOS 7 being EOL
+    sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/fastestmirror.conf
+
+    if [ "$PMM_SERVER_IMAGE" = "percona/pmm-server:2.0.0" ]; then
+      sed -i -e 's/^\(mirrorlist\)/#\1/g' /etc/yum.repos.d/CentOS-Base.repo
+      sed -i -e 's/^#baseurl.*/baseurl=http:\/\/vault.centos.org\/centos\/$releasever\/os\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+
+      # https://stackoverflow.com/questions/26734777/yum-error-cannot-retrieve-metalink-for-repository-epel-please-verify-its-path
+      yum --disablerepo=epel install -y ca-certificates-2020.2.41
+      yum install -y gcc-4.8.5 glibc-static-2.17.317
+    else
+      yum --disablerepo=epel update -y ca-certificates
+      yum --disablerepo="*" --enablerepo=base --enablerepo=updates install -y gcc glibc-static
+
+      sed -i -e 's/^\(mirrorlist\)/#\1/g' /etc/yum.repos.d/CentOS-Base.repo
+      sed -i -e 's/^#baseurl.*/baseurl=http:\/\/vault.centos.org\/centos\/$releasever\/os\/$basearch\//g' /etc/yum.repos.d/CentOS-Base.repo
+    fi
+
+    yum clean all
+    yum makecache fast
 fi
+
+yum update -y percona-release
+percona-release enable pmm2-client testing
 
 # reinstall with man pages
 yum install -y yum rpm
 yum reinstall -y yum rpm
 
-yum install -y gcc git make pkgconfig \
-    ansible \
+yum install -y git make pkgconfig ansible \
     mc tmux psmisc lsof which iproute \
     bash-completion \
     man man-pages
 
 if [ "$RHEL" = '7' ]; then
-    yum install -y ansible-lint glibc-static bash-completion-extras
+    yum install -y ansible-lint bash-completion-extras
 else
-    yum install -y ansible-lint glibc-static --enablerepo=ol9_codeready_builder
+    yum --enablerepo=ol9_codeready_builder install -y gcc glibc-static ansible-lint
 fi
 
 fg || true


### PR DESCRIPTION
PMM-13197

**Issue**
Currently, the update workflow fails on some PMM image versions as yum can't reach RHEL repository mirrors.

**Solution**
In this PR we are working around the issue by changing the base URL to point to the archive.

Link to the Feature Build: N/A, since we are fixing the github workflow
