### PR TITLE
PMM-7 Run supervisor as pmm during build

### DIFF
--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -69,6 +69,7 @@
         - /var/log/nginx
         - /var/lib/pgsql
         - /srv/pmm-encryption.key
+        - /var/cache/yum
 
     - name: Remove users created by installers
       user:

--- a/build/ansible/roles/pmm-images/tasks/main.yml
+++ b/build/ansible/roles/pmm-images/tasks/main.yml
@@ -160,6 +160,9 @@
 # During build time, this will be the first start of supervisord.
 - name: Start supervisord
   shell: supervisord -c /etc/supervisord.conf &
+  become: true
+  become_user: pmm
+  become_method: su
 
 - name: Run initialization playbook
   include_role:

--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -33,11 +33,11 @@ RUN install -T -p -m 644 /opt/ansible/ansible.cfg /etc/ansible/ansible.cfg && \
     ansible-playbook -vvv /opt/ansible/pmm-docker/post-build.yml && \
     sed -i '/^assumeyes/d' /etc/dnf/dnf.conf
 
-LABEL org.opencontainers.image.created ${BUILD_DATE}
-LABEL org.opencontainers.image.licenses AGPL-3.0
-LABEL org.opencontainers.image.title Percona Monitoring and Management
-LABEL org.opencontainers.image.vendor Percona LLC
-LABEL org.opencontainers.image.version ${VERSION}
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.licenses=AGPL-3.0
+LABEL org.opencontainers.image.title="Percona Monitoring and Management"
+LABEL org.opencontainers.image.vendor="Percona LLC"
+LABEL org.opencontainers.image.version=${VERSION}
 
 USER pmm
 


### PR DESCRIPTION
PMM-7

Link to the Feature Build: SUBMODULES-3770

This PR is meant to solve the problem we are currently seeing at build time, during the execution of the ansible `dashboards` role: 
```
# supervisorctl stop grafana
"stdout": "grafana: ERROR (not running)"

# supervisorctl remove grafana
"stdout": "ERROR: process/group still running: grafana"
```

The problem is most probably due to the fact that we do not start `supervisord` as `pmm`, so it ends up being unable to stop a process owned by root. This leads to an eventual pipeline failure resulting in an interrupted build. 

The issues is not reproducible in 100% of builds, but may still be affecting more than 50% of v3 builds.

