### PR TITLE
Encryption - fix typos and improve clarity

### DIFF
--- a/documentation/docs/admin/security/data_encryption.md
+++ b/documentation/docs/admin/security/data_encryption.md
@@ -10,14 +10,22 @@ PMM automatically manages encryption using a key file located at `/srv/pmm-encry
 
 For enhanced security control, PMM supports custom encryption keys.
 
-To set up a custom keys, configure the `PMM_ENCRYPTION_KEY_PATH` environment variable to point to your custom key file.
+**Key format requirements:**
+
+- The key must be a 32-byte (256-bit) random value, suitable for AES-256-GCM encryption.
+- The file must contain exactly 32 raw bytes (not a hex-encoded or base64-encoded string).
+
+
+PMM uses this key with the TINK `AES256GCMKeyTemplate` output prefix type.
+
+To set up a custom key, configure the `PMM_ENCRYPTION_KEY_PATH` environment variable to point to your custom key file.
 
 !!! hint alert alert-success "Important"
-    Make sure to set this configuration  **before** any data encryption occurs—specifically, either before upgrading to PMM 3 or before the initial startup of a new PMM 3.x container.
+    Configure this **before** any data encryption occurs: either before upgrading to PMM 3 or before initially starting a new PMM 3.x instance.
 
 ### Key management requirements
 
-Once configured, PMM will use custom keys to encrypt and decrypt all sensitive data stored within the system.
+Once configured, PMM will use the custom key to encrypt and decrypt all sensitive data stored within the system.
 
 If the custom key is unavailable or misplaced, PMM will be unable to access and decrypt the stored data, which will prevent it from running correctly.
 
@@ -34,14 +42,14 @@ To rotate the encryption key:
 
 1. Log in to the container that runs PMM Server.
 
-2. Run the Encryption Rotation Tool using the following the command:
+2. Run the Encryption Rotation Tool using the following command:
 
     ```bash
-   pmm-encryption-rotation
+     pmm-encryption-rotation
     ```
 
-      - Ensure `PMM_ENCRYPTION_KEY_PATH` is set to the current custom key if using one, so the tool can decrypt data before re-encryption.
-      - If using custom credentials/SSL for the PMM internal database, provide them with the appropriate flags.
+    - Ensure `PMM_ENCRYPTION_KEY_PATH` is set to the current custom key if using one, so the tool can decrypt data before re-encryption.
+    - If using custom credentials/SSL for the PMM internal database, provide them with the appropriate flags.
 
 3. Verify PMM functionality all components are functioning properly to ensure that the encryption key rotation was successful.
 

--- a/documentation/docs/reference/index.md
+++ b/documentation/docs/reference/index.md
@@ -50,7 +50,7 @@ PMM Server includes the following tools:
   - [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) is a scalable time-series database. 
   - [ClickHouse](https://clickhouse.com) is a third-party column-oriented database that facilitates the Query Analytics functionality.
   - [Grafana](http://docs.grafana.org) is a third-party dashboard and graph engine for visualizing data aggregated in an intuitive web interface.
-  - [PMM Dashboards](https://github.com/percona/pmm/dashboards) is a set of metrics dashboards developed by Percona.
+  - [PMM Dashboards](https://github.com/percona/pmm/tree/v3/dashboards) is a set of metrics dashboards developed by Percona.
 
 ### PMM Client
 


### PR DESCRIPTION
This pull request makes minor improvements to the documentation for PMM's data encryption configuration. The changes clarify instructions and correct some wording to improve readability.

- Documentation clarity:
  * Corrected the wording to refer to a "custom key" instead of "custom keys" and clarified that the environment variable should be set before upgrading to PMM 3 or starting a new PMM 3.x instance.
  * Improved phrasing to state that PMM uses "the custom key" for encryption and decryption, rather than "custom keys".
