### PR TITLE
fix: Enable tagliatelle linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,7 +82,7 @@ linters:
         rules:
           avro: snake
           bson: camel
-          json: ""
+          json: snake
           xml: camel
           yaml: ""
     unparam:

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -165,7 +165,7 @@ type Config struct {
 	Debug    bool   `yaml:"debug"`
 	Trace    bool   `yaml:"trace"`
 
-	LogLinesCount         uint   `json:"log-lines-count"`
+	LogLinesCount         uint   `json:"log-lines-count"` //nolint:tagliatelle
 	PerfschemaRefreshRate uint16 `yaml:"perfschema-refresh-rate,omitempty"`
 
 	WindowConnectedTime time.Duration `yaml:"window-connected-time"`

--- a/agent/runner/actions/mongodb_explain_action.go
+++ b/agent/runner/actions/mongodb_explain_action.go
@@ -46,7 +46,7 @@ type explain struct {
 	Op                 string `json:"op"`
 	Query              bson.D `json:"query,omitempty"`
 	Command            bson.D `json:"command,omitempty"`
-	OriginatingCommand bson.D `json:"originatingCommand,omitempty"`
+	OriginatingCommand bson.D `json:"originatingCommand,omitempty"` //nolint:tagliatelle
 	UpdateObj          bson.D `json:"updateobj,omitempty"`
 }
 

--- a/agent/runner/jobs/pbm_helpers.go
+++ b/agent/runner/jobs/pbm_helpers.go
@@ -111,14 +111,14 @@ type pbmRestore struct {
 	StartedAt time.Time
 	Name      string `json:"name"`
 	Snapshot  string `json:"snapshot"`
-	PITR      string `json:"point-in-time"`
+	PITR      string `json:"point-in-time"` //nolint:tagliatelle
 }
 
 type pbmSnapshot struct {
 	Name       string `json:"name"`
 	Status     string `json:"status"`
-	RestoreTo  int64  `json:"restoreTo"`
-	PbmVersion string `json:"pbmVersion"`
+	RestoreTo  int64  `json:"restoreTo"`  //nolint:tagliatelle
+	PbmVersion string `json:"pbmVersion"` //nolint:tagliatelle
 	Type       string `json:"type"`
 	Error      string `json:"error"`
 }
@@ -128,7 +128,7 @@ type pbmListRestore struct {
 	Status   string `json:"status"`
 	Type     string `json:"type"`
 	Snapshot string `json:"snapshot"`
-	PITR     int64  `json:"point-in-time"`
+	PITR     int64  `json:"point-in-time"` //nolint:tagliatelle
 	Name     string `json:"name"`
 	Error    string `json:"error"`
 }
@@ -141,7 +141,7 @@ type pbmStatus struct {
 		Snapshot   []pbmSnapshot `json:"snapshot"`
 		PitrChunks struct {
 			Size int `json:"size"`
-		} `json:"pitrChunks"`
+		} `json:"pitrChunks"` //nolint:tagliatelle
 	} `json:"backups"`
 	Cluster []struct {
 		Rs    string `json:"rs"`
@@ -159,14 +159,14 @@ type pbmStatus struct {
 	Running struct {
 		Type    string `json:"type"`
 		Name    string `json:"name"`
-		StartTS int    `json:"startTS"`
+		StartTS int    `json:"startTS"` //nolint:tagliatelle
 		Status  string `json:"status"`
-		OpID    string `json:"opID"`
+		OpID    string `json:"opID"` //nolint:tagliatelle
 	} `json:"running"`
 }
 
 type pbmError struct {
-	Error string `json:"Error"`
+	Error string `json:"Error"` //nolint:tagliatelle
 }
 
 // pbmConfigParams groups the flags/options for configuring PBM.

--- a/managed/models/settings.go
+++ b/managed/models/settings.go
@@ -106,7 +106,7 @@ type Settings struct {
 	} `json:"backup_management"`
 
 	// PMMServerID is generated on the first start of PMM server.
-	PMMServerID string `json:"pmmServerID"`
+	PMMServerID string `json:"pmmServerID"` //nolint:tagliatelle
 
 	// DefaultRoleID defines a default role to be assigned to new users.
 	DefaultRoleID int `json:"default_role_id"`

--- a/managed/services/alert_rule.go
+++ b/managed/services/alert_rule.go
@@ -33,17 +33,17 @@ type RelativeTimeRange struct {
 
 // Model represents grafana query model.
 type Model struct {
-	RefID   string `json:"refId"`
+	RefID   string `json:"refId"` //nolint:tagliatelle
 	Expr    string `json:"expr"`
 	Instant bool   `json:"instant"`
 }
 
 // Data represents grafana API alert rule data.
 type Data struct {
-	RefID             string            `json:"refId"`
-	DatasourceUID     string            `json:"datasourceUid"`
-	QueryType         string            `json:"queryType"`
-	RelativeTimeRange RelativeTimeRange `json:"relativeTimeRange,omitempty"`
+	RefID             string            `json:"refId"`                       //nolint:tagliatelle
+	DatasourceUID     string            `json:"datasourceUid"`               //nolint:tagliatelle
+	QueryType         string            `json:"queryType"`                   //nolint:tagliatelle
+	RelativeTimeRange RelativeTimeRange `json:"relativeTimeRange,omitempty"` //nolint:tagliatelle
 	Model             Model             `json:"model,omitempty"`
 }
 

--- a/managed/services/grafana/client.go
+++ b/managed/services/grafana/client.go
@@ -321,8 +321,8 @@ func (c *Client) getRoleForServiceToken(ctx context.Context, token string) (role
 }
 
 type serviceAccountSearch struct {
-	TotalCount      int              `json:"totalCount"`
-	ServiceAccounts []serviceAccount `json:"serviceAccounts"`
+	TotalCount      int              `json:"totalCount"`      //nolint:tagliatelle
+	ServiceAccounts []serviceAccount `json:"serviceAccounts"` //nolint:tagliatelle
 }
 
 func (c *Client) getServiceAccountIDFromName(ctx context.Context, nodeName string, authHeaders http.Header) (int, error) {

--- a/managed/services/management/azure_database.go
+++ b/managed/services/management/azure_database.go
@@ -71,7 +71,7 @@ type AzureDatabaseInstanceData struct {
 	Properties    map[string]interface{} `json:"properties"`
 	Tags          map[string]string      `json:"tags"`
 	Sku           map[string]interface{} `json:"sku"`
-	ResourceGroup string                 `json:"resourceGroup"`
+	ResourceGroup string                 `json:"resourceGroup"` //nolint:tagliatelle
 	Type          string                 `json:"type"`
 	Zones         string                 `json:"zones"`
 }

--- a/managed/services/server/updater.go
+++ b/managed/services/server/updater.go
@@ -297,12 +297,12 @@ func (up *Updater) readFromFile() (*version.DockerVersionInfo, error) {
 
 type result struct {
 	Version   string    `json:"version"`
-	ImageInfo imageInfo `json:"imageInfo"`
+	ImageInfo imageInfo `json:"imageInfo"` //nolint:tagliatelle
 }
 
 type imageInfo struct {
-	ImagePath             string    `json:"imagePath"`
-	ImageReleaseTimestamp time.Time `json:"imageReleaseTimestamp"`
+	ImagePath             string    `json:"imagePath"`             //nolint:tagliatelle
+	ImageReleaseTimestamp time.Time `json:"imageReleaseTimestamp"` //nolint:tagliatelle
 }
 
 // MetadataResponse is a response from the metadata endpoint on Percona version service.
@@ -312,7 +312,7 @@ type MetadataResponse struct {
 
 // ReleaseNotesResponse is a response from the release-notes endpoint on Percona version service.
 type ReleaseNotesResponse struct {
-	ReleaseNote string `json:"releaseNote"`
+	ReleaseNote string `json:"releaseNote"` //nolint:tagliatelle
 }
 
 // latestAvailableFromVersionService queries Percona version service and returns:

--- a/qan-api2/services/analytics/filters_test.go
+++ b/qan-api2/services/analytics/filters_test.go
@@ -42,14 +42,14 @@ type listLabels struct {
 	Name []testValuesUnmarshal `json:"name,omitempty"`
 }
 type testValues struct {
-	MainMetricPercent float32 `json:"mainMetricPercent,omitempty"`
-	MainMetricPerSec  float32 `json:"mainMetricPerSec,omitempty"`
+	MainMetricPercent float32 `json:"mainMetricPercent,omitempty"` //nolint:tagliatelle
+	MainMetricPerSec  float32 `json:"mainMetricPerSec,omitempty"`  //nolint:tagliatelle
 }
 
 type testValuesUnmarshal struct {
 	Value             string `json:"value,omitempty"`
-	MainMetricPercent any    `json:"mainMetricPercent,omitempty"`
-	MainMetricPerSec  any    `json:"mainMetricPerSec,omitempty"`
+	MainMetricPercent any    `json:"mainMetricPercent,omitempty"` //nolint:tagliatelle
+	MainMetricPerSec  any    `json:"mainMetricPerSec,omitempty"`  //nolint:tagliatelle
 }
 
 func TestService_GetFilters(t *testing.T) {


### PR DESCRIPTION
Fixes #2345

## Changes
- Enable tagliatelle linter rule for JSON tags with snake_case convention in .golangci.yml
- Add nolint:tagliatelle directives to struct fields that use non-snake_case JSON tags for external API compatibility (PBM, Grafana, Azure, Percona version service, MongoDB)