### PR TITLE
PMM-13571: Include fcv and pbm collectors in default scrape config

### DIFF
--- a/managed/services/victoriametrics/scrape_configs.go
+++ b/managed/services/victoriametrics/scrape_configs.go
@@ -415,34 +415,29 @@ func scrapeConfigsForMongoDBExporter(params *scrapeConfigParams) ([]*config.Scra
 	if hr != nil {
 		r = append(r, hr)
 	}
+
+	var defaultCollectors []string
+	if !params.pmmAgentVersion.Less(version.MustParse("2.43.0-0")) {
+		defaultCollectors = append(defaultCollectors, "fcv", "pbm")
+	}
+
 	if params.agent.MongoDBOptions != nil && params.agent.MongoDBOptions.EnableAllCollectors {
-		defaultCollectors := []string{
-			"dbstats",
-			"indexstats",
-			"collstats",
-		}
+		defaultCollectors = append(defaultCollectors, "dbstats", "indexstats", "collstats")
 		if !params.pmmAgentVersion.Less(version.MustParse("2.41.1-0")) {
 			defaultCollectors = append(defaultCollectors, "shards")
 		}
 		if !params.pmmAgentVersion.Less(version.MustParse("2.42.0-0")) {
 			defaultCollectors = append(defaultCollectors, "currentopmetrics")
 		}
-		if !params.pmmAgentVersion.Less(version.MustParse("2.43.0-0")) {
-			defaultCollectors = append(defaultCollectors, "fcv")
-		}
-		if !params.pmmAgentVersion.Less(version.MustParse("2.43.0-0")) {
-			defaultCollectors = append(defaultCollectors, "pbm")
-		}
+	}
+	defaultCollectors = collectors.FilterOutCollectors("", defaultCollectors, params.agent.DisabledCollectors)
+	lr, err := scrapeConfigForStandardExporter("lr", params.metricsResolution.LR, params, defaultCollectors)
+	if err != nil {
+		return nil, err
+	}
 
-		defaultCollectors = collectors.FilterOutCollectors("", defaultCollectors, params.agent.DisabledCollectors)
-		lr, err := scrapeConfigForStandardExporter("lr", params.metricsResolution.LR, params, defaultCollectors)
-		if err != nil {
-			return nil, err
-		}
-
-		if lr != nil {
-			r = append(r, lr)
-		}
+	if lr != nil {
+		r = append(r, lr)
 	}
 	return r, nil
 }

--- a/managed/services/victoriametrics/scrape_configs_test.go
+++ b/managed/services/victoriametrics/scrape_configs_test.go
@@ -799,6 +799,104 @@ func TestScrapeConfig(t *testing.T) {
 				assertScrapeConfigsEqual(t, expected[i], actual[i])
 			}
 		})
+		t.Run("Without enable-all option on v2.43+", func(t *testing.T) {
+			node := &models.Node{
+				NodeID:       "/node_id/cc663f36-18ca-40a1-aea9-c6310bb4738d",
+				NodeName:     "node_name",
+				Address:      "1.2.3.4",
+				CustomLabels: []byte(`{"_some_node_label": "foo"}`),
+			}
+			service := &models.Service{
+				ServiceID:    "/service_id/014647c3-b2f5-44eb-94f4-d943260a968c",
+				NodeID:       "/node_id/cc663f36-18ca-40a1-aea9-c6310bb4738d",
+				Address:      pointer.ToString("5.6.7.8"),
+				CustomLabels: []byte(`{"_some_service_label": "bar"}`),
+			}
+			agent := &models.Agent{
+				AgentID:      "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+				AgentType:    models.MongoDBExporterType,
+				CustomLabels: []byte(`{"_some_agent_label": "baz"}`),
+				ListenPort:   pointer.ToUint16(12345),
+			}
+
+			expected := []*config.ScrapeConfig{
+				{
+					JobName:        "mongodb_exporter_agent_id_75bb30d3-ef4a-4147-97a8-621a996611dd_hr",
+					ScrapeInterval: config.Duration(s.HR),
+					ScrapeTimeout:  scrapeTimeout(s.HR),
+					MetricsPath:    "/metrics",
+					Params: map[string][]string{
+						"collect[]": {"diagnosticdata", "replicasetstatus", "topmetrics"},
+					},
+					HTTPClientConfig: config.HTTPClientConfig{
+						BasicAuth: &config.BasicAuth{
+							Username: "pmm",
+							Password: "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+						},
+					},
+					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+						StaticConfigs: []*config.Group{{
+							Targets: []string{"4.5.6.7:12345"},
+							Labels: map[string]string{
+								"_some_agent_label":   "baz",
+								"_some_node_label":    "foo",
+								"_some_service_label": "bar",
+								"agent_id":            "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+								"agent_type":          "mongodb_exporter",
+								"instance":            "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+								"node_id":             "/node_id/cc663f36-18ca-40a1-aea9-c6310bb4738d",
+								"node_name":           "node_name",
+								"service_id":          "/service_id/014647c3-b2f5-44eb-94f4-d943260a968c",
+							},
+						}},
+					},
+				}, {
+					JobName:        "mongodb_exporter_agent_id_75bb30d3-ef4a-4147-97a8-621a996611dd_lr",
+					ScrapeInterval: config.Duration(s.LR),
+					ScrapeTimeout:  scrapeTimeout(s.LR),
+					MetricsPath:    "/metrics",
+					Params: map[string][]string{
+						"collect[]": {"fcv", "pbm"},
+					},
+					HTTPClientConfig: config.HTTPClientConfig{
+						BasicAuth: &config.BasicAuth{
+							Username: "pmm",
+							Password: "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+						},
+					},
+					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+						StaticConfigs: []*config.Group{{
+							Targets: []string{"4.5.6.7:12345"},
+							Labels: map[string]string{
+								"_some_agent_label":   "baz",
+								"_some_node_label":    "foo",
+								"_some_service_label": "bar",
+								"agent_id":            "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+								"agent_type":          "mongodb_exporter",
+								"instance":            "/agent_id/75bb30d3-ef4a-4147-97a8-621a996611dd",
+								"node_id":             "/node_id/cc663f36-18ca-40a1-aea9-c6310bb4738d",
+								"node_name":           "node_name",
+								"service_id":          "/service_id/014647c3-b2f5-44eb-94f4-d943260a968c",
+							},
+						}},
+					},
+				},
+			}
+
+			actual, err := scrapeConfigsForMongoDBExporter(&scrapeConfigParams{
+				host:              "4.5.6.7",
+				node:              node,
+				service:           service,
+				agent:             agent,
+				pmmAgentVersion:   version.MustParse("2.43.0"),
+				metricsResolution: s,
+			})
+			require.NoError(t, err)
+			require.Len(t, actual, len(expected))
+			for i := 0; i < len(expected); i++ {
+				assertScrapeConfigsEqual(t, expected[i], actual[i])
+			}
+		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
 			node := &models.Node{}


### PR DESCRIPTION
PMM-13571

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
