### PR TITLE
Changes in docker commands used.

### DIFF
--- a/documentation/docs/setting-up/client/index.md
+++ b/documentation/docs/setting-up/client/index.md
@@ -54,7 +54,7 @@ The [PMM Client Docker image] is a convenient way to run PMM Client as a preconf
 
     ```sh
     docker create \
-    --volume /usr/local/percona/pmm2/ \
+    --volume /usr/local/percona/pmm2/config \
     --name pmm-client-data \
     percona/pmm-client:2 /bin/true
     ```

--- a/documentation/docs/setting-up/client/index.md
+++ b/documentation/docs/setting-up/client/index.md
@@ -54,17 +54,17 @@ The [PMM Client Docker image] is a convenient way to run PMM Client as a preconf
 
     ```sh
     docker create \
-    --volume /srv \
+    --volume /usr/local/percona/pmm2/ \
     --name pmm-client-data \
     percona/pmm-client:2 /bin/true
     ```
 
-3. Run the container to start [PMM Agent](../../details/commands/pmm-agent.md) in setup mode. Set `X.X.X.X` to the IP address of your PMM Server. Do not use the `--detach` flag as PMM Agent only outputs logs to the console:
+3. Run the container to start [PMM Agent](../../details/commands/pmm-agent.md) in setup mode. Set `X.X.X.X` to the IP address of your PMM Server.
 
     ```sh
     PMM_SERVER=X.X.X.X:443
     docker run \
-    --rm \
+    -d \
     --name pmm-client \
     -e PMM_AGENT_SERVER_ADDRESS=${PMM_SERVER} \
     -e PMM_AGENT_SERVER_USERNAME=admin \


### PR DESCRIPTION
The volume path was incorrect for the pmm-client-data container, as it was using /srv/ when it should be using /usr/local/percona/pmm2/.

Also, what was mentioned about -d was incorrect, and using --rm as it was meant that the container will be removed when the process is stopped. It's better to use -d and leave it running in the background, and docker logs will still work in this case, so we don't lose any functionality.

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
