### PR TITLE
Isolate styling of numbered lists to PDF

### DIFF
--- a/documentation/docs/css/extra.css
+++ b/documentation/docs/css/extra.css
@@ -14,22 +14,15 @@
     margin-left: -1.7em;
     opacity: 1;
   }
-} 
-
-.md-sidebar__inner {
-    font-size: 0.65rem;   /* Font size */
-    line-height: 1.6;
-}
-
   /* Do not render html tags with this class in PDF */
   .no-pdf {
     display: none !important;
   }
-
-
-
   .tabbed-content {
     display: contents;
   }
+} 
+.md-sidebar__inner {
+    font-size: 0.65rem;   /* Font size */
+    line-height: 1.6;
 }
-  

--- a/documentation/docs/css/extra.css
+++ b/documentation/docs/css/extra.css
@@ -4,6 +4,16 @@
     top: 0.6rem;
     left: 0.6rem;
   }
+  /* Modify rendering of numbered lists in PDF */
+  .power-number+ol>li::before,
+  .power-number+ol ol>li::before {
+    background-color: var(--md-default-bg-color);
+    color: var(--md-typeset-color);
+    border-radius: 0;
+    width: 1.5em;
+    margin-left: -1.7em;
+    opacity: 1;
+  }
 } 
 
 .md-sidebar__inner {
@@ -16,16 +26,7 @@
     display: none !important;
   }
 
-  /* Modify rendering of numbered lists in PDF */
-  .power-number+ol>li::before,
-  .power-number+ol ol>li::before {
-    background-color: var(--md-default-bg-color);
-    color: var(--md-typeset-color);
-    border-radius: 0;
-    width: 1.5em;
-    margin-left: -1.7em;
-    opacity: 1;
-  }
+
 
   .tabbed-content {
     display: contents;


### PR DESCRIPTION
Suggesting to contain the styling of the numbered lists inside the print media query, so that it can affect the PDF only but not the website (as it's happening now)

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
