### PR TITLE
PMM-14021-enable-auth-request-for-swagger

### DIFF
--- a/build/ansible/roles/nginx/files/conf.d/pmm.conf
+++ b/build/ansible/roles/nginx/files/conf.d/pmm.conf
@@ -204,7 +204,6 @@
     rewrite ^/swagger/swagger.json$ $scheme://$http_host/swagger.json permanent;
     rewrite ^(/swagger)/(.*)$ $scheme://$http_host/swagger permanent;
     location /swagger {
-      auth_request off;
       root /usr/share/pmm-managed/swagger;
       try_files $uri /index.html break;
     }


### PR DESCRIPTION
This comes in additional to #4059 and enables authentication sub-requests for the "/swagger" route.

PMM-14021

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
