### PR TITLE
PMM-14442 Add mutex to add.

### DIFF
--- a/managed/services/ha/services.go
+++ b/managed/services/ha/services.go
@@ -102,9 +102,7 @@ func (s *services) Refresh() chan struct{} {
 }
 
 func (s *services) Wait() {
-	s.wgMu.Lock()
 	s.wg.Wait()
-	s.wgMu.Unlock()
 }
 
 func (s *services) removeService(id string) {

--- a/managed/services/ha/services.go
+++ b/managed/services/ha/services.go
@@ -24,7 +24,8 @@ import (
 )
 
 type services struct {
-	wg sync.WaitGroup
+	wg   sync.WaitGroup
+	wgMu sync.Mutex
 
 	rw      sync.Mutex
 	all     map[string]LeaderService
@@ -66,7 +67,9 @@ func (s *services) StartAllServices(ctx context.Context) {
 
 	for id, service := range s.all {
 		if _, ok := s.running[id]; !ok {
+			s.wgMu.Lock()
 			s.wg.Add(1)
+			s.wgMu.Unlock()
 			s.running[id] = service
 			go func() {
 				s.l.Infoln("Starting", service.ID())
@@ -88,7 +91,9 @@ func (s *services) StopRunningServices() {
 		s.l.Infoln("Stopping", service.ID())
 		service.Stop()
 		delete(s.running, id)
+		s.wgMu.Lock()
 		s.wg.Done()
+		s.wgMu.Unlock()
 	}
 }
 
@@ -97,12 +102,16 @@ func (s *services) Refresh() chan struct{} {
 }
 
 func (s *services) Wait() {
+	s.wgMu.Lock()
 	s.wg.Wait()
+	s.wgMu.Unlock()
 }
 
 func (s *services) removeService(id string) {
 	s.rw.Lock()
 	defer s.rw.Unlock()
 	delete(s.running, id)
+	s.wgMu.Lock()
 	s.wg.Done()
+	s.wgMu.Unlock()
 }


### PR DESCRIPTION
PMM-14442

With huge load and 50+ PMM clients I was able to hit data race in HA. See log below. Even HA is not enabled it is called from main. I believe we need add mutexes to place where is Add, Done etc because it is used in multiple go routines. With this fix I am not able to hit this data race. Also it caused a lot of disconnects and errors in log, once you hit that. 
```==================
WARNING: DATA RACE
Write at 0x00c00036fb08 by goroutine 107:
  runtime.racewrite()
      <autogenerated>:1 +0x1e
  github.com/percona/pmm/managed/services/ha.(*services).Wait()
      /root/go/src/github.com/percona/pmm/managed/services/ha/services.go:100 +0x2d
  github.com/percona/pmm/managed/services/ha.(*Service).Run()
      /root/go/src/github.com/percona/pmm/managed/services/ha/highavailability.go:114 +0x23af
  main.main.func20()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:1164 +0x16f

Previous read at 0x00c00036fb08 by goroutine 108:
  runtime.raceread()
      <autogenerated>:1 +0x1e
  github.com/percona/pmm/managed/services/ha.(*services).StartAllServices()
      /root/go/src/github.com/percona/pmm/managed/services/ha/services.go:69 +0x3a9
  github.com/percona/pmm/managed/services/ha.(*Service).Run.func1()
      /root/go/src/github.com/percona/pmm/managed/services/ha/highavailability.go:103 +0x365

Goroutine 107 (running) created at:
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:1162 +0xc908
  github.com/percona/pmm/managed/services/server.(*Server).UpdateSettingsFromEnv()
      /root/go/src/github.com/percona/pmm/managed/services/server/server.go:149 +0x6d6
  main.setup()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:501 +0x345
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:1021 +0x9f9a
  github.com/percona/pmm/managed/services/grafana.NewClient()
      /root/go/src/github.com/percona/pmm/managed/services/grafana/client.go:81 +0x504
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:916 +0x760e
  github.com/percona/pmm/managed/services/vmalert.NewVMAlert()
      /root/go/src/github.com/percona/pmm/managed/services/vmalert/vmalert.go:75 +0x664
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:830 +0x577b
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:818 +0x5384
  github.com/percona/pmm/managed/models.SetupDB()
      /root/go/src/github.com/percona/pmm/managed/models/database.go:1241 +0x877
  github.com/percona/pmm/managed/models.SetupDB()
      /root/go/src/github.com/percona/pmm/managed/models/database.go:1228 +0x186
  main.migrateDB()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:587 +0x457
  main.main()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:808 +0x4ea4

Goroutine 108 (running) created at:
  github.com/percona/pmm/managed/services/ha.(*Service).Run()
      /root/go/src/github.com/percona/pmm/managed/services/ha/highavailability.go:97 +0x1c4
  main.main.func20()
      /root/go/src/github.com/percona/pmm/managed/cmd/pmm-managed/main.go:1164 +0x16f
==================