### PR TITLE
[DOCS] Removes empty "Supported Technologies" page

### DIFF
--- a/documentation/docs/discover-pmm/supported-technologies.md
+++ b/documentation/docs/discover-pmm/supported-technologies.md
@@ -1,9 +1,0 @@
-# Supported Technologies
-
-PMM supports the following technologies:
-
-
-
-
-
-


### PR DESCRIPTION
Removes empty page.
Even if not linked in the ToC it does appear in the search, and if clicked (from the search) it is shown online:

<img width="952" alt="searching-box" src="https://github.com/user-attachments/assets/858e7752-671c-4fc5-a75e-b03edd9b0124" />

One approach is to refer to officially supported versions from this page (search "PMM 3 supported databases"):
- https://www.percona.com/services/policies/percona-software-support-lifecycle

We can consider to link this page when needed, to avoid the risk of having duplicate content.
Opening this PR to remove this empty page and for possible internal discussions, as appropriate.

In the hope this helps,