### PR TITLE
PMM-14429 Provide ability to generate the encryption key

### DIFF
--- a/managed/cmd/pmm-encryption-rotation/main.go
+++ b/managed/cmd/pmm-encryption-rotation/main.go
@@ -38,8 +38,6 @@ func main() {
 
 	logger.SetupGlobalLogger()
 
-	logrus.Infof("PMM Encryption Rotation Tool version: %s", version.Version)
-
 	var opts flags
 	kong.Parse(
 		&opts,

--- a/managed/cmd/pmm-encryption-rotation/main.go
+++ b/managed/cmd/pmm-encryption-rotation/main.go
@@ -66,7 +66,7 @@ func main() {
 			logrus.Errorf("Failed to generate key: %v", err)
 			os.Exit(1)
 		}
-		fmt.Print(key)
+		fmt.Print(key) //nolint:forbidigo
 		os.Exit(0)
 	}
 

--- a/managed/cmd/pmm-encryption-rotation/main.go
+++ b/managed/cmd/pmm-encryption-rotation/main.go
@@ -91,7 +91,7 @@ type flags struct {
 	SSLCAPath   string `name:"postgres-ssl-ca-path" help:"PostgreSQL SSL CA root certificate path" type:"path"`
 	SSLKeyPath  string `name:"postgres-ssl-key-path" help:"PostgreSQL SSL key path" type:"path"`
 	SSLCertPath string `name:"postgres-ssl-cert-path" help:"PostgreSQL SSL certificate path" type:"path"`
-	GenerateKey bool   `name:"generate-key" default:"false" help:"Only generate a new encryption key and print to stdout"`
+	GenerateKey bool   `name:"generate-key" help:"Only generate a new encryption key and print to stdout"`
 }
 
 func setupParams(opts flags) models.SetupDBParams {

--- a/managed/cmd/pmm-encryption-rotation/main.go
+++ b/managed/cmd/pmm-encryption-rotation/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/percona/pmm/managed/models"
 	encryptionService "github.com/percona/pmm/managed/services/encryption"
+	"github.com/percona/pmm/managed/utils/encryption"
 	"github.com/percona/pmm/utils/logger"
 	"github.com/percona/pmm/version"
 )
@@ -37,9 +38,39 @@ func main() {
 
 	logger.SetupGlobalLogger()
 
-	logrus.Infof("PMM Encryption Rotation Tools version: %s", version.Version)
+	logrus.Infof("PMM Encryption Rotation Tool version: %s", version.Version)
 
-	sqlDB, err := models.OpenDB(setupParams())
+	var opts flags
+	kong.Parse(
+		&opts,
+		kong.Name("encryption-rotation"),
+		kong.Description(fmt.Sprintf("Version %s", version.Version)), //nolint:perfsprint
+		kong.UsageOnError(),
+		kong.ConfigureHelp(kong.HelpOptions{
+			Compact:             true,
+			NoExpandSubcommands: true,
+		}),
+		kong.Vars{
+			"address":             models.DefaultPostgreSQLAddr,
+			"disable_sslmode":     models.DisableSSLMode,
+			"require_sslmode":     models.RequireSSLMode,
+			"verify_sslmode":      models.VerifyCaSSLMode,
+			"verify_full_sslmode": models.VerifyFullSSLMode,
+		},
+	)
+
+	if opts.GenerateKey {
+		e := &encryption.Encryption{}
+		key, err := e.GenerateKey()
+		if err != nil {
+			logrus.Errorf("Failed to generate key: %v", err)
+			os.Exit(1)
+		}
+		fmt.Print(key)
+		os.Exit(0)
+	}
+
+	sqlDB, err := models.OpenDB(setupParams(opts))
 	if err != nil {
 		logrus.Error(err)
 		os.Exit(codeDBConnectionFailed)
@@ -62,28 +93,10 @@ type flags struct {
 	SSLCAPath   string `name:"postgres-ssl-ca-path" help:"PostgreSQL SSL CA root certificate path" type:"path"`
 	SSLKeyPath  string `name:"postgres-ssl-key-path" help:"PostgreSQL SSL key path" type:"path"`
 	SSLCertPath string `name:"postgres-ssl-cert-path" help:"PostgreSQL SSL certificate path" type:"path"`
+	GenerateKey bool   `name:"generate-key" help:"Only generate a new encryption key and print to stdout"`
 }
 
-func setupParams() models.SetupDBParams {
-	var opts flags
-	kong.Parse(
-		&opts,
-		kong.Name("encryption-rotation"),
-		kong.Description(fmt.Sprintf("Version %s", version.Version)), //nolint:perfsprint
-		kong.UsageOnError(),
-		kong.ConfigureHelp(kong.HelpOptions{
-			Compact:             true,
-			NoExpandSubcommands: true,
-		}),
-		kong.Vars{
-			"address":             models.DefaultPostgreSQLAddr,
-			"disable_sslmode":     models.DisableSSLMode,
-			"require_sslmode":     models.RequireSSLMode,
-			"verify_sslmode":      models.VerifyCaSSLMode,
-			"verify_full_sslmode": models.VerifyFullSSLMode,
-		},
-	)
-
+func setupParams(opts flags) models.SetupDBParams {
 	return models.SetupDBParams{
 		Address:     opts.Address,
 		Name:        opts.DBName,

--- a/managed/cmd/pmm-encryption-rotation/main.go
+++ b/managed/cmd/pmm-encryption-rotation/main.go
@@ -93,7 +93,7 @@ type flags struct {
 	SSLCAPath   string `name:"postgres-ssl-ca-path" help:"PostgreSQL SSL CA root certificate path" type:"path"`
 	SSLKeyPath  string `name:"postgres-ssl-key-path" help:"PostgreSQL SSL key path" type:"path"`
 	SSLCertPath string `name:"postgres-ssl-cert-path" help:"PostgreSQL SSL certificate path" type:"path"`
-	GenerateKey bool   `name:"generate-key" help:"Only generate a new encryption key and print to stdout"`
+	GenerateKey bool   `name:"generate-key" default:"false" help:"Only generate a new encryption key and print to stdout"`
 }
 
 func setupParams(opts flags) models.SetupDBParams {

--- a/managed/services/encryption/encryption_rotation.go
+++ b/managed/services/encryption/encryption_rotation.go
@@ -111,7 +111,7 @@ func pmmServerStatus(status string) bool {
 }
 
 func pmmServerStatusWithRetries(status string) bool {
-	for i := 0; i < retries; i++ {
+	for range retries {
 		if !pmmServerStatus(status) {
 			logrus.Infoln("Retry...")
 			time.Sleep(interval)

--- a/managed/services/encryption/encryption_rotation_test.go
+++ b/managed/services/encryption/encryption_rotation_test.go
@@ -31,18 +31,18 @@ import (
 
 const (
 	encryptionKeyTestPath = "/srv/pmm-encryption-rotation-test.key"
-	originEncryptionKey   = `CMatkOIIEmQKWAowdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUuY3J5cHRvLnRpbmsuQWVzR2NtS2V5EiIaIKDxOKZxwiJl5Hj6oPZ/unTzmAvfwHWzZ1Wli0vac15YGAEQARjGrZDiCCAB`
-	// pmm-managed-username encrypted with originEncryptionKey
-	originUsernameHash = `AYxEFsZsg7lp9+eSy6+wPFHlaNNy0ZpTbYN0NuCLPnQOZUYf2S6H9B+XJdF4+DscxC/pJwI=`
-	// pmm-managed-password encrypted with originEncryptionKey
-	originPasswordHash = `AYxEFsZuL5xZb5IxGGh8NI6GrjDxCzFGxIcHe94UXcg+dnZphu7GQSgmZm633XvZ8CBU2wo=` //nolint:gosec
+	originalEncryptionKey = `CMatkOIIEmQKWAowdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUuY3J5cHRvLnRpbmsuQWVzR2NtS2V5EiIaIKDxOKZxwiJl5Hj6oPZ/unTzmAvfwHWzZ1Wli0vac15YGAEQARjGrZDiCCAB`
+	// pmm-managed-username encrypted with originalEncryptionKey
+	originalUsernameHash = `AYxEFsZsg7lp9+eSy6+wPFHlaNNy0ZpTbYN0NuCLPnQOZUYf2S6H9B+XJdF4+DscxC/pJwI=`
+	// pmm-managed-password encrypted with originalEncryptionKey
+	originalPasswordHash = `AYxEFsZuL5xZb5IxGGh8NI6GrjDxCzFGxIcHe94UXcg+dnZphu7GQSgmZm633XvZ8CBU2wo=` //nolint:gosec
 )
 
 func TestEncryptionRotation(t *testing.T) {
 	db := testdb.Open(t, models.SkipFixtures, nil)
 	defer db.Close() //nolint:errcheck
 
-	err := createOriginEncryptionKey(t)
+	err := createOriginalEncryptionKey(t)
 	require.NoError(t, err)
 
 	err = insertTestData(db)
@@ -54,7 +54,7 @@ func TestEncryptionRotation(t *testing.T) {
 
 	newEncryptionKey, err := os.ReadFile(encryptionKeyTestPath)
 	require.NoError(t, err)
-	require.NotEqual(t, newEncryptionKey, []byte(originEncryptionKey))
+	require.NotEqual(t, newEncryptionKey, []byte(originalEncryptionKey))
 
 	err = checkNewlyEncryptedData(db)
 	require.NoError(t, err)
@@ -63,14 +63,14 @@ func TestEncryptionRotation(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func createOriginEncryptionKey(t *testing.T) error {
+func createOriginalEncryptionKey(t *testing.T) error {
 	t.Helper()
 	t.Setenv(encryption.CustomEncryptionKeyPathEnvVar, encryptionKeyTestPath)
-	err := os.WriteFile(encryptionKeyTestPath, []byte(originEncryptionKey), 0o600)
+	err := os.WriteFile(encryptionKeyTestPath, []byte(originalEncryptionKey), 0o600)
 	if err != nil {
 		return err
 	}
-	encryption.DefaultEncryption = encryption.New()
+	// Encryption will be lazily initialized when first used
 	return nil
 }
 
@@ -101,7 +101,7 @@ func insertTestData(db *sql.DB) error {
 	_, err = db.Exec(
 		`INSERT INTO agents (agent_id, agent_type, username, password, runs_on_node_id, pmm_agent_id, disabled, status, created_at, updated_at, tls, tls_skip_verify, qan_options, mysql_options, aws_options, exporter_options) `+
 			`VALUES ('1', 'pmm-agent', $1, $2, '1', NULL, false, '', $3, $4, false, false, '{"max_query_length": 0, "query_examples_disabled": false, "comments_parsing_disabled": true, "max_query_log_size": 0}', '{"table_count_tablestats_group_limit": 0}', '{"rds_basic_metrics_disabled": true, "rds_enhanced_metrics_disabled": true}', '{"push_metrics": false, "expose_exporter": false}')`,
-		originUsernameHash, originPasswordHash, now, now)
+		originalUsernameHash, originalPasswordHash, now, now)
 	if err != nil {
 		return err
 	}
@@ -116,10 +116,10 @@ func checkNewlyEncryptedData(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	if newlyEncryptedUsername == originUsernameHash {
+	if newlyEncryptedUsername == originalUsernameHash {
 		return errors.New("username hash not rotated properly")
 	}
-	if newlyEncryptedPassword == originPasswordHash {
+	if newlyEncryptedPassword == originalPasswordHash {
 		return errors.New("password hash not rotated properly")
 	}
 

--- a/managed/utils/encryption/encryption.go
+++ b/managed/utils/encryption/encryption.go
@@ -39,7 +39,7 @@ var (
 	DefaultEncryptionKeyPath = "/srv/pmm-encryption.key"
 	// ErrEncryptionNotInitialized is error in case of encryption is not initialized.
 	ErrEncryptionNotInitialized = errors.New("encryption is not initialized")
-	// defaultEncryption is the default implementation of encryption, lazily initialized.
+	// DefaultEncryption is the default implementation of encryption, lazily initialized.
 	defaultEncryption    *Encryption
 	defaultEncryptionMtx sync.Mutex
 )

--- a/managed/utils/encryption/encryption.go
+++ b/managed/utils/encryption/encryption.go
@@ -101,7 +101,7 @@ func New() *Encryption {
 	bytes, err := os.ReadFile(e.Path)
 	switch {
 	case os.IsNotExist(err):
-		err := e.generateAndPersistKey()
+		err = e.generateAndPersistKey()
 		if err != nil {
 			logrus.Panicf("Encryption: %v", err)
 		}
@@ -153,6 +153,7 @@ func backupOldEncryptionKey() error {
 	return nil
 }
 
+// GenerateKey generates a new encryption key.
 func (e *Encryption) GenerateKey() (string, error) {
 	handle, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
 	if err != nil {

--- a/managed/utils/encryption/encryption.go
+++ b/managed/utils/encryption/encryption.go
@@ -101,7 +101,7 @@ func New() *Encryption {
 	bytes, err := os.ReadFile(e.Path)
 	switch {
 	case os.IsNotExist(err):
-		err = e.generateKey()
+		err := e.generateAndPersistKey()
 		if err != nil {
 			logrus.Panicf("Encryption: %v", err)
 		}
@@ -153,19 +153,27 @@ func backupOldEncryptionKey() error {
 	return nil
 }
 
-func (e *Encryption) generateKey() error {
+func (e *Encryption) GenerateKey() (string, error) {
 	handle, err := keyset.NewHandle(aead.AES256GCMKeyTemplate())
 	if err != nil {
-		return fmt.Errorf("failed to create keyset: %w", err)
+		return "", fmt.Errorf("failed to create keyset: %w", err)
 	}
 
 	buff := &bytes.Buffer{}
 	err = insecurecleartextkeyset.Write(handle, keyset.NewBinaryWriter(buff))
 	if err != nil {
-		return fmt.Errorf("failed to write encryption key: %w", err)
+		return "", fmt.Errorf("failed to write encryption key: %w", err)
 	}
-	e.Key = base64.StdEncoding.EncodeToString(buff.Bytes())
 
+	return base64.StdEncoding.EncodeToString(buff.Bytes()), nil
+}
+
+func (e *Encryption) generateAndPersistKey() error {
+	key, err := e.GenerateKey()
+	if err != nil {
+		return err
+	}
+	e.Key = key
 	return e.saveKeyToFile()
 }
 

--- a/managed/utils/encryption/encryption.go
+++ b/managed/utils/encryption/encryption.go
@@ -39,13 +39,24 @@ var (
 	DefaultEncryptionKeyPath = "/srv/pmm-encryption.key"
 	// ErrEncryptionNotInitialized is error in case of encryption is not initialized.
 	ErrEncryptionNotInitialized = errors.New("encryption is not initialized")
-	// DefaultEncryption is the default implementation of encryption.
-	DefaultEncryption    = New()
+	// defaultEncryption is the default implementation of encryption, lazily initialized.
+	defaultEncryption    *Encryption
 	defaultEncryptionMtx sync.Mutex
 )
 
 // CustomEncryptionKeyPathEnvVar is an environment variable to set custom encryption key path.
 const CustomEncryptionKeyPathEnvVar = "PMM_ENCRYPTION_KEY_PATH"
+
+// getDefaultEncryption returns the default encryption instance, initializing it lazily if needed.
+func getDefaultEncryption() *Encryption {
+	defaultEncryptionMtx.Lock()
+	defer defaultEncryptionMtx.Unlock()
+
+	if defaultEncryption == nil {
+		defaultEncryption = New()
+	}
+	return defaultEncryption
+}
 
 // Encryption contains fields required for encryption.
 type Encryption struct {
@@ -128,7 +139,7 @@ func RotateEncryptionKey() error {
 	}
 
 	defaultEncryptionMtx.Lock()
-	DefaultEncryption = New()
+	defaultEncryption = New()
 	defaultEncryptionMtx.Unlock()
 
 	return nil
@@ -184,7 +195,7 @@ func (e *Encryption) saveKeyToFile() error {
 
 // Encrypt is a wrapper around DefaultEncryption.Encrypt.
 func Encrypt(secret string) (string, error) {
-	return DefaultEncryption.Encrypt(secret)
+	return getDefaultEncryption().Encrypt(secret)
 }
 
 // Encrypt returns input string encrypted.
@@ -205,7 +216,7 @@ func (e *Encryption) Encrypt(secret string) (string, error) {
 
 // EncryptItems is a wrapper around DefaultEncryption.EncryptItems.
 func EncryptItems(tx *reform.TX, tables []Table) error {
-	return DefaultEncryption.EncryptItems(tx, tables)
+	return getDefaultEncryption().EncryptItems(tx, tables)
 }
 
 // EncryptItems will encrypt all columns provided in DB connection.
@@ -250,7 +261,7 @@ func (e *Encryption) EncryptItems(tx *reform.TX, tables []Table) error {
 
 // Decrypt is wrapper around DefaultEncryption.Decrypt.
 func Decrypt(cipherText string) (string, error) {
-	return DefaultEncryption.Decrypt(cipherText)
+	return getDefaultEncryption().Decrypt(cipherText)
 }
 
 // Decrypt returns input string decrypted.
@@ -275,7 +286,7 @@ func (e *Encryption) Decrypt(cipherText string) (string, error) {
 
 // DecryptItems is wrapper around DefaultEncryption.DecryptItems.
 func DecryptItems(tx *reform.TX, tables []Table) error {
-	return DefaultEncryption.DecryptItems(tx, tables)
+	return getDefaultEncryption().DecryptItems(tx, tables)
 }
 
 // DecryptItems will decrypt all columns provided in DB connection.

--- a/managed/utils/encryption/encryption_test.go
+++ b/managed/utils/encryption/encryption_test.go
@@ -1,0 +1,73 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package encryption
+
+import (
+	"encoding/base64"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptionGenerateKey(t *testing.T) {
+	e := &Encryption{}
+
+	key1, err := e.GenerateKey()
+	require.NoError(t, err)
+	assert.NotEmpty(t, key1)
+
+	// Verify it's valid base64
+	_, err = base64.StdEncoding.DecodeString(key1)
+	assert.NoError(t, err)
+
+	// Generate another key and ensure they are different
+	key2, err := e.GenerateKey()
+	require.NoError(t, err)
+	assert.NotEmpty(t, key2)
+	assert.NotEqual(t, key1, key2)
+
+	// Verify second key is also valid base64
+	_, err = base64.StdEncoding.DecodeString(key2)
+	assert.NoError(t, err)
+}
+
+func TestEncryptionGenerateAndPersistKey(t *testing.T) {
+	// Create a temporary file path for testing
+	tempFile, err := os.CreateTemp("", "encryption_test_*.key")
+	require.NoError(t, err)
+	tempFile.Close()
+
+	t.Cleanup(func() {
+		os.Remove(tempFile.Name())
+	})
+
+	e := &Encryption{Path: tempFile.Name()}
+
+	err = e.generateAndPersistKey()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, e.Key)
+
+	// Verify the file was written with the correct content
+	content, err := os.ReadFile(tempFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, e.Key, string(content))
+
+	// Verify it's valid base64
+	_, err = base64.StdEncoding.DecodeString(e.Key)
+	assert.NoError(t, err)
+}

--- a/managed/utils/encryption/encryption_test.go
+++ b/managed/utils/encryption/encryption_test.go
@@ -48,12 +48,13 @@ func TestEncryptionGenerateKey(t *testing.T) {
 
 func TestEncryptionGenerateAndPersistKey(t *testing.T) {
 	// Create a temporary file path for testing
-	tempFile, err := os.CreateTemp("", "encryption_test_*.key")
+	tempFile, err := os.CreateTemp(t.TempDir(), "encryption_test_*.key")
 	require.NoError(t, err)
-	tempFile.Close()
+	err = tempFile.Close()
+	assert.NoError(t, err)
 
 	t.Cleanup(func() {
-		os.Remove(tempFile.Name())
+		_ = os.Remove(tempFile.Name())
 	})
 
 	e := &Encryption{Path: tempFile.Name()}


### PR DESCRIPTION
PMM-14429

Link to the Feature Build: SUBMODULES-4088


- https://github.com/percona/pmm/pull/4683

This pull request adds support for generating encryption keys directly from the command line and refactors the encryption key generation logic for improved usability and testability. It introduces a new `--generate-key` flag to the `pmm-encryption-rotation` tool, allowing users to generate and print a new encryption key without connecting to the database. The encryption key generation logic is now more modular, and comprehensive unit tests have been added for key generation and persistence.

**Command-line enhancements:**
* Added a `--generate-key` flag to the `pmm-encryption-rotation` CLI, enabling users to generate and print a new encryption key to stdout without performing any database operations. (`managed/cmd/pmm-encryption-rotation/main.go`) [[1]](diffhunk://#diff-ba8004cf6ec19586ee2a7e3cc5bce0697c0d2fe2650a755a935b6a77bd73be0fL40-R73) [[2]](diffhunk://#diff-ba8004cf6ec19586ee2a7e3cc5bce0697c0d2fe2650a755a935b6a77bd73be0fR96-R99)

**Encryption key generation refactor:**
* Refactored the encryption key generation logic by splitting `generateKey` into `GenerateKey` (returns the key as a string) and `generateAndPersistKey` (generates and saves the key to a file), improving separation of concerns and making key generation reusable. (`managed/utils/encryption/encryption.go`) [[1]](diffhunk://#diff-3362a878b70c7502fdebf9be7d77cfbd9bbb77b6a3e4cbc7deff710e1fc608b1L104-R104) [[2]](diffhunk://#diff-3362a878b70c7502fdebf9be7d77cfbd9bbb77b6a3e4cbc7deff710e1fc608b1L156-R176)

**Testing improvements:**
* Added new unit tests for encryption key generation and persistence, ensuring keys are unique, valid base64, and properly written to disk. (`managed/utils/encryption/encryption_test.go`)

**Minor fixes:**
* Corrected a loop in `pmmServerStatusWithRetries` to use a range over the retry count for clarity. (`managed/services/encryption/encryption_rotation.go`)
* Minor log message update for consistency. (`managed/cmd/pmm-encryption-rotation/main.go`)
