### PR TITLE
PMM-13748 krb5 in devcontainer

### DIFF
--- a/.devcontainer/setup.py
+++ b/.devcontainer/setup.py
@@ -30,7 +30,8 @@ def install_packages():
             bash-completion \
             man man-pages \
             openssl-devel \
-            wget",
+            wget \
+             krb5-devel",
         
         "dnf install -y ansible-lint glibc-static --enablerepo=ol9_codeready_builder"
 

--- a/.devcontainer/setup.py
+++ b/.devcontainer/setup.py
@@ -31,7 +31,7 @@ def install_packages():
             man man-pages \
             openssl-devel \
             wget \
-             krb5-devel",
+            krb5-devel",
         
         "dnf install -y ansible-lint glibc-static --enablerepo=ol9_codeready_builder"
 


### PR DESCRIPTION
PMM-13748

Currently, #3738 is failing because it can't find the Kerberos header files while building `pmm-agent`. This adds the krb5-devel libraries in the devcontainer, so that the build can pass before we merge.

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- https://github.com/percona/mongodb_exporter/pull/1042
- https://github.com/percona/pmm/pull/3738
- https://github.com/Percona-Lab/pmm-submodules/pull/3866/
