### PR TITLE
Remove Github version label from header

### DIFF
--- a/documentation/docs/css/pmm.css
+++ b/documentation/docs/css/pmm.css
@@ -65,3 +65,9 @@
             rgba(0,0,0,0.4) 95%
         );
 }
+
+/* Remove Github version label from header */
+
+.md-source__fact.md-source__fact--version {
+    display: none;
+}


### PR DESCRIPTION
Hidden via CSS only. Label represents the latest release fetched from Github. Can be removed again if normalized and we want to show up

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
