### PR TITLE
PMM-7 fix UI typo

### DIFF
--- a/ui/src/pages/updates/update-info/UpdateInfo.messages.ts
+++ b/ui/src/pages/updates/update-info/UpdateInfo.messages.ts
@@ -1,7 +1,7 @@
 export const Messages = {
   title: 'Step 1 of 2: Update PMM Server',
   upgrading:
-    'Upgrading will pause, update, and subsequently restart PMM. While this occurs, data observation will be temporarily halted but will promtly resume, ensuring all peding data from PMM Clients is recovered.',
+    'Upgrading will pause, update, and subsequently restart PMM. While this occurs, data observation will be temporarily halted but will promptly resume, ensuring all pending data from PMM Clients is recovered.',
   readMore: 'Read more',
   whatsNext: "What's next",
   afterCompleting:


### PR DESCRIPTION
PMM-7

This fixes some typo errors on the updates page. Below is what those typos look like to the end user.
![fix-ui-typo](https://github.com/user-attachments/assets/2f12fbc9-ae46-4a93-a284-f39468c76ab2)
