### PR TITLE
PMM-7 Fix devcontainer workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ ARG PMM_SERVER_IMAGE="perconalab/pmm-server:3-dev-latest"
 FROM $PMM_SERVER_IMAGE
 
 ARG PMM_SERVER_IMAGE
-ARG GO_VERSION="1.24.x"
+ARG GO_VERSION="1.25.x"
 
 USER root
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,7 +17,7 @@ COPY ./ ./
 # setup.py uses a task from Makefile.devcontainer but expects it to be in the default Makefile
 COPY ./Makefile.devcontainer ./Makefile
 
-RUN --mount=type=cache,target=/var/cache/dnf && \
+RUN --mount=type=cache,target=/var/cache/dnf \
     python ./.devcontainer/setup.py
 
 RUN mv -f $GOPATH/src/github.com/percona/pmm/bin/* $GOPATH/bin/


### PR DESCRIPTION
PMM-7

This PR fixes an error which prevented the `Devcontainer` workflow from completing successfully. It also allows `pmm-managed` tests to complete without error messages.

> [!NOTE]
> Tested with https://github.com/percona/pmm/actions/runs/19648149923/job/56268371607 ✅ 
