### PR TITLE
PMM-7 Bump up the runner to latest

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     name: Enable auto-merge
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     name: Enable auto-merge
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
PMM-7

We are bumping up the dependabot's runner due to its forthcoming deprecation:

"The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025"

After the deprecation deadline, the actions will be blocked.
