### PR TITLE
Update `pmm-admin add valkey` command in quickstart.md

### DIFF
--- a/documentation/docs/admin/manage-users/edit_users.md
+++ b/documentation/docs/admin/manage-users/edit_users.md
@@ -75,4 +75,4 @@ If your organization currently uses Percona Account authentication:
 6. **Communicate changes** to all affected users, including new login instructions and credentials (if applicable).
 7. **Update documentation** or processes that reference Percona Account sign-in.
 
-For more information, see [Log into PMM](../../reference/ui/log_in.md).RetryClaude can make mistakes. Please double-check responses. Sonnet 4.5
+For more information, see [Log into PMM](../../reference/ui/log_in.md).

--- a/documentation/docs/install-pmm/install-pmm-client/connect-database/remote.md
+++ b/documentation/docs/install-pmm/install-pmm-client/connect-database/remote.md
@@ -34,4 +34,4 @@ If you see timeout errors, increase the metric resolution values in PMM:
 
 ![!image](../../../images/scrape_targets_03.png)
 
-Higher resolution values (lower collection frequency) provide more time for remote agents to respond, reducing timeout errors while maintaining effective monitoring.RetryClaude can make mistakes. Please double-check responses.
+Higher resolution values (lower collection frequency) provide more time for remote agents to respond, reducing timeout errors while maintaining effective monitoring.

--- a/documentation/docs/install-pmm/install-pmm-client/connect-database/valkey-redis.md
+++ b/documentation/docs/install-pmm/install-pmm-client/connect-database/valkey-redis.md
@@ -82,7 +82,8 @@ You can add your Valkey or Redis service to PMM either through the user interfac
         Add a local Valkey instance with default settings:
         ```sh
         pmm-admin add valkey \
-          --address=localhost:6379 \
+          Valkey-Primary \
+          localhost:6379 \
           --environment=production \
           Valkey-Primary
         ```
@@ -92,7 +93,8 @@ You can add your Valkey or Redis service to PMM either through the user interfac
         Add a Valkey instance with authentication:
         ```sh
         pmm-admin add valkey \
-          --address=localhost:6379 \
+          Valkey-Primary \
+          localhost:6379 \
           --username=pmm \
           --password=StrongPassword123! \
           --environment=production \
@@ -116,7 +118,8 @@ You can add your Valkey or Redis service to PMM either through the user interfac
         Add an instance with environment and custom labels:
         ```sh
         pmm-admin add valkey \
-          --address=localhost:6379 \
+          Valkey-Primary \
+          localhost:6379 \
           --username=pmm \
           --password=StrongPassword123! \
           --environment=production \

--- a/documentation/docs/quickstart/quickstart.md
+++ b/documentation/docs/quickstart/quickstart.md
@@ -416,11 +416,11 @@ Once PMM is set up, choose the database or the application that you want it to m
     4. Add the Valkey or Redis database:
         ```sh
         pmm-admin add valkey \
-          --address=localhost:6379 \
+          Valkey-Primary \
+          localhost:6379 \
           --username=pmm \
           --password=<your_password> \
-          --environment=production \
-          Valkey-Primary
+          --environment=production
         ```
 
     For detailed setup instructions, remote monitoring, TLS and advanced options, see [Connecting Valkey/Redis databases to PMM](../install-pmm/install-pmm-client/connect-database/valkey-redis.md).


### PR DESCRIPTION
Changed the `pmm-admin add valkey` command to:
```
pmm-admin add valkey Valkey-Primary localhost:6379 \
  --username=pmm \
  --password=<your password> \
  --environment=production \

```
The original command have syntax error
```
root@v1:/etc/valkey# pmm-admin add valkey \
  --address=localhost:6379 \
  --username=pmm \
  --password=hello \
  --environment=production \
  Valkey-Primary

Usage: pmm-admin add valkey [<name> [<address>]] [flags]

Add Valkey to monitoring

Arguments:
  [<name>]       Service name (autodetected default: v1-valkey)
  [<address>]    Valkey address and port (default: 127.0.0.1:6379)
... 
pmm-admin: error: unknown flag --address
```

