### PR TITLE
PMM-7 Update Grafana feature toogles

### DIFF
--- a/build/ansible/roles/grafana/files/grafana.ini
+++ b/build/ansible/roles/grafana/files/grafana.ini
@@ -3,10 +3,7 @@
 
 #################################### Database ####################################
 [database]
-# You can configure the database connection by specifying type, host, name, user and password
-# as separate properties or as on string using the url properties.
-
-# Either "mysql", "postgres" or "sqlite3", it's your choice
+# Either "mysql", "postgres" or "sqlite3"
 type = postgres
 host = localhost
 user = grafana
@@ -79,31 +76,18 @@ enabled = true
 
 [plugins]
 # Enter a comma-separated list of plugin identifiers to identify plugins that are allowed to be loaded even if they lack a valid signature.
-allow_loading_unsigned_plugins = grafana-polystat-panel,pmm-app,pmm-check-panel-home,pmm-update,pmm-qan-app-panel,pmm-pt-summary-panel,pmm-pt-summary-datasource
+allow_loading_unsigned_plugins = pmm-app,pmm-check-panel-home,pmm-update,pmm-qan-app-panel,pmm-pt-summary-panel,pmm-pt-summary-datasource
 
 [feature_toggles]
-# there are currently two ways to enable feature toggles in the `grafana.ini`.
-# you can either pass an array of feature you want to enable to the `enable` field or
-# configure each toggle by setting the name of the toggle to true/false. Toggles set to true/false
-# will take precedence over toggles in the `enable` list.
+# Configure each feature toggle by setting the name of the toggle to true/false.
+# Ref: https://grafana.com/docs/grafana/v11.6/setup-grafana/configure-grafana/feature-toggles/
+# Ref: https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/feature-toggles/ (latest)
 
-# enable = feature1,feature2
-enable = savedItems,panelTitleSearch
+# Search for dashboards using panel title
+panelTitleSearch = true
 
-# The new prometheus visual query builder
-promQueryBuilder = true
-
-# The new loki visual query builder
-lokiQueryBuilder = true
-
-# Experimental Explore to Dashboard workflow
-explore2Dashboard = true
-
-# Experimental Command Palette
-commandPalette = true
-
-# Use dynamic labels in CloudWatch datasource
-cloudWatchDynamicLabels = true
+# Enables Query Library feature in Explore
+queryLibrary = true
 
 # Hide Angular deprecation warning on UI
 angularDeprecationUI = false


### PR DESCRIPTION
PMM-7

Link to the Feature Build: SUBMODULES-0

This pull request updates the configuration for Grafana in the `grafana.ini` file, focusing on streamlining plugin permissions and modernizing feature toggle management. The changes also clarify and simplify the database configuration.

**Configuration updates:**

* Simplified database configuration comments and retained only the supported database types in the `type` field under the `[database]` section.

**Plugin management:**

* Removed `grafana-polystat-panel` from the list of allowed unsigned plugins in the `[plugins]` section, likely to improve security or compatibility.

**Feature toggles modernization:**

* Switched from using the `enable` array for feature toggles to configuring each toggle individually by setting its name to `true` or `false`, following Grafana's recommended approach.
* Added or updated feature toggles: enabled `panelTitleSearch` and `queryLibrary`, and removed several experimental toggles and legacy comments for clarity.
* Retained the setting to hide Angular deprecation warnings (`angularDeprecationUI = false`).