### PR TITLE
Docs: update public-address page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ This project relies on the following dependencies:
 
 ## Run PMM-Server in Docker
 
-1. Run `docker run -d -p 80:80 -p 443:443  --name pmm-server public.ecr.aws/e7j3v3n0/pmm-server:3-dev-latest`.
+1. Run `docker run -d -p 80:8080 -p 443:8443  --name pmm-server public.ecr.aws/e7j3v3n0/pmm-server:3-dev-latest`.
 2. Open http://localhost/.
 
 Please note, the use of port 80 is discouraged and should be avoided. For optimal security, use port 443 along with a valid SSL certificate.

--- a/build/docker/server/README.md
+++ b/build/docker/server/README.md
@@ -43,4 +43,4 @@ You can use these environment variables (-e VAR) when running the Docker image.
 
 [Percona Monitoring and Management](https://docs.percona.com/percona-monitoring-and-management)
 
-[Setting up PMM Server with Docker](https://docs.percona.com/percona-monitoring-and-management/setting-up/server/docker.html)
+[Setting up PMM Server with Docker](https://docs.percona.com/percona-monitoring-and-management/3/install-pmm/install-pmm-server/index.html)

--- a/documentation/docs/advisors/develop_advisor_checks.md
+++ b/documentation/docs/advisors/develop_advisor_checks.md
@@ -227,7 +227,7 @@ To develop custom checks for PMM:
     - `PERCONA_TEST_CHECKS_RESEND_INTERVAL=2s` to define the frequency for sending the SA-based alerts to Alertmanager.
 
     ```sh
-    docker run -p 80:80 -p 443:443 --name pmm-server \
+    docker run -p 443:8443 --name pmm-server \
     -e PERCONA_TEST_CHECKS_FILE=/srv/custom-checks.yml \
     -e PERCONA_TEST_CHECKS_DISABLE_START_DELAY=true \
     -e PERCONA_TEST_CHECKS_RESEND_INTERVAL=2s \

--- a/documentation/docs/alert/contact_points.md
+++ b/documentation/docs/alert/contact_points.md
@@ -44,7 +44,7 @@ To use SMTP with a PMM Docker installation:
 
 2. Pass in the `.env` file to Docker run using the `--env-file` flag:
     ```
-    docker run --env-file=.env -p 443:443 -p 80:80 percona/pmm-server:3
+    docker run --env-file=.env -p 443:8443 percona/pmm-server:3
     ```
     This command starts a docker container and will keep running as long as the container is also running. Stopping the command (e.g with Ctrl+C) will stop the container hence, subsequent commands should be run in a new terminal.
 

--- a/documentation/docs/configure-pmm/configure.md
+++ b/documentation/docs/configure-pmm/configure.md
@@ -13,7 +13,6 @@ The **PMM Configuration** page gives you access to PMM setup's settings and inve
 * [Public address](public-address.md)
     * [Alerting](public-address.md#alerting)
     * [Microsoft Azure Monitoring](public-address.md#microsoft-azure-monitoring)
-    * [Public Address {: #public-address-1 }](public-address.md#public-address--public-address-1-)
 * [SSH Key](ssh.md)
 * [Alertmanager integration](alertmanager.md)
 * [Percona Platform](percona_platform.md)

--- a/documentation/docs/install-pmm/HA.md
+++ b/documentation/docs/install-pmm/HA.md
@@ -365,8 +365,8 @@ The PMM Server orchestrates the collection, storage, and visualization of metric
         ```sh
         docker run -d \
         --name ${PMM_ACTIVE_NODE_ID} \
-        -p 80:80 \
-        -p 443:443 \
+        -p 80:8080 \
+        -p 443:8443 \
         -p 9094:9094 \
         -p 9096:9096 \
         -p 9094:9094/udp \
@@ -435,8 +435,8 @@ The PMM Server orchestrates the collection, storage, and visualization of metric
         ```sh
         docker run -d \
         --name ${PMM_PASSIVE_NODE_ID} \
-        -p 80:80 \
-        -p 443:443 \
+        -p 80:8080 \
+        -p 443:8443 \
         -p 9094:9094 \
         -p 9096:9096 \
         -p 9094:9094/udp \
@@ -505,8 +505,8 @@ The PMM Server orchestrates the collection, storage, and visualization of metric
         ```sh
         docker run -d \
         --name ${PMM_PASSIVE2_NODE_ID} \
-        -p 80:80 \
-        -p 443:443 \
+        -p 80:8080 \
+        -p 443:8443 \
         -p 9094:9094 \
         -p 9096:9096 \
         -p 9094:9094/udp \

--- a/documentation/docs/install-pmm/install-pmm-server/baremetal/docker/index.md
+++ b/documentation/docs/install-pmm/install-pmm-server/baremetal/docker/index.md
@@ -74,4 +74,4 @@ You can install PMM Server with Watchtower in two ways:
 
     - Eliminate browser certificate warnings by configuring a [trusted certificate](../../../../how-to/secure.html#ssl-encryption).
 
-    - You can optionally enable an (insecure) HTTP connection by adding `--publish 80:80` to the `docker run` command. However, running PMM insecure is not recommended. You should also note that PMM Client *requires* TLS to communicate with the server, only working on a secure port.
+    - You can optionally enable an (insecure) HTTP connection by adding `--publish 80:8080` to the `docker run` command. However, running PMM insecure is not recommended. You should also note that PMM Client *requires* TLS to communicate with the server, only working on a secure port.


### PR DESCRIPTION
It seems like this link leads nowhere other than the page itself, which duplicates the [Public address] section.

Apart from that, the way it's rendered on the page feels broken:

<img width="729" alt="Screenshot 2025-02-04 at 12 29 18" src="https://github.com/user-attachments/assets/3b4e333c-e2f0-4721-9e3c-7701fc809f11" />

This PR also fixes the wrong port mappings in a few places.
