### PR TITLE
PMM-13967 Add support for ClickHouse and VM URLs in dump service

### DIFF
--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -955,7 +955,10 @@ func main() { //nolint:maintidx,cyclop
 	schedulerService := scheduler.New(db, backupService)
 	versionCache := versioncache.New(db, versioner)
 
-	dumpService := dump.New(db)
+	dumpService := dump.New(db, &dump.URLs{
+		ClickhouseURL: chURI.String(),
+		VMURL:         *victoriaMetricsURLF,
+	})
 
 	serverParams := &server.Params{
 		DB:                   db,

--- a/managed/services/dump/dump.go
+++ b/managed/services/dump/dump.go
@@ -118,7 +118,7 @@ func (s *Service) StartDump(params *Params) (string, error) {
 		"export",
 		"--pmm-url=http://127.0.0.1:8080",
 		"--click-house-url="+s.urls.ClickhouseURL,
-		"--vm-url="+s.urls.VMURL,
+		"--victoria-metrics-url="+s.urls.VMURL,
 		fmt.Sprintf("--dump-path=%s", getDumpFilePath(dump.ID)))
 
 	if params.APIKey != "" {

--- a/managed/services/dump/dump.go
+++ b/managed/services/dump/dump.go
@@ -45,6 +45,7 @@ const (
 	dumpsDir   = "/srv/dump"
 )
 
+// URLs contains the URLs for Clickhouse and VictoriaMetrics.
 type URLs struct {
 	ClickhouseURL string
 	VMURL         string

--- a/managed/services/dump/dump.go
+++ b/managed/services/dump/dump.go
@@ -45,11 +45,17 @@ const (
 	dumpsDir   = "/srv/dump"
 )
 
+type URLs struct {
+	ClickhouseURL string
+	VMURL         string
+}
+
 // Service represents the dump service.
 type Service struct {
 	l *logrus.Entry
 
-	db *reform.DB
+	db   *reform.DB
+	urls *URLs
 
 	running atomic.Bool
 
@@ -58,10 +64,11 @@ type Service struct {
 }
 
 // New creates a new instance of the dump service..
-func New(db *reform.DB) *Service {
+func New(db *reform.DB, urls *URLs) *Service {
 	return &Service{
-		l:  logrus.WithField("component", "services/dump"),
-		db: db,
+		l:    logrus.WithField("component", "services/dump"),
+		db:   db,
+		urls: urls,
 	}
 }
 
@@ -109,6 +116,8 @@ func (s *Service) StartDump(params *Params) (string, error) {
 		pmmDumpBin,
 		"export",
 		"--pmm-url=http://127.0.0.1:8080",
+		"--click-house-url="+s.urls.ClickhouseURL,
+		"--vm-url="+s.urls.VMURL,
 		fmt.Sprintf("--dump-path=%s", getDumpFilePath(dump.ID)))
 
 	if params.APIKey != "" {


### PR DESCRIPTION
Enhanced the dump service to accept ClickHouse and VictoriaMetrics URLs. Updated the constructor and related logic to utilize these URLs for exports. Modified initialization in main.go to provide the required URL values.

PMM-13967

Link to the Feature Build: SUBMODULES-3916


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
