### PR TITLE
PMM-10461 [Fix] No absolute Nginx redirects

### DIFF
--- a/build/ansible/roles/nginx/files/conf.d/pmm.conf
+++ b/build/ansible/roles/nginx/files/conf.d/pmm.conf
@@ -135,7 +135,10 @@
     }
 
     # Grafana
-    rewrite ^/$ /graph/;
+    location = / {
+      auth_request off;
+      return 302 /graph/;
+    }
     rewrite ^/graph$ /graph/;
     location /graph {
       proxy_cookie_path / "/;";


### PR DESCRIPTION
PMM-10461

Link to the Feature Build: SUBMODULES-4090

This pull request fixes a regression introduced by #4576, where opening https://IP_ADDRESS would result in "401 Unauthenticated" error.

It updates the Nginx configuration to improve how requests to the root URL are handled. Instead of using a rewrite rule, the configuration now explicitly defines a location block for `/` that disables authentication and issues a redirect to `/graph/`.

Nginx configuration changes:

* Replaced the rewrite rule for `/` with a `location = /` block that disables authentication (`auth_request off`) and returns a 302 redirect to `/graph/`. (`build/ansible/roles/nginx/files/conf.d/pmm.conf`, [build/ansible/roles/nginx/files/conf.d/pmm.confL138-R141](diffhunk://#diff-f306124c6c11a35f71761233a2d55c10fbbcfbd297988c434cb4806719402652L138-R141))

