### PR TITLE
PMM-7 Fix Alerting and Inventory API tests

### DIFF
--- a/api-tests/alerting/alerting_test.go
+++ b/api-tests/alerting/alerting_test.go
@@ -474,7 +474,7 @@ func TestTemplatesAPI(t *testing.T) {
 
 			// list rules, so they are all on the first page
 			listAllTemplates, err := client.ListTemplates(&alerting.ListTemplatesParams{
-				PageSize:  pointer.ToInt32(30),
+				PageSize:  pointer.ToInt32(38),
 				PageIndex: pointer.ToInt32(0),
 				Context:   pmmapitests.Context,
 			})

--- a/api-tests/inventory/agents_mysqld_exporter_test.go
+++ b/api-tests/inventory/agents_mysqld_exporter_test.go
@@ -66,9 +66,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
-				ExtraDsnParams: map[string]string{
-					"allowCleartextPasswords": "1",
-				},
 				SkipConnectionCheck:       true,
 				TablestatsGroupTableLimit: 2000,
 			},
@@ -93,7 +90,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
-				ExtraDsnParams:            map[string]string{"allowCleartextPasswords": "1"},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -125,7 +121,6 @@ func TestMySQLdExporter(t *testing.T) {
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
 				CustomLabels:              map[string]string{},
-				ExtraDsnParams:            map[string]string{"allowCleartextPasswords": "1"},
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
 		}, changeMySQLdExporterOK.Payload)
@@ -156,7 +151,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"new_label": "mysql_exporter",
 				},
-				ExtraDsnParams:            map[string]string{"allowCleartextPasswords": "1"},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -408,7 +402,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
-				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
@@ -438,7 +431,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
-				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -466,7 +458,6 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
-				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,

--- a/api-tests/inventory/agents_mysqld_exporter_test.go
+++ b/api-tests/inventory/agents_mysqld_exporter_test.go
@@ -90,6 +90,7 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
+				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -121,6 +122,7 @@ func TestMySQLdExporter(t *testing.T) {
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
 		}, changeMySQLdExporterOK.Payload)
@@ -151,6 +153,7 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"new_label": "mysql_exporter",
 				},
+				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -402,6 +405,7 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
+				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
@@ -431,6 +435,7 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
+				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				Status:                    &AgentStatusUnknown,
 				DisabledCollectors:        make([]string, 0),
@@ -458,6 +463,7 @@ func TestMySQLdExporter(t *testing.T) {
 				CustomLabels: map[string]string{
 					"custom_label_mysql_exporter": "mysql_exporter",
 				},
+				ExtraDsnParams:            map[string]string{},
 				TablestatsGroupTableLimit: 2000,
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,

--- a/api-tests/inventory/agents_test.go
+++ b/api-tests/inventory/agents_test.go
@@ -403,6 +403,7 @@ func TestPMMAgent(t *testing.T) {
 				},
 				Status:             &AgentStatusUnknown,
 				LogLevel:           pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+				ExtraDsnParams:     map[string]string{},
 				DisabledCollectors: make([]string, 0),
 			},
 		}, listAgentsOK.Payload.MysqldExporter)
@@ -530,8 +531,9 @@ func TestQanAgentExporter(t *testing.T) {
 					CustomLabels: map[string]string{
 						"new_label": "QANMysqlPerfschemaAgent",
 					},
-					Status:   &AgentStatusUnknown,
-					LogLevel: pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+					Status:         &AgentStatusUnknown,
+					LogLevel:       pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+					ExtraDsnParams: map[string]string{},
 				},
 			},
 		}, getAgentRes)
@@ -552,14 +554,15 @@ func TestQanAgentExporter(t *testing.T) {
 		assert.Equal(t, &agents.ChangeAgentOK{
 			Payload: &agents.ChangeAgentOKBody{
 				QANMysqlPerfschemaAgent: &agents.ChangeAgentOKBodyQANMysqlPerfschemaAgent{
-					AgentID:      agentID,
-					ServiceID:    serviceID,
-					Username:     "username",
-					PMMAgentID:   pmmAgentID,
-					Disabled:     true,
-					Status:       &AgentStatusUnknown,
-					CustomLabels: map[string]string{},
-					LogLevel:     pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+					AgentID:        agentID,
+					ServiceID:      serviceID,
+					Username:       "username",
+					PMMAgentID:     pmmAgentID,
+					Disabled:       true,
+					Status:         &AgentStatusUnknown,
+					CustomLabels:   map[string]string{},
+					ExtraDsnParams: map[string]string{},
+					LogLevel:       pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 				},
 			},
 		}, changeQANMySQLPerfSchemaAgentOK)
@@ -591,8 +594,9 @@ func TestQanAgentExporter(t *testing.T) {
 					CustomLabels: map[string]string{
 						"new_label": "QANMysqlPerfschemaAgent",
 					},
-					Status:   &AgentStatusUnknown,
-					LogLevel: pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+					Status:         &AgentStatusUnknown,
+					LogLevel:       pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+					ExtraDsnParams: map[string]string{},
 				},
 			},
 		}, changeQANMySQLPerfSchemaAgentOK)

--- a/api-tests/inventory/nodes_test.go
+++ b/api-tests/inventory/nodes_test.go
@@ -399,12 +399,13 @@ func TestRemoveNode(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []*services.ListServicesOKBodyMysqlItems0{
 			{
-				NodeID:       node.Generic.NodeID,
-				ServiceID:    serviceID,
-				Address:      "localhost",
-				Port:         3306,
-				ServiceName:  serviceName,
-				CustomLabels: map[string]string{},
+				NodeID:         node.Generic.NodeID,
+				ServiceID:      serviceID,
+				Address:        "localhost",
+				Port:           3306,
+				ServiceName:    serviceName,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, listAgentsOK.Payload.Mysql)
 

--- a/api-tests/inventory/services_test.go
+++ b/api-tests/inventory/services_test.go
@@ -355,12 +355,13 @@ func TestMySQLService(t *testing.T) {
 		assert.Equal(t, &services.AddServiceOK{
 			Payload: &services.AddServiceOKBody{
 				Mysql: &services.AddServiceOKBodyMysql{
-					ServiceID:    serviceID,
-					NodeID:       genericNodeID,
-					Address:      "localhost",
-					Port:         3306,
-					ServiceName:  serviceName,
-					CustomLabels: map[string]string{},
+					ServiceID:      serviceID,
+					NodeID:         genericNodeID,
+					Address:        "localhost",
+					Port:           3306,
+					ServiceName:    serviceName,
+					CustomLabels:   map[string]string{},
+					ExtraDsnParams: map[string]string{},
 				},
 			},
 		}, res)
@@ -376,12 +377,13 @@ func TestMySQLService(t *testing.T) {
 		assert.Equal(t, &services.GetServiceOK{
 			Payload: &services.GetServiceOKBody{
 				Mysql: &services.GetServiceOKBodyMysql{
-					ServiceID:    serviceID,
-					NodeID:       genericNodeID,
-					Address:      "localhost",
-					Port:         3306,
-					ServiceName:  serviceName,
-					CustomLabels: map[string]string{},
+					ServiceID:      serviceID,
+					NodeID:         genericNodeID,
+					Address:        "localhost",
+					Port:           3306,
+					ServiceName:    serviceName,
+					CustomLabels:   map[string]string{},
+					ExtraDsnParams: map[string]string{},
 				},
 			},
 		}, serviceRes)

--- a/api-tests/management/mysql_test.go
+++ b/api-tests/management/mysql_test.go
@@ -76,12 +76,13 @@ func TestAddMySQL(t *testing.T) {
 		require.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       nodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         3306,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         nodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           3306,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -102,6 +103,7 @@ func TestAddMySQL(t *testing.T) {
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
 		}, listAgents.Payload.MysqldExporter)
@@ -154,12 +156,13 @@ func TestAddMySQL(t *testing.T) {
 		assert.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       nodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         3306,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         nodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           3306,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -185,6 +188,7 @@ func TestAddMySQL(t *testing.T) {
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				DisabledCollectors:        make([]string, 0),
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
@@ -200,19 +204,21 @@ func TestAddMySQL(t *testing.T) {
 				MaxSlowlogFileSize: "1073741824",
 				Status:             &AgentStatusUnknown,
 				CustomLabels:       map[string]string{},
+				ExtraDsnParams:     map[string]string{},
 				LogLevel:           pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
 		}, listAgents.Payload.QANMysqlSlowlogAgent)
 
 		assert.Equal(t, []*agents.ListAgentsOKBodyQANMysqlPerfschemaAgentItems0{
 			{
-				AgentID:      listAgents.Payload.QANMysqlPerfschemaAgent[0].AgentID,
-				ServiceID:    serviceID,
-				PMMAgentID:   pmmAgentID,
-				Username:     "username",
-				Status:       &AgentStatusUnknown,
-				CustomLabels: map[string]string{},
-				LogLevel:     pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
+				AgentID:        listAgents.Payload.QANMysqlPerfschemaAgent[0].AgentID,
+				ServiceID:      serviceID,
+				PMMAgentID:     pmmAgentID,
+				Username:       "username",
+				Status:         &AgentStatusUnknown,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
+				LogLevel:       pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
 		}, listAgents.Payload.QANMysqlPerfschemaAgent)
 	})
@@ -274,6 +280,7 @@ func TestAddMySQL(t *testing.T) {
 				Cluster:        "cluster-name",
 				ReplicationSet: "replication-set",
 				CustomLabels:   map[string]string{"bar": "foo"},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 	})
@@ -423,12 +430,13 @@ func TestAddMySQL(t *testing.T) {
 		require.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       newNodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         27017,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         newNodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           27017,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -448,6 +456,7 @@ func TestAddMySQL(t *testing.T) {
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 				DisabledCollectors:        make([]string, 0),
 			},
@@ -692,12 +701,13 @@ func TestAddMySQL(t *testing.T) {
 		require.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       nodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         3306,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         nodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           3306,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -717,6 +727,7 @@ func TestAddMySQL(t *testing.T) {
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				DisabledCollectors:        make([]string, 0),
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
@@ -767,12 +778,13 @@ func TestAddMySQL(t *testing.T) {
 		require.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       nodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         3306,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         nodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           3306,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -791,6 +803,7 @@ func TestAddMySQL(t *testing.T) {
 				TablestatsGroupTableLimit: 1000,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				DisabledCollectors:        make([]string, 0),
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},
@@ -841,12 +854,13 @@ func TestAddMySQL(t *testing.T) {
 		require.NotNil(t, serviceOK)
 		assert.Equal(t, services.GetServiceOKBody{
 			Mysql: &services.GetServiceOKBodyMysql{
-				ServiceID:    serviceID,
-				NodeID:       nodeID,
-				ServiceName:  serviceName,
-				Address:      "10.10.10.10",
-				Port:         3306,
-				CustomLabels: map[string]string{},
+				ServiceID:      serviceID,
+				NodeID:         nodeID,
+				ServiceName:    serviceName,
+				Address:        "10.10.10.10",
+				Port:           3306,
+				CustomLabels:   map[string]string{},
+				ExtraDsnParams: map[string]string{},
 			},
 		}, *serviceOK.Payload)
 
@@ -866,6 +880,7 @@ func TestAddMySQL(t *testing.T) {
 				PushMetricsEnabled:        true,
 				Status:                    &AgentStatusUnknown,
 				CustomLabels:              map[string]string{},
+				ExtraDsnParams:            map[string]string{},
 				DisabledCollectors:        make([]string, 0),
 				LogLevel:                  pointer.ToString("LOG_LEVEL_UNSPECIFIED"),
 			},


### PR DESCRIPTION
This PR addresses the following API test failures:
1. We added 8 more alert templates to the free tier via Portal, and now ListTemplates returns +8 templates.
2. It seems like [adding ExtraDsnParams](https://github.com/percona/pmm/pull/4221) broke some Inventory API tests. Example:
```bash
00:06:08.422          	            	Diff:
00:06:08.422          	            	--- Expected
00:06:08.422          	            	+++ Actual
00:06:08.422          	            	@@ -18,3 +18,4 @@
00:06:08.422          	            	   Version: (string) "",
00:06:08.422          	            	-  ExtraDsnParams: (map[string]string) <nil>
00:06:08.422          	            	+  ExtraDsnParams: (map[string]string) {
00:06:08.422          	            	+  }
```


Link to the Feature Build: SUBMODULES-4017

Test results: https://github.com/Percona-Lab/pmm-submodules/pull/4017#issuecomment-3218424435

