### PR TITLE
PMM-14157 - Update MongoDB PBM backup alert template to use max_over_…

### DIFF
--- a/managed/data/alerting-templates/mongodb_pbm_backup_stale.yml
+++ b/managed/data/alerting-templates/mongodb_pbm_backup_stale.yml
@@ -20,8 +20,8 @@ templates:
     for: 1m
     severity: critical
     annotations:
-      summary: Last PBM backup is stale for cluster={{ $labels.cluster }}, replica_set={{ $labels.replica_set }}
+      summary: Last PBM backup is stale for cluster={{ $labels.cluster }}
       description: |-
-        Last PBM backup is stale for cluster={{ $labels.cluster }}, replica_set={{ $labels.replica_set }}
+        Last PBM backup is stale for cluster={{ $labels.cluster }}
         Age: {{ $value | humanizeDuration }} (exceeds [[ .threshold ]] seconds).
         


### PR DESCRIPTION
…time for last successful backup check

- Modified the expression to calculate the age of the last successful backup using max_over_time for better accuracy over a 30-day window.
- Updated the summary and description annotations to include cluster and replica set information for clearer context in alerts.

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds or removes or alters one or more API endpoints, please review and add or update the relevant [API documents](https://github.com/percona/pmm/tree/main/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
