### PR TITLE
Fix PMM Server port mapping

### DIFF
--- a/documentation/docs/how-to/secure.md
+++ b/documentation/docs/how-to/secure.md
@@ -40,7 +40,7 @@ docker run -d -p 443:8443 --name pmm-server  \
 !!! note alert alert-primary ""
     - The certificates must be owned by root. You can do this with: `chown 0:0 /etc/pmm-certs/*`
     - The mounted certificate directory (`/etc/pmm-certs` in this example) must contain the files `certificate.crt`, `certificate.key`, `ca-certs.pem` and `dhparam.pem`.
-    - For SSL encryption, the container must expose port 443 instead of 80.
+    - For SSL encryption, the container must publish port 443 instead of 80.
 
 ### Copying certificates
 

--- a/documentation/docs/how-to/secure.md
+++ b/documentation/docs/how-to/secure.md
@@ -32,15 +32,15 @@ To use your own, you can either:
 For example, if your own certificates are in `/etc/pmm-certs`:
 
 ```sh
-docker run -d -p 443:443 --volumes-from pmm-data \
-  --name pmm-server -v /etc/pmm-certs:/srv/nginx \
+docker run -d -p 443:8443 --name pmm-server  \
+  -v pmm-data:/srv -v /etc/pmm-certs:/srv/nginx \
   --restart always percona/pmm-server:3
 ```
 
 !!! note alert alert-primary ""
     - The certificates must be owned by root. You can do this with: `chown 0:0 /etc/pmm-certs/*`
     - The mounted certificate directory (`/etc/pmm-certs` in this example) must contain the files `certificate.crt`, `certificate.key`, `ca-certs.pem` and `dhparam.pem`.
-    - For SSL encryption, the container must publish on port 443 instead of 80.
+    - For SSL encryption, the container must expose port 443 instead of 80.
 
 ### Copying certificates
 


### PR DESCRIPTION
- Fix PMM Server port mapping
- Use `-v` to mount a volume vs `--volumes-from`, which is outdated

