### PR TITLE
PMM-14657: Fix UI crash when updates are disabled

### DIFF
--- a/ui/apps/pmm/src/components/main/update-modal/UpdateModal.tsx
+++ b/ui/apps/pmm/src/components/main/update-modal/UpdateModal.tsx
@@ -22,7 +22,8 @@ const UpdateModal: FC = () => {
   const isOnUpdatesPage = location.pathname.startsWith(
     PMM_NEW_NAV_UPDATES_PATH
   );
-  const latestVersion = versionInfo?.latest.version || '';
+
+  const latestVersion = versionInfo?.latest?.version || '';
   const releaseNotesUrl = versionInfo?.latest?.releaseNotesUrl ?? '';
   const updateAvailable = Boolean(versionInfo?.updateAvailable);
 


### PR DESCRIPTION
PMM-14657

Added a check to `versionInfo?.latest?` to avoid the UI crash

[Link to the Feature Build](https://github.com/Percona-Lab/pmm-submodules/pull/4171)

