### PR TITLE
PMM-7 Revert mysqld_exporter version

### DIFF
--- a/version/features.go
+++ b/version/features.go
@@ -27,9 +27,8 @@ type FeatureVersion *Parsed
 
 // Features list.
 var (
-	NodeExporterNewTLSConfig FeatureVersion = V3_0_0
-	// TODO: Remove this after 3.2.0 release.
-	MysqlExporterV0_17_2         FeatureVersion = MustParse("3.1.0-0")
+	NodeExporterNewTLSConfig     FeatureVersion = V3_0_0
+	MysqlExporterV0_17_2         FeatureVersion = V3_2_0
 	MysqlExporterPluginCollector FeatureVersion = V2_36_0
 	NomadAgentSupportVersion     FeatureVersion = V3_2_0
 )


### PR DESCRIPTION
During the testing phase we had to force the version to pass the tests. Now that 3.2.0 is in the code, we need to revert it.

PMM-7

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
