### PR TITLE
PMM 13680 Platform user api call

### DIFF
--- a/managed/services/grafana/client.go
+++ b/managed/services/grafana/client.go
@@ -900,7 +900,7 @@ func (c *Client) GetCurrentUserAccessToken(ctx context.Context) (string, error) 
 	headers.Set("Cookie", strings.Join(cookies, "; "))
 
 	var user currentUser
-	if err := c.do(ctx, http.MethodGet, "/percona-api/user/oauth-token", "", headers, nil, &user); err != nil {
+	if err := c.do(ctx, http.MethodGet, "/graph/percona-api/user/oauth-token", "", headers, nil, &user); err != nil {
 		var e *clientError
 		if errors.As(err, &e) && e.ErrorMessage == "Failed to get token" && e.Code == http.StatusInternalServerError {
 			return "", ErrFailedToGetToken


### PR DESCRIPTION
PMM-13680

Due to automatic redirect to subpath if missing introduced in Grafana 9.5 the custom api endpoint was failing due to a redirect to a non-existing api (localhost:443 inside the container).

After introducing the subpath as part of the url it doesn't get redirected a works correctly.

Link to the Feature Build: SUBMODULES-3824