### PR TITLE
PMM-13837 valkey on pmm agent

### DIFF
--- a/agent/agents/supervisor/deps.go
+++ b/agent/agents/supervisor/deps.go
@@ -23,6 +23,7 @@ var (
 	proxysqlExporterRegexp     = regexp.MustCompile("proxysql_exporter, version ([!-~]*).*")
 	rdsExporterRegexp          = regexp.MustCompile("rds_exporter, version ([!-~]*).*")
 	azureMetricsExporterRegexp = regexp.MustCompile("azure_metrics_exporter, version ([!-~]*).*")
+	valkeyExporterRegexp       = regexp.MustCompile("valkey_exporter, version ([!-~]*).*")
 	mongodbExporterRegexp      = regexp.MustCompile("Version: ([!-~]*).*")
 )
 

--- a/agent/agents/supervisor/supervisor.go
+++ b/agent/agents/supervisor/supervisor.go
@@ -708,6 +708,9 @@ func (s *Supervisor) processParams(agentID string, agentProcess *agentv1.SetStat
 		processParams.Path = cfg.Paths.RDSExporter
 	case inventoryv1.AgentType_AGENT_TYPE_AZURE_DATABASE_EXPORTER:
 		processParams.Path = cfg.Paths.AzureExporter
+	case inventoryv1.AgentType_AGENT_TYPE_VALKEY_EXPORTER:
+		templateParams["paths_base"] = cfg.Paths.PathsBase
+		processParams.Path = cfg.Paths.ValkeyExporter
 	case type_TEST_SLEEP:
 		processParams.Path = "sleep"
 	case inventoryv1.AgentType_AGENT_TYPE_VM_AGENT:
@@ -786,6 +789,8 @@ func (s *Supervisor) version(agentType inventoryv1.AgentType, path string) (stri
 		return s.agentVersioner.BinaryVersion(path, 0, rdsExporterRegexp, "--version")
 	case inventoryv1.AgentType_AGENT_TYPE_AZURE_DATABASE_EXPORTER:
 		return s.agentVersioner.BinaryVersion(path, 0, azureMetricsExporterRegexp, "--version")
+	case inventoryv1.AgentType_AGENT_TYPE_VALKEY_EXPORTER:
+		return s.agentVersioner.BinaryVersion(path, 0, valkeyExporterRegexp, "--version")
 	default:
 		return "", nil
 	}

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -89,7 +89,7 @@ func (s *Server) FilteredURL() string {
 	return strings.ReplaceAll(u.String(), ":%2A%2A%2A@", ":***@")
 }
 
-// Paths represents binaries paths configuration.
+// Paths represent binaries paths configuration.
 type Paths struct {
 	PathsBase        string `yaml:"paths_base"`
 	ExportersBase    string `yaml:"exporters_base"`
@@ -100,6 +100,7 @@ type Paths struct {
 	ProxySQLExporter string `yaml:"proxysql_exporter"`
 	RDSExporter      string `yaml:"rds_exporter"`
 	AzureExporter    string `yaml:"azure_exporter"`
+	ValkeyExporter   string `yaml:"valkey_exporter"`
 
 	VMAgent string `yaml:"vmagent"`
 	Nomad   string `yaml:"nomad"`
@@ -225,6 +226,7 @@ func get(args []string, cfg *Config, l *logrus.Entry) (string, error) { //nolint
 			&cfg.Paths.MySQLdExporter:   "mysqld_exporter",
 			&cfg.Paths.MongoDBExporter:  "mongodb_exporter",
 			&cfg.Paths.PostgresExporter: "postgres_exporter",
+			&cfg.Paths.ValkeyExporter:   "valkey_exporter",
 			&cfg.Paths.ProxySQLExporter: "proxysql_exporter",
 			&cfg.Paths.RDSExporter:      "rds_exporter",
 			&cfg.Paths.AzureExporter:    "azure_exporter",
@@ -287,6 +289,7 @@ func get(args []string, cfg *Config, l *logrus.Entry) (string, error) { //nolint
 			"mysqld_exporter":   &cfg.Paths.MySQLdExporter,
 			"mongodb_exporter":  &cfg.Paths.MongoDBExporter,
 			"postgres_exporter": &cfg.Paths.PostgresExporter,
+			"valkey_exporter":   &cfg.Paths.ValkeyExporter,
 			"proxysql_exporter": &cfg.Paths.ProxySQLExporter,
 			"rds_exporter":      &cfg.Paths.RDSExporter,
 			"azure_exporter":    &cfg.Paths.AzureExporter,
@@ -396,6 +399,8 @@ func Application(cfg *Config) (*kingpin.Application, *string) {
 		Envar("PMM_AGENT_PATHS_PROXYSQL_EXPORTER").StringVar(&cfg.Paths.ProxySQLExporter)
 	app.Flag("paths-azure_exporter", "Path to azure_exporter to use [PMM_AGENT_PATHS_AZURE_EXPORTER]").
 		Envar("PMM_AGENT_PATHS_AZURE_EXPORTER").StringVar(&cfg.Paths.AzureExporter)
+	app.Flag("paths-valkey", "Path to valkey_exporter to use [PMM_AGENT_PATHS_VALKEY_EXPORTER]").
+		Envar("PMM_AGENT_PATHS_VALKEY_EXPORTER").StringVar(&cfg.Paths.ValkeyExporter)
 	app.Flag("paths-pt-summary", "Path to pt summary to use [PMM_AGENT_PATHS_PT_SUMMARY]").
 		Envar("PMM_AGENT_PATHS_PT_SUMMARY").StringVar(&cfg.Paths.PTSummary)
 	app.Flag("paths-pt-pg-summary", "Path to pt-pg-summary to use [PMM_AGENT_PATHS_PT_PG_SUMMARY]").

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -114,6 +114,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/usr/local/percona/pmm/exporters/proxysql_exporter",
 				RDSExporter:      "/usr/local/percona/pmm/exporters/rds_exporter",
 				AzureExporter:    "/usr/local/percona/pmm/exporters/azure_exporter",
+				ValkeyExporter:   "/usr/local/percona/pmm/exporters/valkey_exporter",
 				VMAgent:          "/usr/local/percona/pmm/exporters/vmagent",
 				TempDir:          "/usr/local/percona/pmm/tmp",
 				NomadDataDir:     "/usr/local/percona/pmm/data/nomad",
@@ -176,6 +177,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/usr/local/percona/pmm/exporters/proxysql_exporter",
 				RDSExporter:      "/usr/local/percona/pmm/exporters/rds_exporter",
 				AzureExporter:    "/usr/local/percona/pmm/exporters/azure_exporter",
+				ValkeyExporter:   "/usr/local/percona/pmm/exporters/valkey_exporter",
 				VMAgent:          "/usr/local/percona/pmm/exporters/vmagent",
 				TempDir:          "/usr/local/percona/pmm/tmp",
 				NomadDataDir:     "/usr/local/percona/pmm/data/nomad",
@@ -237,6 +239,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/usr/local/percona/pmm/exporters/proxysql_exporter",
 				RDSExporter:      "/usr/local/percona/pmm/exporters/rds_exporter",
 				AzureExporter:    "/usr/local/percona/pmm/exporters/azure_exporter",
+				ValkeyExporter:   "/usr/local/percona/pmm/exporters/valkey_exporter",
 				VMAgent:          "/usr/local/percona/pmm/exporters/vmagent",
 				TempDir:          "/foo/bar/tmp",
 				NomadDataDir:     "/usr/local/percona/pmm/data/nomad",
@@ -306,6 +309,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/base/pro_exporter",     // respect relative value from config file
 				RDSExporter:      "/base/rds_exporter",     // default value
 				AzureExporter:    "/base/azure_exporter",   // default value
+				ValkeyExporter:   "/base/valkey_exporter",  // default value
 				VMAgent:          "/base/vmagent",          // default value
 				TempDir:          "/usr/local/percona/pmm/tmp",
 				NomadDataDir:     "/usr/local/percona/pmm/data/nomad",
@@ -373,6 +377,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/base/exporters/pro_exporter",       // respect relative value from config file
 				RDSExporter:      "/base/exporters/rds_exporter",       // default value
 				AzureExporter:    "/base/exporters/azure_exporter",     // default value
+				ValkeyExporter:   "/base/exporters/valkey_exporter",    // default value
 				VMAgent:          "/base/exporters/vmagent",            // default value
 				TempDir:          "/base/tmp",
 				NomadDataDir:     "/base/data/nomad",
@@ -438,6 +443,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/foo/exporters/proxysql_exporter", // default value
 				RDSExporter:      "/foo/exporters/rds_exporter",      // default value
 				AzureExporter:    "/foo/exporters/azure_exporter",    // default value
+				ValkeyExporter:   "/foo/exporters/valkey_exporter",   // default value
 				VMAgent:          "/foo/exporters/vmagent",           // default value
 				TempDir:          "/foo/tmp",
 				NomadDataDir:     "/base/data/nomad",
@@ -488,6 +494,7 @@ func TestGet(t *testing.T) {
 				ProxySQLExporter: "/usr/local/percona/pmm/exporters/proxysql_exporter",
 				RDSExporter:      "/usr/local/percona/pmm/exporters/rds_exporter",
 				AzureExporter:    "/usr/local/percona/pmm/exporters/azure_exporter",
+				ValkeyExporter:   "/usr/local/percona/pmm/exporters/valkey_exporter",
 				VMAgent:          "/usr/local/percona/pmm/exporters/vmagent",
 				TempDir:          "/usr/local/percona/pmm/tmp",
 				NomadDataDir:     "/usr/local/percona/pmm/data/nomad",

--- a/managed/services/agents/valkey.go
+++ b/managed/services/agents/valkey.go
@@ -16,6 +16,9 @@
 package agents
 
 import (
+	"sort"
+	"time"
+
 	agentv1 "github.com/percona/pmm/api/agent/v1"
 	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
 	"github.com/percona/pmm/managed/models"
@@ -24,18 +27,35 @@ import (
 
 // valkeyExporterConfig returns desired configuration of valkey_exporter process.
 // todo: to be implemented in PMM-13837
-func valkeyExporterConfig(_ *models.Node, service *models.Service, exporter *models.Agent, _ redactMode,
+func valkeyExporterConfig(node *models.Node, service *models.Service, exporter *models.Agent, redactMode redactMode,
 	pmmAgentVersion *version.Parsed,
-) *agentv1.SetStateRequest_AgentProcess {
+) (*agentv1.SetStateRequest_AgentProcess, error) {
+	listenAddress := getExporterListenAddress(node, exporter)
 	tdp := exporter.TemplateDelimiters(service)
-	var args []string
+	args := []string{
+		"--web.listen-address=" + listenAddress + ":" + tdp.Left + " .listen_port " + tdp.Right,
+	}
 
+	if exporter.ExporterOptions.MetricsPath != "" {
+		args = append(args, "--web.telemetry-path="+exporter.ExporterOptions.MetricsPath)
+	}
+
+	dnsParams := models.DSNParams{
+		DialTimeout: 3 * time.Second,
+	}
 	args = withLogLevel(args, exporter.LogLevel, pmmAgentVersion, true)
+	args = append(args, "--redis.addr="+exporter.DSN(service, dnsParams, nil, pmmAgentVersion))
+	sort.Strings(args)
 
-	return &agentv1.SetStateRequest_AgentProcess{
+	res := &agentv1.SetStateRequest_AgentProcess{
 		Type:               inventoryv1.AgentType_AGENT_TYPE_VALKEY_EXPORTER,
 		TemplateLeftDelim:  tdp.Left,
 		TemplateRightDelim: tdp.Right,
 		Args:               args,
+		TextFiles:          exporter.Files(),
 	}
+	if redactMode != exposeSecrets {
+		res.RedactWords = redactWords(exporter)
+	}
+	return res, nil
 }

--- a/managed/services/converters.go
+++ b/managed/services/converters.go
@@ -535,11 +535,9 @@ func ToAPIAgent(q *reform.Querier, agent *models.Agent) (inventoryv1.Agent, erro
 			ExposeExporter:     agent.ExporterOptions.ExposeExporter,
 			MetricsResolutions: ConvertMetricsResolutions(agent.ExporterOptions.MetricsResolutions),
 		}
-
 		return exporter, nil
-
 	default:
-		panic(fmt.Errorf("unhandled Agent type %s", agent.AgentType))
+		panic(fmt.Errorf("cannot convert unknown agent type %s", agent.AgentType))
 	}
 }
 

--- a/managed/services/victoriametrics/prometheus.go
+++ b/managed/services/victoriametrics/prometheus.go
@@ -160,6 +160,16 @@ func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //
 				metricsResolution: &mr,
 			})
 
+		case models.ValkeyExporterType:
+			scfgs, err = scrapeConfigForValkeyExporter(&scrapeConfigParams{
+				host:              paramsHost,
+				node:              paramsNode,
+				service:           paramsService,
+				agent:             agent,
+				streamParse:       true,
+				metricsResolution: &mr,
+			})
+
 		case models.ProxySQLExporterType:
 			scfgs, err = scrapeConfigsForProxySQLExporter(&scrapeConfigParams{
 				host:              paramsHost,

--- a/managed/services/victoriametrics/scrape_configs.go
+++ b/managed/services/victoriametrics/scrape_configs.go
@@ -508,6 +508,19 @@ func scrapeConfigsForPostgresExporter(params *scrapeConfigParams) ([]*config.Scr
 	return r, nil
 }
 
+func scrapeConfigForValkeyExporter(params *scrapeConfigParams) ([]*config.ScrapeConfig, error) {
+	hr, err := scrapeConfigForStandardExporter("hr", params.metricsResolution.HR, params, nil) // TODO https://jira.percona.com/browse/PMM-4619
+	if err != nil {
+		return nil, err
+	}
+
+	var r []*config.ScrapeConfig
+	if hr != nil {
+		r = append(r, hr)
+	}
+	return r, nil
+}
+
 func scrapeConfigsForProxySQLExporter(params *scrapeConfigParams) ([]*config.ScrapeConfig, error) {
 	hr, err := scrapeConfigForStandardExporter("hr", params.metricsResolution.HR, params, nil) // TODO https://jira.percona.com/browse/PMM-4619
 	if err != nil {

--- a/managed/services/victoriametrics/victoriametrics_test.go
+++ b/managed/services/victoriametrics/victoriametrics_test.go
@@ -110,7 +110,7 @@ func TestVictoriaMetrics(t *testing.T) {
 				Version:      pointer.ToString("2.26.0"),
 			},
 
-			// listen port not known
+			// listen port is not known
 			&models.Agent{
 				AgentID:    "711674c2-36e6-42d5-8e63-5d7c84c9053a",
 				AgentType:  models.NodeExporterType,
@@ -146,6 +146,16 @@ func TestVictoriaMetrics(t *testing.T) {
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				Address:      pointer.ToString("5.6.7.8"),
 				Port:         pointer.ToUint16(27017),
+				CustomLabels: []byte(`{"_service_label": "bam"}`),
+			},
+
+			&models.Service{
+				ServiceID:    "a04c391a-b3d0-40c2-95c5-3cfec462c8e5",
+				ServiceType:  models.ValkeyServiceType,
+				ServiceName:  "test-valkey",
+				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
+				Address:      pointer.ToString("1.3.5.7"),
+				Port:         pointer.ToUint16(6379),
 				CustomLabels: []byte(`{"_service_label": "bam"}`),
 			},
 
@@ -193,6 +203,15 @@ func TestVictoriaMetrics(t *testing.T) {
 				PMMAgentID:   pointer.ToString("217907dc-d34d-4e2e-aa84-a1b765d49853"),
 				ServiceID:    pointer.ToString("9cffbdd4-3cd2-47f8-a5f9-a749c3d5fee1"),
 				CustomLabels: []byte(`{"_agent_label": "postgres-baz"}`),
+				ListenPort:   pointer.ToUint16(12345),
+			},
+
+			&models.Agent{
+				AgentID:      "fd2dcf41-0718-4319-9fa9-b7a509787c98",
+				AgentType:    models.ValkeyExporterType,
+				PMMAgentID:   pointer.ToString("217907dc-d34d-4e2e-aa84-a1b765d49853"),
+				ServiceID:    pointer.ToString("a04c391a-b3d0-40c2-95c5-3cfec462c8e5"),
+				CustomLabels: []byte(`{"_agent_label": "valkey-baz"}`),
 				ListenPort:   pointer.ToUint16(12345),
 			},
 
@@ -741,6 +760,32 @@ scrape_configs:
       basic_auth:
         username: pmm
         password: 29e14468-d479-4b4d-bfb7-4ac2fb865bac
+      follow_redirects: false
+      stream_parse: true
+    - job_name: valkey_exporter_fd2dcf41-0718-4319-9fa9-b7a509787c98_hr
+      honor_timestamps: false
+      scrape_interval: 5s
+      scrape_timeout: 4500ms
+      metrics_path: /metrics
+      static_configs:
+        - targets:
+            - 1.2.3.4:12345
+          labels:
+            _agent_label: valkey-baz
+            _node_label: foo
+            _service_label: bam
+            agent_id: fd2dcf41-0718-4319-9fa9-b7a509787c98
+            agent_type: valkey_exporter
+            instance: fd2dcf41-0718-4319-9fa9-b7a509787c98
+            node_id: cc663f36-18ca-40a1-aea9-c6310bb4738d
+            node_name: test-generic-node
+            node_type: generic
+            service_id: a04c391a-b3d0-40c2-95c5-3cfec462c8e5
+            service_name: test-valkey
+            service_type: valkey
+      basic_auth:
+        username: pmm
+        password: fd2dcf41-0718-4319-9fa9-b7a509787c98
       follow_redirects: false
       stream_parse: true
 `) + "\n"


### PR DESCRIPTION
This includes triggering the binary update from supervisord and passing the relevant args/flags to the valkey_exporter.

One more big part left is passing in the correct flags to support TLS, and checking the exporter docs for other flags that we might need to use.

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
