### PR TITLE
PMM-7 Update pg_query_go dependency to v6

### DIFF
--- a/agent/agents/postgres/parser/parser.go
+++ b/agent/agents/postgres/parser/parser.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	pgquery "github.com/pganalyze/pg_query_go/v5"
+	pgquery "github.com/pganalyze/pg_query_go/v6"
 	"github.com/pkg/errors"
 )
 

--- a/agent/agents/postgres/pgstatmonitor/stat_monitor_cache.go
+++ b/agent/agents/postgres/pgstatmonitor/stat_monitor_cache.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
-	pgquery "github.com/pganalyze/pg_query_go/v5"
+	pgquery "github.com/pganalyze/pg_query_go/v6"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/reform.v1"

--- a/agent/testqueries/postgres/pg_stat_monitor_load.sql
+++ b/agent/testqueries/postgres/pg_stat_monitor_load.sql
@@ -1,18 +1,17 @@
 DROP EXTENSION pg_stat_monitor;
 Create EXTENSION pg_stat_monitor;
-​
+
 Set application_name = 'naeem' ; 
 SELECT 1 AS num;
 Set application_name = 'psql' ; 
 SELECT 1 AS num;
 SELECT query,application_name FROM pg_stat_monitor ORDER BY query, application_name COLLATE "C";
-​
+
 SELECT 1 AS num;
 SELECT query,application_name FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 SELECT 1 AS num;
 SELECT query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
 CREATE TABLE t1 (a INTEGER);
 CREATE TABLE t2 (b INTEGER);
 INSERT INTO t1 VALUES(1);
@@ -24,24 +23,24 @@ TRUNCATE t1;
 DROP TABLE t1;
 DROP TABLE t2;
 SELECT query, cmd_type,  cmd_type_text FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 CREATE TABLE t1 (a INTEGER);
 CREATE TABLE t2 (b INTEGER);
 CREATE TABLE t3 (c INTEGER);
 CREATE TABLE t4 (d INTEGER);
-​
+
 Select * from pg_stat_monitor_settings; 
 SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
 SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
 SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
 SELECT a,b,c,d FROM t1, t2, t3, t4 WHERE t1.a = t2.b AND t3.c = t4.d ORDER BY a;
 SELECT query,calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 ALTER SYSTEM SET pg_stat_monitor.pgsm_track TO 'all';
 SELECT pg_reload_conf();
 Select * from pg_stat_monitor_settings; 
 SELECT pg_sleep(2);
-​
+
 do $$
 declare
    n integer:= 1;
@@ -53,43 +52,43 @@ begin
 	end loop;
 end $$;
 SELECT query,calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 ALTER SYSTEM SET pg_stat_monitor.pgsm_track TO 'top';
 SELECT pg_reload_conf();
 SELECT pg_sleep(1);
-​
+
 DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
-​
+
 Drop Table if exists Company;
-​
+
 CREATE TABLE Company(
    ID INT PRIMARY KEY     NOT NULL,
    NAME TEXT    NOT NULL
 );
-​
+
 INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
 INSERT  INTO Company(ID, Name) VALUES (1, 'Percona'); 
-​
+
 Drop Table if exists Company;
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
-​
+
 SELECT 1/0;   -- divide by zero
 SELECT * FROM unknown; -- unknown table
 ELECET * FROM unknown; -- syntax error
-​
+
 do $$
 BEGIN
 RAISE WARNING 'warning message';
 END $$;
-​
+
 SELECT query, elevel, sqlcode, message FROM pg_stat_monitor ORDER BY query COLLATE "C",elevel;
-​
+
 select pg_sleep(.5);
 SELECT * FROM pg_stat_monitor_settings ORDER BY name COLLATE "C";
-​
+
 CREATE OR REPLACE FUNCTION generate_histogram()
     RETURNS TABLE (
     range TEXT, freq INT, bar TEXT
@@ -106,7 +105,7 @@ BEGIN
     SELECT * FROM histogram(bucket_id, query_id) AS a(range TEXT, freq INT, bar TEXT);
 END;
 $$ LANGUAGE plpgsql;
-​
+
 CREATE OR REPLACE FUNCTION run_pg_sleep(INTEGER) RETURNS VOID AS $$
 DECLARE
     loops ALIAS FOR $1;
@@ -118,95 +117,95 @@ BEGIN
     END LOOP;
 END;
 $$ LANGUAGE 'plpgsql' STRICT;
-​
+
 Set pg_stat_monitor.pgsm_track='all';
 select run_pg_sleep(5);
-​
+
 SELECT substr(query, 0,50) as query, calls, resp_calls FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 select * from generate_histogram();
-​
+
 CREATE TABLE foo1(a int);
 CREATE TABLE foo2(b int);
 CREATE TABLE foo3(c int);
 CREATE TABLE foo4(d int);
-​
+
 -- test the simple table names
 SELECT * FROM foo1;
 SELECT * FROM foo1, foo2;
 SELECT * FROM foo1, foo2, foo3;
 SELECT * FROM foo1, foo2, foo3, foo4;
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-​
+
 -- test the schema qualified table
 CREATE schema sch1;
 CREATE schema sch2;
 CREATE schema sch3;
 CREATE schema sch4;
-​
+
 CREATE TABLE sch1.foo1(a int);
 CREATE TABLE sch2.foo2(b int);
 CREATE TABLE sch3.foo3(c int);
 CREATE TABLE sch4.foo4(d int);
-​
+
 SELECT * FROM sch1.foo1;
 SELECT * FROM sch1.foo1, sch2.foo2;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3;
 SELECT * FROM sch1.foo1, sch2.foo2, sch3.foo3, sch4.foo4;
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-​
+
 SELECT * FROM sch1.foo1, foo1;
 SELECT * FROM sch1.foo1, sch2.foo2, foo1, foo2;
 SELECT query, relations from pg_stat_monitor ORDER BY query;
-​
+
 -- test the view
 CREATE VIEW v1 AS SELECT * from foo1;
 CREATE VIEW v2 AS SELECT * from foo1,foo2;
 CREATE VIEW v3 AS SELECT * from foo1,foo2,foo3;
 CREATE VIEW v4 AS SELECT * from foo1,foo2,foo3,foo4;
-​
+
 SELECT * FROM v1;
 SELECT * FROM v1,v2;
 SELECT * FROM v1,v2,v3;
 SELECT * FROM v1,v2,v3,v4;
 SELECT query, relations from pg_stat_monitor ORDER BY query collate "C";
-​
+
 DROP VIEW v1;
 DROP VIEW v2;
 DROP VIEW v3;
 DROP VIEW v4;
-​
+
 DROP TABLE foo1;
 DROP TABLE foo2;
 DROP TABLE foo3;
 DROP TABLE foo4;
-​
+
 DROP TABLE sch1.foo1;
 DROP TABLE sch2.foo2;
 DROP TABLE sch3.foo3;
 DROP TABLE sch4.foo4;
-​
+
 DROP SCHEMA sch1;
 DROP SCHEMA sch2;
 DROP SCHEMA sch3;
 DROP SCHEMA sch4;
-​
+
 CREATE TABLE t1(a int);
 CREATE TABLE t2(b int);
 INSERT INTO t1 VALUES(generate_series(1,1000));
 INSERT INTO t2 VALUES(generate_series(1,5000));
-​
+
 SELECT * FROM t1;
 SELECT * FROM t2;
-​
+
 SELECT * FROM t1 LIMIT 10;
 SELECt * FROM t2  WHERE b % 2 = 0;
-​
+
 SELECT query, rows_retrieved FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 DROP TABLE t1;
 DROP TABLE t2;
-​
+
 SELECT 1 AS num /* { "application", psql_app, "real_ip", 192.168.1.3) */;
 SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
 ALTER SYSTEM SET pg_stat_monitor.pgsm_extract_comments TO 'yes';
@@ -216,69 +215,69 @@ SELECT 1 AS num /* { "application", psql_app, "real_ip", 192.168.1.3) */;
 SELECT query, comments FROM pg_stat_monitor ORDER BY query COLLATE "C";
 ALTER SYSTEM SET pg_stat_monitor.pgsm_extract_comments TO 'no';
 SELECT pg_reload_conf();
-​
+
 CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS
 $$
 BEGIN
 	return (select $1 + $2);
 END; $$ language plpgsql;
-​
+
 CREATE OR REPLACE function add2(int, int) RETURNS int as
 $$
 BEGIN
 	return add($1,$2);
 END;
 $$ language plpgsql;
-​
+
 SELECT add2(1,2);
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
-​
+
 ALTER SYSTEM SET pg_stat_monitor.pgsm_track TO 'all';
 SELECT pg_reload_conf();
 SELECT pg_sleep(1);
-​
+
 CREATE OR REPLACE FUNCTION add(int, int) RETURNS INTEGER AS
 $$
 BEGIN
 	return (select $1 + $2);
 END; $$ language plpgsql;
-​
+
 CREATE OR REPLACE function add2(int, int) RETURNS int as
 $$
 BEGIN
 	return add($1,$2);
 END;
 $$ language plpgsql;
-​
+
 SELECT add2(1,2);
 SELECT query, top_query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 ALTER SYSTEM SET pg_stat_monitor.pgsm_track TO 'top';
 SELECT pg_reload_conf();
 SELECT pg_sleep(1);
-​
+
 CREATE USER su WITH SUPERUSER;
-​
+
 SET ROLE su;
-​
+
 CREATE USER u1;
 CREATE USER u2;
-​
+
 SET ROLE su;
-​
+
 SET ROLE u1;
 CREATE TABLE t1 (a int);
 SELECT * FROM t1;
-​
+
 SET ROLE u2;
 CREATE TABLE t2 (a int);
 SELECT * FROM t2;
-​
+
 SET ROLE su;
 SELECT  bucket, userid, datname, client_ip, application_name,top_queryid, planid, queryid, calls, substr(query,0,50) as query FROM pg_stat_monitor ORDER BY query COLLATE "C";
 DROP TABLE t1;
 DROP TABLE t2;
-​
+
 DROP USER u1;
 DROP USER u2;
-​
+
 SELECT pg_stat_monitor_version();

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/percona/percona-toolkit v0.0.0-20250514130928-84095fd7d7d9
 	github.com/percona/promconfig v0.2.5
 	github.com/percona/saas v0.0.0-20240923141535-da19f6682c6e
-	github.com/pganalyze/pg_query_go/v5 v5.1.0
+	github.com/pganalyze/pg_query_go/v6 v6.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.6
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2

--- a/go.sum
+++ b/go.sum
@@ -427,8 +427,8 @@ github.com/percona/promconfig v0.2.5 h1:f/HN/CbECQs7d9RIB6MKVkuXstsrsqEDxRvf6yig
 github.com/percona/promconfig v0.2.5/go.mod h1:Y2uXi5QNk71+ceJHuI9poank+0S1kjxd3K105fXKVkg=
 github.com/percona/saas v0.0.0-20240923141535-da19f6682c6e h1:xhk5ivxlTPat0SwLBqU1UdfqJb+2R3x4yAhjCf6WMEU=
 github.com/percona/saas v0.0.0-20240923141535-da19f6682c6e/go.mod h1:UP4WqGWy8xeGhEoDFaB1aPNNtNs/TYXQ8MjUrN6rXis=
-github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
-github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
+github.com/pganalyze/pg_query_go/v6 v6.1.0 h1:jG5ZLhcVgL1FAw4C/0VNQaVmX1SUJx71wBGdtTtBvls=
+github.com/pganalyze/pg_query_go/v6 v6.1.0/go.mod h1:nvTHIuoud6e1SfrUaFwHqT0i4b5Nr+1rPWVds3B5+50=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
Upgraded pg_query_go library from v5 to v6 across the codebase. Adjusted files to reflect changes and ensure compatibility with the new version.

PMM-7

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
