### PR TITLE
[DOCS] Alert templates - remove strange section

### DIFF
--- a/documentation/docs/alert/templates_list.md
+++ b/documentation/docs/alert/templates_list.md
@@ -2,7 +2,7 @@
 
 The table below lists all the alert templates available in Percona Monitoring and Management (PMM). This list includes both built-in templates (accessible to all PMM users), and customer-only templates.
 
-To access the customer-only templates, you must be a Percona customer and [connect PMM to Percona Platform](../configure-pmm/percona_platform/check_percona_platform.md) using a Percona Account.## Template catalog
+To access the customer-only templates, you must be a Percona customer and [connect PMM to Percona Platform](../configure-pmm/percona_platform/check_percona_platform.md) using a Percona Account.
 
 - [Operating System templates](#os_alerts)
 - [PMM templates](#pmm_alerts)

--- a/documentation/docs/alert/templates_list.md
+++ b/documentation/docs/alert/templates_list.md
@@ -4,6 +4,8 @@ The table below lists all the alert templates available in Percona Monitoring an
 
 To access the customer-only templates, you must be a Percona customer and [connect PMM to Percona Platform](../configure-pmm/percona_platform/check_percona_platform.md) using a Percona Account.
 
+## Template catalog
+
 - [Operating System templates](#os_alerts)
 - [PMM templates](#pmm_alerts)
 - [MongoDB templates](#mongodb_alerts)


### PR DESCRIPTION
Page https://docs.percona.com/percona-monitoring-and-management/3/alert/templates_list.html
has strange "## Template catalog" section, see screenshot below:

<img width="791" alt="Screenshot 2025-05-23 at 13 47 47" src="https://github.com/user-attachments/assets/e0b4cda7-aa39-4763-9802-b07aa1c4e292" />

This PR removes it.
If it was used for different reason, @catalinaadam  please let me know and we can try a different fix.

Thanks!