### PR TITLE
PMM-13652 Improve location sending

### DIFF
--- a/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
@@ -107,9 +107,13 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (!isBrowser() || !isLoaded) return;
 
-    const state = location.state as LocationState;
+    const isGrafanaPage = location.pathname.includes('/graph');
+    const isSourceGrafana = (location.state as LocationState)?.fromGrafana;
+    const isBackNavigation = navigationType === 'POP';
 
-    if (!location.pathname.includes('/graph') || state?.fromGrafana) return;
+    if (!isGrafanaPage || (isSourceGrafana && !isBackNavigation)) {
+      return;
+    }
 
     messenger.sendMessage({
       type: 'LOCATION_CHANGE',

--- a/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
@@ -8,8 +8,9 @@ import {
 } from 'lib/constants';
 import type {
   ColorMode,
+  LocationState,
   DocumentTitleUpdateMessage,
-  LocationChangeMessage
+  LocationChangeMessage,
 } from '@pmm/shared';
 import { updateDocumentTitle } from 'lib/utils/document.utils';
 import { useKioskMode } from 'hooks/utils/useKioskMode';
@@ -42,9 +43,6 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
 
   // Theme source
   const { colorMode, setFromGrafana } = useColorMode();
-
-  // Keep track of the last received location from Grafana
-  const lastReceivedLocationRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (isGrafanaPage) setIsLoaded(true);
@@ -82,9 +80,8 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
           return;
         }
 
-        lastReceivedLocationRef.current = getLocationUrl(location);
-
         navigate(getLocationUrl(location), {
+          state: { fromGrafana: true },
           replace: true,
         });
       },
@@ -110,11 +107,9 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (!isBrowser() || !isLoaded) return;
 
-    const isFromGrafana =
-      lastReceivedLocationRef.current === getLocationUrl(location);
+    const state = location.state as LocationState;
 
-    // prevent broadcasting the same location back to Grafana
-    if (!location.pathname.includes('/graph') || isFromGrafana) return;
+    if (!location.pathname.includes('/graph') || state?.fromGrafana) return;
 
     messenger.sendMessage({
       type: 'LOCATION_CHANGE',

--- a/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
@@ -8,7 +8,6 @@ import {
 } from 'lib/constants';
 import type {
   ColorMode,
-  LocationState,
   DocumentTitleUpdateMessage,
   LocationChangeMessage
 } from '@pmm/shared';
@@ -44,6 +43,9 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
   // Theme source
   const { colorMode, setFromGrafana } = useColorMode();
 
+  // Keep track of the last received location from Grafana
+  const lastReceivedLocationRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (isGrafanaPage) setIsLoaded(true);
   }, [isGrafanaPage]);
@@ -76,12 +78,13 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
     messenger.addListener({
       type: 'LOCATION_CHANGE',
       onMessage: ({ payload: location }: LocationChangeMessage) => {
-        if (!location || location.action === 'POP') {
+        if (!location) {
           return;
         }
 
+        lastReceivedLocationRef.current = getLocationUrl(location);
+
         navigate(getLocationUrl(location), {
-          state: { fromGrafana: true },
           replace: true,
         });
       },
@@ -107,8 +110,11 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
   useEffect(() => {
     if (!isBrowser() || !isLoaded) return;
 
-    const state = location.state as LocationState;
-    if (!location.pathname.includes('/graph') || state?.fromGrafana) return;
+    const isFromGrafana =
+      lastReceivedLocationRef.current === getLocationUrl(location);
+
+    // prevent broadcasting the same location back to Grafana
+    if (!location.pathname.includes('/graph') || isFromGrafana) return;
 
     messenger.sendMessage({
       type: 'LOCATION_CHANGE',

--- a/ui/apps/pmm/src/contexts/grafana/grafana.utils.ts
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.utils.ts
@@ -1,6 +1,7 @@
 import { PMM_NEW_NAV_GRAFANA_PATH, PMM_NEW_NAV_PATH } from 'lib/constants';
+import { Path } from 'react-router-dom';
 
-export const getLocationUrl = (location: Location) => {
+export const getLocationUrl = (location: Path) => {
   const pathname = location.pathname.startsWith('/pmm-ui')
     ? location.pathname.replace('/pmm-ui', PMM_NEW_NAV_PATH)
     : PMM_NEW_NAV_GRAFANA_PATH + location.pathname;


### PR DESCRIPTION
Previous check for message source (location state) was preventing the back button (browser history) from working correctly (prevented resending previous location to Grafana), keeping only the last received location info should prevent this behaviour.