### PR TITLE
Use consistent Host in mysql config examples

### DIFF
--- a/documentation/docs/install-pmm/install-pmm-client/connect-database/mysql/mysql.md
+++ b/documentation/docs/install-pmm/install-pmm-client/connect-database/mysql/mysql.md
@@ -103,7 +103,7 @@ This example creates a pmm user account that has just enough access to collect m
 === "On MySQL 5.7/MariaDB 10.x"
 
     ```sql
-    CREATE USER 'pmm'@'127.0.0.1' IDENTIFIED BY '<your_strong_password>' WITH MAX_USER_CONNECTIONS 10;
+    CREATE USER 'pmm'@'localhost' IDENTIFIED BY '<your_strong_password>' WITH MAX_USER_CONNECTIONS 10;
     GRANT SELECT, PROCESS, REPLICATION CLIENT, RELOAD ON *.* TO 'pmm'@'localhost';
     ```
 


### PR DESCRIPTION
Currently it creates a user @'127.0.0.1' but then tries to grant perms to @'localhost'. 

I don't know which one of these two you would prefer to be in the documentation, but at the moment the instructions do not work.