### PR TITLE
PMM-7 Bump up Go and golangci-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
           fail_level: error
           cache: false
           golangci_lint_flags: "-c=.golangci.yml"
-          golangci_lint_version: v2.3.0 # Version should match specified in Makefile
+          golangci_lint_version: v2.6.2 # Version should match specified in Makefile
 
       - name: Run go-consistent
         env:

--- a/Makefile.include
+++ b/Makefile.include
@@ -14,7 +14,7 @@ init:                 ## Install tools
 	cd tools && go generate -x -tags=tools
 
 	# Install golangci-lint
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.3.0 # Version should match specified in CI
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./bin v2.6.2 # Version should match specified in CI
 
 release:              ## Build release versions of all components
 	make -C agent release

--- a/api-tests/tools/go.mod
+++ b/api-tests/tools/go.mod
@@ -1,5 +1,5 @@
 module tools
 
-go 1.24.9
+go 1.25.4
 
 require github.com/jstemmer/go-junit-report v1.0.0

--- a/build/docker/rpmbuild/Dockerfile.el8
+++ b/build/docker/rpmbuild/Dockerfile.el8
@@ -25,7 +25,7 @@ RUN dnf update -y && \
     dnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
 # keep that format for easier search
-ENV GO_VERSION=1.24.9
+ENV GO_VERSION=1.25.4
 ENV GO_RELEASER_VERSION=2.12.7
 
 RUN if [ `uname -m` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -26,7 +26,7 @@ RUN dnf update -y && \
     dnf clean all && rm -rf /var/cache/dnf /var/cache/yum
 
 # keep that format for easier search
-ENV GO_VERSION=1.24.9
+ENV GO_VERSION=1.25.4
 ENV GO_RELEASER_VERSION=2.12.7
 
 RUN if [ `uname -m` == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \

--- a/build/docker/rpmbuild/Dockerfile.hetzner-el9
+++ b/build/docker/rpmbuild/Dockerfile.hetzner-el9
@@ -43,7 +43,7 @@ RUN sed -i 's|metalink=|#metalink=|g' /etc/yum.repos.d/epel*.repo && \
     sed -i 's|#baseurl=.*|baseurl=https://ftp.fau.de/epel/9/Everything/$basearch/|g' /etc/yum.repos.d/epel.repo || true
 
 # keep that format for easier search
-ENV GO_VERSION=1.24.9
+ENV GO_VERSION=1.25.4
 ENV GO_RELEASER_VERSION=2.12.7
 
 RUN if [ "$(uname -m)" == "x86_64" ]; then ARCH=amd64; else ARCH=arm64; fi && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm
 
-go 1.24.9
+go 1.25.4
 
 // Update saas with
 // go get -v github.com/percona/saas@latest


### PR DESCRIPTION
PMM-7

This PR is needed to support https://perconadev.atlassian.net/browse/PMM-14546.

> [!NOTE]
> pmm-managed tests actually pass, it's the `go: no such tool "covdata"` message that makes the pipeline fail until we merge and rebuild the devcontainer. 

This pull request updates the Go toolchain and related dependencies across the project to ensure consistency and compatibility with the latest versions. The main changes involve upgrading the Go version from 1.24.9 to 1.25.4 and updating the `golangci-lint` version used in CI and local builds.

**Go version upgrades:**

* Updated the Go version from `1.24.9` to `1.25.4` in `go.mod`, `api-tests/tools/go.mod`, and all relevant Dockerfiles (`Dockerfile.el8`, `Dockerfile.el9`, `Dockerfile.hetzner-el9`) to standardize the environment across development and CI. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-6d0204f2a52d9e09ceaace26cdee206d3d301d376d5ec8a215468fb0d5d25816L3-R3) [[3]](diffhunk://#diff-6a082bcfee0148936e8d691e442f37a661c1fc032412dbb81b703441d1a3e05dL28-R28) [[4]](diffhunk://#diff-b6ce80cd4c4f659dc46fa648354dd5c32b50793cd448f6fa65840a7dde069dafL29-R29) [[5]](diffhunk://#diff-08a1ccc6cf8bbfb2e62f52b83dcf57ab02e32ea7e1c86c131660300bfc3a5de9L46-R46)

**Linting tool upgrades:**

* Updated the `golangci-lint` version from `v2.3.0` to `v2.6.2` in both the GitHub Actions workflow (`main.yml`) and the installation command in `Makefile.include` to match the specified version in CI and ensure consistent linting results. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L113-R113) [[2]](diffhunk://#diff-3c8fb3a3507e1db4ca93b4d7b28883c763dc084a2ca0dc45adc907d9e4abedefL17-R17)
