### PR TITLE
[Docs] 3.3.1 Rel Notes: make the CVE affected versions more specific

### DIFF
--- a/documentation/docs/release-notes/3.3.1.md
+++ b/documentation/docs/release-notes/3.3.1.md
@@ -13,14 +13,14 @@ Percona Monitoring and Management (PMM) is an open source database monitoring, m
 - manage databases across on-premises, cloud, and hybrid environments
 
 ## RCE vulnerability in PMM - Immediate action required
-We have identified a critical Remote Command Execution (RCE) vulnerability affecting all PMM 2.x and PMM 3.x installations. This vulnerability allows users with CLI access to PMM Client nodes or those with admin-level privileges to exploit the API and execute unauthorized commands on registered nodes.
+We have identified a critical Remote Command Execution (RCE) vulnerability affecting all PMM 2.x and PMM 3.x up to 3.3.0 installations. This vulnerability allows users with CLI access to PMM Client nodes or those with admin-level privileges to exploit the API and execute unauthorized commands on registered nodes.
 
 ### Affected installations
-This vulnerability affects all PMM 2.x and 3.x deployments where PMM Client nodes are connected to the PMM Server. The security flaw originates from the `pt-mysql-summary` tool, a component of the Percona Toolkit that automatically collects MySQL system information and diagnostics from PMM Client installations.
+This vulnerability affects all PMM 2.x and 3.x up to 3.3.0 deployments where PMM Client nodes are connected to the PMM Server. The security flaw originates from the `pt-mysql-summary` tool, a component of the Percona Toolkit that automatically collects MySQL system information and diagnostics from PMM Client installations.
 
 | **Affected deployments** | **Version** | **Notes** |
 |---------------------------|-------------|-----------|
-| All PMM installations with connected PMM Client nodes | PMM 2.x and PMM 3.x | Remote Command Execution vulnerability through `pt-mysql-summary` tool deployed when setting up PMM Clients |
+| All PMM installations with connected PMM Client nodes | PMM 2.x and PMM 3.x up to 3.3.0 | Remote Command Execution vulnerability through `pt-mysql-summary` tool deployed when setting up PMM Clients |
 
 ### Remediation options
 === "RECOMMENDED: Upgrade to PMM 3.3.1"


### PR DESCRIPTION
An improvement is proposed to avoid the use of 3.x for v3, as it seems too generic and unnecessary. 
In future this page can be seen and cause possible confusion wrt the exact impacted versions.

This PR proposes mentioning the upper limit as well:
- Any 3.0 up to 3.3.0. In fact, the fix is in 3.3.1

Thanks,