### PR TITLE
PMM-7 Set user info for target URL in proxy requests

### DIFF
--- a/vmproxy/proxy/proxy.go
+++ b/vmproxy/proxy/proxy.go
@@ -95,6 +95,7 @@ func prepareRequest(req *http.Request, target *url.URL, headerName string) {
 		req.Host = hostHeader
 		req.Header.Set("Host", hostHeader)
 	}
+	req.URL.User = target.User
 
 	rp, err := target.Parse(strings.TrimPrefix(req.URL.Path, "/"))
 	if err != nil {


### PR DESCRIPTION
This change ensures that the user information from the target URL is correctly assigned to the request's URL. It addresses potential issues with authentication or routing when the user part of the URL is required.

PMM-7

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
