### PR TITLE
Update documentation for helm deployment

### DIFF
--- a/documentation/docs/install-pmm/install-pmm-server/deployment-options/helm/index.md
+++ b/documentation/docs/install-pmm/install-pmm-server/deployment-options/helm/index.md
@@ -147,10 +147,10 @@ Create the required Kubernetes secret and deploy PMM Server using Helm:
 
         ```bash
         # If using ClusterIP (default)
-        kubectl port-forward svc/pmm-service 443:443
+        kubectl port-forward svc/monitoring-service 443:443
 
         # If using NodePort
-        kubectl get svc pmm-service -o jsonpath='{.spec.ports[0].nodePort}'
+        kubectl get svc monitoring-service -o jsonpath='{.spec.ports[0].nodePort}'
         ```
 
     === "On OpenShift"

--- a/documentation/docs/install-pmm/install-pmm-server/deployment-options/helm/index.md
+++ b/documentation/docs/install-pmm/install-pmm-server/deployment-options/helm/index.md
@@ -158,13 +158,13 @@ Create the required Kubernetes secret and deploy PMM Server using Helm:
 
         ```bash
         # Create a Route to expose PMM
-        oc expose svc/pmm-service --port=443
+        oc expose svc/monitoring-service --port=443
 
         # Get the Route URL
-        oc get route pmm-service -o jsonpath='{.spec.host}'
+        oc get route monitoring-service -o jsonpath='{.spec.host}'
         
         # Or use port-forwarding for testing
-        oc port-forward svc/pmm-service 443:443
+        oc port-forward svc/monitoring-service 443:443
         ```
 
 ### Configure PMM Server


### PR DESCRIPTION
Has the Kubernetes service name changed 🤔 ? I followed the [helm deployment guide](https://docs.percona.com/percona-monitoring-and-management/3/install-pmm/install-pmm-server/deployment-options/helm/index.html#__tabbed_2_1) and noticed the service name was different.

```
kubectl get svc 
NAME                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                      AGE
kubernetes           ClusterIP   10.43.0.1      <none>        443/TCP                      21h
monitoring-service   NodePort    10.43.233.57   <none>        443:31197/TCP,80:31056/TCP   20h
```