### PR TITLE
PMM-7 Better grafana start/stop handler

### DIFF
--- a/build/ansible/roles/dashboards/tasks/main.yml
+++ b/build/ansible/roles/dashboards/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: Stop Grafana
-  community.general.supervisorctl:
-    name: grafana
-    state: stopped
-  become: true
-  become_user: pmm
-  become_method: su
-  register: stop_grafana
-
 - name: Retrieve Percona plugins
   find:
     paths: /usr/share/percona-dashboards/panels/
@@ -44,11 +35,12 @@
     mode: 0644
     remote_src: yes
 
-- name: Start Grafana
-  community.general.supervisorctl:
-    name: grafana
-    state: started
+- name: Restart Grafana service with new plugins 
+  shell: "supervisorctl {{ item }} grafana"
   become: true
   become_user: pmm
   become_method: su
-  when: stop_grafana.changed == true
+  loop:
+    - stop
+    - remove
+    - add

--- a/build/ansible/roles/dashboards/tasks/main.yml
+++ b/build/ansible/roles/dashboards/tasks/main.yml
@@ -6,6 +6,7 @@
   become: true
   become_user: pmm
   become_method: su
+  register: stop_grafana
 
 - name: Retrieve Percona plugins
   find:
@@ -50,3 +51,4 @@
   become: true
   become_user: pmm
   become_method: su
+  when: stop_grafana.changed == true


### PR DESCRIPTION
PMM-7

Link to the Feature Build: SUBMODULES-3778

We are still seeing issues when we try to start grafana during the execution of the `dashboards` role. Reverting to `stop/remove/add` (as it was before) will hopefully fix it.