### PR TITLE
fix: Enable paralleltest linter rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@ linters:
     - godox               # we sometimes leave TODOS right in the code
     - gomoddirectives     # we use replace directives
     - nlreturn            # too annoying
-    - paralleltest
     - protogetter         # we need direct access to proto fields
     - rowserrcheck        # disabled because of generics
     - tagalign

--- a/admin/cmd/pmm-admin/main_test.go
+++ b/admin/cmd/pmm-admin/main_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestPackages(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("pmm-admin", "-h")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
@@ -34,6 +35,7 @@ func TestPackages(t *testing.T) {
 }
 
 func TestVersionPlain(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("pmm-admin", "--version")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
@@ -43,6 +45,7 @@ func TestVersionPlain(t *testing.T) {
 }
 
 func TestVersionJson(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("pmm-admin", "--version", "--json")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)

--- a/admin/commands/config_test.go
+++ b/admin/commands/config_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestConfigCommandArgs(t *testing.T) {
+	t.Parallel()
 	cmd := &ConfigCommand{
 		NodeAddress: "1.2.3.4",
 		NodeType:    "generic",
@@ -32,6 +33,7 @@ func TestConfigCommandArgs(t *testing.T) {
 	}
 
 	t.Run("SwitchToTLS1", func(t *testing.T) {
+		t.Parallel()
 		u, err := url.Parse("http://127.0.0.1:80")
 		require.NoError(t, err)
 		args, switchedToTLS := cmd.args(&flags.GlobalFlags{ServerURL: u})
@@ -45,6 +47,7 @@ func TestConfigCommandArgs(t *testing.T) {
 	})
 
 	t.Run("SwitchToTLS2", func(t *testing.T) {
+		t.Parallel()
 		cmd := &ConfigCommand{
 			NodeAddress: "1.2.3.4",
 			NodeType:    "generic",
@@ -64,6 +67,7 @@ func TestConfigCommandArgs(t *testing.T) {
 		assert.True(t, switchedToTLS)
 	})
 	t.Run("DisableCollectors", func(t *testing.T) {
+		t.Parallel()
 		cmd := &ConfigCommand{
 			NodeAddress:       "1.2.3.4",
 			NodeType:          "generic",
@@ -87,6 +91,7 @@ func TestConfigCommandArgs(t *testing.T) {
 	})
 
 	t.Run("LoggingLevel", func(t *testing.T) {
+		t.Parallel()
 		cmd := &ConfigCommand{
 			NodeAddress: "1.2.3.4",
 			NodeType:    "generic",

--- a/admin/commands/inventory/add_agent_mysqld_exporter_test.go
+++ b/admin/commands/inventory/add_agent_mysqld_exporter_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 func TestAddAgentMysqldExporter(t *testing.T) {
+	t.Parallel()
 	t.Run("TablestatEnabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",
@@ -61,6 +63,7 @@ Tablestat collectors  : enabled (the limit is 1000, the actual table count is 50
 	})
 
 	t.Run("TablestatEnabledNoLimit", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",
@@ -96,6 +99,7 @@ Tablestat collectors  : enabled (the table count limit is not set).
 	})
 
 	t.Run("TablestatEnabledUnknown", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",
@@ -131,6 +135,7 @@ Tablestat collectors  : enabled (the limit is 1000, the actual table count is un
 	})
 
 	t.Run("TablestatDisabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",
@@ -166,6 +171,7 @@ Tablestat collectors  : disabled (the limit is 1000, the actual table count is 2
 	})
 
 	t.Run("TablestatDisabledAlways", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",
@@ -201,6 +207,7 @@ Tablestat collectors  : disabled (always).
 	})
 
 	t.Run("with allowCleartextPasswords DSN param", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentMysqldExporterResult{
 			Agent: &agents.AddAgentOKBodyMysqldExporter{
 				AgentID:    "1",

--- a/admin/commands/inventory/add_agent_postgres_exporter_test.go
+++ b/admin/commands/inventory/add_agent_postgres_exporter_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 func TestAddAgentPostgresExporter(t *testing.T) {
+	t.Parallel()
 	t.Run("TablestatEnabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addAgentPostgresExporterResult{
 			Agent: &agents.AddAgentOKBodyPostgresExporter{
 				AgentID:    "1",

--- a/admin/commands/inventory/add_node_remote_rds_test.go
+++ b/admin/commands/inventory/add_node_remote_rds_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestAddNodeRemoteRDS(t *testing.T) {
+	t.Parallel()
 	res := &addNodeRemoteRDSResult{
 		Node: &nodes.AddNodeOKBodyRemoteRDS{
 			NodeID:       "1",

--- a/admin/commands/inventory/add_service_external_test.go
+++ b/admin/commands/inventory/add_service_external_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceExternal(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceExternalResult{
 			Service: &services.AddServiceOKBodyExternal{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_haproxy_test.go
+++ b/admin/commands/inventory/add_service_haproxy_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceHAProxy(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceHAProxyResult{
 			Service: &services.AddServiceOKBodyHaproxy{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_mongodb_test.go
+++ b/admin/commands/inventory/add_service_mongodb_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceMongoDB(t *testing.T) {
+	t.Parallel()
 	t.Run("Address and port", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceMongoDBResult{
 			Service: &services.AddServiceOKBodyMongodb{
 				ServiceID:      "1",
@@ -52,6 +54,7 @@ Custom labels  : map[foo:bar key:value]
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceMongoDBResult{
 			Service: &services.AddServiceOKBodyMongodb{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_mysql_test.go
+++ b/admin/commands/inventory/add_service_mysql_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceMySQL(t *testing.T) {
+	t.Parallel()
 	t.Run("Address and port", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceMySQLResult{
 			Service: &services.AddServiceOKBodyMysql{
 				ServiceID:      "1",
@@ -52,6 +54,7 @@ Custom labels  : map[foo:bar key:value]
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceMySQLResult{
 			Service: &services.AddServiceOKBodyMysql{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_postgres_test.go
+++ b/admin/commands/inventory/add_service_postgres_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServicePostgreSQL(t *testing.T) {
+	t.Parallel()
 	t.Run("Address and port", func(t *testing.T) {
+		t.Parallel()
 		res := &addServicePostgreSQLResult{
 			Service: &services.AddServiceOKBodyPostgresql{
 				ServiceID:      "1",
@@ -52,6 +54,7 @@ Custom labels  : map[foo:bar key:value]
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		res := &addServicePostgreSQLResult{
 			Service: &services.AddServiceOKBodyPostgresql{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_proxysql_test.go
+++ b/admin/commands/inventory/add_service_proxysql_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceProxySQL(t *testing.T) {
+	t.Parallel()
 	t.Run("Address and port", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceProxySQLResult{
 			Service: &services.AddServiceOKBodyProxysql{
 				ServiceID:      "1",
@@ -52,6 +54,7 @@ Custom labels  : map[foo:bar key:value]
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceProxySQLResult{
 			Service: &services.AddServiceOKBodyProxysql{
 				ServiceID:      "1",

--- a/admin/commands/inventory/add_service_valkey_test.go
+++ b/admin/commands/inventory/add_service_valkey_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestAddServiceValkey(t *testing.T) {
+	t.Parallel()
 	t.Run("Address and port", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceValkeyResult{
 			Service: &services.AddServiceOKBodyValkey{
 				ServiceID:      "1",
@@ -52,6 +54,7 @@ Custom labels  : map[foo:bar key:value]
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		res := &addServiceValkeyResult{
 			Service: &services.AddServiceOKBodyValkey{
 				ServiceID:      "1",

--- a/admin/commands/list_test.go
+++ b/admin/commands/list_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestListResultString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		listResult listResult
@@ -82,6 +83,7 @@ external-exporter        Running                            8b732ac3-8256-40b0-a
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			actual := strings.TrimSpace(tt.listResult.String())
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -89,6 +91,7 @@ external-exporter        Running                            8b732ac3-8256-40b0-a
 }
 
 func TestNiceAgentStatus(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		Status   string
 		Disabled bool
@@ -115,6 +118,7 @@ func TestNiceAgentStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a := listResultAgent{
 				Status:   tt.fields.Status,
 				Disabled: tt.fields.Disabled,

--- a/admin/commands/management/add_external_test.go
+++ b/admin/commands/management/add_external_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestAddExternal(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		res := &addExternalResult{
 			Service: &mservice.AddServiceOKBodyExternalService{
 				ServiceID:   "1",

--- a/admin/commands/management/add_haproxy_test.go
+++ b/admin/commands/management/add_haproxy_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestAddHAProxy(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		res := &addHAProxyResult{
 			Service: &mservice.AddServiceOKBodyHaproxyService{
 				ServiceID:   "1",

--- a/admin/commands/management/add_mongodb_test.go
+++ b/admin/commands/management/add_mongodb_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestAddMongoDB(t *testing.T) {
+	t.Parallel()
 	t.Run("TablestatEnabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addMongoDBResult{
 			Service: &mservice.AddServiceOKBodyMongodbService{
 				ServiceID:   "1",

--- a/admin/commands/management/add_mysql_test.go
+++ b/admin/commands/management/add_mysql_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestAddMySQL(t *testing.T) {
+	t.Parallel()
 	t.Run("TablestatEnabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			Service: &mservice.AddServiceOKBodyMysqlService{
 				ServiceID:   "1",
@@ -47,6 +49,7 @@ Table statistics collection enabled (the limit is 1000, the actual table count i
 	})
 
 	t.Run("TablestatEnabledNoLimit", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			Service: &mservice.AddServiceOKBodyMysqlService{
 				ServiceID:   "1",
@@ -69,6 +72,7 @@ Table statistics collection enabled (the table count limit is not set).
 	})
 
 	t.Run("TablestatEnabledUnknown", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			Service: &mservice.AddServiceOKBodyMysqlService{
 				ServiceID:   "1",
@@ -91,6 +95,7 @@ Table statistics collection enabled (the limit is 1000, the actual table count i
 	})
 
 	t.Run("TablestatDisabled", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			Service: &mservice.AddServiceOKBodyMysqlService{
 				ServiceID:   "1",
@@ -117,6 +122,7 @@ Table statistics collection disabled (the limit is 1000, the actual table count 
 	})
 
 	t.Run("TablestatDisabledAlways", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			Service: &mservice.AddServiceOKBodyMysqlService{
 				ServiceID:   "1",
@@ -139,6 +145,7 @@ Table statistics collection disabled (always).
 	})
 
 	t.Run("EmptyMysqlExporter", func(t *testing.T) {
+		t.Parallel()
 		res := &addMySQLResult{
 			MysqldExporter: nil,
 		}
@@ -148,7 +155,9 @@ Table statistics collection disabled (always).
 }
 
 func TestRun(t *testing.T) {
+	t.Parallel()
 	t.Run("CreateUser", func(t *testing.T) {
+		t.Parallel()
 		cmd := &AddMySQLCommand{
 			CreateUser: true,
 		}

--- a/admin/commands/management/add_test.go
+++ b/admin/commands/management/add_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestManagementGlobalFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		testName string
 
@@ -111,6 +112,7 @@ func TestManagementGlobalFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
 			cmd := &AddMongoDBCommand{
 				ServiceName: test.nameArg,
 				Address:     test.addressArg,

--- a/admin/commands/management/add_valkey_test.go
+++ b/admin/commands/management/add_valkey_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestAddValkey(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		res := &addValkeyResult{
 			Service: &mservice.AddServiceOKBodyValkeyService{
 				ServiceID:   "uuid-valkey",

--- a/admin/commands/management/register_test.go
+++ b/admin/commands/management/register_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestRegisterResult(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		result registerResult
@@ -61,6 +62,7 @@ Warning: Couldn't create a Service Key
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equalf(t, tt.want, tt.result.String(), "String()")
 		})
 	}

--- a/admin/commands/status_test.go
+++ b/admin/commands/status_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestStatus(t *testing.T) {
+	t.Parallel()
 	res := newStatusResult(&agentlocal.Status{
 		AgentID:       "pmm-server",
 		NodeID:        "pmm-server",
@@ -78,6 +79,7 @@ Agents:
 }
 
 func TestStatusJSON(t *testing.T) {
+	t.Parallel()
 	res := newStatusResult(&agentlocal.Status{
 		ServerURL: "https://username:password@address/",
 	})

--- a/admin/commands/summary_test.go
+++ b/admin/commands/summary_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestSummary(t *testing.T) {
+	t.Parallel()
 	agentlocal.SetTransport(context.TODO(), true, agentlocal.DefaultPMMAgentListenPort)
 
 	f, err := os.CreateTemp("", "pmm-admin-test-summary")
@@ -40,6 +41,7 @@ func TestSummary(t *testing.T) {
 	assert.NoError(t, f.Close())
 
 	t.Run("Summary default", func(t *testing.T) {
+		t.Parallel()
 		cmd := &SummaryCommand{
 			Filename: filename,
 		}
@@ -52,6 +54,7 @@ func TestSummary(t *testing.T) {
 	})
 
 	t.Run("Summary skip server", func(t *testing.T) {
+		t.Parallel()
 		cmd := &SummaryCommand{
 			Filename:   filename,
 			SkipServer: true,
@@ -65,6 +68,7 @@ func TestSummary(t *testing.T) {
 	})
 
 	t.Run("Summary pprof", func(t *testing.T) {
+		t.Parallel()
 		if os.Getenv("DEVCONTAINER") == "" {
 			t.Skip("can be tested only inside devcontainer")
 		}

--- a/agent/agentlocal/agent_local_test.go
+++ b/agent/agentlocal/agent_local_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestServerStatus(t *testing.T) {
+	t.Parallel()
 	setup := func(t *testing.T) ([]*agentlocal.AgentInfo, *mockSupervisor, *mockClient, configGetReloader) {
 		t.Helper()
 		agentInfo := []*agentlocal.AgentInfo{{
@@ -65,6 +66,7 @@ func TestServerStatus(t *testing.T) {
 	}
 
 	t.Run("without network info", func(t *testing.T) {
+		t.Parallel()
 		agentInfo, supervisor, client, cfg := setup(t)
 		defer supervisor.AssertExpectations(t)
 		defer client.AssertExpectations(t)
@@ -90,6 +92,7 @@ func TestServerStatus(t *testing.T) {
 	})
 
 	t.Run("with network info", func(t *testing.T) {
+		t.Parallel()
 		agentInfo, supervisor, client, cfg := setup(t)
 		latency := 5 * time.Millisecond
 		clockDrift := time.Second
@@ -121,6 +124,7 @@ func TestServerStatus(t *testing.T) {
 }
 
 func TestGetZipFile(t *testing.T) {
+	t.Parallel()
 	setup := func(t *testing.T) ([]*agentlocal.AgentInfo, *mockSupervisor, *mockClient, configGetReloader) {
 		t.Helper()
 		agentInfo := []*agentlocal.AgentInfo{{
@@ -157,6 +161,7 @@ func TestGetZipFile(t *testing.T) {
 	}
 
 	t.Run("test zip file", func(t *testing.T) {
+		t.Parallel()
 		_, supervisor, client, cfg := setup(t)
 		defer supervisor.AssertExpectations(t)
 		defer client.AssertExpectations(t)

--- a/agent/agents/agents_test.go
+++ b/agent/agents/agents_test.go
@@ -18,5 +18,6 @@ import "testing"
 
 // TestAgents is a test function for the Agents module.
 func TestAgents(t *testing.T) { //nolint:revive
+	t.Parallel()
 	// we need at least one test per package to correctly calculate coverage
 }

--- a/agent/agents/mongodb/mongolog/mongodb_test.go
+++ b/agent/agents/mongodb/mongolog/mongodb_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestMongoRun(t *testing.T) {
+	t.Parallel()
 	testdata, err := filepath.Abs("../../../testdata/mongo")
 	require.NoError(t, err)
 	sslDSNTemplate, files := tests.GetTestMongoDBWithSSLDSN(t, "../../..")

--- a/agent/agents/mongodb/profiler/internal/collector/collector_test.go
+++ b/agent/agents/mongodb/profiler/internal/collector/collector_test.go
@@ -112,6 +112,7 @@ func BenchmarkCollector(b *testing.B) {
 }
 
 func TestCollector(t *testing.T) {
+	t.Parallel()
 	maxLoops := 3
 	maxDocs := 100
 

--- a/agent/agents/mongodb/profiler/internal/parser/parser_test.go
+++ b/agent/agents/mongodb/profiler/internal/parser/parser_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
+	t.Parallel()
 	docsChan := make(chan pm.SystemProfile)
 	a := aggregator.New(time.Now(), "test-id", logrus.WithField("component", "aggregator"), truncate.GetMongoDBDefaultMaxQueryLength())
 
@@ -55,6 +56,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := New(tt.args.docsChan, tt.args.aggregator, logrus.WithField("component", "test-parser")); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New(%v, %v) = %v, want %v", tt.args.docsChan, tt.args.aggregator, got, tt.want)
 			}
@@ -63,6 +65,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestParserStartStop(t *testing.T) {
+	t.Parallel()
 	var err error
 	docsChan := make(chan pm.SystemProfile)
 	a := aggregator.New(time.Now(), "test-id", logrus.WithField("component", "aggregator"), truncate.GetMongoDBDefaultMaxQueryLength())
@@ -82,6 +85,7 @@ func TestParserStartStop(t *testing.T) {
 }
 
 func TestParserRunning(t *testing.T) {
+	t.Parallel()
 	oldInterval := aggregator.DefaultInterval
 	aggregator.DefaultInterval = 10 * time.Second
 	defer func() { aggregator.DefaultInterval = oldInterval }()

--- a/agent/agents/mongodb/profiler/internal/profiler_test.go
+++ b/agent/agents/mongodb/profiler/internal/profiler_test.go
@@ -55,6 +55,7 @@ func GetMongoVersion(ctx context.Context, client *mongo.Client) (string, error) 
 }
 
 func TestProfiler(t *testing.T) {
+	t.Parallel()
 	defaultInterval := aggregator.DefaultInterval
 	aggregator.DefaultInterval = time.Second
 	defer func() { aggregator.DefaultInterval = defaultInterval }()
@@ -71,6 +72,7 @@ func TestProfiler(t *testing.T) {
 		"ssl":    sslDSN,
 	} {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			testProfiler(t, url)
 		})
 	}

--- a/agent/agents/mongodb/profiler/mongodb_test.go
+++ b/agent/agents/mongodb/profiler/mongodb_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestMongoRun(t *testing.T) {
+	t.Parallel()
 	sslDSNTemplate, files := tests.GetTestMongoDBWithSSLDSN(t, "../../../")
 	tempDir := t.TempDir()
 	sslDSN, err := templates.RenderDSN(sslDSNTemplate, files, tempDir)

--- a/agent/agents/mongodb/shared/aggregator/aggregator_test.go
+++ b/agent/agents/mongodb/shared/aggregator/aggregator_test.go
@@ -34,9 +34,14 @@ import (
 )
 
 func TestAggregator(t *testing.T) {
+	t.Parallel(
 	// we need at least one test per package to correctly calculate coverage
+	)
+
 	t.Run("Add", func(t *testing.T) {
+		t.Parallel()
 		t.Run("error if aggregator is not running", func(t *testing.T) {
+			t.Parallel()
 			a := New(time.Now(), "test-agent", logrus.WithField("component", "test"), truncate.GetMongoDBDefaultMaxQueryLength())
 			err := a.Add(context.TODO(), proto.SystemProfile{})
 			assert.EqualError(t, err, "aggregator is not running")
@@ -44,6 +49,7 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("createResult", func(t *testing.T) {
+		t.Parallel()
 		agentID := "test-agent"
 		startPeriod := time.Now()
 		aggregator := New(startPeriod, agentID, logrus.WithField("component", "test"), truncate.GetMongoDBDefaultMaxQueryLength())
@@ -103,6 +109,7 @@ func TestAggregator(t *testing.T) {
 	})
 
 	t.Run("createResultInvalidUTF8", func(t *testing.T) {
+		t.Parallel()
 		agentID := "test-agent"
 		startPeriod := time.Now()
 		aggregator := New(startPeriod, agentID, logrus.WithField("component", "test"), truncate.GetMongoDBDefaultMaxQueryLength())

--- a/agent/agents/mongodb/shared/fingerprinter/fingerprinter_test.go
+++ b/agent/agents/mongodb/shared/fingerprinter/fingerprinter_test.go
@@ -86,7 +86,9 @@ func createSession(dsn string, agentID string) (*mongo.Client, error) {
 }
 
 func TestProfilerFingerprinter(t *testing.T) {
+	t.Parallel()
 	t.Run("CheckWithRealDB", func(t *testing.T) {
+		t.Parallel()
 		url := "mongodb://root:root-password@127.0.0.1:27017"
 		dbName := "test_fingerprint"
 
@@ -305,6 +307,7 @@ func TestProfilerFingerprinter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			pf := &ProfilerFingerprinter{}
 			fingerprint, err := pf.Fingerprint(tt.doc)
 			require.NoError(t, err)

--- a/agent/agents/mongodb/shared/report/report_test.go
+++ b/agent/agents/mongodb/shared/report/report_test.go
@@ -16,6 +16,7 @@ package report
 
 import "testing"
 
-func TestReport(_ *testing.T) {
+func TestReport(t *testing.T) {
+	t.Parallel()
 	// we need at least one test per package to correctly calculate coverage
 }

--- a/agent/agents/mongodb/shared/sender/sender_test.go
+++ b/agent/agents/mongodb/shared/sender/sender_test.go
@@ -38,6 +38,7 @@ func (w *testWriter) Write(actual *report.Report) error {
 }
 
 func TestSender(t *testing.T) {
+	t.Parallel()
 	expected := &report.Report{
 		StartTS: time.Now(),
 		EndTS:   time.Now().Add(time.Second * 10),

--- a/agent/agents/mysql/perfschema/perfschema_test.go
+++ b/agent/agents/mysql/perfschema/perfschema_test.go
@@ -35,9 +35,11 @@ import (
 )
 
 func TestPerfSchemaMakeBuckets(t *testing.T) {
+	t.Parallel()
 	defaultMaxQueryLength := truncate.GetDefaultMaxQueryLength()
 
 	t.Run("Normal", func(t *testing.T) {
+		t.Parallel()
 		prev := map[string]*eventsStatementsSummaryByDigest{
 			"Normal": {
 				Digest:          pointer.ToString("Normal"),
@@ -72,6 +74,7 @@ func TestPerfSchemaMakeBuckets(t *testing.T) {
 	})
 
 	t.Run("New", func(t *testing.T) {
+		t.Parallel()
 		prev := make(map[string]*eventsStatementsSummaryByDigest)
 		current := map[string]*eventsStatementsSummaryByDigest{
 			"New": {
@@ -99,6 +102,7 @@ func TestPerfSchemaMakeBuckets(t *testing.T) {
 	})
 
 	t.Run("Same", func(t *testing.T) {
+		t.Parallel()
 		prev := map[string]*eventsStatementsSummaryByDigest{
 			"Same": {
 				Digest:          pointer.ToString("Same"),
@@ -120,6 +124,7 @@ func TestPerfSchemaMakeBuckets(t *testing.T) {
 	})
 
 	t.Run("Truncate", func(t *testing.T) {
+		t.Parallel()
 		prev := map[string]*eventsStatementsSummaryByDigest{
 			"Truncate": {
 				Digest:          pointer.ToString("Truncate"),
@@ -134,6 +139,7 @@ func TestPerfSchemaMakeBuckets(t *testing.T) {
 	})
 
 	t.Run("TruncateAndNew", func(t *testing.T) {
+		t.Parallel()
 		prev := map[string]*eventsStatementsSummaryByDigest{
 			"TruncateAndNew": {
 				Digest:          pointer.ToString("TruncateAndNew"),
@@ -266,6 +272,7 @@ func prepareDBCopy(t *testing.T, db *reform.DB) {
 }
 
 func TestPerfSchema(t *testing.T) {
+	t.Parallel()
 	sqlDB := tests.OpenTestMySQL(t)
 	defer sqlDB.Close() //nolint:errcheck
 	db := reform.NewDB(sqlDB, mysql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -360,6 +367,7 @@ func TestPerfSchema(t *testing.T) {
 	}
 
 	t.Run("Sleep", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, &setupParams{
 			db:                   db,
 			disableQueryExamples: false,
@@ -407,6 +415,7 @@ func TestPerfSchema(t *testing.T) {
 	})
 
 	t.Run("AllCities", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, &setupParams{
 			db:                   db,
 			disableQueryExamples: false,
@@ -459,6 +468,7 @@ func TestPerfSchema(t *testing.T) {
 	})
 
 	t.Run("Same queries in different DBs", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, &setupParams{
 			db:                   db,
 			disableQueryExamples: false,
@@ -522,6 +532,7 @@ func TestPerfSchema(t *testing.T) {
 	})
 
 	t.Run("Invalid UTF-8", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, &setupParams{
 			db:                   db,
 			disableQueryExamples: false,
@@ -602,6 +613,7 @@ func TestPerfSchema(t *testing.T) {
 	})
 
 	t.Run("DisableQueryExamples", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, &setupParams{
 			db:                   db,
 			disableQueryExamples: true,

--- a/agent/agents/mysql/slowlog/parser/parser_test.go
+++ b/agent/agents/mysql/slowlog/parser/parser_test.go
@@ -93,6 +93,7 @@ func TestParserGolden(t *testing.T) {
 }
 
 func TestParseTime(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		description string
 		input       string
@@ -112,6 +113,7 @@ func TestParseTime(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			p := NewSlowLogParser(nil, log.Options{})
 			p.parseTime(tc.input)
 			actual := p.event.Ts
@@ -123,6 +125,7 @@ func TestParseTime(t *testing.T) {
 }
 
 func TestParseUser(t *testing.T) {
+	t.Parallel()
 	type Expected struct {
 		UserName string
 		Host     string
@@ -153,6 +156,7 @@ func TestParseUser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			p := NewSlowLogParser(nil, log.Options{})
 			p.parseUser(tc.input)
 			actualEvent := p.event
@@ -165,6 +169,7 @@ func TestParseUser(t *testing.T) {
 }
 
 func TestParseMetrics(t *testing.T) {
+	t.Parallel()
 	const (
 		TimeMetrics int = iota
 		NumberMetrics
@@ -246,6 +251,7 @@ func TestParseMetrics(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
 			p := NewSlowLogParser(nil, log.Options{})
 			p.parseMetrics(tc.input)
 			actualEvent := p.event

--- a/agent/agents/mysql/slowlog/slowlog_test.go
+++ b/agent/agents/mysql/slowlog/slowlog_test.go
@@ -47,6 +47,7 @@ func getDataFromFile(t *testing.T, filePath string, data interface{}) {
 }
 
 func TestSlowLogMakeBucketsInvalidUTF8(t *testing.T) {
+	t.Parallel()
 	const agentID = "73ee2f92-d5aa-45f0-8b09-6d3df605fd44"
 	periodStart := time.Unix(1557137220, 0)
 
@@ -228,6 +229,7 @@ func TestSlowLog(t *testing.T) {
 	})
 
 	t.Run("NormalWithRotation", func(t *testing.T) {
+		t.Parallel()
 		params := &Params{
 			DSN:                tests.GetTestMySQLDSN(t),
 			MaxSlowlogFileSize: 1,

--- a/agent/agents/noop/noop_test.go
+++ b/agent/agents/noop/noop_test.go
@@ -17,5 +17,6 @@ package noop
 import "testing"
 
 func TestNoOp(t *testing.T) { //nolint:revive
+	t.Parallel()
 	// we need at least one test per package to correctly calculate coverage
 }

--- a/agent/agents/postgres/parser/parser_test.go
+++ b/agent/agents/postgres/parser/parser_test.go
@@ -31,11 +31,13 @@ type expectedResult struct {
 }
 
 func TestExtractTables(t *testing.T) {
+	t.Parallel()
 	files, err := filepath.Glob(filepath.FromSlash("./testdata/*.sql"))
 	require.NoError(t, err)
 
 	for _, file := range files {
 		t.Run(filepath.Base(file), func(t *testing.T) {
+			t.Parallel()
 			d, err := os.ReadFile(file) //nolint:gosec
 			require.NoError(t, err)
 			query := string(d)

--- a/agent/agents/postgres/pgstatmonitor/pgstatmonitor_test.go
+++ b/agent/agents/postgres/pgstatmonitor/pgstatmonitor_test.go
@@ -90,12 +90,14 @@ func filter(mb []*agentv1.MetricsBucket) []*agentv1.MetricsBucket {
 }
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
 	pgsmVersion, err := ver.NewVersion("1.0.0-beta-2")
 	require.NoError(t, err)
 	require.True(t, pgsmVersion.LessThan(v10))
 }
 
 func TestPGStatMonitorSchema(t *testing.T) {
+	t.Parallel()
 	t.Skip("Skip it until the sandbox supports pg_stat_monitor by default. The current PostgreSQL image is the official, not the one from PerconaLab")
 	sqlDB := tests.OpenTestPostgreSQL(t)
 	defer sqlDB.Close() //nolint:errcheck
@@ -205,6 +207,7 @@ func TestPGStatMonitorSchema(t *testing.T) {
 	}
 
 	t.Run("AllCountries", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, db, false, false)
 
 		_, err := db.Exec(selectAllCountries)
@@ -339,6 +342,7 @@ func TestPGStatMonitorSchema(t *testing.T) {
 	})
 
 	t.Run("AllCountriesTruncated", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, db, false, false)
 
 		const n = 500
@@ -478,6 +482,7 @@ func TestPGStatMonitorSchema(t *testing.T) {
 	})
 
 	t.Run("CheckMBlkReadTime", func(t *testing.T) {
+		t.Parallel()
 		r := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec
 		tableName := fmt.Sprintf("customer%d", r.Int())
 		_, err := db.Exec(fmt.Sprintf(`

--- a/agent/agents/postgres/pgstatmonitor/stat_monitor_cache_test.go
+++ b/agent/agents/postgres/pgstatmonitor/stat_monitor_cache_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestPGStatMonitorStructs(t *testing.T) {
+	t.Parallel()
 	sqlDB := tests.OpenTestPostgreSQL(t)
 	defer sqlDB.Close() //nolint:errcheck
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))

--- a/agent/agents/postgres/pgstatstatements/pgstatstatements_test.go
+++ b/agent/agents/postgres/pgstatstatements/pgstatstatements_test.go
@@ -65,6 +65,7 @@ func filter(mb []*agentv1.MetricsBucket) []*agentv1.MetricsBucket {
 }
 
 func TestPGStatStatementsQAN(t *testing.T) {
+	t.Parallel()
 	sqlDB := tests.OpenTestPostgreSQL(t)
 	defer sqlDB.Close() //nolint:errcheck
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -177,6 +178,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 	}
 
 	t.Run("AllCities", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, db)
 
 		_, err := db.Exec(selectAllCities)
@@ -267,6 +269,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 	})
 
 	t.Run("AllCitiesTruncated", func(t *testing.T) {
+		t.Parallel()
 		m := setup(t, db)
 
 		const n = 500
@@ -368,6 +371,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 	})
 
 	t.Run("CheckMBlkReadTime", func(t *testing.T) {
+		t.Parallel()
 		r := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec
 		tableName := fmt.Sprintf("customer%d", r.Int())
 		_, err := db.Exec(fmt.Sprintf(`
@@ -464,6 +468,7 @@ func TestPGStatStatementsQAN(t *testing.T) {
 }
 
 func TestPGStatStatementsQPS(t *testing.T) {
+	t.Parallel()
 	sqlDB := tests.OpenTestPostgreSQL(t)
 	defer sqlDB.Close() //nolint:errcheck
 	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
@@ -492,11 +497,13 @@ func TestPGStatStatementsQPS(t *testing.T) {
 	}
 
 	t.Run("uses pgss.max value", func(t *testing.T) {
+		t.Parallel()
 		p := setup(t, db)
 		assert.Equal(t, uint(10000), p.statementsCache.cache.Capacity())
 	})
 
 	t.Run("check query count when cache size equals pgss.max", func(t *testing.T) {
+		t.Parallel()
 		var cacheSize uint
 		err = db.Querier.QueryRow(pgssMaxQuery).Scan(&cacheSize)
 		require.NoError(t, err)

--- a/agent/agents/process/process_logger_test.go
+++ b/agent/agents/process/process_logger_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestProcessLogger(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		testName       string
 		writerLines    int
@@ -130,6 +131,7 @@ func TestProcessLogger(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
 			pl := newProcessLogger(nil, tt.writerLines, tt.redactWords)
 			for _, arg := range tt.writeArgs {
 				_, err := pl.Write([]byte(arg))

--- a/agent/agents/process/process_test.go
+++ b/agent/agents/process/process_test.go
@@ -69,7 +69,9 @@ func setup(t *testing.T) (context.Context, context.CancelFunc, *logrus.Entry) {
 }
 
 func TestProcess(t *testing.T) {
+	t.Parallel()
 	t.Run("Normal", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel, l := setup(t)
 		p := New(&Params{Path: "sleep", Args: []string{"100500"}}, nil, l)
 		go p.Run(ctx)
@@ -80,6 +82,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("FailedToStart", func(t *testing.T) {
+		t.Parallel()
 		ctx, _, l := setup(t)
 		p := New(&Params{Path: "no_such_command"}, nil, l)
 		go p.Run(ctx)
@@ -89,6 +92,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("ExitedEarly", func(t *testing.T) {
+		t.Parallel()
 		sleep := strconv.FormatFloat(runningT.Seconds()-0.5, 'f', -1, 64)
 		ctx, _, l := setup(t)
 		p := New(&Params{Path: "sleep", Args: []string{sleep}}, nil, l)
@@ -99,6 +103,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("Exited", func(t *testing.T) {
+		t.Parallel()
 		sleep := strconv.FormatFloat(runningT.Seconds()+0.5, 'f', -1, 64)
 		ctx, cancel, l := setup(t)
 		p := New(&Params{Path: "sleep", Args: []string{sleep}}, nil, l)
@@ -110,6 +115,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("Killed", func(t *testing.T) {
+		t.Parallel()
 		f, err := os.CreateTemp("", "pmm-agent-process-test-noterm")
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
@@ -129,6 +135,7 @@ func TestProcess(t *testing.T) {
 	})
 
 	t.Run("KillChild", func(t *testing.T) {
+		t.Parallel()
 		if runtime.GOOS != "linux" {
 			t.Skip("Pdeathsig is implemented only on Linux")
 		}
@@ -177,6 +184,7 @@ func TestProcess(t *testing.T) {
 }
 
 func TestExtractLogLevel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		testName      string
 		line          string
@@ -195,6 +203,7 @@ func TestExtractLogLevel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
 			level, found, err := extractLogLevel(tt.line)
 
 			require.Equal(t, tt.expectedLevel, level)

--- a/agent/agents/supervisor/ports_registry_test.go
+++ b/agent/agents/supervisor/ports_registry_test.go
@@ -23,7 +23,10 @@ import (
 )
 
 func TestRegistry(t *testing.T) {
+	t.Parallel(
 	// 65000 is marked as reserved, 65001 is busy, 65002 is free
+	)
+
 	r := newPortsRegistry(65000, 65002, []uint16{65000})
 	l1, err := net.Listen("tcp", "127.0.0.1:65001")
 	require.NoError(t, err)
@@ -69,6 +72,7 @@ func TestRegistry(t *testing.T) {
 }
 
 func TestPreferNewPort(t *testing.T) {
+	t.Parallel()
 	r := newPortsRegistry(65000, 65002, nil)
 
 	p, err := r.Reserve()
@@ -92,6 +96,7 @@ func TestPreferNewPort(t *testing.T) {
 }
 
 func TestSinglePort(t *testing.T) {
+	t.Parallel()
 	r := newPortsRegistry(65000, 65000, nil)
 
 	p, err := r.Reserve()

--- a/agent/agents/supervisor/supervisor_test.go
+++ b/agent/agents/supervisor/supervisor_test.go
@@ -46,6 +46,7 @@ func assertChanges(t *testing.T, s *Supervisor, expected ...*agentv1.StateChange
 }
 
 func TestSupervisor(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tempDir := t.TempDir()
@@ -59,6 +60,7 @@ func TestSupervisor(t *testing.T) {
 	go s.Run(ctx)
 
 	t.Run("Start13", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{}
 		require.Equal(t, expectedList, s.AgentsList())
 
@@ -91,6 +93,7 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	t.Run("Restart1Start2", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{
 			{AgentType: type_TEST_NOOP, AgentId: "noop3", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
 			{AgentType: type_TEST_SLEEP, AgentId: "sleep1", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING, ListenPort: 65000, ProcessExecPath: "sleep"},
@@ -133,6 +136,7 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	t.Run("Restart3Start4", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{
 			{AgentType: type_TEST_NOOP, AgentId: "noop3", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
 			{AgentType: type_TEST_SLEEP, AgentId: "sleep1", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING, ListenPort: 65000, ProcessExecPath: "sleep"},
@@ -180,6 +184,7 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	t.Run("Stop1", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{
 			{AgentType: type_TEST_NOOP, AgentId: "noop3", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
 			{AgentType: type_TEST_NOOP, AgentId: "noop4", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
@@ -211,6 +216,7 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	t.Run("Stop3", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{
 			{AgentType: type_TEST_NOOP, AgentId: "noop3", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
 			{AgentType: type_TEST_NOOP, AgentId: "noop4", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
@@ -239,6 +245,7 @@ func TestSupervisor(t *testing.T) {
 	})
 
 	t.Run("Exit", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{
 			{AgentType: type_TEST_NOOP, AgentId: "noop4", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING},
 			{AgentType: type_TEST_SLEEP, AgentId: "sleep2", Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING, ListenPort: 65001, ProcessExecPath: "sleep"},
@@ -259,6 +266,7 @@ func TestSupervisor(t *testing.T) {
 }
 
 func TestStartProcessFail(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tempDir := t.TempDir()
@@ -272,6 +280,7 @@ func TestStartProcessFail(t *testing.T) {
 	go s.Run(ctx)
 
 	t.Run("Start", func(t *testing.T) {
+		t.Parallel()
 		expectedList := []*agentlocal.AgentInfo{}
 		require.Equal(t, expectedList, s.AgentsList())
 

--- a/agent/client/channel/channel_test.go
+++ b/agent/client/channel/channel_test.go
@@ -107,6 +107,7 @@ func setup(t *testing.T, connect func(agentv1.AgentService_ConnectServer) error,
 }
 
 func TestAgentRequestWithTruncatedInvalidUTF8(t *testing.T) {
+	t.Parallel()
 	defaultMaxQueryLength := truncate.GetDefaultMaxQueryLength()
 	fingerprint, _ := truncate.Query("SELECT * FROM contacts t0 WHERE t0.person_id = '?';", defaultMaxQueryLength, truncate.GetDefaultMaxQueryLength())
 	invalidQuery := "SELECT * FROM contacts t0 WHERE t0.person_id = '\u0241\xff\\uD83D\xddÃ¼\xf1'"
@@ -156,6 +157,7 @@ func TestAgentRequestWithTruncatedInvalidUTF8(t *testing.T) {
 }
 
 func TestAgentRequest(t *testing.T) {
+	t.Parallel()
 	const count = 50
 	require.Greater(t, count, serverRequestsCap)
 
@@ -220,6 +222,7 @@ pmm_agent_channel_messages_sent_total 50
 }
 
 func TestServerRequest(t *testing.T) {
+	t.Parallel()
 	const count = 50
 	require.Greater(t, count, serverRequestsCap)
 
@@ -260,6 +263,7 @@ func TestServerRequest(t *testing.T) {
 }
 
 func TestServerExitsWithGRPCError(t *testing.T) {
+	t.Parallel()
 	errUnimplemented := status.Error(codes.Unimplemented, "Test error")
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
 		msg, err := stream.Recv()
@@ -279,6 +283,7 @@ func TestServerExitsWithGRPCError(t *testing.T) {
 }
 
 func TestServerExitsWithUnknownError(t *testing.T) {
+	t.Parallel()
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
 		msg, err := stream.Recv()
 		require.NoError(t, err)
@@ -297,6 +302,7 @@ func TestServerExitsWithUnknownError(t *testing.T) {
 }
 
 func TestAgentClosesStream(t *testing.T) {
+	t.Parallel()
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
 		err := stream.Send(&agentv1.ServerMessage{
 			Id:      1,
@@ -323,6 +329,7 @@ func TestAgentClosesStream(t *testing.T) {
 }
 
 func TestAgentClosesConnection(t *testing.T) {
+	t.Parallel()
 	var wg sync.WaitGroup
 	wg.Add(1)
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
@@ -360,6 +367,7 @@ func TestAgentClosesConnection(t *testing.T) {
 }
 
 func TestUnexpectedResponseIDFromServer(t *testing.T) {
+	t.Parallel()
 	unexpectedIDSent := make(chan struct{})
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
 		// This message triggers no error, we ignore message ids that have no subscriber.
@@ -395,6 +403,7 @@ func TestUnexpectedResponseIDFromServer(t *testing.T) {
 }
 
 func TestUnexpectedResponsePayloadFromServer(t *testing.T) {
+	t.Parallel()
 	connect := func(stream agentv1.AgentService_ConnectServer) error {
 		// establish the connection
 		err := stream.Send(&agentv1.ServerMessage{

--- a/agent/client/client_test.go
+++ b/agent/client/client_test.go
@@ -121,7 +121,9 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("WithServer", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			serverMD := &agentv1.ServerConnectMetadata{
 				ServerVersion: t.Name(),
 			}
@@ -171,6 +173,7 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("NoManaged", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("FIXME https://jira.percona.com/browse/PMM-4076")
 
 			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -201,6 +204,7 @@ func TestClient(t *testing.T) {
 }
 
 func TestUnexpectedActionType(t *testing.T) {
+	t.Parallel()
 	serverMD := &agentv1.ServerConnectMetadata{
 		ServerVersion: t.Name(),
 	}
@@ -254,6 +258,7 @@ func TestUnexpectedActionType(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				err = stream.Send(&agentv1.ServerMessage{Id: tc.id, Payload: tc.payload})
 				require.NoError(t, err)
 
@@ -289,6 +294,7 @@ func TestUnexpectedActionType(t *testing.T) {
 }
 
 func TestArgListFromPgParams(t *testing.T) {
+	t.Parallel()
 	type testParams struct {
 		req      *agentv1.StartActionRequest_PTPgSummaryParams
 		expected []string
@@ -323,6 +329,7 @@ func TestArgListFromPgParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(prototext.Format(tc.req), func(t *testing.T) {
+			t.Parallel()
 			actual := argListFromPgParams(tc.req)
 			t.Logf("\n%+v\n", actual)
 			assert.ElementsMatch(t, tc.expected, actual)
@@ -331,6 +338,7 @@ func TestArgListFromPgParams(t *testing.T) {
 }
 
 func TestArgListFromMongoDBParams(t *testing.T) {
+	t.Parallel()
 	type testParams struct {
 		req      *agentv1.StartActionRequest_PTMongoDBSummaryParams
 		expected []string
@@ -372,6 +380,7 @@ func TestArgListFromMongoDBParams(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(prototext.Format(tc.req), func(t *testing.T) {
+			t.Parallel()
 			actual := argListFromMongoDBParams(tc.req)
 			assert.ElementsMatch(t, tc.expected, actual)
 		})

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -48,7 +48,9 @@ func generateTempDirPath(t *testing.T, basePath string) string {
 }
 
 func TestLoadFromFile(t *testing.T) {
+	t.Parallel()
 	t.Run("Normal", func(t *testing.T) {
+		t.Parallel()
 		name := writeConfig(t, &Config{ID: "agent-id"})
 		t.Cleanup(func() { removeConfig(t, name) })
 
@@ -58,12 +60,14 @@ func TestLoadFromFile(t *testing.T) {
 	})
 
 	t.Run("NotExist", func(t *testing.T) {
+		t.Parallel()
 		cfg, err := loadFromFile("not-exist.yaml")
 		assert.Equal(t, ConfigFileDoesNotExistError("not-exist.yaml"), err)
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("PermissionDenied", func(t *testing.T) {
+		t.Parallel()
 		name := writeConfig(t, &Config{ID: "agent-id"})
 		require.NoError(t, os.Chmod(name, 0o000))
 		t.Cleanup(func() { removeConfig(t, name) })
@@ -76,6 +80,7 @@ func TestLoadFromFile(t *testing.T) {
 	})
 
 	t.Run("NotYAML", func(t *testing.T) {
+		t.Parallel()
 		name := writeConfig(t, nil)
 		require.NoError(t, os.WriteFile(name, []byte(`not YAML`), 0o666)) //nolint:gosec
 		t.Cleanup(func() { removeConfig(t, name) })
@@ -88,7 +93,9 @@ func TestLoadFromFile(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
+	t.Parallel()
 	t.Run("OnlyFlags", func(t *testing.T) {
+		t.Parallel()
 		var actual Config
 		configFilepath, err := get([]string{
 			"--id=agent-id",
@@ -137,6 +144,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("OnlyConfig", func(t *testing.T) {
+		t.Parallel()
 		var name string
 		var actual Config
 
@@ -202,6 +210,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("BothFlagsAndConfig", func(t *testing.T) {
+		t.Parallel()
 		var name string
 		var actual Config
 		tmpDir := generateTempDirPath(t, "/foo/bar")
@@ -269,6 +278,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("MixExportersBase", func(t *testing.T) {
+		t.Parallel()
 		var name string
 		var actual Config
 
@@ -339,6 +349,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("MixPathsBase", func(t *testing.T) {
+		t.Parallel()
 		var name string
 		var actual Config
 
@@ -408,6 +419,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("MixPathsBaseExporterBase", func(t *testing.T) {
+		t.Parallel()
 		var name string
 		var actual Config
 
@@ -475,6 +487,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("NoFile", func(t *testing.T) {
+		t.Parallel()
 		wd, err := os.Getwd()
 		require.NoError(t, err)
 
@@ -529,6 +542,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestFilteredURL(t *testing.T) {
+	t.Parallel()
 	s := &Server{
 		Address:  "1.2.3.4:443",
 		Username: "username",
@@ -541,6 +555,7 @@ func TestFilteredURL(t *testing.T) {
 		"$&+,/:*;=?@", // all special reserved characters from RFC plus *
 	} {
 		t.Run(password, func(t *testing.T) {
+			t.Parallel()
 			s.Password = password
 			assert.Equal(t, "https://username:***@1.2.3.4:443/", s.FilteredURL())
 		})

--- a/agent/connectionchecker/connection_checker_test.go
+++ b/agent/connectionchecker/connection_checker_test.go
@@ -265,6 +265,7 @@ func TestConnectionChecker(t *testing.T) {
 	}
 
 	t.Run("Stats should be empty", func(t *testing.T) {
+		t.Parallel()
 		cfgStorage := config.NewStorage(&config.Config{
 			Paths: config.Paths{TempDir: t.TempDir()},
 		})
@@ -277,6 +278,7 @@ func TestConnectionChecker(t *testing.T) {
 	})
 
 	t.Run("MongoDBWithSSL", func(t *testing.T) {
+		t.Parallel()
 		mongoDBDSNWithSSL, mongoDBTextFiles := tests.GetTestMongoDBWithSSLDSN(t, "../")
 
 		cfgStorage := config.NewStorage(&config.Config{

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -93,6 +93,7 @@ exit status 2
 */
 
 func TestImports(t *testing.T) {
+	t.Parallel()
 	type constraint struct {
 		denyPrefixes  []string
 		allowPrefixes []string

--- a/agent/queryparser/parser_test.go
+++ b/agent/queryparser/parser_test.go
@@ -29,6 +29,7 @@ type testCase struct {
 }
 
 func TestMySQL(t *testing.T) {
+	t.Parallel()
 	sqls := []testCase{
 		{
 			Query:                     "SELECT /* Sleep */ sleep(0.1)",
@@ -88,6 +89,7 @@ type testCaseComments struct {
 }
 
 func TestMySQLComments(t *testing.T) {
+	t.Parallel()
 	testCases := []testCaseComments{
 		{
 			Name: "No comment",
@@ -156,6 +158,7 @@ func TestMySQLComments(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
 			comments, err := MySQLComments(c.Query)
 			require.NoError(t, err)
 			require.Equal(t, c.Comments, comments)
@@ -164,6 +167,7 @@ func TestMySQLComments(t *testing.T) {
 }
 
 func TestPostgreSQLComments(t *testing.T) {
+	t.Parallel()
 	testCases := []testCaseComments{
 		{
 			Name: "No comment",
@@ -205,6 +209,7 @@ func TestPostgreSQLComments(t *testing.T) {
 
 	for _, c := range testCases {
 		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
 			comments, err := PostgreSQLComments(c.Query)
 			require.NoError(t, err)
 			require.Equal(t, c.Comments, comments)

--- a/agent/runner/actions/common_test.go
+++ b/agent/runner/actions/common_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestPrepareQueryWithDatabaseTableName(t *testing.T) {
+	t.Parallel()
 	expected := "SHOW /* pmm-agent */ INDEX IN `table`"
 	assert.Equal(t, expected, prepareQueryWithDatabaseTableName("SHOW /* pmm-agent */ INDEX IN", "table"))
 	assert.Equal(t, expected, prepareQueryWithDatabaseTableName("SHOW /* pmm-agent */ INDEX IN", "`table`"))

--- a/agent/runner/actions/mongodb_explain_action_test.go
+++ b/agent/runner/actions/mongodb_explain_action_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 func TestQueryExplain(t *testing.T) {
+	t.Parallel()
 	database := "testdb"
 	ctx := context.TODO()
 
@@ -48,6 +49,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Find", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "config.collections",
 			"op": "query",
@@ -66,6 +68,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Count", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.collection",
 			"op": "command",
@@ -86,6 +89,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Count with aggregate", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.collection",
 			"op": "command",
@@ -118,6 +122,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.inventory",
 			"op": "update",
@@ -142,6 +147,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.inventory",
 			"op": "remove",
@@ -171,6 +177,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Distinct", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.inventory",
 			"op": "command",
@@ -186,6 +193,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Insert - not supported", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.listingsAndReviews",
 			"op": "insert",
@@ -199,6 +207,7 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("Drop - not supported", func(t *testing.T) {
+		t.Parallel()
 		query := `{
 			"ns": "testdb.listingsAndReviews",
 			"op": "command",
@@ -211,7 +220,10 @@ func TestQueryExplain(t *testing.T) {
 	})
 
 	t.Run("PMM-12451", func(t *testing.T) {
+		t.Parallel(
 		// Query from customer to prevent wrong date/time, timestamp parsing in future and prevent regression.
+		)
+
 		query := `{"ns":"testdb.testDoc","op":"query","command":{"find":"testDoc","filter":{"$and":[{"c23":{"$ne":""}},{"c23":{"$ne":null},"delete":{"$ne":true}},{"$and":[{"c23":"985662747"},{"c15":{"$gte":{"$date":"2023-09-19T22:00:00.000Z"}}},{"c15":{"$lte":{"$date":"2023-10-20T21:59:59.000Z"}}},{"c8":{"$in":["X1118630710X","X1118630720X","X1118630730X","X1118630740X","X1118630750X","X1118630760X"]},"c22":{"$in":["X1118630710X","X1118630710XA","X1118630710XB","X1118630710XC","X1118630710XD","X1118630710XE"]},"c34":{"$in":["X1118630710X","X1118630710Y","X1118630710Z","X1118630710U","X1118630710V","X1118630710W"]}},{"c2":"xxxxxxx"},{"c29":{"$in":["X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X","X1118630710X"]}}]}]},"lsid":{"id":{"$binary":{"base64":"n/f5RI2jTTCoyt0y+8D9Cw==","subType":"04"}}},"$db":"testdb"}}`
 		runExplain(ctx, t, prepareParams(t, query))
 	})
@@ -252,6 +264,7 @@ func runExplainExpectError(ctx context.Context, t *testing.T, params *agentv1.St
 }
 
 func TestMongoDBExplain(t *testing.T) {
+	t.Parallel()
 	database := "test"
 	collection := "test_col"
 	id := "abcd1234"
@@ -265,6 +278,7 @@ func TestMongoDBExplain(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Valid MongoDB query", func(t *testing.T) {
+		t.Parallel()
 		params := &agentv1.StartActionRequest_MongoDBExplainParams{
 			Dsn:   tests.GetTestMongoDBDSN(t),
 			Query: `{"ns":"test.coll","op":"query","query":{"k":{"$lte":{"$numberInt":"1"}}}}`,
@@ -321,6 +335,7 @@ func TestMongoDBExplain(t *testing.T) {
 
 // These tests are based on v3 tests. The previous ones are inherited from PMM 1/Toolkit.
 func TestNewMongoDBExplain(t *testing.T) {
+	t.Parallel()
 	database := "sbtest"
 	id := "abcd1234"
 	ctx := context.TODO()
@@ -354,6 +369,7 @@ func TestNewMongoDBExplain(t *testing.T) {
 	}
 	for _, tf := range testFiles {
 		t.Run(tf.in, func(t *testing.T) {
+			t.Parallel()
 			query, err := os.ReadFile(filepath.Join("testdata/", filepath.Clean(tf.in)))
 			assert.NoError(t, err)
 			params := &agentv1.StartActionRequest_MongoDBExplainParams{

--- a/agent/runner/actions/mysql_explain_action_test.go
+++ b/agent/runner/actions/mysql_explain_action_test.go
@@ -346,6 +346,7 @@ func TestMySQLExplain(t *testing.T) {
 }
 
 func TestParseRealTableNameMySQL(t *testing.T) {
+	t.Parallel()
 	type testCase struct {
 		Query    string
 		Expected string
@@ -370,6 +371,7 @@ func TestParseRealTableNameMySQL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Query, func(t *testing.T) {
+			t.Parallel()
 			assert.Equal(t, test.Expected, parseRealTableName(test.Query))
 		})
 	}

--- a/agent/runner/actions/pt_mysql_summary_action_test.go
+++ b/agent/runner/actions/pt_mysql_summary_action_test.go
@@ -56,6 +56,7 @@ func TestPTMySQLSummaryActionRunAndCancel(t *testing.T) {
 }
 
 func TestBuildMyCnfConfig(t *testing.T) {
+	t.Parallel()
 	type testParams struct {
 		Params   *agentv1.StartActionRequest_PTMySQLSummaryParams
 		Expected string
@@ -106,6 +107,7 @@ func TestBuildMyCnfConfig(t *testing.T) {
 			params: tc.Params,
 		}
 		t.Run(fmt.Sprintf(t.Name()+" %d", i), func(t *testing.T) {
+			t.Parallel()
 			s, err := a.buildMyCnfConfig()
 			if tc.WantErr != nil {
 				require.Error(t, err)

--- a/agent/runner/actions/query_transform_test.go
+++ b/agent/runner/actions/query_transform_test.go
@@ -168,6 +168,7 @@ func Test_dmlToSelect(t *testing.T) {
 }
 
 func Test_isDMLQuery(t *testing.T) {
+	t.Parallel()
 	assert.True(t, isDMLQuery("SELECT * FROM table"))
 	assert.True(t, isDMLQuery(`update tabla set nombre = "carlos" where id = 0`))
 	assert.True(t, isDMLQuery("delete from tabla join tabla2 on tabla.id = tabla2.tabla2_id"))

--- a/agent/runner/jobs/pbm_helpers_test.go
+++ b/agent/runner/jobs/pbm_helpers_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestCreatePBMConfig(t *testing.T) {
+	t.Parallel()
 	s3Config := S3LocationConfig{
 		Endpoint:     "test_endpoint",
 		AccessKey:    "test_access_key",
@@ -114,6 +115,7 @@ func TestCreatePBMConfig(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			inputLocation := test.inputLocation
 			res, err := createPBMConfig(&inputLocation, "test_prefix", test.inputPitr)
 			if test.errString != "" {
@@ -128,7 +130,10 @@ func TestCreatePBMConfig(t *testing.T) {
 }
 
 func TestFindPITRRestore(t *testing.T) {
+	t.Parallel(
 	// Tested func searches from the end, so we place records to be skipped at the end.
+	)
+
 	testList := []pbmListRestore{
 		{
 			Name: "2022-10-11T14:53:19.000000001Z",
@@ -188,6 +193,7 @@ func TestFindPITRRestore(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			startedAt, err := time.Parse(time.RFC3339Nano, tc.startedAtString)
 			require.NoError(t, err)
 

--- a/agent/serviceinfobroker/service_info_broker_test.go
+++ b/agent/serviceinfobroker/service_info_broker_test.go
@@ -199,6 +199,7 @@ func TestServiceInfoBroker(t *testing.T) {
 	}
 
 	t.Run("TableCount", func(t *testing.T) {
+		t.Parallel()
 		cfgStorage := config.NewStorage(&config.Config{
 			Paths: config.Paths{TempDir: t.TempDir()},
 		})
@@ -212,6 +213,7 @@ func TestServiceInfoBroker(t *testing.T) {
 	})
 
 	t.Run("PostgreSQLOptions", func(t *testing.T) {
+		t.Parallel()
 		cfgStorage := config.NewStorage(&config.Config{
 			Paths: config.Paths{TempDir: t.TempDir()},
 		})
@@ -319,6 +321,7 @@ func TestServiceInfoBrokerMongoDB(t *testing.T) {
 	}
 
 	t.Run("MongoDB no params", func(t *testing.T) {
+		t.Parallel()
 		cfgStorage := config.NewStorage(&config.Config{
 			Paths: config.Paths{TempDir: t.TempDir()},
 		})
@@ -342,6 +345,7 @@ func TestServiceInfoBrokerMongoDB(t *testing.T) {
 	})
 
 	t.Run("MongoDBWithSSL", func(t *testing.T) {
+		t.Parallel()
 		mongoDBDSNWithSSL, mongoDBTextFiles := tests.GetTestMongoDBWithSSLDSN(t, "../")
 
 		cfgStorage := config.NewStorage(&config.Config{

--- a/agent/utils/backoff/backoff_test.go
+++ b/agent/utils/backoff/backoff_test.go
@@ -17,5 +17,6 @@ package backoff
 import "testing"
 
 func TestBackoff(t *testing.T) { //nolint:revive
+	t.Parallel()
 	// we need at least one test per package to correctly calculate coverage
 }

--- a/agent/utils/depstests/protobuf_test.go
+++ b/agent/utils/depstests/protobuf_test.go
@@ -25,9 +25,11 @@ import (
 )
 
 func TestDuration(t *testing.T) {
+	t.Parallel(
 	// https://github.com/golang/protobuf/issues/883
 	// https://github.com/golang/protobuf/issues/1219
 	// https://jira.percona.com/browse/PMM-6760
+	)
 
 	b, err := protojson.Marshal(durationpb.New(-time.Nanosecond))
 	require.NoError(t, err)

--- a/agent/utils/mongo_fix/mongo_fix_test.go
+++ b/agent/utils/mongo_fix/mongo_fix_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestClientOptionsForDSN(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		error            string
@@ -67,6 +68,7 @@ func TestClientOptionsForDSN(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ClientOptionsForDSN(tt.dsn)
 			if tt.error != "" {
 				assert.Equal(t, err.Error(), tt.error)

--- a/agent/utils/truncate/query_test.go
+++ b/agent/utils/truncate/query_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestQuery(t *testing.T) {
+	t.Parallel()
 	for q, expected := range map[string]struct {
 		query     string
 		truncated bool

--- a/agent/utils/version/mysql_test.go
+++ b/agent/utils/version/mysql_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGetMySQLVersion(t *testing.T) {
+	t.Parallel()
 	sqlDB, mock, err := sqlmock.New()
 	if err != nil {
 		t.Log("error creating mock database")
@@ -110,12 +111,14 @@ func TestGetMySQLVersion(t *testing.T) {
 		},
 	}
 
-	//nolint:paralleltest
 	for _, testCase := range testCases {
 		tc := testCase //nolint:varnamelen
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel(
 			// Don't run in parallel. If this is ran in parallel, there is no way to know
 			// in which case we are.
+			)
+
 			columns := []string{"variable_name", "value"}
 			for _, mockedVar := range tc.mockedData {
 				mock.ExpectQuery("SHOW").

--- a/agent/utils/version/postgresql_test.go
+++ b/agent/utils/version/postgresql_test.go
@@ -21,12 +21,14 @@ import (
 )
 
 func TestParsePostgreSQLVersion(t *testing.T) {
+	t.Parallel()
 	for v, expected := range map[string]string{
 		"PostgreSQL 12beta2 (Debian 12~beta2-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit":              "12",
 		"PostgreSQL 10.9 (Debian 10.9-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit":     "10",
 		"PostgreSQL 9.4.23 on x86_64-pc-linux-gnu (Debian 9.4.23-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit": "9.4",
 	} {
 		t.Run(v, func(t *testing.T) {
+			t.Parallel()
 			actual := ParsePostgreSQLVersion(v)
 			assert.Equal(t, expected, actual, "%s", v)
 		})

--- a/agent/versioner/versioner_test.go
+++ b/agent/versioner/versioner_test.go
@@ -32,10 +32,12 @@ func (m *mockedExec) CombinedOutput() ([]byte, error) { //nolint:unparam
 }
 
 func TestVersioner(t *testing.T) {
+	t.Parallel()
 	execMock := &MockExecFunctions{}
 	versioner := New(execMock)
 
 	t.Run("not found", func(t *testing.T) {
+		t.Parallel()
 		execMock.On("LookPath", mysqldBin).Return("", &exec.Error{Err: exec.ErrNotFound}).Once()
 
 		version, err := versioner.MySQLdVersion()
@@ -45,6 +47,7 @@ func TestVersioner(t *testing.T) {
 
 	// mysql software
 	t.Run("mysqld", func(t *testing.T) {
+		t.Parallel()
 		mysqldVersionOutput := []byte(`/usr/sbin/mysqld  Ver 8.0.22-13 for Linux on x86_64 (Percona Server (GPL), Release '13', Revision '6f7822f')
 `)
 		execMock.On("LookPath", mysqldBin).Return("", nil).Once()
@@ -56,6 +59,7 @@ func TestVersioner(t *testing.T) {
 	})
 
 	t.Run("xtrabackup 2", func(t *testing.T) {
+		t.Parallel()
 		xtrabackup2VersionOutput := []byte(`xtrabackup: recognized server arguments: --datadir=/var/lib/mysql
 xtrabackup version 2.4.23 based on MySQL server 5.7.34 Linux (x86_64) (revision id: 3320f39)
 `)
@@ -68,6 +72,7 @@ xtrabackup version 2.4.23 based on MySQL server 5.7.34 Linux (x86_64) (revision 
 	})
 
 	t.Run("xtrabackup 8", func(t *testing.T) {
+		t.Parallel()
 		xtrabackup8VersionOutput := []byte(`xtrabackup version 8.0.23-16 based on MySQL server 8.0.23 Linux (x86_64) (revision id: 934bc8f)
 `)
 		execMock.On("LookPath", xtrabackupBin).Return("", nil).Once()
@@ -79,6 +84,7 @@ xtrabackup version 2.4.23 based on MySQL server 5.7.34 Linux (x86_64) (revision 
 	})
 
 	t.Run("xbcloud", func(t *testing.T) {
+		t.Parallel()
 		xbcloudVersionOutput := []byte(`xbcloud  Ver 8.0.23-16 for Linux (x86_64) (revision id: 934bc8f)
 `)
 		execMock.On("LookPath", xbcloudBin).Return("", nil).Once()
@@ -90,6 +96,7 @@ xtrabackup version 2.4.23 based on MySQL server 5.7.34 Linux (x86_64) (revision 
 	})
 
 	t.Run("qpress", func(t *testing.T) {
+		t.Parallel()
 		qpressVersionOutput := []byte(`qpress 1.1 - Copyright 2006-2010 Lasse Reinhold - www.quicklz.com
 Using QuickLZ 1.4.1 compression library
 Compiled for: Windows [*nix]    [x86/x64] RISC    32-bit [64-bit]
@@ -105,6 +112,7 @@ Compiled for: Windows [*nix]    [x86/x64] RISC    32-bit [64-bit]
 
 	// mongo software
 	t.Run("mongod", func(t *testing.T) {
+		t.Parallel()
 		mongodVersionOutput := []byte(`db version v6.0.2-1
 Build Info: {
     "version": "6.0.2-1",
@@ -119,6 +127,7 @@ Build Info: {
 	})
 
 	t.Run("pbm", func(t *testing.T) {
+		t.Parallel()
 		pbmVersionOutput := []byte(`Version:   2.0.2
 Platform:  linux/amd64
 GitCommit: 3ec38a5fc6706515fb1be72b015972af1500aa17

--- a/api-tests/alerting/alerting_test.go
+++ b/api-tests/alerting/alerting_test.go
@@ -429,12 +429,15 @@ func TestModifyTemplatesAPI(t *testing.T) {
 // We keep it separate from the tests in TestModifyTemplatesAPI to avoid
 // race conditions when other tests add or remove templates while we are listing them.
 func TestListTemplatesAPI(t *testing.T) {
+	t.Parallel()
 	client := alertingClient.Default.AlertingService
 
 	templateData, err := os.ReadFile("../testdata/alerting/template.yaml")
 	require.NoError(t, err)
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		t.Run("without pagination", func(t *testing.T) {
+			t.Parallel()
 			name := uuid.New().String()
 			expr := uuid.New().String()
 			alertTemplates, yml := formatTemplateYaml(t, fmt.Sprintf(string(templateData), name, expr, "%", "s"))
@@ -459,6 +462,7 @@ func TestListTemplatesAPI(t *testing.T) {
 		})
 
 		t.Run("with pagination", func(t *testing.T) {
+			t.Parallel()
 			const templatesCount = 5
 
 			templateNames := make(map[string]struct{})

--- a/api-tests/backup/backup_test.go
+++ b/api-tests/backup/backup_test.go
@@ -34,7 +34,9 @@ import (
 )
 
 func TestScheduleBackup(t *testing.T) {
+	t.Parallel()
 	t.Run("mongo", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := management.RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -104,6 +106,7 @@ func TestScheduleBackup(t *testing.T) {
 		defer deleteLocation(t, backupClient.Default.LocationsService, locationID)
 
 		t.Run("schedule logical backup", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 			backupRes, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
 				Body: backup.ScheduleBackupBody{
@@ -183,6 +186,7 @@ func TestScheduleBackup(t *testing.T) {
 		})
 
 		t.Run("create multiple snapshot backups", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 			sb1, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
 				Body: backup.ScheduleBackupBody{
@@ -220,6 +224,7 @@ func TestScheduleBackup(t *testing.T) {
 		})
 
 		t.Run("create PITR backup when other backups disabled", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 
 			sb1, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
@@ -275,6 +280,7 @@ func TestScheduleBackup(t *testing.T) {
 		})
 
 		t.Run("only one enabled PITR backup allowed for the same cluster", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 			sb1, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
 				Body: backup.ScheduleBackupBody{
@@ -311,6 +317,7 @@ func TestScheduleBackup(t *testing.T) {
 		})
 
 		t.Run("physical backups fail when PITR is enabled", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 			_, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
 				Body: backup.ScheduleBackupBody{
@@ -330,6 +337,7 @@ func TestScheduleBackup(t *testing.T) {
 		})
 
 		t.Run("physical backup snapshots can be scheduled", func(t *testing.T) {
+			t.Parallel()
 			client := backupClient.Default.BackupService
 			backupRes, err := client.ScheduleBackup(&backup.ScheduleBackupParams{
 				Body: backup.ScheduleBackupBody{

--- a/api-tests/inventory/agents_azure_database_exporter_test.go
+++ b/api-tests/inventory/agents_azure_database_exporter_test.go
@@ -28,7 +28,9 @@ import (
 	agents "github.com/percona/pmm/api/inventory/v1/json/client/agents_service"
 )
 
-func TestAzureDatabaseExporter(t *testing.T) { //nolint:tparallel
+func TestAzureDatabaseExporter(t *testing.T) {
+	t. //nolint:tparallel
+		Parallel()
 	// TODO Fix this test to run in parallel.
 	// t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
@@ -219,6 +221,7 @@ func TestAzureDatabaseExporter(t *testing.T) { //nolint:tparallel
 	})
 
 	t.Run("With PushMetrics", func(t *testing.T) {
+		t.Parallel()
 		genericNodeID := pmmapitests.AddGenericNode(t, pmmapitests.TestString(t, "")).NodeID
 		require.NotEmpty(t, genericNodeID)
 		defer pmmapitests.RemoveNodes(t, genericNodeID)

--- a/api-tests/inventory/agents_proxysql_exporter_test.go
+++ b/api-tests/inventory/agents_proxysql_exporter_test.go
@@ -283,6 +283,7 @@ func TestProxySQLExporter(t *testing.T) {
 		}
 	})
 	t.Run("With PushMetrics", func(t *testing.T) {
+		t.Parallel()
 		genericNodeID := pmmapitests.AddGenericNode(t, pmmapitests.TestString(t, "")).NodeID
 		require.NotEmpty(t, genericNodeID)
 		defer pmmapitests.RemoveNodes(t, genericNodeID)

--- a/api-tests/inventory/agents_rds_exporter_test.go
+++ b/api-tests/inventory/agents_rds_exporter_test.go
@@ -31,6 +31,7 @@ import (
 func TestRDSExporter(t *testing.T) {
 	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		genericNodeID := pmmapitests.AddGenericNode(t, pmmapitests.TestString(t, "")).NodeID
 		require.NotEmpty(t, genericNodeID)
 		defer pmmapitests.RemoveNodes(t, genericNodeID)
@@ -219,6 +220,7 @@ func TestRDSExporter(t *testing.T) {
 	})
 
 	t.Run("With PushMetrics", func(t *testing.T) {
+		t.Parallel()
 		genericNodeID := pmmapitests.AddGenericNode(t, pmmapitests.TestString(t, "")).NodeID
 		require.NotEmpty(t, genericNodeID)
 		defer pmmapitests.RemoveNodes(t, genericNodeID)

--- a/api-tests/inventory/nodes_test.go
+++ b/api-tests/inventory/nodes_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestNodes(t *testing.T) {
+	t.Parallel()
 	t.Run("List", func(t *testing.T) {
+		t.Parallel()
 		remoteNode := pmmapitests.AddNode(t, &nodes.AddNodeBody{
 			Remote: &nodes.AddNodeParamsBodyRemote{
 				NodeName: pmmapitests.TestString(t, "Test Remote Node for List"),
@@ -100,7 +102,9 @@ func TestNodes(t *testing.T) {
 }
 
 func TestGetNode(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "TestGenericNode")
 		nodeID := pmmapitests.AddGenericNode(t, nodeName).NodeID
 		require.NotEmpty(t, nodeID)
@@ -127,6 +131,7 @@ func TestGetNode(t *testing.T) {
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
+		t.Parallel()
 		params := &nodes.GetNodeParams{
 			NodeID:  "pmm-not-found",
 			Context: pmmapitests.Context,
@@ -137,6 +142,7 @@ func TestGetNode(t *testing.T) {
 	})
 
 	t.Run("EmptyNodeID", func(t *testing.T) {
+		t.Parallel()
 		params := &nodes.GetNodeParams{
 			Context: pmmapitests.Context,
 		}
@@ -147,7 +153,9 @@ func TestGetNode(t *testing.T) {
 }
 
 func TestGenericNode(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Test Generic Node")
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
@@ -192,6 +200,7 @@ func TestGenericNode(t *testing.T) {
 	})
 
 	t.Run("AddNameEmpty", func(t *testing.T) {
+		t.Parallel()
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
 				Generic: &nodes.AddNodeParamsBodyGeneric{NodeName: ""},
@@ -207,7 +216,9 @@ func TestGenericNode(t *testing.T) {
 }
 
 func TestContainerNode(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Test Container Node")
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
@@ -257,6 +268,7 @@ func TestContainerNode(t *testing.T) {
 	})
 
 	t.Run("AddNameEmpty", func(t *testing.T) {
+		t.Parallel()
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
 				Container: &nodes.AddNodeParamsBodyContainer{NodeName: ""},
@@ -272,7 +284,9 @@ func TestContainerNode(t *testing.T) {
 }
 
 func TestRemoteNode(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Test Remote Node")
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
@@ -321,6 +335,7 @@ func TestRemoteNode(t *testing.T) {
 	})
 
 	t.Run("AddNameEmpty", func(t *testing.T) {
+		t.Parallel()
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
 				Remote: &nodes.AddNodeParamsBodyRemote{NodeName: ""},
@@ -336,7 +351,9 @@ func TestRemoteNode(t *testing.T) {
 }
 
 func TestRemoveNode(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Generic Node for basic remove test")
 		node := pmmapitests.AddNode(t,
 			&nodes.AddNodeBody{
@@ -356,6 +373,7 @@ func TestRemoveNode(t *testing.T) {
 	})
 
 	t.Run("With service", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Generic Node for remove test")
 		node := pmmapitests.AddNode(t,
 			&nodes.AddNodeBody{
@@ -444,6 +462,7 @@ func TestRemoveNode(t *testing.T) {
 	})
 
 	t.Run("With pmm-agent", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "Generic Node for remove test")
 		node := pmmapitests.AddNode(t,
 			&nodes.AddNodeBody{
@@ -490,6 +509,7 @@ func TestRemoveNode(t *testing.T) {
 	})
 
 	t.Run("Not-exist node", func(t *testing.T) {
+		t.Parallel()
 		nodeID := "not-exist-node-id"
 		removeResp, err := client.Default.NodesService.RemoveNode(&nodes.RemoveNodeParams{
 			NodeID:  nodeID,
@@ -500,6 +520,7 @@ func TestRemoveNode(t *testing.T) {
 	})
 
 	t.Run("Empty params", func(t *testing.T) {
+		t.Parallel()
 		removeResp, err := client.Default.NodesService.RemoveNode(&nodes.RemoveNodeParams{
 			Context: context.Background(),
 		})
@@ -508,6 +529,7 @@ func TestRemoveNode(t *testing.T) {
 	})
 
 	t.Run("PMM Server", func(t *testing.T) {
+		t.Parallel()
 		removeResp, err := client.Default.NodesService.RemoveNode(&nodes.RemoveNodeParams{
 			NodeID:  "pmm-server",
 			Force:   pointer.ToBool(true),

--- a/api-tests/management/action/explain_test.go
+++ b/api-tests/management/action/explain_test.go
@@ -29,9 +29,11 @@ import (
 )
 
 func TestRunExplain(t *testing.T) {
+	t.Parallel()
 	t.Skip("not implemented yet")
 
 	t.Run("ByQueryID", func(t *testing.T) {
+		t.Parallel()
 		explainActionOK, err := client.Default.ActionsService.StartServiceAction(
 			&actions.StartServiceActionParams{
 				Context: pmmapitests.Context,
@@ -59,8 +61,11 @@ func TestRunExplain(t *testing.T) {
 }
 
 func TestRunMongoDBExplain(t *testing.T) {
+	t.Parallel(
 	// When we have an pmm-agent in dev-container and we can remove this skip, please remove the t.Logf at the end
 	// of this test and replace it with a proper test that checks the results.
+	)
+
 	t.Skip("pmm-agent in dev-container is not fully implemented yet")
 
 	explainActionOK, err := client.Default.ActionsService.StartServiceAction(

--- a/api-tests/management/action/ptsummary_test.go
+++ b/api-tests/management/action/ptsummary_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestPTSummary(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(pmmapitests.Context, 30*time.Second)
 	defer cancel()
 

--- a/api-tests/management/annotation_test.go
+++ b/api-tests/management/annotation_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestAddAnnotation(t *testing.T) {
+	t.Parallel()
 	t.Run("Add Basic Annotation", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddAnnotationParams{
 			Body: mservice.AddAnnotationBody{
 				Text: "Annotation Text",
@@ -46,6 +48,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Add Empty Annotation", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddAnnotationParams{
 			Body: mservice.AddAnnotationBody{
 				Text: "",
@@ -58,6 +61,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Non-existent service", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddAnnotationParams{
 			Body: mservice.AddAnnotationBody{
 				Text:         "Some text",
@@ -70,6 +74,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Non-existent node", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddAnnotationParams{
 			Body: mservice.AddAnnotationBody{
 				Text:     "Some text",
@@ -82,6 +87,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Tag length exceeded", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, strings.Repeat("long-annotation-node-name-", 10))
 		paramsNode := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
@@ -109,6 +115,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Existing service", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "annotation-node")
 		paramsNode := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{
@@ -155,6 +162,7 @@ func TestAddAnnotation(t *testing.T) {
 	})
 
 	t.Run("Existing node", func(t *testing.T) {
+		t.Parallel()
 		nodeName := "annotation-node"
 		params := &nodes.AddNodeParams{
 			Body: nodes.AddNodeBody{

--- a/api-tests/management/external_test.go
+++ b/api-tests/management/external_test.go
@@ -34,7 +34,9 @@ import (
 )
 
 func TestAddExternal(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -100,6 +102,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -159,6 +162,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("OnRemoteNode", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 
 		serviceName := pmmapitests.TestString(t, "service-for-basic-name")
@@ -247,6 +251,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -294,6 +299,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -316,6 +322,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("Empty ListenPort", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -340,6 +347,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("Empty Node ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -364,6 +372,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("Empty Runs On Node ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -388,6 +397,7 @@ func TestAddExternal(t *testing.T) {
 	})
 
 	t.Run("Empty Address for Add Node", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -416,6 +426,7 @@ func TestAddExternal(t *testing.T) {
 }
 
 func TestRemoveExternal(t *testing.T) {
+	t.Parallel()
 	addExternal := func(t *testing.T, serviceName, nodeName string) (nodeID string, serviceID string) {
 		t.Helper()
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
@@ -445,6 +456,7 @@ func TestRemoveExternal(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, serviceID := addExternal(t, serviceName, nodeName)
@@ -471,6 +483,7 @@ func TestRemoveExternal(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, serviceID := addExternal(t, serviceName, nodeName)
@@ -497,6 +510,7 @@ func TestRemoveExternal(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, serviceID := addExternal(t, serviceName, nodeName)
@@ -513,6 +527,7 @@ func TestRemoveExternal(t *testing.T) {
 	})
 
 	t.Run("No params", func(t *testing.T) {
+		t.Parallel()
 		removeServiceOK, err := client.Default.ManagementService.RemoveService(&mservice.RemoveServiceParams{
 			Context: pmmapitests.Context,
 		})

--- a/api-tests/management/haproxy_test.go
+++ b/api-tests/management/haproxy_test.go
@@ -34,7 +34,9 @@ import (
 )
 
 func TestAddHAProxy(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -100,6 +102,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -158,6 +161,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("OnRemoteNode", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 
 		serviceName := pmmapitests.TestString(t, "service-for-basic-name")
@@ -244,6 +248,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "genericNode-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -289,6 +294,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -308,6 +314,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("Empty ListenPort", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -329,6 +336,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("Empty Node ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -350,6 +358,7 @@ func TestAddHAProxy(t *testing.T) {
 	})
 
 	t.Run("Empty Address for Add Node", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
 		nodeID := genericNode.NodeID
@@ -376,6 +385,7 @@ func TestAddHAProxy(t *testing.T) {
 }
 
 func TestRemoveHAProxy(t *testing.T) {
+	t.Parallel()
 	addHAProxy := func(t *testing.T, serviceName, nodeName string) (nodeID string, serviceID string) {
 		t.Helper()
 		genericNode := pmmapitests.AddGenericNode(t, nodeName)
@@ -403,6 +413,7 @@ func TestRemoveHAProxy(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, serviceID := addHAProxy(t, serviceName, nodeName)
@@ -429,6 +440,7 @@ func TestRemoveHAProxy(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, serviceID := addHAProxy(t, serviceName, nodeName)
@@ -455,6 +467,7 @@ func TestRemoveHAProxy(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, serviceID := addHAProxy(t, serviceName, nodeName)
@@ -471,6 +484,7 @@ func TestRemoveHAProxy(t *testing.T) {
 	})
 
 	t.Run("No params", func(t *testing.T) {
+		t.Parallel()
 		removeServiceOK, err := client.Default.ManagementService.RemoveService(&mservice.RemoveServiceParams{
 			Context: pmmapitests.Context,
 		})

--- a/api-tests/management/mongodb_test.go
+++ b/api-tests/management/mongodb_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestAddMongoDB(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -108,6 +110,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With agents", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name-for-all-fields")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -213,6 +216,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name-for-all-fields")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -272,6 +276,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -322,6 +327,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With add_node block", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -444,6 +450,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With Wrong Node Type", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "generic-node-for-wrong-node-type")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -477,6 +484,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -499,6 +507,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Empty Address", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -524,6 +533,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Empty Port", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -550,6 +560,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Empty Pmm Agent ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -576,6 +587,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Address And Socket Conflict.", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -606,6 +618,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("Socket", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-mongo-socket-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -677,6 +690,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePush", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -751,6 +765,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePull", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -824,6 +839,7 @@ func TestAddMongoDB(t *testing.T) {
 	})
 
 	t.Run("With MetricsModeAuto", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -899,6 +915,7 @@ func TestAddMongoDB(t *testing.T) {
 }
 
 func TestRemoveMongoDB(t *testing.T) {
+	t.Parallel()
 	addMongoDB := func(t *testing.T, serviceName, nodeName string, withAgents bool) (nodeID string, pmmAgentID string, serviceID string) {
 		t.Helper()
 		nodeID, pmmAgentID = RegisterGenericNode(t, mservice.RegisterNodeBody{
@@ -933,6 +950,7 @@ func TestRemoveMongoDB(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, pmmAgentID, serviceID := addMongoDB(t, serviceName, nodeName, true)
@@ -960,6 +978,7 @@ func TestRemoveMongoDB(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, pmmAgentID, serviceID := addMongoDB(t, serviceName, nodeName, true)
@@ -987,6 +1006,7 @@ func TestRemoveMongoDB(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, pmmAgentID, serviceID := addMongoDB(t, serviceName, nodeName, false)

--- a/api-tests/management/mysql_test.go
+++ b/api-tests/management/mysql_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestAddMySQL(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -111,6 +113,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With agents", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -224,6 +227,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -286,6 +290,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -338,6 +343,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With add_node block", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -465,6 +471,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With Wrong Node Type", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "generic-node-for-wrong-node-type")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -499,6 +506,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -521,6 +529,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Address And Socket", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -548,6 +557,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Port", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -576,6 +586,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Address And Socket Conflict.", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -606,6 +617,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Pmm Agent ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -632,6 +644,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("Empty username", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -659,6 +672,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePush", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -736,6 +750,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePull", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -812,6 +827,7 @@ func TestAddMySQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModeAuto", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -890,6 +906,7 @@ func TestAddMySQL(t *testing.T) {
 }
 
 func TestRemoveMySQL(t *testing.T) {
+	t.Parallel()
 	addMySQL := func(t *testing.T, serviceName, nodeName string, withAgents bool) (nodeID string, pmmAgentID string, serviceID string) {
 		t.Helper()
 		nodeID, pmmAgentID = RegisterGenericNode(t, mservice.RegisterNodeBody{
@@ -924,6 +941,7 @@ func TestRemoveMySQL(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, pmmAgentID, serviceID := addMySQL(t, serviceName, nodeName, true)
@@ -951,6 +969,7 @@ func TestRemoveMySQL(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, pmmAgentID, serviceID := addMySQL(t, serviceName, nodeName, true)
@@ -978,6 +997,7 @@ func TestRemoveMySQL(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, pmmAgentID, serviceID := addMySQL(t, serviceName, nodeName, false)
@@ -995,6 +1015,7 @@ func TestRemoveMySQL(t *testing.T) {
 	})
 
 	t.Run("No params", func(t *testing.T) {
+		t.Parallel()
 		removeServiceOK, err := client.Default.ManagementService.RemoveService(&mservice.RemoveServiceParams{
 			Context: pmmapitests.Context,
 		})

--- a/api-tests/management/nodes_test.go
+++ b/api-tests/management/nodes_test.go
@@ -33,8 +33,11 @@ import (
 )
 
 func TestNodeRegister(t *testing.T) {
+	t.Parallel()
 	t.Run("Generic Node", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-name")
 			nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -59,6 +62,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Reregister with same node name (no re-register - should fail)", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-all")
 			nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -85,6 +89,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Reregister with same node name (re-register)", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-all")
 			nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -116,6 +121,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Reregister with different node name (no re-register - should fail)", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-all")
 			nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -142,6 +148,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Reregister with different node name (re-register)", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-all")
 			nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -174,6 +181,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("With all fields", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-name")
 			machineID := pmmapitests.TestString(t, "machine-id")
 			nodeModel := pmmapitests.TestString(t, "node-model")
@@ -235,6 +243,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Re-register", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("Re-register logic is not defined yet. https://jira.percona.com/browse/PMM-3717")
 
 			nodeName := pmmapitests.TestString(t, "node-name")
@@ -292,7 +301,9 @@ func TestNodeRegister(t *testing.T) {
 	})
 
 	t.Run("Container Node", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-name")
 			nodeID, pmmAgentID := registerContainerNode(t, mservice.RegisterNodeBody{
 				NodeName: nodeName,
@@ -321,6 +332,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("With all fields", func(t *testing.T) {
+			t.Parallel()
 			nodeName := pmmapitests.TestString(t, "node-name")
 			nodeModel := pmmapitests.TestString(t, "node-model")
 			containerID := pmmapitests.TestString(t, "container-id")
@@ -366,6 +378,7 @@ func TestNodeRegister(t *testing.T) {
 		})
 
 		t.Run("Re-register", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("Re-register logic is not defined yet. https://jira.percona.com/browse/PMM-3717")
 
 			nodeName := pmmapitests.TestString(t, "node-name")
@@ -424,6 +437,7 @@ func TestNodeRegister(t *testing.T) {
 	})
 
 	t.Run("Empty node name", func(t *testing.T) {
+		t.Parallel()
 		params := mservice.RegisterNodeParams{
 			Context: pmmapitests.Context,
 			Body:    mservice.RegisterNodeBody{},
@@ -434,6 +448,7 @@ func TestNodeRegister(t *testing.T) {
 	})
 
 	t.Run("Unsupported node type", func(t *testing.T) {
+		t.Parallel()
 		params := mservice.RegisterNodeParams{
 			Context: pmmapitests.Context,
 			Body: mservice.RegisterNodeBody{

--- a/api-tests/management/postgresql_test.go
+++ b/api-tests/management/postgresql_test.go
@@ -33,9 +33,11 @@ import (
 )
 
 func TestAddPostgreSQL(t *testing.T) {
+	t.Parallel()
 	const defaultPostgresDBName = "postgres"
 
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -115,6 +117,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With agents", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -226,6 +229,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -283,6 +287,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -336,6 +341,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With add_node block", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -464,6 +470,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With Wrong Node Type", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "generic-node-for-wrong-node-type")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -498,6 +505,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -520,6 +528,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Empty Address", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -546,6 +555,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Empty Port", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -573,6 +583,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Empty Pmm Agent ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -599,6 +610,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Address And Socket Conflict.", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -629,6 +641,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePush", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -705,6 +718,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModePull", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -780,6 +794,7 @@ func TestAddPostgreSQL(t *testing.T) {
 	})
 
 	t.Run("With MetricsModeAuto", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -858,6 +873,7 @@ func TestAddPostgreSQL(t *testing.T) {
 }
 
 func TestRemovePostgreSQL(t *testing.T) {
+	t.Parallel()
 	addPostgreSQL := func(t *testing.T, serviceName, nodeName string, withAgents bool) (nodeID string, pmmAgentID string, serviceID string) {
 		t.Helper()
 		nodeID, pmmAgentID = RegisterGenericNode(t, mservice.RegisterNodeBody{
@@ -891,6 +907,7 @@ func TestRemovePostgreSQL(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, pmmAgentID, serviceID := addPostgreSQL(t, serviceName, nodeName, true)
@@ -918,6 +935,7 @@ func TestRemovePostgreSQL(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, pmmAgentID, serviceID := addPostgreSQL(t, serviceName, nodeName, true)
@@ -945,6 +963,7 @@ func TestRemovePostgreSQL(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, pmmAgentID, serviceID := addPostgreSQL(t, serviceName, nodeName, false)

--- a/api-tests/management/proxysql_test.go
+++ b/api-tests/management/proxysql_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestAddProxySQL(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -108,6 +110,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("With agents", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -184,6 +187,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("With labels", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -245,6 +249,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -297,6 +302,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("With add_node block", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -421,6 +427,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("With Wrong Node Type", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "generic-node-for-wrong-node-type")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -455,6 +462,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -477,6 +485,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Address And Socket", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -503,6 +512,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Port", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -530,6 +540,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Address And Socket Conflict.", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -560,6 +571,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Empty Pmm Agent ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -586,6 +598,7 @@ func TestAddProxySQL(t *testing.T) {
 	})
 
 	t.Run("Empty username", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -614,6 +627,7 @@ func TestAddProxySQL(t *testing.T) {
 }
 
 func TestRemoveProxySQL(t *testing.T) {
+	t.Parallel()
 	addProxySQL := func(t *testing.T, serviceName, nodeName string) (nodeID string, pmmAgentID string, serviceID string) {
 		t.Helper()
 		nodeID, pmmAgentID = RegisterGenericNode(t, mservice.RegisterNodeBody{
@@ -646,6 +660,7 @@ func TestRemoveProxySQL(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, pmmAgentID, serviceID := addProxySQL(t, serviceName, nodeName)
@@ -673,6 +688,7 @@ func TestRemoveProxySQL(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, pmmAgentID, serviceID := addProxySQL(t, serviceName, nodeName)
@@ -700,6 +716,7 @@ func TestRemoveProxySQL(t *testing.T) {
 	})
 
 	t.Run("Wrong type", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-wrong-type")
 		nodeName := pmmapitests.TestString(t, "node-remove-wrong-type")
 		nodeID, pmmAgentID, serviceID := addProxySQL(t, serviceName, nodeName)
@@ -717,6 +734,7 @@ func TestRemoveProxySQL(t *testing.T) {
 	})
 
 	t.Run("No params", func(t *testing.T) {
+		t.Parallel()
 		removeServiceOK, err := client.Default.ManagementService.RemoveService(&mservice.RemoveServiceParams{
 			Context: pmmapitests.Context,
 		})

--- a/api-tests/management/rds_test.go
+++ b/api-tests/management/rds_test.go
@@ -34,7 +34,9 @@ import (
 )
 
 func TestRDSDiscovery(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		accessKey, secretKey := os.Getenv("AWS_ACCESS_KEY"), os.Getenv("AWS_SECRET_KEY")
 		if accessKey == "" || secretKey == "" {
 			// TODO remove skip once secrets are added
@@ -58,7 +60,9 @@ func TestRDSDiscovery(t *testing.T) {
 }
 
 func TestAddRds(t *testing.T) {
+	t.Parallel()
 	t.Run("BasicAddRDS", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddServiceParams{
 			Body: mservice.AddServiceBody{
 				RDS: &mservice.AddServiceParamsBodyRDS{
@@ -120,6 +124,7 @@ func TestAddRds(t *testing.T) {
 	})
 
 	t.Run("AddRDSPostgres", func(t *testing.T) {
+		t.Parallel()
 		params := &mservice.AddServiceParams{
 			Body: mservice.AddServiceBody{
 				RDS: &mservice.AddServiceParamsBodyRDS{

--- a/api-tests/management/services/agent_test.go
+++ b/api-tests/management/services/agent_test.go
@@ -28,11 +28,13 @@ import (
 )
 
 func TestListAgentVersions(t *testing.T) {
+	t.Parallel()
 	t.Skip("Skip for now, it fails randomly")
 	ctx, cancel := context.WithTimeout(pmmapitests.Context, 30*time.Second)
 	t.Cleanup(func() { cancel() })
 
 	t.Run("PMM Agent needs no update", func(t *testing.T) {
+		t.Parallel()
 		resp, err := client.Default.ManagementService.ListAgentVersions(
 			&mgmtSvc.ListAgentVersionsParams{
 				Context: ctx,

--- a/api-tests/management/valkey_test.go
+++ b/api-tests/management/valkey_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestAddValkey(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-basic-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -105,6 +107,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("With agents", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-all-fields-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -179,6 +182,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("With the same name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-for-the-same-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -230,6 +234,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("With Wrong Node Type", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "generic-node-for-wrong-node-type")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -263,6 +268,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("Empty Service Name", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -285,6 +291,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("Empty Address", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -311,6 +318,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("Empty Port", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -338,6 +346,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("Empty Pmm Agent ID", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -364,6 +373,7 @@ func TestAddValkey(t *testing.T) {
 	})
 
 	t.Run("Address And Socket Conflict.", func(t *testing.T) {
+		t.Parallel()
 		nodeName := pmmapitests.TestString(t, "node-name")
 		nodeID, pmmAgentID := RegisterGenericNode(t, mservice.RegisterNodeBody{
 			NodeName: nodeName,
@@ -395,6 +405,7 @@ func TestAddValkey(t *testing.T) {
 }
 
 func TestRemoveValkey(t *testing.T) {
+	t.Parallel()
 	addValkey := func(t *testing.T, serviceName, nodeName string) (nodeID string, pmmAgentID string, serviceID string) {
 		t.Helper()
 		nodeID, pmmAgentID = RegisterGenericNode(t, mservice.RegisterNodeBody{
@@ -426,6 +437,7 @@ func TestRemoveValkey(t *testing.T) {
 	}
 
 	t.Run("By name", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-name")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-name")
 		nodeID, pmmAgentID, serviceID := addValkey(t, serviceName, nodeName)
@@ -453,6 +465,7 @@ func TestRemoveValkey(t *testing.T) {
 	})
 
 	t.Run("By ID", func(t *testing.T) {
+		t.Parallel()
 		serviceName := pmmapitests.TestString(t, "service-remove-by-id")
 		nodeName := pmmapitests.TestString(t, "node-remove-by-id")
 		nodeID, pmmAgentID, serviceID := addValkey(t, serviceName, nodeName)

--- a/api-tests/server/advisor_metrics_test.go
+++ b/api-tests/server/advisor_metrics_test.go
@@ -31,11 +31,13 @@ import (
 )
 
 func TestAdvisorMetrics(t *testing.T) {
+	t.Parallel()
 	if !pmmapitests.RunAdvisorTests {
 		t.Skip("Skipping Advisor tests until we have environment: https://jira.percona.com/browse/PMM-5106")
 	}
 
 	t.Run("StartAdvisorChecksAndRecordMetrics", func(t *testing.T) {
+		t.Parallel()
 		client, err := api.NewClient(api.Config{
 			Address: pmmapitests.BaseURL.ResolveReference(&url.URL{
 				Path: "/prometheus",

--- a/api-tests/server/advisors_test.go
+++ b/api-tests/server/advisors_test.go
@@ -32,7 +32,9 @@ import (
 )
 
 func TestStartChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("with advisors enabled", func(t *testing.T) {
+		t.Parallel()
 		toggleAdvisorChecks(t, true)
 		t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -42,6 +44,7 @@ func TestStartChecks(t *testing.T) {
 	})
 
 	t.Run("with advisors disabled", func(t *testing.T) {
+		t.Parallel()
 		toggleAdvisorChecks(t, false)
 		t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -52,7 +55,9 @@ func TestStartChecks(t *testing.T) {
 }
 
 func TestGetAdvisorCheckResults(t *testing.T) {
+	t.Parallel()
 	t.Run("with disabled Advisors", func(t *testing.T) {
+		t.Parallel()
 		toggleAdvisorChecks(t, false)
 		t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -62,6 +67,7 @@ func TestGetAdvisorCheckResults(t *testing.T) {
 	})
 
 	t.Run("with enabled Advisors", func(t *testing.T) {
+		t.Parallel()
 		toggleAdvisorChecks(t, true)
 		t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -76,6 +82,7 @@ func TestGetAdvisorCheckResults(t *testing.T) {
 }
 
 func TestListAdvisorChecks(t *testing.T) {
+	t.Parallel()
 	toggleAdvisorChecks(t, true)
 	t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -91,6 +98,7 @@ func TestListAdvisorChecks(t *testing.T) {
 }
 
 func TestListAdvisors(t *testing.T) {
+	t.Parallel()
 	toggleAdvisorChecks(t, true)
 	t.Cleanup(func() { restoreSettingsDefaults(t) })
 
@@ -115,11 +123,14 @@ func TestListAdvisors(t *testing.T) {
 }
 
 func TestChangeAdvisorChecks(t *testing.T) {
+	t.Parallel()
 	toggleAdvisorChecks(t, true)
 	t.Cleanup(func() { restoreSettingsDefaults(t) })
 
 	t.Run("enable disable", func(t *testing.T) {
+		t.Parallel()
 		t.Run("enable disable", func(t *testing.T) {
+			t.Parallel()
 			resp, err := advisorClient.Default.AdvisorService.ListAdvisorChecks(nil)
 			require.NoError(t, err)
 			require.NotEmpty(t, resp.Payload.Checks)
@@ -159,6 +170,7 @@ func TestChangeAdvisorChecks(t *testing.T) {
 		})
 
 		t.Run("unrecognized interval is ignored", func(t *testing.T) {
+			t.Parallel()
 			t.Cleanup(func() { restoreCheckIntervalDefaults(t) })
 
 			resp, err := advisorClient.Default.AdvisorService.ListAdvisorChecks(nil)
@@ -198,6 +210,7 @@ func TestChangeAdvisorChecks(t *testing.T) {
 		})
 
 		t.Run("change interval normal", func(t *testing.T) {
+			t.Parallel()
 			t.Cleanup(func() { restoreSettingsDefaults(t) })
 
 			resp, err := advisorClient.Default.AdvisorService.ListAdvisorChecks(nil)
@@ -229,6 +242,7 @@ func TestChangeAdvisorChecks(t *testing.T) {
 			}
 
 			t.Run("intervals should be preserved on restart", func(t *testing.T) {
+				t.Parallel()
 				resp, err := advisorClient.Default.AdvisorService.ListAdvisorChecks(nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, resp.Payload.Checks)

--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -44,7 +44,9 @@ const (
 )
 
 func TestAuth(t *testing.T) {
+	t.Parallel()
 	t.Run("AuthErrors", func(t *testing.T) {
+		t.Parallel()
 		for user, code := range map[*url.Userinfo]int{
 			nil:                              401,
 			url.UserPassword("bad", "wrong"): 401,
@@ -76,6 +78,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	t.Run("NormalErrors", func(t *testing.T) {
+		t.Parallel()
 		for grpcCode, httpCode := range map[codes.Code]int{
 			codes.Unauthenticated:  401,
 			codes.PermissionDenied: 403,
@@ -171,6 +174,7 @@ func doRequest(tb testing.TB, client *http.Client, req *http.Request) (*http.Res
 }
 
 func TestBasicAuthPermissions(t *testing.T) {
+	t.Parallel()
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
 	none := "none-" + ts
 	viewer := "viewer-" + ts
@@ -211,8 +215,11 @@ func TestBasicAuthPermissions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			for _, user := range test.userCase {
-				t.Run(fmt.Sprintf("Basic auth %s", user.userType), func(t *testing.T) { //nolint:perfsprint
+				t.Run(fmt.Sprintf("Basic auth %s", user.userType), func(t *testing.T) {
+					t. //nolint:perfsprint
+						Parallel()
 					// make a BaseURL without authentication
 					u, err := url.Parse(pmmapitests.BaseURL.String())
 					require.NoError(t, err)
@@ -307,10 +314,13 @@ func setRole(t *testing.T, userID int, role string) {
 }
 
 func TestServiceAccountPermissions(t *testing.T) {
+	t.Parallel(
 	// service account role options: viewer, editor, admin
 	// service token role options: editor, admin
 	// basic auth format is skipped, endpoint /auth/serviceaccount (to get info about currently used token in request) requires Bearer authorization
 	// service_token:token format could be used in pmm-agent and pmm-admin (its transformed into Bearer authorization)
+	)
+
 	nodeName, err := stringsgen.GenerateRandomString(256)
 	require.NoError(t, err)
 
@@ -354,8 +364,11 @@ func TestServiceAccountPermissions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			for _, user := range test.userCase {
-				t.Run(fmt.Sprintf("Service Token auth %s", user.userType), func(t *testing.T) { //nolint:perfsprint
+				t.Run(fmt.Sprintf("Service Token auth %s", user.userType), func(t *testing.T) {
+					t. //nolint:perfsprint
+						Parallel()
 					// make a BaseURL without authentication
 					u, err := url.Parse(pmmapitests.BaseURL.String())
 					require.NoError(t, err)
@@ -374,7 +387,9 @@ func TestServiceAccountPermissions(t *testing.T) {
 					assert.Equal(t, user.statusCode, resp.StatusCode)
 				})
 
-				t.Run(fmt.Sprintf("Basic auth with Service Token %s", user.userType), func(t *testing.T) { //nolint:perfsprint
+				t.Run(fmt.Sprintf("Basic auth with Service Token %s", user.userType), func(t *testing.T) {
+					t. //nolint:perfsprint
+						Parallel()
 					u, err := url.Parse(pmmapitests.BaseURL.String())
 					require.NoError(t, err)
 					u.User = url.UserPassword("service_token", user.serviceToken)

--- a/api-tests/server/logs_test.go
+++ b/api-tests/server/logs_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestDownloadLogs(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	res, err := serverClient.Default.ServerService.Logs(&server_service.LogsParams{
 		Context: pmmapitests.Context,

--- a/api-tests/server/platform_test.go
+++ b/api-tests/server/platform_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestPlatform(t *testing.T) {
+	t.Parallel()
 	t.Skip("Skip until we have the environment ready.")
 
 	client := platformClient.Default.PlatformService
@@ -42,7 +43,9 @@ func TestPlatform(t *testing.T) {
 
 	const serverName = string("my PMM")
 	t.Run("connect and disconnect", func(t *testing.T) {
+		t.Parallel()
 		t.Run("PMM server does not have address set", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					PersonalAccessToken: "JReeZA5EqM4b6bZMxBOEaAxoc4rWd5teK7HF",
@@ -64,6 +67,7 @@ func TestPlatform(t *testing.T) {
 		assert.Equal(t, "localhost", res.Payload.Settings.PMMPublicAddress)
 
 		t.Run("empty access token", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					PersonalAccessToken: "",
@@ -75,6 +79,7 @@ func TestPlatform(t *testing.T) {
 		})
 
 		t.Run("empty server name", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					PersonalAccessToken: "JReeZA5EqM4b6bZMxBOEaAxoc4rWd5teK7HF",
@@ -86,6 +91,7 @@ func TestPlatform(t *testing.T) {
 		})
 
 		t.Run("successful connect and disconnect", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					ServerName:          serverName,
@@ -115,7 +121,9 @@ func TestPlatform(t *testing.T) {
 	})
 
 	t.Run("search tickets", func(t *testing.T) {
+		t.Parallel()
 		t.Run("success", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					ServerName:          serverName,
@@ -137,8 +145,11 @@ func TestPlatform(t *testing.T) {
 		})
 	})
 
-	t.Run("search entitlements", func(t *testing.T) { //nolint:dupl
+	t.Run("search entitlements", func(t *testing.T) {
+		t. //nolint:dupl
+			Parallel()
 		t.Run("success", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					ServerName:          serverName,
@@ -160,8 +171,11 @@ func TestPlatform(t *testing.T) {
 		})
 	})
 
-	t.Run("get contact information", func(t *testing.T) { //nolint:dupl
+	t.Run("get contact information", func(t *testing.T) {
+		t. //nolint:dupl
+			Parallel()
 		t.Run("success", func(t *testing.T) {
+			t.Parallel()
 			_, err := client.Connect(&platform.ConnectParams{
 				Body: platform.ConnectBody{
 					ServerName:          serverName,

--- a/api-tests/server/serialization_test.go
+++ b/api-tests/server/serialization_test.go
@@ -33,7 +33,10 @@ import (
 
 // This test checks if all (even empty) fields are present in json responses.
 func TestSerialization(t *testing.T) {
+	t.Parallel(
 	// Get json filed names from settings model
+	)
+
 	var settings server.GetSettingsOKBodySettings
 	jsonFields := extractJSONTagNames(settings)
 	require.NotEmpty(t, jsonFields)

--- a/api-tests/server/settings_test.go
+++ b/api-tests/server/settings_test.go
@@ -37,7 +37,9 @@ import (
 )
 
 func TestSettings(t *testing.T) {
+	t.Parallel()
 	t.Run("GetSettings", func(t *testing.T) {
+		t.Parallel()
 		res, err := serverClient.Default.ServerService.GetSettings(nil)
 		require.NoError(t, err)
 		assert.True(t, res.Payload.Settings.TelemetryEnabled)
@@ -60,10 +62,13 @@ func TestSettings(t *testing.T) {
 		assert.True(t, res.Payload.Settings.AlertingEnabled)
 
 		t.Run("ChangeSettings", func(t *testing.T) {
+			t.Parallel()
 			defer restoreSettingsDefaults(t)
 
 			t.Run("Updates", func(t *testing.T) {
+				t.Parallel()
 				t.Run("DisableAndEnableUpdatesSettingsUpdate", func(t *testing.T) {
+					t.Parallel()
 					defer restoreSettingsDefaults(t)
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 						Body: server.ChangeSettingsBody{
@@ -94,6 +99,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("ValidAlertingSettingsUpdate", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -107,6 +113,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("EnableAdviorsAndEnableTelemetry", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -127,6 +134,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("EnableAdvisorsAndDisableTelemetry", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -142,6 +150,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DisableAdvisorsAndEnableTelemetry", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -162,6 +171,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DisableAdvisorsAndDisableTelemetry", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -182,6 +192,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("EnableAdvisorsWhileTelemetryEnabled", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				// Ensure Telemetry is enabled
@@ -210,6 +221,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DisableAdvisorsWhileItIsDisabled", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -228,6 +240,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("AdvisorsEnabledState", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -246,6 +259,7 @@ func TestSettings(t *testing.T) {
 				assert.True(t, resg.Payload.Settings.AdvisorEnabled)
 
 				t.Run("EnableAdvisorsWhileItIsEnabled", func(t *testing.T) {
+					t.Parallel()
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 						Body: server.ChangeSettingsBody{
 							EnableAdvisor: pointer.ToBool(true),
@@ -262,6 +276,7 @@ func TestSettings(t *testing.T) {
 				})
 
 				t.Run("DisableTelemetryWhileAdvisorsEnabled", func(t *testing.T) {
+					t.Parallel()
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 						Body: server.ChangeSettingsBody{
 							EnableTelemetry: pointer.ToBool(false),
@@ -275,6 +290,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("TelemetryDisabledState", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -293,6 +309,7 @@ func TestSettings(t *testing.T) {
 				assert.True(t, resg.Payload.Settings.AdvisorEnabled)
 
 				t.Run("EnableAdvisorsWhileTelemetryDisabled", func(t *testing.T) {
+					t.Parallel()
 					defer restoreSettingsDefaults(t)
 
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -312,6 +329,7 @@ func TestSettings(t *testing.T) {
 				})
 
 				t.Run("EnableTelemetryWhileItIsDisabled", func(t *testing.T) {
+					t.Parallel()
 					defer restoreSettingsDefaults(t)
 
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -331,6 +349,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("InvalidPartition", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -345,6 +364,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("TooManyPartitions", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -360,6 +380,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("HRInvalid", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -376,6 +397,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("HRTooSmall", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -392,6 +414,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("HRFractional", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -408,6 +431,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("AdvisorsCheckIntervalInvalid", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -424,6 +448,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("SetPMMPublicAddressWithoutScheme", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 				publicAddress := "192.168.0.42:8443"
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -437,6 +462,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("AdvisorsCheckIntervalTooSmall", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -453,6 +479,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("AdviorsCheckIntervalFractional", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -469,6 +496,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DataRetentionInvalid", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -483,6 +511,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DataRetentionInvalidToSmall", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -497,6 +526,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("DataRetentionFractional", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -511,6 +541,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("InvalidSSHKey", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -524,6 +555,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("ChangeSSHKey only on AMI and OVF", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				sshKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQClY/8sz3w03vA2bY6mBFgUzrvb2FIoHw8ZjUXGGClJzJg5HC" +
@@ -542,6 +574,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("OK", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -580,6 +613,7 @@ func TestSettings(t *testing.T) {
 				assert.Equal(t, []string{"aws", "aws-cn"}, res.Payload.Settings.AWSPartitions)
 
 				t.Run("DefaultsAreNotRestored", func(t *testing.T) {
+					t.Parallel()
 					defer restoreSettingsDefaults(t)
 
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -612,6 +646,7 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("AdvisorCheckIntervalsValid", func(t *testing.T) {
+				t.Parallel()
 				defer restoreSettingsDefaults(t)
 
 				res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -642,6 +677,7 @@ func TestSettings(t *testing.T) {
 				assert.Equal(t, getExpected, getRes.Payload.Settings.AdvisorRunIntervals)
 
 				t.Run("DefaultsAreNotRestored", func(t *testing.T) {
+					t.Parallel()
 					defer restoreSettingsDefaults(t)
 
 					res, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
@@ -669,8 +705,10 @@ func TestSettings(t *testing.T) {
 			})
 
 			t.Run("grpc-gateway", func(t *testing.T) {
+				t.Parallel(
 				// Test with pure JSON without swagger for tracking grpc-gateway behavior:
 				// https://github.com/grpc-ecosystem/grpc-gateway/issues/400
+				)
 
 				// do not use generated types as they can do extra work in generated methods
 				type params struct {
@@ -698,6 +736,7 @@ func TestSettings(t *testing.T) {
 					"1w":  "", // w suffix => error
 				} {
 					t.Run(change, func(t *testing.T) {
+						t.Parallel()
 						defer restoreSettingsDefaults(t)
 
 						var p params
@@ -765,7 +804,10 @@ func TestSettings(t *testing.T) {
 	})
 
 	t.Run("InternalPgQAN", func(t *testing.T) {
+		t.Parallel(
 		// First, get the internal PostgreSQL QAN agent to verify it exists
+		)
+
 		listAgentsRes, err := inventoryClient.Default.AgentsService.ListAgents(&agents.ListAgentsParams{
 			Context: pmmapitests.Context,
 		})

--- a/api-tests/server/updates_test.go
+++ b/api-tests/server/updates_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestCheckUpdates(t *testing.T) {
+	t.Parallel(
 	// do not run this test in parallel with other tests as it also tests timings
+	)
 
 	const fast, slow = 5 * time.Second, 60 * time.Second
 
@@ -95,6 +97,7 @@ func TestCheckUpdates(t *testing.T) {
 	assert.NotEmpty(t, res.Payload.LastCheck)
 
 	t.Run("HotCache", func(t *testing.T) {
+		t.Parallel()
 		params = &server.CheckUpdatesParams{
 			Context: pmmapitests.Context,
 		}
@@ -106,6 +109,7 @@ func TestCheckUpdates(t *testing.T) {
 	})
 
 	t.Run("Force", func(t *testing.T) {
+		t.Parallel()
 		params = &server.CheckUpdatesParams{
 			Force:   pointer.ToBool(true),
 			Context: pmmapitests.Context,
@@ -120,6 +124,7 @@ func TestCheckUpdates(t *testing.T) {
 	})
 
 	t.Run("forced with updates disabled", func(t *testing.T) {
+		t.Parallel()
 		defer restoreSettingsDefaults(t)
 		settingsRes, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 			Body: server.ChangeSettingsBody{
@@ -142,6 +147,7 @@ func TestCheckUpdates(t *testing.T) {
 }
 
 func TestListUpdates(t *testing.T) {
+	t.Parallel()
 	const fast, slow = 5 * time.Second, 60 * time.Second
 
 	if !pmmapitests.RunUpdateTest {
@@ -167,6 +173,7 @@ func TestListUpdates(t *testing.T) {
 	}
 
 	t.Run("with updates disabled", func(t *testing.T) {
+		t.Parallel()
 		defer restoreSettingsDefaults(t)
 		settingsRes, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 			Body: server.ChangeSettingsBody{
@@ -187,7 +194,9 @@ func TestListUpdates(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel(
 	// do not run this test in parallel with other tests
+	)
 
 	if !pmmapitests.RunUpdateTest {
 		t.Skip("skipping PMM Server update test")
@@ -214,6 +223,7 @@ func TestUpdate(t *testing.T) {
 	pmmapitests.AssertAPIErrorf(t, err, 401, codes.Unauthenticated, "Unauthorized")
 
 	t.Run("with PMM updates disabled", func(t *testing.T) {
+		t.Parallel()
 		defer restoreSettingsDefaults(t)
 		settingsRes, err := serverClient.Default.ServerService.ChangeSettings(&server.ChangeSettingsParams{
 			Body: server.ChangeSettingsBody{

--- a/api-tests/user/snooze_test.go
+++ b/api-tests/user/snooze_test.go
@@ -29,7 +29,9 @@ import (
 )
 
 func TestUpdateSnoozing(t *testing.T) {
+	t.Parallel()
 	t.Run("provides default snooze information in user info", func(t *testing.T) {
+		t.Parallel()
 		res, err := userClient.Default.UserService.GetUser(nil)
 
 		require.NoError(t, err)
@@ -40,6 +42,7 @@ func TestUpdateSnoozing(t *testing.T) {
 	})
 
 	t.Run("snoozes the update", func(t *testing.T) {
+		t.Parallel()
 		res, err1 := userClient.Default.UserService.UpdateUser(&userService.UpdateUserParams{
 			Body: userService.UpdateUserBody{
 				SnoozedPMMVersion: pointer.ToString("1.0.0"),
@@ -54,6 +57,7 @@ func TestUpdateSnoozing(t *testing.T) {
 	})
 
 	t.Run("increments the snooze count", func(t *testing.T) {
+		t.Parallel()
 		res, err := userClient.Default.UserService.UpdateUser(&userService.UpdateUserParams{
 			Body: userService.UpdateUserBody{
 				SnoozedPMMVersion: pointer.ToString("1.0.0"),
@@ -68,6 +72,7 @@ func TestUpdateSnoozing(t *testing.T) {
 	})
 
 	t.Run("resets the snooze count when version is different", func(t *testing.T) {
+		t.Parallel()
 		res, err := userClient.Default.UserService.UpdateUser(&userService.UpdateUserParams{
 			Body: userService.UpdateUserBody{
 				SnoozedPMMVersion: pointer.ToString("2.0.0"),

--- a/api/agent/v1/query_test.go
+++ b/api/agent/v1/query_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 func TestQuerySQLResultsSerialization(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		now := time.Now().UTC().Round(0) // strip monotonic clock reading
 		columns := []string{
 			"bool",
@@ -139,6 +141,7 @@ func TestQuerySQLResultsSerialization(t *testing.T) {
 	})
 
 	t.Run("InvalidColumns", func(t *testing.T) {
+		t.Parallel()
 		columns := []string{"foo"}
 		rows := [][]interface{}{{}}
 
@@ -148,7 +151,9 @@ func TestQuerySQLResultsSerialization(t *testing.T) {
 }
 
 func TestQueryDocsResultsSerialization(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		now := time.Now().UTC().Round(0) // strip monotonic clock reading
 		expected := []map[string]interface{}{
 			{},
@@ -189,6 +194,7 @@ func TestQueryDocsResultsSerialization(t *testing.T) {
 	})
 
 	t.Run("Conversions", func(t *testing.T) {
+		t.Parallel()
 		now := time.Now().UTC().Round(0) // strip monotonic clock reading
 		b, err := MarshalActionQueryDocsResult([]map[string]interface{}{
 			// non-zero values

--- a/api/inventory/v1/agents_test.go
+++ b/api/inventory/v1/agents_test.go
@@ -30,6 +30,7 @@ import (
 // result is a non-empty string, meaning that the AgentTypeNames list matches the proto
 // definitions.
 func TestAgentTypes(t *testing.T) {
+	t.Parallel()
 	for _, val := range AgentType_name {
 		if strings.HasSuffix(val, "UNSPECIFIED") {
 			continue

--- a/api/inventory/v1/nodes_test.go
+++ b/api/inventory/v1/nodes_test.go
@@ -30,6 +30,7 @@ import (
 // result is a non-empty string, meaning that the NodetypeNames list matches the proto
 // definitions.
 func TestNodeTypes(t *testing.T) {
+	t.Parallel()
 	for _, val := range NodeType_name {
 		if strings.HasSuffix(val, "UNSPECIFIED") {
 			continue

--- a/api/inventory/v1/services_test.go
+++ b/api/inventory/v1/services_test.go
@@ -30,6 +30,7 @@ import (
 // result is a non-empty string, meaning that the ServiceTypeNames list matches the proto
 // definitions.
 func TestServiceTypes(t *testing.T) {
+	t.Parallel()
 	for _, val := range ServiceType_name {
 		if strings.HasSuffix(val, "UNSPECIFIED") {
 			continue

--- a/api/main_test.go
+++ b/api/main_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestImports(t *testing.T) {
+	t.Parallel()
 	type constraint struct {
 		blacklistPrefixes []string
 	}

--- a/managed/cmd/pmm-managed-starlark/main_test.go
+++ b/managed/cmd/pmm-managed-starlark/main_test.go
@@ -49,7 +49,9 @@ var validQueryActionResult = []map[string]interface{}{
 	{"Value": "-log", "Variable_name": "version_suffix"},
 }
 
-func TestStarlarkSandbox(t *testing.T) { //nolint:tparallel
+func TestStarlarkSandbox(t *testing.T) {
+	t. //nolint:tparallel
+		Parallel()
 	testCases := []struct {
 		name         string
 		script       string

--- a/managed/cmd/pmm-managed/main_test.go
+++ b/managed/cmd/pmm-managed/main_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestPackages(t *testing.T) {
+	t.Parallel()
 	cmd := exec.Command("pmm-managed", "-h")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
@@ -39,6 +40,7 @@ func TestPackages(t *testing.T) {
 }
 
 func TestImports(t *testing.T) {
+	t.Parallel()
 	type constraint struct {
 		blacklistPrefixes []string
 		whitelistPrefixes []string

--- a/managed/models/action_helpers_test.go
+++ b/managed/models/action_helpers_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestActionHelpers(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -63,6 +64,7 @@ func TestActionHelpers(t *testing.T) {
 	}
 
 	t.Run("FindActionResultByID", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -75,6 +77,7 @@ func TestActionHelpers(t *testing.T) {
 	})
 
 	t.Run("FindPmmAgentIDToRunActionOrJob", func(t *testing.T) {
+		t.Parallel()
 		a := []*models.Agent{
 			{AgentID: "A1", AgentType: models.PMMAgentType},
 			{AgentID: "A2", AgentType: models.MySQLdExporterType, PMMAgentID: pointer.ToString("A1")},
@@ -104,6 +107,7 @@ func TestActionHelpers(t *testing.T) {
 	})
 
 	t.Run("QueryActionBinaryData", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -113,6 +117,7 @@ func TestActionHelpers(t *testing.T) {
 }
 
 func TestCleanupResults(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -166,6 +171,7 @@ func TestCleanupResults(t *testing.T) {
 	}
 
 	t.Run("CheckActionResultByID", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/models/agent_helpers_test.go
+++ b/managed/models/agent_helpers_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestAgentHelpers(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -219,6 +220,7 @@ func TestAgentHelpers(t *testing.T) {
 	}
 
 	t.Run("AgentsForNode", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -334,6 +336,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("AgentsRunningByPMMAgent", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -362,6 +365,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("AgentsRunningByPMMAgentAndType", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -381,6 +385,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("AgentsForService", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -418,6 +423,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("RemoveAgent", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -452,6 +458,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindPMMAgentsForNode", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -466,6 +473,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindPMMAgentsForServicesOnNode", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -476,6 +484,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindPMMAgentsForService", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -490,7 +499,9 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("CreateExternalExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			q, teardown := setup(t)
 			defer teardown(t)
 			agent, err := models.CreateExternalExporter(q, &models.CreateExternalExporterParams{
@@ -514,6 +525,7 @@ func TestAgentHelpers(t *testing.T) {
 			}, agent)
 		})
 		t.Run("Invalid listen port", func(t *testing.T) {
+			t.Parallel()
 			q, teardown := setup(t)
 			defer teardown(t)
 			agent, err := models.CreateExternalExporter(q, &models.CreateExternalExporterParams{
@@ -526,6 +538,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("TestFindPMMAgentsForVersion", func(t *testing.T) {
+		t.Parallel()
 		l := logrus.WithField("component", "test")
 		agentInvalid := &models.Agent{
 			Version: pointer.ToString("invalid"),
@@ -552,6 +565,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindAgentsForScrapeConfig", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -577,6 +591,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindAllPMMAgentsIDs", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -587,6 +602,7 @@ func TestAgentHelpers(t *testing.T) {
 	})
 
 	t.Run("FindAllAgentsWithoutNomad", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 		agents, err := models.FindAgents(q, models.AgentFilters{IgnoreNomad: true, PMMAgentID: "A12"})

--- a/managed/models/agent_model_test.go
+++ b/managed/models/agent_model_test.go
@@ -32,7 +32,9 @@ import (
 )
 
 func TestAgent(t *testing.T) {
+	t.Parallel()
 	t.Run("UnifiedLabels", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			AgentID:      "agent_id",
 			CustomLabels: []byte(`{"foo": "bar"}`),
@@ -47,6 +49,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	t.Run("DSN", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:          pointer.ToString("username"),
 			Password:          pointer.ToString("s3cur3 p@$$w0r4."),
@@ -70,12 +73,14 @@ func TestAgent(t *testing.T) {
 			models.PostgresExporterType:        "postgres://username:s3cur3%20p%40$$w0r4.@1.2.3.4:12345/database?connect_timeout=1&sslmode=disable",
 		} {
 			t.Run(string(typ), func(t *testing.T) {
+				t.Parallel()
 				agent.AgentType = typ
 				assert.Equal(t, expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 			})
 		}
 
 		t.Run("MongoDBNoDatabase", func(t *testing.T) {
+			t.Parallel()
 			agent.AgentType = models.MongoDBExporterType
 
 			assert.Equal(t, "mongodb://username:s3cur3%20p%40$$w0r4.@1.2.3.4:12345/?connectTimeoutMS=1000&directConnection=true&serverSelectionTimeoutMS=1000", agent.DSN(service, models.DSNParams{DialTimeout: time.Second}, nil, nil))
@@ -84,6 +89,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	t.Run("DSN socket", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:        pointer.ToString("username"),
 			Password:        pointer.ToString("s3cur3 p@$$w0r4."),
@@ -101,6 +107,7 @@ func TestAgent(t *testing.T) {
 			models.QANMySQLSlowlogAgentType:    "username:s3cur3 p@$$w0r4.@unix(/var/run/mysqld/mysqld.sock)/database?clientFoundRows=true&parseTime=true&timeout=1s",
 		} {
 			t.Run(string(typ), func(t *testing.T) {
+				t.Parallel()
 				agent.AgentType = typ
 				assert.Equal(t, expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 			})
@@ -108,6 +115,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	t.Run("DSN timeout", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:        pointer.ToString("username"),
 			Password:        pointer.ToString("s3cur3 p@$$w0r4."),
@@ -123,6 +131,7 @@ func TestAgent(t *testing.T) {
 			models.QANMongoDBProfilerAgentType: "mongodb://username:s3cur3%20p%40$$w0r4.@%2Fvar%2Frun%2Fmysqld%2Fmysqld.sock/database?connectTimeoutMS=1000&directConnection=true&serverSelectionTimeoutMS=1000",
 		} {
 			t.Run(string(typ), func(t *testing.T) {
+				t.Parallel()
 				agent.AgentType = typ
 				assert.Equal(t, expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 			})
@@ -130,6 +139,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	t.Run("DSN ssl", func(t *testing.T) {
+		t.Parallel()
 		mongoDBOptions := models.MongoDBOptions{
 			TLSCertificateKey:             "key",
 			TLSCertificateKeyFilePassword: "pass",
@@ -170,12 +180,14 @@ func TestAgent(t *testing.T) {
 			models.PostgresExporterType:        "postgres://username:s3cur3%20p%40$$w0r4.@1.2.3.4:12345/database?connect_timeout=1&sslcert={{.TextFiles.certificateFilePlaceholder}}&sslkey={{.TextFiles.certificateKeyFilePlaceholder}}&sslmode=verify-ca&sslrootcert={{.TextFiles.caFilePlaceholder}}",
 		} {
 			t.Run(string(typ), func(t *testing.T) {
+				t.Parallel()
 				agent.AgentType = typ
 				assert.Equal(t, expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 			})
 		}
 
 		t.Run("MongoDBNoDatabase", func(t *testing.T) {
+			t.Parallel()
 			agent.AgentType = models.MongoDBExporterType
 			// reset values from the previous test
 			agent.MongoDBOptions.TLSCertificateKeyFilePassword = ""
@@ -191,6 +203,7 @@ func TestAgent(t *testing.T) {
 		})
 
 		t.Run("MongoDB Auth Database", func(t *testing.T) {
+			t.Parallel()
 			agent.AgentType = models.MongoDBExporterType
 			// reset values from the previous test
 			agent.MongoDBOptions.TLSCertificateKeyFilePassword = ""
@@ -208,6 +221,7 @@ func TestAgent(t *testing.T) {
 	})
 
 	t.Run("DSN ssl-skip-verify", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:          pointer.ToString("username"),
 			Password:          pointer.ToString("s3cur3 p@$$w0r4."),
@@ -233,12 +247,14 @@ func TestAgent(t *testing.T) {
 			models.PostgresExporterType:        "postgres://username:s3cur3%20p%40$$w0r4.@1.2.3.4:12345/database?connect_timeout=1&sslmode=require",
 		} {
 			t.Run(string(typ), func(t *testing.T) {
+				t.Parallel()
 				agent.AgentType = typ
 				assert.Equal(t, expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 			})
 		}
 
 		t.Run("MongoDBNoDatabase", func(t *testing.T) {
+			t.Parallel()
 			agent.AgentType = models.MongoDBExporterType
 
 			assert.Equal(t, "mongodb://username:s3cur3%20p%40$$w0r4.@1.2.3.4:12345/?connectTimeoutMS=1000&directConnection=true&serverSelectionTimeoutMS=1000&ssl=true&tlsInsecure=true", agent.DSN(service, models.DSNParams{DialTimeout: time.Second}, nil, nil))
@@ -248,6 +264,7 @@ func TestAgent(t *testing.T) {
 }
 
 func TestPostgresAgentTLS(t *testing.T) {
+	t.Parallel()
 	agent := &models.Agent{
 		Username:          pointer.ToString("username"),
 		Password:          pointer.ToString("s3cur3 p@$$w0r4."),
@@ -272,11 +289,13 @@ func TestPostgresAgentTLS(t *testing.T) {
 	} {
 		name := fmt.Sprintf("TLS:%v/TLSSkipVerify:%v", testCase.tls, testCase.tlsSkipVerify)
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			agent.TLS = testCase.tls
 			agent.TLSSkipVerify = testCase.tlsSkipVerify
 			assert.Equal(t, testCase.expected, agent.DSN(service, models.DSNParams{DialTimeout: time.Second, Database: "database"}, nil, nil))
 		})
 		t.Run(fmt.Sprintf("AutodiscoveryLimit set TLS:%v/TLSSkipVerify:%v", testCase.tls, testCase.tlsSkipVerify), func(t *testing.T) {
+			t.Parallel()
 			agent.TLS = testCase.tls
 			agent.TLSSkipVerify = testCase.tlsSkipVerify
 			agent.PostgreSQLOptions = models.PostgreSQLOptions{AutoDiscoveryLimit: pointer.ToInt32(10)}
@@ -286,7 +305,9 @@ func TestPostgresAgentTLS(t *testing.T) {
 }
 
 func TestValkey(t *testing.T) {
+	t.Parallel()
 	t.Run("Redis DSN", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:        pointer.ToString("username"),
 			Password:        pointer.ToString("s3cur3 p@$$w0r4."),
@@ -305,6 +326,7 @@ func TestValkey(t *testing.T) {
 	})
 
 	t.Run("Valkey DSN with TLS", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:        pointer.ToString("username"),
 			Password:        pointer.ToString("s3cur3 p@$$w0r4."),
@@ -329,7 +351,9 @@ func TestValkey(t *testing.T) {
 }
 
 func TestPostgresWithSocket(t *testing.T) {
+	t.Parallel()
 	t.Run("empty-password", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:          pointer.ToString("username"),
 			AgentType:         models.PostgresExporterType,
@@ -346,6 +370,7 @@ func TestPostgresWithSocket(t *testing.T) {
 	})
 
 	t.Run("empty-user-password", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			AgentType:         models.PostgresExporterType,
 			ExporterOptions:   models.ExporterOptions{},
@@ -359,6 +384,7 @@ func TestPostgresWithSocket(t *testing.T) {
 	})
 
 	t.Run("dir-with-symbols", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			AgentType:         models.PostgresExporterType,
 			ExporterOptions:   models.ExporterOptions{},
@@ -373,7 +399,9 @@ func TestPostgresWithSocket(t *testing.T) {
 }
 
 func TestMongoWithSocket(t *testing.T) {
+	t.Parallel()
 	t.Run("empty-password", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			Username:        pointer.ToString("username"),
 			AgentType:       models.MongoDBExporterType,
@@ -390,6 +418,7 @@ func TestMongoWithSocket(t *testing.T) {
 	})
 
 	t.Run("empty-user-password", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			AgentType:       models.MongoDBExporterType,
 			ExporterOptions: models.ExporterOptions{},
@@ -403,6 +432,7 @@ func TestMongoWithSocket(t *testing.T) {
 	})
 
 	t.Run("dir-with-symbols", func(t *testing.T) {
+		t.Parallel()
 		agent := &models.Agent{
 			AgentType:       models.MongoDBExporterType,
 			ExporterOptions: models.ExporterOptions{},
@@ -417,6 +447,7 @@ func TestMongoWithSocket(t *testing.T) {
 }
 
 func TestIsMySQLTablestatsGroupEnabled(t *testing.T) {
+	t.Parallel()
 	for _, testCase := range []struct {
 		count    *int32
 		limit    int32
@@ -437,6 +468,7 @@ func TestIsMySQLTablestatsGroupEnabled(t *testing.T) {
 			c = strconv.Itoa(int(*testCase.count))
 		}
 		t.Run(fmt.Sprintf("Count:%s/Limit:%d", c, testCase.limit), func(t *testing.T) {
+			t.Parallel()
 			agent := &models.Agent{
 				AgentType: models.MySQLdExporterType,
 				MySQLOptions: models.MySQLOptions{
@@ -450,6 +482,7 @@ func TestIsMySQLTablestatsGroupEnabled(t *testing.T) {
 }
 
 func TestExporterURL(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -602,6 +635,7 @@ func TestExporterURL(t *testing.T) {
 	}
 
 	t.Run("ExporterURL", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -613,6 +647,7 @@ func TestExporterURL(t *testing.T) {
 			"ExporterServerlessWithEmptyMetricsPath": "http://user:secret@nomad_exporter:9121/",
 		} {
 			t.Run(agentID, func(t *testing.T) {
+				t.Parallel()
 				agent, err := models.FindAgentByID(q, agentID)
 				assert.NoError(t, err)
 				actual, err := agent.ExporterURL(q)

--- a/managed/models/agentversion_test.go
+++ b/managed/models/agentversion_test.go
@@ -84,17 +84,20 @@ func TestPMMAgentSupported(t *testing.T) {
 	}
 
 	t.Run("No version info", func(t *testing.T) {
+		t.Parallel()
 		err := models.IsAgentSupported(&models.Agent{AgentID: "Test agent ID"}, prefix, version.Must(version.NewVersion("2.30.0")))
 		assert.Contains(t, err.Error(), "has no version info")
 	})
 
 	t.Run("Nil agent", func(t *testing.T) {
+		t.Parallel()
 		err := models.IsAgentSupported(nil, prefix, version.Must(version.NewVersion("2.30.0")))
 		assert.Contains(t, err.Error(), "nil agent")
 	})
 }
 
 func TestIsPostgreSQLSSLSniSupported(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -161,6 +164,7 @@ func TestIsPostgreSQLSSLSniSupported(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.pmmAgentID, func(t *testing.T) {
+			t.Parallel()
 			actual, err := models.IsPostgreSQLSSLSniSupported(q, tt.pmmAgentID)
 			assert.Equal(t, tt.expected, actual)
 			assert.NoError(t, err)
@@ -168,6 +172,7 @@ func TestIsPostgreSQLSSLSniSupported(t *testing.T) {
 	}
 
 	t.Run("Non-existing ID", func(t *testing.T) {
+		t.Parallel()
 		_, err := models.IsPostgreSQLSSLSniSupported(q, "Not exist")
 		assert.Error(t, err)
 	})

--- a/managed/models/artifact_helpers_test.go
+++ b/managed/models/artifact_helpers_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestArtifacts(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -88,6 +89,7 @@ func TestArtifacts(t *testing.T) {
 	}
 
 	t.Run("create and update", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -138,6 +140,7 @@ func TestArtifacts(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -216,6 +219,7 @@ func TestArtifacts(t *testing.T) {
 	})
 
 	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -247,6 +251,7 @@ func TestArtifacts(t *testing.T) {
 	})
 
 	t.Run("MetadataRemoveFirstN", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -297,6 +302,7 @@ func TestArtifacts(t *testing.T) {
 }
 
 func TestArtifactValidation(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -426,6 +432,7 @@ func TestArtifactValidation(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tx, err := db.Begin()
 			require.NoError(t, err)
 			t.Cleanup(func() {

--- a/managed/models/check_settings_helper_test.go
+++ b/managed/models/check_settings_helper_test.go
@@ -36,6 +36,7 @@ func TestChecksSettings(t *testing.T) { //nolint:tparallel
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -51,6 +52,7 @@ func TestChecksSettings(t *testing.T) { //nolint:tparallel
 	})
 
 	t.Run("change", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -72,6 +74,7 @@ func TestChecksSettings(t *testing.T) { //nolint:tparallel
 	})
 
 	t.Run("find by name", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -89,6 +92,7 @@ func TestChecksSettings(t *testing.T) { //nolint:tparallel
 	})
 
 	t.Run("find all", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/managed/models/database_test.go
+++ b/managed/models/database_test.go
@@ -63,7 +63,9 @@ func getTX(t *testing.T, db *sql.DB) (*sql.Tx, func()) {
 }
 
 func TestDatabaseChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("Nodes", func(t *testing.T) {
+		t.Parallel()
 		db := testdb.Open(t, models.SkipFixtures, nil)
 		defer func() {
 			require.NoError(t, db.Close())
@@ -138,6 +140,7 @@ func TestDatabaseChecks(t *testing.T) {
 	})
 
 	t.Run("Services", func(t *testing.T) {
+		t.Parallel()
 		db := testdb.Open(t, models.SkipFixtures, nil)
 		defer func() {
 			require.NoError(t, db.Close())
@@ -187,6 +190,7 @@ func TestDatabaseChecks(t *testing.T) {
 	})
 
 	t.Run("Agents", func(t *testing.T) {
+		t.Parallel()
 		db := testdb.Open(t, models.SkipFixtures, nil)
 		defer func() {
 			require.NoError(t, db.Close())
@@ -211,7 +215,9 @@ func TestDatabaseChecks(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("runs_on_node_id_xor_pmm_agent_id", func(t *testing.T) {
+			t.Parallel()
 			t.Run("Normal", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -228,6 +234,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("BothNULL", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -239,6 +246,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("BothSet", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -250,7 +258,9 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 		})
 		t.Run("runs_on_node_id_only_for_pmm_agent", func(t *testing.T) {
+			t.Parallel()
 			t.Run("NotPMMAgent", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -262,6 +272,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("PMMAgent", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -273,9 +284,12 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 		})
 		t.Run("node_id_or_service_id_or_pmm_agent_id", func(t *testing.T) {
+			t.Parallel(
 			// pmm_agent_id is always set in that test - NULL is tested above
+			)
 
 			t.Run("node_id set", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -287,6 +301,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("service_id set", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -298,6 +313,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("Both NULL", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -309,6 +325,7 @@ func TestDatabaseChecks(t *testing.T) {
 			})
 
 			t.Run("Both set", func(t *testing.T) {
+				t.Parallel()
 				tx, rollback := getTX(t, db)
 				defer rollback()
 
@@ -323,7 +340,9 @@ func TestDatabaseChecks(t *testing.T) {
 }
 
 func TestDatabaseMigrations(t *testing.T) {
+	t.Parallel()
 	t.Run("push metrics field migration: from root to exporter_options", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, pointer.ToInt(58))
 		defer sqlDB.Close() //nolint:errcheck
 

--- a/managed/models/dsn_helpers_test.go
+++ b/managed/models/dsn_helpers_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestFindDSNByServiceID(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -177,6 +178,7 @@ func TestFindDSNByServiceID(t *testing.T) {
 	}
 
 	t.Run("FindDSNByServiceIDandPMMAgentIDWithNoAgent", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -186,6 +188,7 @@ func TestFindDSNByServiceID(t *testing.T) {
 	})
 
 	t.Run("FindDSNByServiceIDandPMMAgentID", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -197,6 +200,7 @@ func TestFindDSNByServiceID(t *testing.T) {
 	})
 
 	t.Run("FindDSNWithSocketByServiceIDandPMMAgentID", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -208,6 +212,7 @@ func TestFindDSNByServiceID(t *testing.T) {
 	})
 
 	t.Run("FindDSNWithFilesByServiceIDandPMMAgentID", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -228,6 +233,7 @@ func TestFindDSNByServiceID(t *testing.T) {
 	})
 
 	t.Run("FindDSNByServiceIDandPMMAgentIDWithTwoAgentsOfSameType", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/models/dump_helpers_test.go
+++ b/managed/models/dump_helpers_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestDumps(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	tx, err := db.Begin()
@@ -40,7 +41,9 @@ func TestDumps(t *testing.T) {
 	})
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		t.Run("normal", func(t *testing.T) {
+			t.Parallel()
 			endTime := time.Now()
 			startTime := endTime.Add(-10 * time.Minute)
 
@@ -63,6 +66,7 @@ func TestDumps(t *testing.T) {
 		})
 
 		t.Run("invalid start and end time", func(t *testing.T) {
+			t.Parallel()
 			endTime := time.Now()
 			startTime := endTime.Add(10 * time.Minute)
 
@@ -79,6 +83,7 @@ func TestDumps(t *testing.T) {
 	})
 
 	t.Run("find", func(t *testing.T) {
+		t.Parallel()
 		findTX, err := db.Begin()
 		require.NoError(t, err)
 		defer findTX.Rollback() //nolint:errcheck
@@ -164,6 +169,7 @@ func TestDumps(t *testing.T) {
 }
 
 func TestDumpLogs(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	tx, err := db.Begin()
@@ -198,6 +204,7 @@ func TestDumpLogs(t *testing.T) {
 	}
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		for _, req := range createRequests {
 			log, err := models.CreateDumpLog(tx.Querier, req)
 			require.NoError(t, err)
@@ -209,6 +216,7 @@ func TestDumpLogs(t *testing.T) {
 	})
 
 	t.Run("find", func(t *testing.T) {
+		t.Parallel()
 		type expectLog struct {
 			DumpID  string
 			ChunkID uint32
@@ -266,6 +274,7 @@ func TestDumpLogs(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.Name, func(t *testing.T) {
+				t.Parallel()
 				logs, err := models.FindDumpLogs(tx.Querier, tc.Filters)
 				require.NoError(t, err)
 				require.Len(t, logs, len(tc.Expect))

--- a/managed/models/job_helpers_test.go
+++ b/managed/models/job_helpers_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestJobs(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	tx, err := db.Begin()
@@ -42,6 +43,7 @@ func TestJobs(t *testing.T) {
 	})
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		createJobParams := models.CreateJobParams{
 			PMMAgentID: "agentid",
 			Type:       models.MongoDBBackupJob,
@@ -71,6 +73,7 @@ func TestJobs(t *testing.T) {
 	})
 
 	t.Run("find", func(t *testing.T) {
+		t.Parallel()
 		findTX, err := db.Begin()
 		require.NoError(t, err)
 		defer findTX.Rollback() //nolint:errcheck
@@ -126,6 +129,7 @@ func TestJobs(t *testing.T) {
 }
 
 func TestJobLogs(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	tx, err := db.Begin()
@@ -168,6 +172,7 @@ func TestJobLogs(t *testing.T) {
 	}
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		for _, req := range createRequests {
 			log, err := models.CreateJobLog(tx.Querier, req)
 			require.NoError(t, err)
@@ -179,6 +184,7 @@ func TestJobLogs(t *testing.T) {
 	})
 
 	t.Run("find", func(t *testing.T) {
+		t.Parallel()
 		type expectLog struct {
 			JobID   string
 			ChunkID int
@@ -237,6 +243,7 @@ func TestJobLogs(t *testing.T) {
 		for _, tc := range testCases {
 			tc := tc
 			t.Run(tc.Name, func(t *testing.T) {
+				t.Parallel()
 				logs, err := models.FindJobLogs(tx.Querier, tc.Filters)
 				require.NoError(t, err)
 				require.Len(t, logs, len(tc.Expect))
@@ -249,6 +256,7 @@ func TestJobLogs(t *testing.T) {
 	})
 
 	t.Run("delete job", func(t *testing.T) {
+		t.Parallel()
 		require.NoError(t, models.CleanupOldJobs(tx.Querier, time.Now()))
 		for _, jobID := range []string{job1.ID, job2.ID} {
 			logs, err := models.FindJobLogs(tx.Querier, models.JobLogsFilter{

--- a/managed/models/location_helpers_test.go
+++ b/managed/models/location_helpers_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestBackupLocations(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -42,6 +43,7 @@ func TestBackupLocations(t *testing.T) {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("create - pmm client", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -70,6 +72,7 @@ func TestBackupLocations(t *testing.T) {
 	})
 
 	t.Run("create - s3", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -106,6 +109,7 @@ func TestBackupLocations(t *testing.T) {
 	})
 
 	t.Run("create - two configs", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -136,6 +140,7 @@ func TestBackupLocations(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -191,6 +196,7 @@ func TestBackupLocations(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -242,6 +248,7 @@ func TestBackupLocations(t *testing.T) {
 	})
 
 	t.Run("remove restrict", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -271,6 +278,7 @@ func TestBackupLocations(t *testing.T) {
 		assert.Empty(t, locations)
 	})
 	t.Run("remove cascade", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -348,6 +356,7 @@ func TestBackupLocations(t *testing.T) {
 }
 
 func TestCreateBackupLocationValidation(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -551,6 +560,7 @@ func TestCreateBackupLocationValidation(t *testing.T) {
 
 	for _, test := range tableTests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tx, err := db.Begin()
 			require.NoError(t, err)
 			defer func() {
@@ -571,6 +581,7 @@ func TestCreateBackupLocationValidation(t *testing.T) {
 }
 
 func TestParseEndpoint(t *testing.T) {
+	t.Parallel()
 	tableTests := []struct {
 		name     string
 		endpoint string
@@ -609,6 +620,7 @@ func TestParseEndpoint(t *testing.T) {
 	}
 	for _, test := range tableTests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			res, err := models.ParseEndpoint(test.endpoint)
 			if test.errorMsg != "" {
 				assert.EqualError(t, err, test.errorMsg)

--- a/managed/models/models_json_test.go
+++ b/managed/models/models_json_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/percona/pmm/managed/utils/testdb"
 )
 
-func TestJSON(t *testing.T) { //nolint:tparallel
+func TestJSON(t *testing.T) {
+	t. //nolint:tparallel
+		Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 

--- a/managed/models/node_helpers_test.go
+++ b/managed/models/node_helpers_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestNodeHelpers(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -119,8 +120,11 @@ func TestNodeHelpers(t *testing.T) {
 	}
 
 	t.Run("CreateNode", func(t *testing.T) {
+		t.Parallel()
 		t.Run("DuplicateMachineID", func(t *testing.T) {
+			t.Parallel(
 			// https://jira.percona.com/browse/PMM-4196
+			)
 
 			q, teardown := setup(t)
 			defer teardown(t)
@@ -157,6 +161,7 @@ func TestNodeHelpers(t *testing.T) {
 	})
 
 	t.Run("FindNodes", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -201,6 +206,7 @@ func TestNodeHelpers(t *testing.T) {
 	})
 
 	t.Run("FindNodesByType", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -221,6 +227,7 @@ func TestNodeHelpers(t *testing.T) {
 	})
 
 	t.Run("RemoveNode", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/models/node_model_test.go
+++ b/managed/models/node_model_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestNode(t *testing.T) {
+	t.Parallel()
 	t.Run("UnifiedLabels", func(t *testing.T) {
+		t.Parallel()
 		node := &Node{
 			NodeID:       "node_id",
 			Region:       pointer.ToString("hidden"),

--- a/managed/models/percona_sso_model_helpers_test.go
+++ b/managed/models/percona_sso_model_helpers_test.go
@@ -41,12 +41,14 @@ func setupDB(t *testing.T) (*reform.DB, func()) {
 }
 
 func TestPerconaSSODetails(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	issuerURL := "https://id-dev.percona.com/oauth2/aus15pi5rjdtfrcH51d7/v1"
 	wrongIssuerURL := "https://id-dev.percona.com/wrong"
 	orgID := uuid.NewString()
 
 	t.Run("CorrectCredentials", func(t *testing.T) {
+		t.Parallel()
 		clientID, clientSecret := os.Getenv("PMM_DEV_OAUTH_CLIENT_ID"), os.Getenv("PMM_DEV_OAUTH_CLIENT_SECRET")
 		if clientID == "" || clientSecret == "" {
 			t.Skip("Environment variables PMM_DEV_OAUTH_CLIENT_ID / PMM_DEV_OAUTH_CLIENT_SECRET are not defined, skipping test")
@@ -100,6 +102,7 @@ func TestPerconaSSODetails(t *testing.T) {
 	})
 
 	t.Run("WrongCredentials", func(t *testing.T) {
+		t.Parallel()
 		db, cleanup := setupDB(t)
 		defer cleanup()
 
@@ -117,6 +120,7 @@ func TestPerconaSSODetails(t *testing.T) {
 	})
 
 	t.Run("WrongURL", func(t *testing.T) {
+		t.Parallel()
 		clientID, clientSecret := os.Getenv("PMM_DEV_OAUTH_CLIENT_ID"), os.Getenv("PMM_DEV_OAUTH_CLIENT_SECRET")
 		if clientID == "" || clientSecret == "" {
 			t.Skip("Environment variables PMM_DEV_OAUTH_CLIENT_ID / PMM_DEV_OAUTH_CLIENT_SECRET are not defined, skipping test")

--- a/managed/models/restore_history_helpers_test.go
+++ b/managed/models/restore_history_helpers_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestRestoreHistory(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -104,6 +105,7 @@ func TestRestoreHistory(t *testing.T) {
 	}
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -129,6 +131,7 @@ func TestRestoreHistory(t *testing.T) {
 	})
 
 	t.Run("change", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -167,6 +170,7 @@ func TestRestoreHistory(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -211,6 +215,7 @@ func TestRestoreHistory(t *testing.T) {
 	})
 
 	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/managed/models/role_helpers_test.go
+++ b/managed/models/role_helpers_test.go
@@ -99,8 +99,7 @@ func TestRoleHelpers(t *testing.T) {
 	})
 
 	t.Run("unassigned role", func(t *testing.T) {
-		t.Parallel(
-		)
+		t.Parallel()
 
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
 			t.Parallel()
@@ -128,8 +127,7 @@ func TestRoleHelpers(t *testing.T) {
 	})
 
 	t.Run("single role assigned", func(t *testing.T) {
-		t.Parallel(
-		)
+		t.Parallel()
 
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
 			t.Parallel()
@@ -168,8 +166,7 @@ func TestRoleHelpers(t *testing.T) {
 	})
 
 	t.Run("multiple roles assigned", func(t *testing.T) {
-		t.Parallel(
-		)
+		t.Parallel()
 
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
 			t.Parallel()

--- a/managed/models/role_helpers_test.go
+++ b/managed/models/role_helpers_test.go
@@ -32,8 +32,8 @@ const (
 	roleBTitle = "Role B"
 )
 
-//nolint:paralleltest
 func TestRoleHelpers(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -62,8 +62,8 @@ func TestRoleHelpers(t *testing.T) {
 		return tx, teardown
 	}
 
-	//nolint:paralleltest
 	t.Run("shall assign role", func(t *testing.T) {
+		t.Parallel()
 		tx, teardown := setup(t)
 		defer teardown(t)
 
@@ -76,8 +76,8 @@ func TestRoleHelpers(t *testing.T) {
 		require.Equal(t, roles[0].ID, role.ID)
 	})
 
-	//nolint:paralleltest
 	t.Run("shall throw on assigning non-existent role", func(t *testing.T) {
+		t.Parallel()
 		tx, teardown := setup(t)
 		defer teardown(t)
 
@@ -85,8 +85,8 @@ func TestRoleHelpers(t *testing.T) {
 		require.True(t, errors.Is(err, models.ErrRoleNotFound))
 	})
 
-	//nolint:paralleltest
 	t.Run("shall create a new user on role assign", func(t *testing.T) {
+		t.Parallel()
 		tx, teardown := setup(t)
 		defer teardown(t)
 
@@ -98,10 +98,12 @@ func TestRoleHelpers(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	//nolint:paralleltest
 	t.Run("unassigned role", func(t *testing.T) {
-		//nolint:paralleltest
+		t.Parallel(
+		)
+
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -111,8 +113,8 @@ func TestRoleHelpers(t *testing.T) {
 			require.NoError(t, models.DeleteRole(tx, int(role.ID), 0))
 		})
 
-		//nolint:paralleltest
 		t.Run("shall delete role with replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -125,10 +127,12 @@ func TestRoleHelpers(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("single role assigned", func(t *testing.T) {
-		//nolint:paralleltest
+		t.Parallel(
+		)
+
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -143,8 +147,8 @@ func TestRoleHelpers(t *testing.T) {
 			require.Empty(t, roles)
 		})
 
-		//nolint:paralleltest
 		t.Run("shall delete role with replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -163,10 +167,12 @@ func TestRoleHelpers(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("multiple roles assigned", func(t *testing.T) {
-		//nolint:paralleltest
+		t.Parallel(
+		)
+
 		t.Run("shall delete role with no replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -184,8 +190,8 @@ func TestRoleHelpers(t *testing.T) {
 			require.Equal(t, roles[0].ID, roleB.ID)
 		})
 
-		//nolint:paralleltest
 		t.Run("shall delete role with replacement", func(t *testing.T) {
+			t.Parallel()
 			tx, teardown := setup(t)
 			defer teardown(t)
 
@@ -204,8 +210,8 @@ func TestRoleHelpers(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("shall not delete default role", func(t *testing.T) {
+		t.Parallel()
 		tx, teardown := setup(t)
 		defer teardown(t)
 
@@ -218,8 +224,8 @@ func TestRoleHelpers(t *testing.T) {
 		require.Equal(t, err, models.ErrRoleIsDefaultRole)
 	})
 
-	//nolint:paralleltest
 	t.Run("shall return roles for a user", func(t *testing.T) {
+		t.Parallel()
 		tx, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/models/scheduled_tasks_helpers_test.go
+++ b/managed/models/scheduled_tasks_helpers_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestScheduledTaskHelpers(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	t.Cleanup(func() {
@@ -118,6 +119,7 @@ func TestScheduledTaskHelpers(t *testing.T) {
 	}
 
 	t.Run("CreateAndFind", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -153,6 +155,7 @@ func TestScheduledTaskHelpers(t *testing.T) {
 	})
 
 	t.Run("Change", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -194,6 +197,7 @@ func TestScheduledTaskHelpers(t *testing.T) {
 	})
 
 	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -211,6 +215,7 @@ func TestScheduledTaskHelpers(t *testing.T) {
 	})
 
 	t.Run("Find", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {

--- a/managed/models/service_helpers_test.go
+++ b/managed/models/service_helpers_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestServiceHelpers(t *testing.T) {
+	t.Parallel()
 	now, origNowF := models.Now(), models.Now
 	models.Now = func() time.Time {
 		return now
@@ -156,6 +157,7 @@ func TestServiceHelpers(t *testing.T) {
 	}
 
 	t.Run("FindServices", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -286,6 +288,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("FindActiveServiceTypes", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -295,6 +298,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("RemoveService", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -323,6 +327,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("MySQL Conflict socket and address", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -337,6 +342,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("MySQL empty connection", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -348,6 +354,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("PostgreSQL conflict socket and address", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -362,6 +369,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("PostgreSQL empty connection", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 
 		defer teardown(t)
@@ -373,6 +381,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("MongoDB conflict socket and address", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -387,6 +396,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("MongoDB empty connection", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -397,6 +407,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("ProxySQL empty connection", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -408,6 +419,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("ProxySQL conflict socket and address", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 
@@ -422,6 +434,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("MongoDB find services in the same cluster", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 		s1, err := models.AddNewService(q, models.MongoDBServiceType, &models.AddDBMSServiceParams{
@@ -460,6 +473,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("Change standard labels", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 		s, err := models.AddNewService(q, models.ExternalServiceType, &models.AddDBMSServiceParams{
@@ -490,6 +504,7 @@ func TestServiceHelpers(t *testing.T) {
 	})
 
 	t.Run("Software versions record created when adding a service", func(t *testing.T) {
+		t.Parallel()
 		q, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/models/service_model_test.go
+++ b/managed/models/service_model_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	t.Run("UnifiedLabels", func(t *testing.T) {
+		t.Parallel()
 		service := &Service{
 			ServiceID:      "service_id",
 			Cluster:        "hidden",

--- a/managed/models/settings_helpers_test.go
+++ b/managed/models/settings_helpers_test.go
@@ -29,12 +29,14 @@ import (
 )
 
 func TestSettings(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
 	}()
 
 	t.Run("Defaults", func(t *testing.T) {
+		t.Parallel()
 		actual, err := models.GetSettings(sqlDB)
 		require.NoError(t, err)
 		require.Empty(t, actual.EncryptedItems)
@@ -61,6 +63,7 @@ func TestSettings(t *testing.T) {
 	})
 
 	t.Run("SaveWithDefaults", func(t *testing.T) {
+		t.Parallel()
 		s := &models.Settings{}
 		err := models.SaveSettings(sqlDB, s)
 		require.NoError(t, err)
@@ -85,7 +88,9 @@ func TestSettings(t *testing.T) {
 	})
 
 	t.Run("Validation", func(t *testing.T) {
+		t.Parallel()
 		t.Run("AWSPartitions", func(t *testing.T) {
+			t.Parallel()
 			s := &models.ChangeSettingsParams{
 				AWSPartitions: []string{"foo"},
 			}
@@ -122,6 +127,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("", func(t *testing.T) {
+			t.Parallel()
 			mr := models.MetricsResolutions{MR: 500 * time.Millisecond} // 0.5s
 			_, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				MetricsResolutions: mr,
@@ -151,6 +157,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("Updates validation", func(t *testing.T) {
+			t.Parallel()
 			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableUpdates: pointer.ToBool(true),
 			})
@@ -173,7 +180,10 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("Telemetry and Advisors validation", func(t *testing.T) {
+			t.Parallel(
 			// ensure initial default state
+			)
+
 			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableTelemetry: pointer.ToBool(true),
 				EnableAdvisors:  pointer.ToBool(true),
@@ -236,6 +246,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("Check that telemetry disabling resets telemetry UUID", func(t *testing.T) {
+			t.Parallel()
 			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
 				EnableTelemetry: pointer.ToBool(true),
 			})
@@ -258,6 +269,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("disable checks", func(t *testing.T) {
+			t.Parallel()
 			disChecks := []string{"one", "two", "three"}
 
 			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{
@@ -268,6 +280,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("enable checks", func(t *testing.T) {
+			t.Parallel()
 			disChecks := []string{"one", "two", "three"}
 
 			_, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{DisableAdvisorChecks: disChecks})
@@ -279,6 +292,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("enable azure discover", func(t *testing.T) {
+			t.Parallel()
 			s, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableAzurediscover: pointer.ToBool(false)})
 			require.NoError(t, err)
 			assert.False(t, *s.Azurediscover.Enabled)
@@ -289,6 +303,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("enable Access Control", func(t *testing.T) {
+			t.Parallel()
 			s, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableAccessControl: pointer.ToBool(false)})
 			require.NoError(t, err)
 			assert.False(t, *s.AccessControl.Enabled)
@@ -299,6 +314,7 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("disable percona alerting", func(t *testing.T) {
+			t.Parallel()
 			s, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableAlerting: pointer.ToBool(false)})
 			require.NoError(t, err)
 			assert.False(t, *s.Alerting.Enabled)
@@ -309,7 +325,9 @@ func TestSettings(t *testing.T) {
 		})
 
 		t.Run("Set PMM server ID", func(t *testing.T) {
+			t.Parallel()
 			t.Run("not set", func(t *testing.T) {
+				t.Parallel()
 				settings, err := models.GetSettings(sqlDB)
 				require.NoError(t, err)
 				require.NotNil(t, settings)
@@ -324,6 +342,7 @@ func TestSettings(t *testing.T) {
 				assert.NotEmpty(t, settings.PMMServerID)
 			})
 			t.Run("already set", func(t *testing.T) {
+				t.Parallel()
 				settings, err := models.GetSettings(sqlDB)
 				require.NoError(t, err)
 				require.NotNil(t, settings)

--- a/managed/models/software_version_helpers_test.go
+++ b/managed/models/software_version_helpers_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestSoftwareVersions(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -69,6 +70,7 @@ func TestSoftwareVersions(t *testing.T) {
 	}
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -106,6 +108,7 @@ func TestSoftwareVersions(t *testing.T) {
 	})
 
 	t.Run("list and remove", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -183,6 +186,7 @@ func TestSoftwareVersions(t *testing.T) {
 	})
 
 	t.Run("update", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -245,6 +249,7 @@ func TestSoftwareVersions(t *testing.T) {
 }
 
 func TestSoftwareVersionsParamsValidation(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -300,6 +305,7 @@ func TestSoftwareVersionsParamsValidation(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			tx, err := db.Begin()
 			require.NoError(t, err)
 			t.Cleanup(func() {
@@ -322,6 +328,7 @@ func TestSoftwareVersionsParamsValidation(t *testing.T) {
 }
 
 func TestUpdateServiceSoftwareVersionsParamsValidation(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name     string
 		params   models.UpdateServiceSoftwareVersionsParams
@@ -361,6 +368,7 @@ func TestUpdateServiceSoftwareVersionsParamsValidation(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			err := test.params.Validate()
 			if test.errorMsg != "" {
 				assert.EqualError(t, err, test.errorMsg)

--- a/managed/models/template_helpers_test.go
+++ b/managed/models/template_helpers_test.go
@@ -35,10 +35,12 @@ import (
 )
 
 func TestRuleTemplates(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("create", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -84,6 +86,7 @@ func TestRuleTemplates(t *testing.T) {
 	})
 
 	t.Run("change", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -134,6 +137,7 @@ func TestRuleTemplates(t *testing.T) {
 	})
 
 	t.Run("change err - mismatch names", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -155,6 +159,7 @@ func TestRuleTemplates(t *testing.T) {
 	})
 
 	t.Run("remove", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {
@@ -178,6 +183,7 @@ func TestRuleTemplates(t *testing.T) {
 	})
 
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		tx, err := db.Begin()
 		require.NoError(t, err)
 		defer func() {

--- a/managed/models/victoriametrics_params_test.go
+++ b/managed/models/victoriametrics_params_test.go
@@ -23,16 +23,20 @@ import (
 )
 
 func TestVictoriaMetricsParams(t *testing.T) {
+	t.Parallel()
 	t.Run("read non exist baseConfigFile", func(t *testing.T) {
+		t.Parallel()
 		_, err := NewVictoriaMetricsParams("nonExistConfigFile.yml", VMBaseURL)
 		require.NoError(t, err)
 	})
 	t.Run("check params for VMAlert", func(t *testing.T) {
+		t.Parallel()
 		vmp, err := NewVictoriaMetricsParams("../testdata/victoriametrics/prometheus.external.alerts.yml", VMBaseURL)
 		require.NoError(t, err)
 		require.Equal(t, []string{"--rule=/srv/external_rules/rul1.yml", "--rule=/srv/external_rules/rule2.yml", "--evaluationInterval=10s"}, vmp.VMAlertFlags)
 	})
 	t.Run("check external VM", func(t *testing.T) {
+		t.Parallel()
 		tests := []struct {
 			url  string
 			want bool
@@ -56,6 +60,7 @@ func TestVictoriaMetricsParams(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.url, func(t *testing.T) {
+				t.Parallel()
 				vmp, err := NewVictoriaMetricsParams(BasePrometheusConfigPath, tt.url)
 				require.NoError(t, err)
 				assert.Equalf(t, tt.want, vmp.ExternalVM(), "ExternalVM()")

--- a/managed/services/agents/agents_test.go
+++ b/managed/services/agents/agents_test.go
@@ -41,6 +41,7 @@ func requireNoDuplicateFlags(t *testing.T, flags []string) {
 }
 
 func TestPathsBaseForDifferentVersions(t *testing.T) {
+	t.Parallel()
 	left := "{{"
 	right := "}}"
 	assert.Equal(t, "/usr/local/percona/pmm", pathsBase(version.MustParse("2.22.01"), left, right))
@@ -51,7 +52,9 @@ func TestPathsBaseForDifferentVersions(t *testing.T) {
 }
 
 func TestGetExporterListenAddress(t *testing.T) {
+	t.Parallel()
 	t.Run("uses 127.0.0.1 in push mode", func(t *testing.T) {
+		t.Parallel()
 		node := &models.Node{
 			Address: "1.2.3.4",
 		}
@@ -64,6 +67,7 @@ func TestGetExporterListenAddress(t *testing.T) {
 		assert.Equal(t, "127.0.0.1", getExporterListenAddress(node, exporter))
 	})
 	t.Run("exposes exporter address when enabled in push mode", func(t *testing.T) {
+		t.Parallel()
 		node := &models.Node{
 			Address: "1.2.3.4",
 		}
@@ -77,6 +81,7 @@ func TestGetExporterListenAddress(t *testing.T) {
 		assert.Equal(t, "0.0.0.0", getExporterListenAddress(node, exporter))
 	})
 	t.Run("exposes exporter address when enabled in pull mode", func(t *testing.T) {
+		t.Parallel()
 		node := &models.Node{
 			Address: "1.2.3.4",
 		}
@@ -90,6 +95,7 @@ func TestGetExporterListenAddress(t *testing.T) {
 		assert.Equal(t, "0.0.0.0", getExporterListenAddress(node, exporter))
 	})
 	t.Run("exposes exporter address if node IP is unavailable in pull mode", func(t *testing.T) {
+		t.Parallel()
 		exporter := &models.Agent{
 			ExporterOptions: models.ExporterOptions{
 				PushMetrics: false,

--- a/managed/services/agents/azure_database_test.go
+++ b/managed/services/agents/azure_database_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestAzureExporterConfig(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.28.0")
 
 	node1 := &models.Node{

--- a/managed/services/agents/channel/channel_test.go
+++ b/managed/services/agents/channel/channel_test.go
@@ -110,6 +110,7 @@ func setup(t *testing.T, connect func(*Channel) error, expected ...error) (agent
 }
 
 func TestAgentRequest(t *testing.T) {
+	t.Parallel()
 	const count = 50
 	require.Greater(t, count, agentRequestsCap)
 
@@ -162,6 +163,7 @@ func TestAgentRequest(t *testing.T) {
 }
 
 func TestServerRequest(t *testing.T) {
+	t.Parallel()
 	const count = 50
 	require.Greater(t, count, agentRequestsCap)
 
@@ -203,6 +205,7 @@ func TestServerRequest(t *testing.T) {
 }
 
 func TestServerExitsWithGRPCError(t *testing.T) {
+	t.Parallel()
 	errUnimplemented := status.Error(codes.Unimplemented, "Test error")
 	connect := func(ch *Channel) error {
 		req := <-ch.Requests()
@@ -228,6 +231,7 @@ func TestServerExitsWithGRPCError(t *testing.T) {
 }
 
 func TestServerExitsWithUnknownErrorIntercepted(t *testing.T) {
+	t.Parallel()
 	connect := func(ch *Channel) error {
 		req := <-ch.Requests()
 		require.NotNil(t, req)
@@ -252,6 +256,7 @@ func TestServerExitsWithUnknownErrorIntercepted(t *testing.T) {
 }
 
 func TestAgentClosesStream(t *testing.T) {
+	t.Parallel()
 	connect := func(ch *Channel) error {
 		resp, err := ch.SendAndWaitResponse(&agentv1.Ping{})
 		assert.Errorf(t, err, "channel is closed")
@@ -273,6 +278,7 @@ func TestAgentClosesStream(t *testing.T) {
 }
 
 func TestAgentClosesConnection(t *testing.T) {
+	t.Parallel()
 	connect := func(ch *Channel) error {
 		resp, err := ch.SendAndWaitResponse(&agentv1.Ping{})
 		assert.Errorf(t, err, "channel is closed")
@@ -294,6 +300,7 @@ func TestAgentClosesConnection(t *testing.T) {
 }
 
 func TestUnexpectedResponseIdFromAgent(t *testing.T) {
+	t.Parallel()
 	invalidIDSent := make(chan struct{})
 	connect := func(ch *Channel) error {
 		<-invalidIDSent
@@ -341,6 +348,7 @@ func TestUnexpectedResponseIdFromAgent(t *testing.T) {
 }
 
 func TestUnexpectedResponsePayloadFromAgent(t *testing.T) {
+	t.Parallel()
 	stop := make(chan struct{})
 	stopServer := make(chan struct{})
 	connect := func(_ *Channel) error {

--- a/managed/services/agents/jobs_test.go
+++ b/managed/services/agents/jobs_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 func TestArtifactMetadataFromProto(t *testing.T) {
+	t.Parallel()
 	t.Run("all fields are filled", func(t *testing.T) {
+		t.Parallel()
 		protoMetadata := backuppb.Metadata{
 			FileList:           []*backuppb.File{{Name: "dir1", IsDirectory: true}, {Name: "file1"}, {Name: "file2"}},
 			RestoreTo:          &timestamppb.Timestamp{Seconds: 123, Nanos: 456},
@@ -46,6 +48,7 @@ func TestArtifactMetadataFromProto(t *testing.T) {
 	})
 
 	t.Run("some fields are empty", func(t *testing.T) {
+		t.Parallel()
 		protoMetadata := backuppb.Metadata{
 			FileList: []*backuppb.File{{Name: "dir1", IsDirectory: true}, {Name: "file1"}, {Name: "file2"}},
 		}
@@ -59,6 +62,7 @@ func TestArtifactMetadataFromProto(t *testing.T) {
 	})
 
 	t.Run("argument is nil", func(t *testing.T) {
+		t.Parallel()
 		var protoMetadata *backuppb.Metadata
 		var expected *models.Metadata
 

--- a/managed/services/agents/mongodb_test.go
+++ b/managed/services/agents/mongodb_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestMongodbExporterConfig225(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.25.0")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -72,6 +73,7 @@ func TestMongodbExporterConfig225(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("Having collstats limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			StatsCollections: []string{"col1", "col2", "col3"},
 			CollectionsLimit: 79014,
@@ -91,6 +93,7 @@ func TestMongodbExporterConfig225(t *testing.T) {
 }
 
 func TestMongodbExporterConfig226(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.26.0")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -135,6 +138,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("Having collstats limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			StatsCollections: []string{"col1", "col2", "col3"},
 			CollectionsLimit: 79014,
@@ -156,6 +160,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 	})
 
 	t.Run("Enabling all collectors with non zero limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			StatsCollections:    []string{"col1", "col2", "col3"},
 			CollectionsLimit:    79014,
@@ -183,6 +188,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 	})
 
 	t.Run("Enabling all collectors", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			EnableAllCollectors: true,
 			StatsCollections:    []string{"db1.col1.one", "db2.col2", "db3"},
@@ -211,6 +217,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 	})
 
 	t.Run("collstats-limit=-1 -> automatically set the limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			EnableAllCollectors: true,
 			StatsCollections:    []string{"db1.col1.one", "db2.col2", "db3"},
@@ -239,6 +246,7 @@ func TestMongodbExporterConfig226(t *testing.T) {
 }
 
 func TestMongodbExporterConfig2411(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.41.1")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -286,6 +294,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("Having collstats limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			StatsCollections: []string{"col1", "col2", "col3"},
 			CollectionsLimit: 79014,
@@ -308,6 +317,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 	})
 
 	t.Run("Enabling all collectors with non zero limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			StatsCollections:    []string{"col1", "col2", "col3"},
 			CollectionsLimit:    79014,
@@ -337,6 +347,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 	})
 
 	t.Run("Enabling all collectors", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			EnableAllCollectors: true,
 			StatsCollections:    []string{"db1.col1.one", "db2.col2", "db3"},
@@ -367,6 +378,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 	})
 
 	t.Run("collstats-limit=-1 -> automatically set the limit", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			EnableAllCollectors: true,
 			StatsCollections:    []string{"db1.col1.one", "db2.col2", "db3"},
@@ -396,6 +408,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 	})
 
 	t.Run("Enable all collectors and disable some", func(t *testing.T) {
+		t.Parallel()
 		exporter.ExporterOptions = models.ExporterOptions{
 			DisabledCollectors: []string{"dbstats", "topmetrics"},
 		}
@@ -428,6 +441,7 @@ func TestMongodbExporterConfig2411(t *testing.T) {
 }
 
 func TestMongodbExporterConfig2432(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.43.2")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -477,6 +491,7 @@ func TestMongodbExporterConfig2432(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("Enabling all collectors", func(t *testing.T) {
+		t.Parallel()
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			EnableAllCollectors: true,
 			StatsCollections:    []string{"db1.col1.one", "db2.col2", "db3"},
@@ -511,6 +526,7 @@ func TestMongodbExporterConfig2432(t *testing.T) {
 }
 
 func TestMongodbExporterConfig(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.0.0")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -554,6 +570,7 @@ func TestMongodbExporterConfig(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual, err := mongodbExporterConfig(node, mongodb, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -561,12 +578,14 @@ func TestMongodbExporterConfig(t *testing.T) {
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		actual, err := mongodbExporterConfig(node, mongodb, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
 		assert.Equal(t, "MONGODB_URI=mongodb://1.2.3.4:27017/?connectTimeoutMS=1000&directConnection=true&serverSelectionTimeoutMS=1000", actual.Env[0])
 	})
 	t.Run("SSLEnabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.TLS = true
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			TLSCertificateKey:             "content-of-tls-certificate-key",
@@ -586,6 +605,7 @@ func TestMongodbExporterConfig(t *testing.T) {
 	})
 
 	t.Run("AuthenticationDatabase", func(t *testing.T) {
+		t.Parallel()
 		exporter.TLS = true
 		exporter.MongoDBOptions = models.MongoDBOptions{
 			TLSCertificateKey:             "content-of-tls-certificate-key",
@@ -613,6 +633,7 @@ func TestMongodbExporterConfig(t *testing.T) {
 	})
 
 	t.Run("DisabledCollectors", func(t *testing.T) {
+		t.Parallel()
 		exporter.ExporterOptions = models.ExporterOptions{
 			DisabledCollectors: []string{"topmetrics"},
 		}
@@ -636,6 +657,7 @@ func TestMongodbExporterConfig(t *testing.T) {
 }
 
 func TestNewMongodbExporterConfig(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.10.0")
 	node := &models.Node{
 		Address: "1.2.3.4",
@@ -675,6 +697,7 @@ func TestNewMongodbExporterConfig(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual, err := mongodbExporterConfig(node, mongodb, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -682,6 +705,7 @@ func TestNewMongodbExporterConfig(t *testing.T) {
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		actual, err := mongodbExporterConfig(node, mongodb, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)

--- a/managed/services/agents/mysql_test.go
+++ b/managed/services/agents/mysql_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestMySQLdExporterConfig(t *testing.T) {
+	t.Parallel()
 	mysql := &models.Service{
 		Address: pointer.ToString("1.2.3.4"),
 		Port:    pointer.ToUint16(3306),
@@ -105,6 +106,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -112,6 +114,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -119,6 +122,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 	})
 
 	t.Run("SSLEnabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.TLS = true
 		exporter.MySQLOptions = models.MySQLOptions{
 			TLSCa:   "content-of-tls-ca",
@@ -138,6 +142,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 	})
 
 	t.Run("with allowCleartextPasswords dsn param", func(t *testing.T) {
+		t.Parallel()
 		pmmAgentVersion = version.MustParse("3.4.0")
 		t.Cleanup(func() {
 			pmmAgentVersion = version.MustParse("2.21.0")
@@ -155,6 +160,7 @@ func TestMySQLdExporterConfig(t *testing.T) {
 }
 
 func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
+	t.Parallel()
 	node := &models.Node{
 		Address: "1.2.3.4",
 	}
@@ -236,6 +242,7 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -243,6 +250,7 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -250,6 +258,7 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 	})
 
 	t.Run("V236_EnablesPluginCollector", func(t *testing.T) {
+		t.Parallel()
 		pmmAgentVersion := version.MustParse("2.36.0")
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -257,6 +266,7 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 	})
 
 	t.Run("beforeV236_NoPluginCollector", func(t *testing.T) {
+		t.Parallel()
 		pmmAgentVersion := version.MustParse("2.35.0")
 		actual, err := mysqldExporterConfig(node, mysql, exporter, exposeSecrets, pmmAgentVersion)
 		require.NoError(t, err)
@@ -265,6 +275,7 @@ func TestMySQLdExporterConfigTablestatsGroupDisabled(t *testing.T) {
 }
 
 func TestMySQLdExporterConfigDisabledCollectors(t *testing.T) {
+	t.Parallel()
 	node := &models.Node{
 		Address: "1.2.3.4",
 	}
@@ -339,6 +350,7 @@ func TestMySQLdExporterConfigDisabledCollectors(t *testing.T) {
 }
 
 func TestMySQLdExporterConfigMySQL8Support(t *testing.T) {
+	t.Parallel()
 	mysql := &models.Service{
 		Address: pointer.ToString("1.2.3.4"),
 		Port:    pointer.ToUint16(3306),
@@ -357,6 +369,7 @@ func TestMySQLdExporterConfigMySQL8Support(t *testing.T) {
 	pmmAgentVersion := version.MustParse("3.2.0")
 
 	t.Run("SSLEnabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.MySQLOptions = models.MySQLOptions{
 			TLSCa:   "content-of-tls-ca",
 			TLSCert: "content-of-tls-certificate-key",
@@ -427,6 +440,7 @@ func TestMySQLdExporterConfigMySQL8Support(t *testing.T) {
 	})
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual, err := mysqldExporterConfig(node, mysql, exporter, redactSecrets, pmmAgentVersion)
 		expected := &agentv1.SetStateRequest_AgentProcess{
@@ -489,6 +503,7 @@ func TestMySQLdExporterConfigMySQL8Support(t *testing.T) {
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		exporter.Password = pointer.ToString("s3cur3 p@$$w0r4.")
 		exporter.MySQLOptions = models.MySQLOptions{}

--- a/managed/services/agents/nomad_test.go
+++ b/managed/services/agents/nomad_test.go
@@ -27,7 +27,9 @@ import (
 )
 
 func TestGenerateNomadAgentConfig(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		node := &models.Node{
 			NodeName: "node-name",
 			NodeID:   "node-id",

--- a/managed/services/agents/postgresql_test.go
+++ b/managed/services/agents/postgresql_test.go
@@ -208,6 +208,7 @@ func (s *PostgresExporterConfigTestSuite) TestDisabledCollectors() {
 }
 
 func TestAutoDiscovery(t *testing.T) {
+	t.Parallel()
 	const discoveryFlag = "--auto-discover-databases"
 	const excludedFlag = "--exclude-databases=template0,template1,cloudsqladmin,pmm-managed-dev,azure_maintenance,rdsadmin"
 
@@ -252,6 +253,7 @@ func TestAutoDiscovery(t *testing.T) {
 	}
 
 	t.Run("Not supported version - disabled", func(t *testing.T) {
+		t.Parallel()
 		res, err := postgresExporterConfig(node, postgresql, exporter, redactSecrets, pmmAgentVersion)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -260,6 +262,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Supported version - enabled", func(t *testing.T) {
+		t.Parallel()
 		pmmAgentVersion = version.MustParse("2.16.0")
 		res, err := postgresExporterConfig(node, postgresql, exporter, redactSecrets, pmmAgentVersion)
 		assert.NoError(t, err)
@@ -268,6 +271,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Database count more than limit - disabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			AutoDiscoveryLimit: pointer.ToInt32(5),
 			DatabaseCount:      10,
@@ -279,6 +283,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Database count equal to limit - enabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			AutoDiscoveryLimit: pointer.ToInt32(5),
 			DatabaseCount:      5,
@@ -290,6 +295,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Database count less than limit - enabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			AutoDiscoveryLimit: pointer.ToInt32(5),
 			DatabaseCount:      3,
@@ -301,6 +307,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Negative limit - disabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			AutoDiscoveryLimit: pointer.ToInt32(-1),
 			DatabaseCount:      3,
@@ -312,6 +319,7 @@ func TestAutoDiscovery(t *testing.T) {
 	})
 
 	t.Run("Default - enabled", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			AutoDiscoveryLimit: pointer.ToInt32(0),
 			DatabaseCount:      3,
@@ -324,6 +332,7 @@ func TestAutoDiscovery(t *testing.T) {
 }
 
 func TestMaxConnections(t *testing.T) {
+	t.Parallel()
 	const maxConnectionsFlag = "--max-connections"
 
 	pmmAgentVersion := version.MustParse("2.42.0")
@@ -372,6 +381,7 @@ func TestMaxConnections(t *testing.T) {
 	}
 
 	t.Run("Not supported version - disabled", func(t *testing.T) {
+		t.Parallel()
 		res, err := postgresExporterConfig(node, postgresql, exporter, redactSecrets, version.MustParse("2.41.0"))
 		assert.NoError(t, err)
 		assert.Equal(t, expected, res)
@@ -379,12 +389,14 @@ func TestMaxConnections(t *testing.T) {
 	})
 
 	t.Run("Supported version - enabled", func(t *testing.T) {
+		t.Parallel()
 		res, err := postgresExporterConfig(node, postgresql, exporter, redactSecrets, pmmAgentVersion)
 		assert.NoError(t, err)
 		assert.Contains(t, res.Args, fmt.Sprintf("%s=%d", maxConnectionsFlag, 10))
 	})
 
 	t.Run("Max exporter connections set to 0 - ignore", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			MaxExporterConnections: 0,
 		}
@@ -394,6 +406,7 @@ func TestMaxConnections(t *testing.T) {
 	})
 
 	t.Run("Max exporter connections set to 5 - apply", func(t *testing.T) {
+		t.Parallel()
 		exporter.PostgreSQLOptions = models.PostgreSQLOptions{
 			MaxExporterConnections: 5,
 		}
@@ -562,5 +575,6 @@ func (s *PostgresExporterConfigTestSuite) TestSSLSni() {
 }
 
 func TestPostgresExporterConfigTestSuite(t *testing.T) {
+	t.Parallel()
 	suite.Run(t, &PostgresExporterConfigTestSuite{})
 }

--- a/managed/services/agents/proxysql_test.go
+++ b/managed/services/agents/proxysql_test.go
@@ -69,18 +69,21 @@ func TestProxySQLExporterConfig(t *testing.T) {
 	require.Equal(t, expected, actual)
 
 	t.Run("EmptyPassword", func(t *testing.T) {
+		t.Parallel()
 		exporter.Password = nil
 		actual := proxysqlExporterConfig(node, proxysql, exporter, exposeSecrets, pmmAgentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=username@tcp(1.2.3.4:3306)/?timeout=1s", actual.Env[0])
 	})
 
 	t.Run("EmptyUsername", func(t *testing.T) {
+		t.Parallel()
 		exporter.Username = nil
 		actual := proxysqlExporterConfig(node, proxysql, exporter, exposeSecrets, pmmAgentVersion)
 		assert.Equal(t, "DATA_SOURCE_NAME=tcp(1.2.3.4:3306)/?timeout=1s", actual.Env[0])
 	})
 
 	t.Run("DisabledCollector", func(t *testing.T) {
+		t.Parallel()
 		exporter.ExporterOptions.DisabledCollectors = []string{"mysql_connection_list", "stats_memory_metrics"}
 		actual := proxysqlExporterConfig(node, proxysql, exporter, exposeSecrets, pmmAgentVersion)
 		expected := &agentv1.SetStateRequest_AgentProcess{

--- a/managed/services/agents/rds_test.go
+++ b/managed/services/agents/rds_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestRDSExporterConfig(t *testing.T) {
+	t.Parallel()
 	pmmAgentVersion := version.MustParse("2.28.0")
 
 	node1 := &models.Node{

--- a/managed/services/agents/roster_test.go
+++ b/managed/services/agents/roster_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestRoster(t *testing.T) {
+	t.Parallel()
 	setup := func(t *testing.T) (*roster, func(t *testing.T)) {
 		t.Helper()
 
@@ -45,6 +46,7 @@ func TestRoster(t *testing.T) {
 	}
 
 	t.Run("Add", func(t *testing.T) {
+		t.Parallel()
 		r, teardown := setup(t)
 		defer teardown(t)
 
@@ -73,6 +75,7 @@ func TestRoster(t *testing.T) {
 	})
 
 	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
 		r, teardown := setup(t)
 		defer teardown(t)
 
@@ -85,6 +88,7 @@ func TestRoster(t *testing.T) {
 	})
 
 	t.Run("Clear", func(t *testing.T) {
+		t.Parallel()
 		r, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/services/agents/vmagent_test.go
+++ b/managed/services/agents/vmagent_test.go
@@ -26,13 +26,16 @@ import (
 )
 
 func TestMaxScrapeSize(t *testing.T) {
+	t.Parallel()
 	t.Run("by default 64MiB", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 		actual := vmAgentConfig("", params)
 		assert.Contains(t, actual.Env, "VMAGENT_promscrape_maxScrapeSize="+maxScrapeSizeDefault)
 	})
 	t.Run("overridden with ENV", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 		newValue := "16MiB"
@@ -41,6 +44,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.Contains(t, actual.Env, "VMAGENT_promscrape_maxScrapeSize="+newValue)
 	})
 	t.Run("VMAGENT_ ENV variables", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 		t.Setenv("VMAGENT_promscrape_maxScrapeSize", "16MiB")
@@ -51,6 +55,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.NotContains(t, actual.Env, "VM_remoteWrite_basicAuth_password=password")
 	})
 	t.Run("External Victoria Metrics ENV variables", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, "http://victoriametrics:8428")
 		require.NoError(t, err)
 		t.Setenv("VMAGENT_promscrape_maxScrapeSize", "16MiB")
@@ -60,6 +65,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.NotContains(t, actual.Env, "VMAGENT_remoteWrite_basicAuth_username={{.server_username}}")
 	})
 	t.Run("External Victoria Metrics with credentials in URL", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, "http://user:pass@victoriametrics:8428")
 		require.NoError(t, err)
 		actual := vmAgentConfig("", params)
@@ -71,6 +77,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.NotContains(t, actual.Env, "VMAGENT_remoteWrite_basicAuth_password={{.server_password}}")
 	})
 	t.Run("External Victoria Metrics with username only in URL", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, "http://user@victoriametrics:8428")
 		require.NoError(t, err)
 		actual := vmAgentConfig("", params)
@@ -82,6 +89,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.NotContains(t, actual.Env, "VMAGENT_remoteWrite_basicAuth_password={{.server_password}}")
 	})
 	t.Run("External Victoria Metrics with special characters in credentials", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, "http://user%40domain:p%40ss%21@victoriametrics:8428")
 		require.NoError(t, err)
 		actual := vmAgentConfig("", params)
@@ -90,6 +98,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.Contains(t, actual.Env, "VMAGENT_remoteWrite_basicAuth_password=p@ss!")
 	})
 	t.Run("System VMAGENT_ variables override defaults", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 		// Set system environment variables that should override defaults
@@ -109,6 +118,7 @@ func TestMaxScrapeSize(t *testing.T) {
 		assert.NotContains(t, actual.Env, "VMAGENT_remoteWrite_maxDiskUsagePerURL=1073741824")
 	})
 	t.Run("httpListenAddr is in Args not Env", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 		actual := vmAgentConfig("", params)
@@ -131,6 +141,7 @@ func TestMaxScrapeSize(t *testing.T) {
 }
 
 func TestVMAgentExternalVM(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name                  string
 		vmURL                 string
@@ -177,6 +188,7 @@ func TestVMAgentExternalVM(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, tc.vmURL)
 			require.NoError(t, err)
 
@@ -207,7 +219,9 @@ func TestVMAgentExternalVM(t *testing.T) {
 }
 
 func TestVMAgentInternalVM(t *testing.T) {
+	t.Parallel()
 	t.Run("Internal VM uses server credentials", func(t *testing.T) {
+		t.Parallel()
 		params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 
@@ -227,6 +241,7 @@ func TestVMAgentInternalVM(t *testing.T) {
 }
 
 func TestExtractCredentialsFromURL(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name             string
 		url              string
@@ -285,6 +300,7 @@ func TestExtractCredentialsFromURL(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			username, password := extractCredentialsFromURL(tc.url)
 			assert.Equal(t, tc.expectedUsername, username, "Username mismatch")
 			assert.Equal(t, tc.expectedPassword, password, "Password mismatch")

--- a/managed/services/alerting/service_test.go
+++ b/managed/services/alerting/service_test.go
@@ -36,6 +36,7 @@ const (
 )
 
 func TestCollect(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {

--- a/managed/services/backup/backup_service_test.go
+++ b/managed/services/backup/backup_service_test.go
@@ -68,6 +68,7 @@ func setup(t *testing.T, q *reform.Querier, serviceType models.ServiceType, serv
 }
 
 func TestPerformBackup(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 
@@ -108,6 +109,7 @@ func TestPerformBackup(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MySQLServiceType, "test-mysql-backup-service")
 
 		for _, tc := range []struct {
@@ -149,6 +151,7 @@ func TestPerformBackup(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				var retErr error
 				if tc.errFromCheckSoftwareCompatibilityForService {
 					retErr = tc.expectedError
@@ -191,9 +194,11 @@ func TestPerformBackup(t *testing.T) {
 	})
 
 	t.Run("mongodb", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MongoDBServiceType, "test-mongo-backup-service")
 
 		t.Run("PITR is incompatible with physical backups", func(t *testing.T) {
+			t.Parallel()
 			mockedCompatibilityService.On("CheckSoftwareCompatibilityForService", ctx, pointer.GetString(agent.ServiceID)).
 				Return("", nil).Once()
 			artifactID, err := backupService.PerformBackup(ctx, PerformBackupParams{
@@ -209,6 +214,7 @@ func TestPerformBackup(t *testing.T) {
 		})
 
 		t.Run("backup fails for empty service ID", func(t *testing.T) {
+			t.Parallel()
 			mockedCompatibilityService.On("CheckSoftwareCompatibilityForService", ctx, "").Return("", nil).Once()
 			artifactID, err := backupService.PerformBackup(ctx, PerformBackupParams{
 				ServiceID:  "",
@@ -223,6 +229,7 @@ func TestPerformBackup(t *testing.T) {
 		})
 
 		t.Run("Incremental backups fails for MongoDB", func(t *testing.T) {
+			t.Parallel()
 			mockedCompatibilityService.On("CheckSoftwareCompatibilityForService", ctx, pointer.GetString(agent.ServiceID)).
 				Return("", nil).Once()
 			artifactID, err := backupService.PerformBackup(ctx, PerformBackupParams{
@@ -242,6 +249,7 @@ func TestPerformBackup(t *testing.T) {
 }
 
 func TestRestoreBackup(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 
@@ -284,6 +292,7 @@ func TestRestoreBackup(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MySQLServiceType, "test-mysql-restore-service")
 		artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 			Name:       "mysql-artifact-name",
@@ -320,6 +329,7 @@ func TestRestoreBackup(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				mockedCompatibilityService.On("CheckSoftwareCompatibilityForService", ctx, pointer.GetString(agent.ServiceID)).
 					Return(tc.dbVersion, nil).Once()
 				mockedCompatibilityService.On("CheckArtifactCompatibility", artifact.ID, tc.dbVersion).Return(tc.expectedError).Once()
@@ -340,6 +350,7 @@ func TestRestoreBackup(t *testing.T) {
 		}
 
 		t.Run("artifact not ready", func(t *testing.T) {
+			t.Parallel()
 			updatedArtifact, err := models.UpdateArtifact(db.Querier, artifact.ID, models.UpdateArtifactParams{
 				Status: models.PendingBackupStatus.Pointer(),
 			})
@@ -353,6 +364,7 @@ func TestRestoreBackup(t *testing.T) {
 	})
 
 	t.Run("mongo", func(t *testing.T) {
+		t.Parallel()
 		agent, service := setup(t, db.Querier, models.MongoDBServiceType, "test-mongo-restore-service")
 		artifactWithVersion, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 			Name:       "mongodb-artifact-name-version",
@@ -415,6 +427,7 @@ func TestRestoreBackup(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				mockedCompatibilityService.On("CheckSoftwareCompatibilityForService", ctx, pointer.GetString(agent.ServiceID)).
 					Return(tc.dbVersion, nil).Once()
 				mockedCompatibilityService.On("CheckArtifactCompatibility", tc.artifact.ID, tc.dbVersion).Return(tc.expectedError).Once()
@@ -442,6 +455,7 @@ func TestRestoreBackup(t *testing.T) {
 		}
 
 		t.Run("artifact not ready", func(t *testing.T) {
+			t.Parallel()
 			artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 				Name:       "mongo-artifact-name-s3",
 				Vendor:     string(models.MongoDBServiceType),
@@ -459,6 +473,7 @@ func TestRestoreBackup(t *testing.T) {
 		})
 
 		t.Run("PITR not supported for local storages", func(t *testing.T) {
+			t.Parallel()
 			artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 				Name:       "mongo-artifact-name-local",
 				Vendor:     string(models.MongoDBServiceType),
@@ -480,6 +495,7 @@ func TestRestoreBackup(t *testing.T) {
 }
 
 func TestCheckArtifactModePreconditions(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 
@@ -507,6 +523,7 @@ func TestCheckArtifactModePreconditions(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MySQLServiceType, "test-mysql-restore-service")
 
 		for _, tc := range []struct {
@@ -562,6 +579,7 @@ func TestCheckArtifactModePreconditions(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				artifact, err := models.CreateArtifact(db.Querier, tc.artifactParams)
 				require.NoError(t, err)
 
@@ -576,6 +594,7 @@ func TestCheckArtifactModePreconditions(t *testing.T) {
 	})
 
 	t.Run("mongo", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MongoDBServiceType, "test-mongodb-restore-service")
 
 		rangeStart1 := uint32(1)
@@ -699,6 +718,7 @@ func TestCheckArtifactModePreconditions(t *testing.T) {
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				artifact, err := models.CreateArtifact(db.Querier, tc.artifactParams)
 				require.NoError(t, err)
 
@@ -720,6 +740,7 @@ func TestCheckArtifactModePreconditions(t *testing.T) {
 }
 
 func TestInTimeSpan(t *testing.T) {
+	t.Parallel()
 	now := time.Now()
 	for _, tc := range []struct {
 		name    string
@@ -758,6 +779,7 @@ func TestInTimeSpan(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			res := inTimeSpan(tc.start, tc.end, tc.value)
 			assert.Equal(t, tc.inRange, res)
 		})

--- a/managed/services/backup/compatibility_helpers_test.go
+++ b/managed/services/backup/compatibility_helpers_test.go
@@ -163,6 +163,7 @@ func TestMysqlAndXtrabackupCompatible(t *testing.T) {
 }
 
 func TestVendorToServiceType(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name      string
 		input     string
@@ -189,6 +190,7 @@ func TestVendorToServiceType(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			res, err := vendorToServiceType(test.input)
 
 			assert.Equal(t, test.output, res)
@@ -202,6 +204,7 @@ func TestVendorToServiceType(t *testing.T) {
 }
 
 func TestSoftwareVersionsToMap(t *testing.T) {
+	t.Parallel()
 	input := models.SoftwareVersions{
 		{Name: "mysqld", Version: "8.0.25"},
 		{Name: "xtrabackup", Version: "8.0.25"},
@@ -223,6 +226,7 @@ func TestSoftwareVersionsToMap(t *testing.T) {
 }
 
 func TestMySQLSoftwaresInstalledAndCompatible(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name  string
 		input map[models.SoftwareName]string
@@ -288,6 +292,7 @@ func TestMySQLSoftwaresInstalledAndCompatible(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			err := mySQLBackupSoftwareInstalledAndCompatible(test.input)
 			if test.err != nil {
 				assert.ErrorIs(t, err, test.err)
@@ -299,6 +304,7 @@ func TestMySQLSoftwaresInstalledAndCompatible(t *testing.T) {
 }
 
 func TestMongoDBBackupSoftwareInstalledAndCompatible(t *testing.T) {
+	t.Parallel()
 	for _, test := range []struct {
 		name  string
 		input map[models.SoftwareName]string
@@ -338,6 +344,7 @@ func TestMongoDBBackupSoftwareInstalledAndCompatible(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			err := mongoDBBackupSoftwareInstalledAndCompatible(test.input)
 			if test.err != nil {
 				assert.ErrorIs(t, err, test.err)

--- a/managed/services/backup/compatibility_service_test.go
+++ b/managed/services/backup/compatibility_service_test.go
@@ -379,6 +379,7 @@ func TestFindCompatibleServiceIDs(t *testing.T) {
 }
 
 func TestFindArtifactCompatibleServices(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	cSvc := NewCompatibilityService(db, nil)
@@ -465,6 +466,7 @@ func TestFindArtifactCompatibleServices(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			serviceModel, nodeModel, locationModel := setupSoftwareTest(t, db)
 			t.Cleanup(func() {
 				dropRecords(serviceModel, nodeModel, locationModel)
@@ -493,6 +495,7 @@ func TestFindArtifactCompatibleServices(t *testing.T) {
 	}
 
 	t.Run("find several services", func(t *testing.T) {
+		t.Parallel()
 		serviceModel, nodeModel, locationModel := setupSoftwareTest(t, db)
 		t.Cleanup(func() {
 			dropRecords(serviceModel, nodeModel, locationModel)

--- a/managed/services/backup/pitr_timerange_service_test.go
+++ b/managed/services/backup/pitr_timerange_service_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestPitrMetaFromFileName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		filename string
@@ -76,6 +77,7 @@ func TestPitrMetaFromFileName(t *testing.T) {
 	prefix := path.Join("test_artifact_name", pitrFSPrefix)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			chunk := pitrMetaFromFileName(prefix, tt.filename)
 			assert.Equal(t, tt.expected, chunk)
 		})
@@ -83,6 +85,7 @@ func TestPitrMetaFromFileName(t *testing.T) {
 }
 
 func TestGetPITROplogs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	location := &models.BackupLocation{
 		S3Config: &models.S3LocationConfig{
@@ -97,6 +100,7 @@ func TestGetPITROplogs(t *testing.T) {
 	mockedStorage := &MockStorage{}
 
 	t.Run("successful", func(t *testing.T) {
+		t.Parallel()
 		listedFiles := []minio.FileInfo{
 			{
 				Name: "rs0/20220829/20220829115611-1.20220829120544-10.oplog.s2",
@@ -117,6 +121,7 @@ func TestGetPITROplogs(t *testing.T) {
 	})
 
 	t.Run("fails on file list error", func(t *testing.T) {
+		t.Parallel()
 		mockedStorage.On("List", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("listing object error")).Once()
 
 		service := NewPBMPITRService()
@@ -126,6 +131,7 @@ func TestGetPITROplogs(t *testing.T) {
 	})
 
 	t.Run("skips artifacts with deletion markers", func(t *testing.T) {
+		t.Parallel()
 		listedFiles := []minio.FileInfo{
 			{
 				Name:           "rs0/20220829/20220829115611-1.20220829120544-10.oplog.s2",
@@ -146,6 +152,7 @@ func TestGetPITROplogs(t *testing.T) {
 }
 
 func TestPitrParseTs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		filename string
@@ -170,6 +177,7 @@ func TestPitrParseTs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ts := pitrParseTS(tt.filename)
 			assert.Equal(t, tt.expected, ts)
 		})
@@ -177,6 +185,7 @@ func TestPitrParseTs(t *testing.T) {
 }
 
 func TestPITRMergeTimelines(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name   string
 		tl     [][]Timeline
@@ -430,6 +439,7 @@ func TestPITRMergeTimelines(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			got := mergeTimelines(test.tl...)
 			if len(test.expect) != len(got) {
 				t.Fatalf("wrong timelines, exepct <%d> %v, got <%d> %v", len(test.expect), printTTL(test.expect...), len(got), printTTL(got...))
@@ -497,6 +507,7 @@ func printTTL(tlns ...Timeline) string {
 }
 
 func TestGetPITRFiles(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	S3Config := models.S3LocationConfig{
 		Endpoint:     "https://s3.us-west-2.amazonaws.com",
@@ -521,6 +532,7 @@ func TestGetPITRFiles(t *testing.T) {
 	}
 
 	t.Run("'until' not specified", func(t *testing.T) {
+		t.Parallel()
 		mockedStorage.On("List", ctx, S3Config.Endpoint, S3Config.AccessKey, S3Config.SecretKey, S3Config.BucketName, pitrFSPrefix, "").Return(listedFiles, nil).Twice()
 
 		PITRChunks, err := service.GetPITRFiles(ctx, mockedStorage, location, &models.Artifact{}, nil)
@@ -533,6 +545,7 @@ func TestGetPITRFiles(t *testing.T) {
 	})
 
 	t.Run("'until' specified", func(t *testing.T) {
+		t.Parallel()
 		mockedStorage.On("List", ctx, S3Config.Endpoint, S3Config.AccessKey, S3Config.SecretKey, S3Config.BucketName, pitrFSPrefix, "").Return(listedFiles, nil).Twice()
 
 		until, err := time.Parse("2006-01-02T15:04:05", "2023-04-11T11:25:14")

--- a/managed/services/backup/removal_service_test.go
+++ b/managed/services/backup/removal_service_test.go
@@ -41,6 +41,7 @@ const (
 )
 
 func TestDeleteArtifact(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -86,6 +87,7 @@ func TestDeleteArtifact(t *testing.T) {
 	mockedStorage := &MockStorage{}
 
 	t.Run("artifact not in final status", func(t *testing.T) {
+		t.Parallel()
 		artifact := createArtifact(models.PendingBackupStatus)
 		t.Cleanup(func() {
 			err := models.DeleteArtifact(db.Querier, artifact.ID)
@@ -102,6 +104,7 @@ func TestDeleteArtifact(t *testing.T) {
 	})
 
 	t.Run("failed to remove restore history sets artifact error status", func(t *testing.T) {
+		t.Parallel()
 		artifact := createArtifact(models.SuccessBackupStatus)
 		t.Cleanup(func() {
 			err := models.DeleteArtifact(db.Querier, artifact.ID)
@@ -138,6 +141,7 @@ func TestDeleteArtifact(t *testing.T) {
 	})
 
 	t.Run("error during removing files", func(t *testing.T) {
+		t.Parallel()
 		artifact := createArtifact(models.SuccessBackupStatus)
 		t.Cleanup(func() {
 			err := models.DeleteArtifact(db.Querier, artifact.ID)
@@ -162,6 +166,7 @@ func TestDeleteArtifact(t *testing.T) {
 	})
 
 	t.Run("successful delete snapshot", func(t *testing.T) {
+		t.Parallel()
 		artifact := createArtifact(models.SuccessBackupStatus)
 
 		mockedStorage.On("RemoveRecursive", mock.Anything, s3Config.Endpoint, s3Config.AccessKey, s3Config.SecretKey, s3Config.BucketName, artifact.Name+"/").
@@ -179,6 +184,7 @@ func TestDeleteArtifact(t *testing.T) {
 	})
 
 	t.Run("successful delete pitr", func(t *testing.T) {
+		t.Parallel()
 		agent, _ := setup(t, db.Querier, models.MongoDBServiceType, "test-service2")
 
 		artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
@@ -240,6 +246,7 @@ func TestDeleteArtifact(t *testing.T) {
 }
 
 func TestTrimPITRArtifact(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -306,6 +313,7 @@ func TestTrimPITRArtifact(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("artifact not in final status", func(t *testing.T) {
+		t.Parallel()
 		err := removalService.TrimPITRArtifact(mockedStorage, artifact.ID, 1)
 		require.ErrorIs(t, err, ErrIncorrectArtifactStatus)
 
@@ -319,6 +327,7 @@ func TestTrimPITRArtifact(t *testing.T) {
 	})
 
 	t.Run("error during removing files sets artifact status", func(t *testing.T) {
+		t.Parallel()
 		artifact, err = models.UpdateArtifact(db.Querier, artifact.ID, models.UpdateArtifactParams{Status: models.SuccessBackupStatus.Pointer()})
 		require.NoError(t, err)
 
@@ -338,6 +347,7 @@ func TestTrimPITRArtifact(t *testing.T) {
 	})
 
 	t.Run("successful", func(t *testing.T) {
+		t.Parallel()
 		chunksRet := []*oplogChunk{
 			{FName: "chunk1"},
 			{FName: "chunk2"},
@@ -379,6 +389,7 @@ func TestTrimPITRArtifact(t *testing.T) {
 }
 
 func TestLockArtifact(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -411,6 +422,7 @@ func TestLockArtifact(t *testing.T) {
 	removalService := NewRemovalService(db, nil)
 
 	t.Run("wrong locking status", func(t *testing.T) {
+		t.Parallel()
 		res, oldStatus, err := removalService.lockArtifact(artifact.ID, models.FailedToDeleteBackupStatus)
 		assert.Nil(t, res)
 		assert.Empty(t, oldStatus)
@@ -423,6 +435,7 @@ func TestLockArtifact(t *testing.T) {
 	})
 
 	t.Run("artifact not in final status", func(t *testing.T) {
+		t.Parallel()
 		res, oldStatus, err := removalService.lockArtifact(artifact.ID, models.DeletingBackupStatus)
 		assert.Nil(t, res)
 		assert.Empty(t, oldStatus)
@@ -435,6 +448,7 @@ func TestLockArtifact(t *testing.T) {
 	})
 
 	t.Run("restore in progress", func(t *testing.T) {
+		t.Parallel()
 		artifact, err = models.UpdateArtifact(db.Querier, artifact.ID, models.UpdateArtifactParams{Status: models.SuccessBackupStatus.Pointer()})
 		require.NoError(t, err)
 
@@ -462,6 +476,7 @@ func TestLockArtifact(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		res, oldStatus, err := removalService.lockArtifact(artifact.ID, models.DeletingBackupStatus)
 		require.NotNil(t, res)
 		assert.Equal(t, models.SuccessBackupStatus, oldStatus)
@@ -475,6 +490,7 @@ func TestLockArtifact(t *testing.T) {
 }
 
 func TestReleaseArtifact(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -507,6 +523,7 @@ func TestReleaseArtifact(t *testing.T) {
 	removalService := NewRemovalService(db, nil)
 
 	t.Run("wrong releasing status", func(t *testing.T) {
+		t.Parallel()
 		err := removalService.releaseArtifact(artifact.ID, models.PendingBackupStatus)
 		assert.ErrorIs(t, err, ErrIncorrectArtifactStatus)
 
@@ -517,6 +534,7 @@ func TestReleaseArtifact(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		err := removalService.releaseArtifact(artifact.ID, models.SuccessBackupStatus)
 		assert.NoError(t, err)
 

--- a/managed/services/backup/retention_service_test.go
+++ b/managed/services/backup/retention_service_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestEnsureRetention(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -60,6 +61,7 @@ func TestEnsureRetention(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("wrong task mode", func(t *testing.T) {
+		t.Parallel()
 		wrongModetask, err := models.CreateScheduledTask(db.Querier, models.CreateScheduledTaskParams{
 			CronExpression: "* * * * *",
 			Type:           models.ScheduledMongoDBBackupTask,
@@ -80,6 +82,7 @@ func TestEnsureRetention(t *testing.T) {
 	})
 
 	t.Run("successful snapshot", func(t *testing.T) {
+		t.Parallel()
 		task, err := models.CreateScheduledTask(db.Querier, models.CreateScheduledTaskParams{
 			CronExpression: "* * * * *",
 			Type:           models.ScheduledMongoDBBackupTask,
@@ -170,6 +173,7 @@ func TestEnsureRetention(t *testing.T) {
 	})
 
 	t.Run("pitr", func(t *testing.T) {
+		t.Parallel()
 		task, err := models.CreateScheduledTask(db.Querier, models.CreateScheduledTaskParams{
 			CronExpression: "* * * * *",
 			Type:           models.ScheduledMongoDBBackupTask,
@@ -189,6 +193,7 @@ func TestEnsureRetention(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("successful", func(t *testing.T) {
+			t.Parallel()
 			artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 				Name:       gofakeit.Name(),
 				Vendor:     "MongoDB",
@@ -223,6 +228,7 @@ func TestEnsureRetention(t *testing.T) {
 		})
 
 		t.Run("more than one pitr artifact", func(t *testing.T) {
+			t.Parallel()
 			_, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 				Name:       gofakeit.Name(),
 				Vendor:     "MongoDB",

--- a/managed/services/checks/checks_test.go
+++ b/managed/services/checks/checks_test.go
@@ -49,6 +49,7 @@ var (
 )
 
 func TestLoadBuiltinAdvisors(t *testing.T) {
+	t.Parallel()
 	setupClients(t)
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
@@ -60,6 +61,7 @@ func TestLoadBuiltinAdvisors(t *testing.T) {
 	s := New(db, nil, vmClient, clickhouseDB)
 
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		checks, err := s.GetAdvisors()
 		require.NoError(t, err)
 		assert.Empty(t, checks)
@@ -78,6 +80,7 @@ func TestLoadBuiltinAdvisors(t *testing.T) {
 	})
 
 	t.Run("advisors are loaded with telemetry disabled", func(t *testing.T) {
+		t.Parallel()
 		_, err := models.UpdateSettings(db.Querier, &models.ChangeSettingsParams{
 			EnableTelemetry: pointer.ToBool(false),
 		})
@@ -97,6 +100,7 @@ func TestLoadBuiltinAdvisors(t *testing.T) {
 }
 
 func TestUpdateAdvisorsList(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -105,6 +109,7 @@ func TestUpdateAdvisorsList(t *testing.T) {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
 
 	t.Run("collect custom checks", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 		s.customCheckFile = testChecksFile
 
@@ -134,7 +139,9 @@ func TestUpdateAdvisorsList(t *testing.T) {
 }
 
 func TestDisableChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		t.Cleanup(func() {
 			require.NoError(t, sqlDB.Close())
@@ -164,6 +171,7 @@ func TestDisableChecks(t *testing.T) {
 	})
 
 	t.Run("disable same check twice", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		t.Cleanup(func() {
 			require.NoError(t, sqlDB.Close())
@@ -196,6 +204,7 @@ func TestDisableChecks(t *testing.T) {
 	})
 
 	t.Run("disable unknown check", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		t.Cleanup(func() {
 			require.NoError(t, sqlDB.Close())
@@ -218,7 +227,9 @@ func TestDisableChecks(t *testing.T) {
 }
 
 func TestEnableChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		t.Cleanup(func() {
 			require.NoError(t, sqlDB.Close())
@@ -249,7 +260,9 @@ func TestEnableChecks(t *testing.T) {
 }
 
 func TestChangeInterval(t *testing.T) {
+	t.Parallel()
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		t.Cleanup(func() {
 			require.NoError(t, sqlDB.Close())
@@ -281,6 +294,7 @@ func TestChangeInterval(t *testing.T) {
 		}
 
 		t.Run("preserve intervals on restarts", func(t *testing.T) {
+			t.Parallel()
 			err = s.runChecksGroup(context.Background(), "")
 			require.NoError(t, err)
 
@@ -294,6 +308,7 @@ func TestChangeInterval(t *testing.T) {
 }
 
 func TestStartChecks(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -303,6 +318,7 @@ func TestStartChecks(t *testing.T) {
 	setupClients(t)
 
 	t.Run("unknown interval", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 		s.customCheckFile = testChecksFile
 
@@ -311,6 +327,7 @@ func TestStartChecks(t *testing.T) {
 	})
 
 	t.Run("advisors enabled", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 
 		s.customCheckFile = testChecksFile
@@ -323,6 +340,7 @@ func TestStartChecks(t *testing.T) {
 	})
 
 	t.Run("advisors disabled", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 
 		settings, err := models.GetSettings(db)
@@ -572,6 +590,7 @@ func TestFilterChecksByInterval(t *testing.T) {
 }
 
 func TestGetFailedChecks(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())
@@ -580,6 +599,7 @@ func TestGetFailedChecks(t *testing.T) {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
 
 	t.Run("no failed check for service", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 
 		results, err := s.GetChecksResults(context.Background(), "test_svc")
@@ -588,6 +608,7 @@ func TestGetFailedChecks(t *testing.T) {
 	})
 
 	t.Run("non empty failed checks", func(t *testing.T) {
+		t.Parallel()
 		checkResults := []services.CheckResult{
 			{
 				CheckName: "test_check",
@@ -640,6 +661,7 @@ func TestGetFailedChecks(t *testing.T) {
 	})
 
 	t.Run("non empty failed checks for specific service", func(t *testing.T) {
+		t.Parallel()
 		checkResults := []services.CheckResult{
 			{
 				CheckName: "test_check",
@@ -693,6 +715,7 @@ func TestGetFailedChecks(t *testing.T) {
 	})
 
 	t.Run("Advisors disabled", func(t *testing.T) {
+		t.Parallel()
 		s := New(db, nil, vmClient, clickhouseDB)
 
 		settings, err := models.GetSettings(db)

--- a/managed/services/checks/funcs_test.go
+++ b/managed/services/checks/funcs_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	t.Parallel()
 	script := strings.TrimSpace(`
 def check_context(rows, context):
     v = parse_version(rows[0].get("version"))

--- a/managed/services/checks/registry_test.go
+++ b/managed/services/checks/registry_test.go
@@ -27,7 +27,9 @@ import (
 )
 
 func TestRegistry(t *testing.T) {
+	t.Parallel()
 	t.Run("create and collect Alerts", func(t *testing.T) {
+		t.Parallel()
 		r := newRegistry()
 		checkResults := []services.CheckResult{
 			{
@@ -81,6 +83,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("delete check results by interval", func(t *testing.T) {
+		t.Parallel()
 		r := newRegistry()
 		checkResults := []services.CheckResult{
 			{
@@ -134,6 +137,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("delete check result by name", func(t *testing.T) {
+		t.Parallel()
 		r := newRegistry()
 		checkResults := []services.CheckResult{
 			{
@@ -187,6 +191,7 @@ func TestRegistry(t *testing.T) {
 	})
 
 	t.Run("empty interval recognized as standard", func(t *testing.T) {
+		t.Parallel()
 		r := newRegistry()
 		checkResults := []services.CheckResult{
 			{

--- a/managed/services/encryption/encryption_rotation_test.go
+++ b/managed/services/encryption/encryption_rotation_test.go
@@ -39,6 +39,7 @@ const (
 )
 
 func TestEncryptionRotation(t *testing.T) {
+	t.Parallel()
 	db := testdb.Open(t, models.SkipFixtures, nil)
 	defer db.Close() //nolint:errcheck
 

--- a/managed/services/grafana/auth_server_test.go
+++ b/managed/services/grafana/auth_server_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 func TestNextPrefix(t *testing.T) {
+	t.Parallel()
 	for _, paths := range [][]string{
 		{"/inventory.Nodes/ListNodes", "/inventory.Nodes/", "/inventory.Nodes", "/inventory.", "/inventory", "/", "/"},
 		{"/v1/inventory/Nodes/List", "/v1/inventory/Nodes/", "/v1/inventory/Nodes", "/v1/inventory/", "/v1/inventory", "/v1/", "/v1", "/", "/"},
@@ -53,6 +54,7 @@ func TestNextPrefix(t *testing.T) {
 		{"/v1/server/AWSInstanceCheck/..%2f..%2finventory/Services/List'"},
 	} {
 		t.Run(paths[0], func(t *testing.T) {
+			t.Parallel()
 			for i, path := range paths[:len(paths)-1] {
 				tests.AddToFuzzCorpus(t, "", []byte(path))
 
@@ -246,6 +248,7 @@ func TestServerClientConnection(t *testing.T) {
 }
 
 func TestAuthServerAddVMGatewayToken(t *testing.T) {
+	t.Parallel()
 	ctx := logger.Set(context.Background(), t.Name())
 	uuid.SetRand(&tests.IDReader{})
 
@@ -303,6 +306,7 @@ func TestAuthServerAddVMGatewayToken(t *testing.T) {
 	}
 
 	t.Run("shall properly evaluate adding filters", func(t *testing.T) {
+		t.Parallel()
 		for uri, shallAdd := range map[string]bool{
 			"/":                          false,
 			"/dummy":                     false,
@@ -339,8 +343,8 @@ func TestAuthServerAddVMGatewayToken(t *testing.T) {
 		}
 	})
 
-	//nolint:paralleltest
 	t.Run("shall be a valid JSON array", func(t *testing.T) {
+		t.Parallel()
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/prometheus/api/v1/", nil)
 		require.NoError(t, err)
@@ -362,8 +366,8 @@ func TestAuthServerAddVMGatewayToken(t *testing.T) {
 		require.Equal(t, "filter B", parsed[1])
 	})
 
-	//nolint:paralleltest
 	t.Run("shall not add any filters if at least one role has full access", func(t *testing.T) {
+		t.Parallel()
 		rw := httptest.NewRecorder()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/prometheus/api/v1/", nil)
 		require.NoError(t, err)

--- a/managed/services/grafana/client_test.go
+++ b/managed/services/grafana/client_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	t.Parallel()
 	logrus.SetLevel(logrus.TraceLevel)
 	l := logrus.WithField("test", t.Name())
 
@@ -44,7 +45,9 @@ func TestClient(t *testing.T) {
 	authHeaders := req.Header
 
 	t.Run("getRole", func(t *testing.T) {
+		t.Parallel()
 		t.Run("GrafanaAdmin", func(t *testing.T) {
+			t.Parallel()
 			u, err := c.getAuthUser(ctx, authHeaders, l)
 			role := u.role
 			assert.NoError(t, err)
@@ -53,8 +56,10 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("NoAnonymousAccess", func(t *testing.T) {
+			t.Parallel(
 			// See [auth.anonymous] in grafana.ini.
 			// Even if anonymous access is enabled, returned role is None, not org_role.
+			)
 
 			u, err := c.getAuthUser(ctx, nil, l)
 			role := u.role
@@ -72,7 +77,9 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("NewUserViewerByDefault", func(t *testing.T) {
+			t.Parallel(
 			// See [users] in grafana.ini.
+			)
 
 			login := fmt.Sprintf("%s-%d", none, time.Now().Nanosecond())
 			userID, err := c.testCreateUser(ctx, login, none, authHeaders)
@@ -99,6 +106,7 @@ func TestClient(t *testing.T) {
 
 		for _, role := range []role{viewer, editor, admin} {
 			t.Run(fmt.Sprintf("Basic auth %s", role.String()), func(t *testing.T) {
+				t.Parallel()
 				login := fmt.Sprintf("basic-%s-%d", role, time.Now().Nanosecond())
 				userID, err := c.testCreateUser(ctx, login, role, authHeaders)
 				require.NoError(t, err)
@@ -123,6 +131,7 @@ func TestClient(t *testing.T) {
 			})
 
 			t.Run(fmt.Sprintf("Service token auth %s", role.String()), func(t *testing.T) {
+				t.Parallel()
 				name, err := stringsgen.GenerateRandomString(256)
 				require.NoError(t, err)
 				nodeName := fmt.Sprintf("%s-%s", name, role)
@@ -154,12 +163,14 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("CreateAnnotation", func(t *testing.T) {
+		t.Parallel()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/dummy", nil)
 		require.NoError(t, err)
 		req.SetBasicAuth("admin", "admin")
 		authorization := req.Header.Get("Authorization")
 
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			from := time.Now()
 			msg, err := c.CreateAnnotation(ctx, []string{"tag1", "tag2"}, from, "Normal", authorization)
 			require.NoError(t, err)
@@ -178,11 +189,13 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("Empty", func(t *testing.T) {
+			t.Parallel()
 			_, err := c.CreateAnnotation(ctx, nil, time.Now(), "", authorization)
 			require.Error(t, err)
 		})
 
 		t.Run("No tags", func(t *testing.T) {
+			t.Parallel()
 			from := time.Now()
 			msg, err := c.CreateAnnotation(ctx, nil, from, "No tags", authorization)
 			require.NoError(t, err)
@@ -201,6 +214,7 @@ func TestClient(t *testing.T) {
 		})
 
 		t.Run("Auth error", func(t *testing.T) {
+			t.Parallel()
 			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/dummy", nil)
 			req.SetBasicAuth("nouser", "wrongpassword")
 			authorization := req.Header.Get("Authorization")
@@ -211,6 +225,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("IsReady", func(t *testing.T) {
+		t.Parallel()
 		err := c.IsReady(ctx)
 		require.NoError(t, err)
 	})

--- a/managed/services/inventory/agents_test.go
+++ b/managed/services/inventory/agents_test.go
@@ -37,7 +37,9 @@ import (
 )
 
 func TestAgents(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -56,6 +58,7 @@ func TestAgents(t *testing.T) {
 		)
 
 		t.Run("AddPMMAgent", func(t *testing.T) {
+			t.Parallel()
 			as.r.(*mockAgentsRegistry).On("IsConnected", models.PMMServerAgentID).Return(true)
 			actualAgents, err := as.List(ctx, models.AgentFilters{})
 			require.NoError(t, err)
@@ -88,6 +91,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddNodeExporter", func(t *testing.T) {
+			t.Parallel()
 			actualNodeExporter, err := as.AddNodeExporter(ctx, &inventoryv1.AddNodeExporterParams{
 				PmmAgentId:   pmmAgentID,
 				CustomLabels: map[string]string{"cluster": "test-cluster", "environment": "test-env"},
@@ -106,6 +110,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("ChangeNodeExporterAndRemoveCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			actualNodeExporter, err := as.ChangeNodeExporter(
 				ctx,
 				"00000000-0000-4000-8000-000000000006",
@@ -136,6 +141,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddMySQLExporter", func(t *testing.T) {
+			t.Parallel()
 			var err error
 			ss.vc.(*mockVersionCache).On("RequestSoftwareVersionsUpdate").Once()
 			ms, err = ss.AddMySQL(ctx, &models.AddDBMSServiceParams{
@@ -167,6 +173,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddMongoDBExporter", func(t *testing.T) {
+			t.Parallel()
 			ms, err := ss.AddMongoDB(ctx, &models.AddDBMSServiceParams{
 				ServiceName: "test-mongo",
 				NodeID:      models.PMMServerNodeID,
@@ -198,6 +205,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddQANMySQLSlowlogAgent", func(t *testing.T) {
+			t.Parallel()
 			actualAgent, err := as.AddQANMySQLSlowlogAgent(ctx, &inventoryv1.AddQANMySQLSlowlogAgentParams{
 				PmmAgentId: pmmAgentID,
 				ServiceId:  ms.ServiceId,
@@ -219,6 +227,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddPostgreSQLExporter", func(t *testing.T) {
+			t.Parallel()
 			var err error
 			ps, err = ss.AddPostgreSQL(ctx, &models.AddDBMSServiceParams{
 				ServiceName: "test-postgres",
@@ -249,6 +258,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddExternalExporter", func(t *testing.T) {
+			t.Parallel()
 			actualAgent, err := as.AddExternalExporter(ctx, &inventoryv1.AddExternalExporterParams{
 				RunsOnNodeId: models.PMMServerNodeID,
 				ServiceId:    ps.ServiceId,
@@ -269,6 +279,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("AddValkeyExporter", func(t *testing.T) {
+			t.Parallel()
 			var err error
 			valkey, err = ss.AddValkey(ctx, &models.AddDBMSServiceParams{
 				ServiceName: "test-valkey",
@@ -301,6 +312,7 @@ func TestAgents(t *testing.T) {
 
 		var actualAgents []inventoryv1.Agent
 		t.Run("ListAllAgents", func(t *testing.T) {
+			t.Parallel()
 			actualAgents, err := as.List(ctx, models.AgentFilters{})
 			require.NoError(t, err)
 			for i, a := range actualAgents {
@@ -319,6 +331,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("FilterByServiceID", func(t *testing.T) {
+			t.Parallel()
 			actualAgents, err := as.List(ctx, models.AgentFilters{ServiceID: ms.ServiceId})
 			require.NoError(t, err)
 			require.Len(t, actualAgents, 2)
@@ -327,6 +340,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("FilterByPMMAgent", func(t *testing.T) {
+			t.Parallel()
 			actualAgents, err := as.List(ctx, models.AgentFilters{PMMAgentID: pmmAgentID})
 			require.NoError(t, err)
 			require.Len(t, actualAgents, 6)
@@ -338,6 +352,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("FilterByNode", func(t *testing.T) {
+			t.Parallel()
 			actualAgents, err := as.List(ctx, models.AgentFilters{NodeID: models.PMMServerNodeID})
 			require.NoError(t, err)
 			require.Len(t, actualAgents, 2)
@@ -345,6 +360,7 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("FilterByAgentType", func(t *testing.T) {
+			t.Parallel()
 			agentType := models.ExternalExporterType
 			actualAgents, err := as.List(ctx, models.AgentFilters{AgentType: &agentType})
 			require.NoError(t, err)
@@ -353,12 +369,14 @@ func TestAgents(t *testing.T) {
 		})
 
 		t.Run("FilterByMultipleFields", func(t *testing.T) {
+			t.Parallel()
 			actualAgents, err := as.List(ctx, models.AgentFilters{PMMAgentID: pmmAgentID, NodeID: models.PMMServerNodeID})
 			tests.AssertGRPCError(t, status.New(codes.InvalidArgument, `expected at most one param: pmm_agent_id, node_id or service_id`), err)
 			assert.Nil(t, actualAgents)
 		})
 
 		t.Run("RemovePMMAgent", func(t *testing.T) {
+			t.Parallel()
 			as.r.(*mockAgentsRegistry).On("Kick", ctx, "00000000-0000-4000-8000-000000000005").Return(true)
 			err := as.Remove(ctx, "00000000-0000-4000-8000-000000000005", true)
 			require.NoError(t, err)
@@ -373,6 +391,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("GetEmptyID", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -382,6 +401,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("AddPMMAgent", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -411,6 +431,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("AddPmmAgentNotFound", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -421,6 +442,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("AddRDSExporter", func(t *testing.T) {
+		t.Parallel()
 		_, as, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -466,6 +488,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("AddExternalExporter", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -503,6 +526,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("AddServiceNotFound", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -520,6 +544,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("RemoveNotFound", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -528,6 +553,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsMongodbExporter", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -583,6 +609,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsNodeExporter", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -620,6 +647,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsPostgresSQLExporter", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -676,6 +704,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsMySQLExporter", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -734,6 +763,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsRdsExporter", func(t *testing.T) {
+		t.Parallel()
 		_, as, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -781,6 +811,7 @@ func TestAgents(t *testing.T) {
 	})
 
 	t.Run("PushMetricsExternalExporter", func(t *testing.T) {
+		t.Parallel()
 		ss, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 		as.state.(*mockAgentsStateUpdater).On("RequestStateUpdate", ctx, "pmm-server")
@@ -820,7 +851,9 @@ func TestAgents(t *testing.T) {
 }
 
 func TestChangeQANPostgreSQLPgStatementsAgentWithEnvVar(t *testing.T) {
+	t.Parallel()
 	t.Run("FailWhenEnvVarSet", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -838,6 +871,7 @@ func TestChangeQANPostgreSQLPgStatementsAgentWithEnvVar(t *testing.T) {
 	})
 
 	t.Run("SucceedWhenEnvVarNotSet", func(t *testing.T) {
+		t.Parallel()
 		_, as, _, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/inventory/inventory_metrics_test.go
+++ b/managed/services/inventory/inventory_metrics_test.go
@@ -33,7 +33,9 @@ import (
 )
 
 func TestNewInventoryMetricsCollector(t *testing.T) {
+	t.Parallel()
 	t.Run("Metrics returns inventory metrics", func(t *testing.T) {
+		t.Parallel()
 		client := http.Client{}
 
 		ctx, cancelCtx := context.WithTimeout(context.Background(), 3*time.Second)
@@ -56,6 +58,7 @@ func TestNewInventoryMetricsCollector(t *testing.T) {
 	})
 
 	t.Run("Collector", func(t *testing.T) {
+		t.Parallel()
 		metricsMock := &mockInventoryMetrics{}
 		metricsMock.Test(t)
 

--- a/managed/services/inventory/nodes_test.go
+++ b/managed/services/inventory/nodes_test.go
@@ -30,7 +30,9 @@ import (
 )
 
 func TestNodes(t *testing.T) {
+	t.Parallel()
 	t.Run("Basic", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -69,6 +71,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("GetEmptyID", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -78,6 +81,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("AddNameEmpty", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -90,6 +94,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("AddNameNotUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -114,6 +119,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("AddHostnameNotUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -139,6 +145,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("AddRemoteRDSNodeNotUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -151,6 +158,7 @@ func TestNodes(t *testing.T) {
 	})
 
 	t.Run("RemoveNotFound", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -160,7 +168,9 @@ func TestNodes(t *testing.T) {
 }
 
 func TestAddNode(t *testing.T) {
+	t.Parallel()
 	t.Run("BasicGeneric", func(t *testing.T) {
+		t.Parallel()
 		const nodeID = "00000000-0000-4000-8000-000000000005"
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
@@ -201,6 +211,7 @@ func TestAddNode(t *testing.T) {
 	})
 
 	t.Run("AddAllNodeTypes", func(t *testing.T) {
+		t.Parallel()
 		const (
 			nodeID1 = "00000000-0000-4000-8000-000000000005"
 			nodeID2 = "00000000-0000-4000-8000-000000000006"
@@ -334,6 +345,7 @@ func TestAddNode(t *testing.T) {
 	})
 
 	t.Run("AddRemoteRDSNodeNonUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -354,6 +366,7 @@ func TestAddNode(t *testing.T) {
 	})
 
 	t.Run("AddHostnameNotUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -373,6 +386,7 @@ func TestAddNode(t *testing.T) {
 	})
 
 	t.Run("AddNameEmpty", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -387,6 +401,7 @@ func TestAddNode(t *testing.T) {
 	})
 
 	t.Run("AddNameNotUnique", func(t *testing.T) {
+		t.Parallel()
 		_, _, ns, teardown, ctx, _ := setup(t)
 		t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/inventory/services_test.go
+++ b/managed/services/inventory/services_test.go
@@ -96,7 +96,9 @@ func setup(t *testing.T) (*ServicesService, *AgentsService, *NodesService, func(
 }
 
 func TestServices(t *testing.T) {
+	t.Parallel()
 	t.Run("BasicMySQL", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -138,6 +140,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("RDSServiceRemoving", func(t *testing.T) {
+		t.Parallel()
 		ss, as, ns, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -200,6 +203,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("AzureServiceRemoving", func(t *testing.T) {
+		t.Parallel()
 		ss, as, ns, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -261,6 +265,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicMySQLWithSocket", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -300,6 +305,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("MySQLSocketAddressConflict", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -317,6 +323,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("MySQLSocketAndPort", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -334,6 +341,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicMongoDB", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -375,7 +383,9 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("PostgreSQL", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -417,6 +427,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocket", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -456,6 +467,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocketAddressConflict", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -475,6 +487,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocketAndPort", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -494,7 +507,9 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("Valkey", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -535,6 +550,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocket", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -573,6 +589,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocketAddressConflict", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -592,6 +609,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("WithSocketAndPort", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -611,6 +629,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicProxySQL", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -651,6 +670,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicProxySQLWithSocket", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -689,6 +709,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("ProxySQLSocketAddressConflict", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -706,6 +727,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("ProxySQLSocketAndPort", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -723,6 +745,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicHAProxyService", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -759,6 +782,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("BasicExternalService", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -797,6 +821,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("GetEmptyID", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -806,6 +831,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("AddNameNotUnique", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -828,6 +854,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("AddNodeNotFound", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -841,6 +868,7 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("RemoveNotFound", func(t *testing.T) {
+		t.Parallel()
 		ss, _, _, teardown, ctx, _ := setup(t)
 		defer teardown(t)
 
@@ -849,7 +877,9 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("MongoDB", func(t *testing.T) {
+		t.Parallel()
 		t.Run("WithSocket", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -888,6 +918,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("SocketAddressConflict", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -905,6 +936,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("SocketAndPort", func(t *testing.T) {
+			t.Parallel()
 			ss, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -923,7 +955,9 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("AddCustomLabels", func(t *testing.T) {
+		t.Parallel()
 		t.Run("No Service ID", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("TODO: fix")
 			s, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
@@ -934,6 +968,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("Add a label", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("FIXME: fix")
 			s, _, _, teardown, ctx, vmdb := setup(t)
 			defer teardown(t)
@@ -975,6 +1010,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("Replace a label", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("FIXME: fix")
 			s, _, _, teardown, ctx, vmdb := setup(t)
 			defer teardown(t)
@@ -1020,7 +1056,9 @@ func TestServices(t *testing.T) {
 	})
 
 	t.Run("RemoveCustomLabels", func(t *testing.T) {
+		t.Parallel()
 		t.Run("No Service ID", func(t *testing.T) {
+			t.Parallel()
 			s, _, _, teardown, ctx, _ := setup(t)
 			defer teardown(t)
 
@@ -1030,6 +1068,7 @@ func TestServices(t *testing.T) {
 		})
 
 		t.Run("Remove a label", func(t *testing.T) {
+			t.Parallel()
 			t.Skip("FIXME: fix")
 			s, _, _, teardown, ctx, vmdb := setup(t)
 			defer teardown(t)

--- a/managed/services/management/accesscontrol_test.go
+++ b/managed/services/management/accesscontrol_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/percona/pmm/utils/logger"
 )
 
-//nolint:paralleltest
 func TestAccessControlService(t *testing.T) {
+	t.Parallel()
 	ctx := logger.Set(context.Background(), t.Name())
 	uuid.SetRand(&tests.IDReader{})
 
@@ -60,9 +60,10 @@ func TestAccessControlService(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	//nolint:paralleltest
 	t.Run("Create role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			res, err := s.CreateRole(ctx, &rolev1beta1.CreateRoleRequest{
@@ -74,9 +75,10 @@ func TestAccessControlService(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("Update role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			_, roleID := createDummyRoles(ctx, t, s)
@@ -100,6 +102,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("Shall return not found", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			createDummyRoles(ctx, t, s)
@@ -111,9 +114,10 @@ func TestAccessControlService(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("Delete role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			_, roleID := createDummyRoles(ctx, t, s)
@@ -128,6 +132,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("Shall return not found", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			createDummyRoles(ctx, t, s)
@@ -137,9 +142,10 @@ func TestAccessControlService(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("Get role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			_, roleID := createDummyRoles(ctx, t, s)
@@ -150,6 +156,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("Shall return not found", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			createDummyRoles(ctx, t, s)
@@ -159,9 +166,10 @@ func TestAccessControlService(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("List roles", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			createDummyRoles(ctx, t, s)
@@ -172,9 +180,10 @@ func TestAccessControlService(t *testing.T) {
 		})
 	})
 
-	//nolint:paralleltest
 	t.Run("Assign role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall assign role to the correct user", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			roleIDA, roleIDB := createDummyRoles(ctx, t, s)
@@ -198,6 +207,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("Shall assign multiple roles", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			roleIDA, roleIDB := createDummyRoles(ctx, t, s)
@@ -216,6 +226,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("Shall return not found for non-existent role", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 
 			createDummyRoles(ctx, t, s)
@@ -229,7 +240,9 @@ func TestAccessControlService(t *testing.T) {
 	})
 
 	t.Run("Set default role", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Shall work", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 			settings, err := models.GetSettings(db)
 			require.NoError(t, err)
@@ -248,6 +261,7 @@ func TestAccessControlService(t *testing.T) {
 		})
 
 		t.Run("shall return error on non existent role", func(t *testing.T) {
+			t.Parallel()
 			defer teardown(t)
 			_, err := s.SetDefaultRole(ctx, &rolev1beta1.SetDefaultRoleRequest{
 				RoleId: 1337,

--- a/managed/services/management/agent_test.go
+++ b/managed/services/management/agent_test.go
@@ -102,7 +102,9 @@ func setup(t *testing.T) (context.Context, *ManagementService, func(t *testing.T
 }
 
 func TestAgentService(t *testing.T) {
+	t.Parallel()
 	t.Run("Should return a validation error when no params passed", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -112,6 +114,7 @@ func TestAgentService(t *testing.T) {
 	})
 
 	t.Run("Should return a validation error when both params passed", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -121,12 +124,14 @@ func TestAgentService(t *testing.T) {
 	})
 
 	t.Run("ListAgents", func(t *testing.T) {
+		t.Parallel()
 		const (
 			pgExporterID      = "00000000-0000-4000-8000-000000000003"
 			pgStatStatementID = "00000000-0000-4000-8000-000000000004"
 		)
 
 		t.Run("should output a list of agents provisioned by default", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -194,6 +199,7 @@ func TestAgentService(t *testing.T) {
 		})
 
 		t.Run("should output a list of agents provisioned for RDS service", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -244,6 +250,7 @@ func TestAgentService(t *testing.T) {
 		})
 
 		t.Run("should output a list of agents provisioned for Azure service", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -297,7 +304,9 @@ func TestAgentService(t *testing.T) {
 }
 
 func TestListAgentVersions(t *testing.T) {
+	t.Parallel()
 	t.Run("Should suggest critical severity if major versions differ", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -320,6 +329,7 @@ func TestListAgentVersions(t *testing.T) {
 	})
 
 	t.Run("Should suggest an update if minor versions differ", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -342,6 +352,7 @@ func TestListAgentVersions(t *testing.T) {
 	})
 
 	t.Run("Should suggest an update if patch versions differ", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -364,6 +375,7 @@ func TestListAgentVersions(t *testing.T) {
 	})
 
 	t.Run("Should suggest no update if versions are the same", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -386,6 +398,7 @@ func TestListAgentVersions(t *testing.T) {
 	})
 
 	t.Run("Should say unsupported if client version is newer", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/management/annotation_test.go
+++ b/managed/services/management/annotation_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 func TestAnnotations(t *testing.T) {
+	t.Parallel()
 	authorization := "admin:admin"
 
 	setup := func(t *testing.T) (context.Context, *ManagementService, *reform.DB, *mockGrafanaClient, func(t *testing.T)) {
@@ -89,6 +90,7 @@ func TestAnnotations(t *testing.T) {
 	}
 
 	t.Run("Non-existing service", func(t *testing.T) {
+		t.Parallel()
 		ctx, ss, _, _, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -100,6 +102,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Non-existing node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, _, _, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -111,6 +114,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Existing service", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, grafanaClient, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -133,6 +137,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Existing node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, grafanaClient, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -152,6 +157,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Non-existing service and non-existing node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, _, _, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -164,6 +170,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Empty service and empty node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, _, grafanaClient, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -180,6 +187,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Existing service and non-existing node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, _, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -200,6 +208,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("Existing service and existing node", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, grafanaClient, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -228,6 +237,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("More services", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, grafanaClient, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 
@@ -258,6 +268,7 @@ func TestAnnotations(t *testing.T) {
 	})
 
 	t.Run("More services, but one non-existing", func(t *testing.T) {
+		t.Parallel()
 		ctx, s, db, _, teardown := setup(t)
 		t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/management/backup/backup_service_test.go
+++ b/managed/services/management/backup/backup_service_test.go
@@ -79,7 +79,9 @@ func setup(t *testing.T, q *reform.Querier, serviceType models.ServiceType, serv
 }
 
 func TestStartBackup(t *testing.T) {
+	t.Parallel()
 	t.Run("mysql", func(t *testing.T) {
+		t.Parallel()
 		backupService := &mockBackupService{}
 		mockedPbmPITRService := &mockPbmPITRService{}
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
@@ -109,6 +111,7 @@ func TestStartBackup(t *testing.T) {
 			},
 		} {
 			t.Run(tc.testName, func(t *testing.T) {
+				t.Parallel()
 				backupError := fmt.Errorf("error: %w", tc.backupError)
 				backupService.On("PerformBackup", mock.Anything, mock.Anything).
 					Return("", backupError).Once()
@@ -136,6 +139,7 @@ func TestStartBackup(t *testing.T) {
 	})
 
 	t.Run("mongodb", func(t *testing.T) {
+		t.Parallel()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 		db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 		agent := setup(t, db.Querier, models.MongoDBServiceType, t.Name(), "cluster")
@@ -156,6 +160,7 @@ func TestStartBackup(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("starting mongodb physical snapshot is successful", func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			backupService := &mockBackupService{}
 			mockedPbmPITRService := &mockPbmPITRService{}
@@ -174,6 +179,7 @@ func TestStartBackup(t *testing.T) {
 		})
 
 		t.Run("check folder and artifact name", func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			backupService := &mockBackupService{}
 			mockedPbmPITRService := &mockPbmPITRService{}
@@ -226,6 +232,7 @@ func TestStartBackup(t *testing.T) {
 
 			for _, test := range tc {
 				t.Run(test.TestName, func(t *testing.T) {
+					t.Parallel()
 					if test.ErrString == "" {
 						backupService.On("PerformBackup", mock.Anything, mock.Anything).Return("", nil).Once()
 					}
@@ -251,6 +258,7 @@ func TestStartBackup(t *testing.T) {
 }
 
 func TestScheduledBackups(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -273,6 +281,7 @@ func TestScheduledBackups(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("mysql", func(t *testing.T) {
+		t.Parallel()
 		backupService := &mockBackupService{}
 		mockedPbmPITRService := &mockPbmPITRService{}
 		schedulerService := scheduler.New(db, backupService)
@@ -281,6 +290,7 @@ func TestScheduledBackups(t *testing.T) {
 		agent := setup(t, db.Querier, models.MySQLServiceType, t.Name(), "cluster")
 
 		t.Run("schedule/change", func(t *testing.T) {
+			t.Parallel()
 			req := &backupv1.ScheduleBackupRequest{
 				ServiceId:      pointer.GetString(agent.ServiceID),
 				LocationId:     locationRes.ID,
@@ -336,6 +346,7 @@ func TestScheduledBackups(t *testing.T) {
 		})
 
 		t.Run("list", func(t *testing.T) {
+			t.Parallel()
 			res, err := backupSvc.ListScheduledBackups(ctx, &backupv1.ListScheduledBackupsRequest{})
 
 			assert.NoError(t, err)
@@ -343,6 +354,7 @@ func TestScheduledBackups(t *testing.T) {
 		})
 
 		t.Run("remove", func(t *testing.T) {
+			t.Parallel()
 			task, err := models.CreateScheduledTask(db.Querier, models.CreateScheduledTaskParams{
 				CronExpression: "* * * * *",
 				Type:           models.ScheduledMySQLBackupTask,
@@ -383,9 +395,11 @@ func TestScheduledBackups(t *testing.T) {
 	})
 
 	t.Run("mongo", func(t *testing.T) {
+		t.Parallel()
 		agent := setup(t, db.Querier, models.MongoDBServiceType, t.Name(), "cluster")
 
 		t.Run("PITR unsupported for physical model", func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			schedulerService := &mockScheduleService{}
 			mockedPbmPITRService := &mockPbmPITRService{}
@@ -407,6 +421,7 @@ func TestScheduledBackups(t *testing.T) {
 		})
 
 		t.Run("normal", func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			schedulerService := &mockScheduleService{}
 			mockedPbmPITRService := &mockPbmPITRService{}
@@ -428,6 +443,7 @@ func TestScheduledBackups(t *testing.T) {
 }
 
 func TestGetLogs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -468,6 +484,7 @@ func TestGetLogs(t *testing.T) {
 	}
 
 	t.Run("get backup logs", func(t *testing.T) {
+		t.Parallel()
 		artifactID := uuid.New().String()
 		job, err := models.CreateJob(db.Querier, models.CreateJobParams{
 			PMMAgentID: "agent",
@@ -506,6 +523,7 @@ func TestGetLogs(t *testing.T) {
 }
 
 func TestListPitrTimeranges(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
@@ -550,6 +568,7 @@ func TestListPitrTimeranges(t *testing.T) {
 	locationID = loc.ID
 
 	t.Run("successfully lists PITR time ranges", func(t *testing.T) {
+		t.Parallel()
 		artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 			Name:       "test_artifact",
 			Vendor:     "test_vendor",
@@ -571,6 +590,7 @@ func TestListPitrTimeranges(t *testing.T) {
 	})
 
 	t.Run("fails for invalid artifact ID", func(t *testing.T) {
+		t.Parallel()
 		unknownID := uuid.New().String()
 		response, err := backupSvc.ListPitrTimeranges(ctx, &backupv1.ListPitrTimerangesRequest{
 			ArtifactId: unknownID,
@@ -580,6 +600,7 @@ func TestListPitrTimeranges(t *testing.T) {
 	})
 
 	t.Run("fails for non-PITR artifact", func(t *testing.T) {
+		t.Parallel()
 		artifact, err := models.CreateArtifact(db.Querier, models.CreateArtifactParams{
 			Name:       "test_non_pitr_artifact",
 			Vendor:     "test_vendor",
@@ -602,6 +623,7 @@ func TestListPitrTimeranges(t *testing.T) {
 }
 
 func TestArtifactMetadataListToProto(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())

--- a/managed/services/management/backup/locations_service_test.go
+++ b/managed/services/management/backup/locations_service_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestCreateBackupLocation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -45,6 +46,7 @@ func TestCreateBackupLocation(t *testing.T) {
 		mock.Anything).Return("us-east-2", nil)
 	svc := NewLocationsService(db, mockedS3)
 	t.Run("add server config", func(t *testing.T) {
+		t.Parallel()
 		loc, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			FilesystemConfig: &backuppb.FilesystemLocationConfig{
@@ -57,6 +59,7 @@ func TestCreateBackupLocation(t *testing.T) {
 	})
 
 	t.Run("add client config", func(t *testing.T) {
+		t.Parallel()
 		loc, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			FilesystemConfig: &backuppb.FilesystemLocationConfig{
@@ -69,6 +72,7 @@ func TestCreateBackupLocation(t *testing.T) {
 	})
 
 	t.Run("add awsS3", func(t *testing.T) {
+		t.Parallel()
 		loc, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			S3Config: &backuppb.S3LocationConfig{
@@ -84,6 +88,7 @@ func TestCreateBackupLocation(t *testing.T) {
 	})
 
 	t.Run("multiple configs", func(t *testing.T) {
+		t.Parallel()
 		_, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			FilesystemConfig: &backuppb.FilesystemLocationConfig{
@@ -101,6 +106,7 @@ func TestCreateBackupLocation(t *testing.T) {
 }
 
 func TestListBackupLocations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -131,6 +137,7 @@ func TestListBackupLocations(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("list", func(t *testing.T) {
+		t.Parallel()
 		res, err := svc.ListLocations(ctx, &backuppb.ListLocationsRequest{})
 		require.NoError(t, err)
 
@@ -172,6 +179,7 @@ func TestListBackupLocations(t *testing.T) {
 }
 
 func TestChangeBackupLocation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -181,6 +189,7 @@ func TestChangeBackupLocation(t *testing.T) {
 		mock.Anything).Return("us-east-2", nil)
 	svc := NewLocationsService(db, mockedS3)
 	t.Run("update existing config", func(t *testing.T) {
+		t.Parallel()
 		loc, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			FilesystemConfig: &backuppb.FilesystemLocationConfig{
@@ -217,6 +226,7 @@ func TestChangeBackupLocation(t *testing.T) {
 	})
 
 	t.Run("update only name", func(t *testing.T) {
+		t.Parallel()
 		addReq := &backuppb.AddLocationRequest{
 			Name: gofakeit.Name(),
 			FilesystemConfig: &backuppb.FilesystemLocationConfig{
@@ -242,6 +252,7 @@ func TestChangeBackupLocation(t *testing.T) {
 	})
 
 	t.Run("update to existing name", func(t *testing.T) {
+		t.Parallel()
 		name := gofakeit.Name()
 		_, err := svc.AddLocation(ctx, &backuppb.AddLocationRequest{
 			Name: name,
@@ -272,6 +283,7 @@ func TestChangeBackupLocation(t *testing.T) {
 }
 
 func TestRemoveBackupLocation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -327,6 +339,7 @@ func TestRemoveBackupLocation(t *testing.T) {
 }
 
 func TestVerifyBackupLocationValidation(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
@@ -444,6 +457,7 @@ func TestVerifyBackupLocationValidation(t *testing.T) {
 
 	for _, test := range tableTests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := svc.TestLocationConfig(ctx, test.req)
 			if test.errorMsg != "" {
 				assert.EqualError(t, err, test.errorMsg)

--- a/managed/services/management/backup/restore_service_test.go
+++ b/managed/services/management/backup/restore_service_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestRestoreServiceGetLogs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
@@ -77,6 +78,7 @@ func TestRestoreServiceGetLogs(t *testing.T) {
 	}
 
 	t.Run("get physical restore logs", func(t *testing.T) {
+		t.Parallel()
 		restoreID := uuid.New().String()
 		job, err := models.CreateJob(db.Querier, models.CreateJobParams{
 			PMMAgentID: "agent",
@@ -114,6 +116,7 @@ func TestRestoreServiceGetLogs(t *testing.T) {
 	})
 
 	t.Run("get logical restore logs", func(t *testing.T) {
+		t.Parallel()
 		restoreID := uuid.New().String()
 		logicalRestore, err := models.CreateJob(db.Querier, models.CreateJobParams{
 			PMMAgentID: "agent",
@@ -153,6 +156,7 @@ func TestRestoreServiceGetLogs(t *testing.T) {
 }
 
 func TestRestoreBackupErrors(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	backupService := &mockBackupService{}
@@ -191,6 +195,7 @@ func TestRestoreBackupErrors(t *testing.T) {
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
 			backupError := fmt.Errorf("error: %w", tc.backupError)
 			backupService.On("RestoreBackup", mock.Anything, "serviceID1", "artifactID1", mock.Anything).
 				Return("", backupError).Once()

--- a/managed/services/management/checks_test.go
+++ b/managed/services/management/checks_test.go
@@ -37,7 +37,9 @@ import (
 )
 
 func TestStartAdvisorChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("internal error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("StartChecks", []string(nil)).Return(errors.New("random error"))
 
@@ -49,6 +51,7 @@ func TestStartAdvisorChecks(t *testing.T) {
 	})
 
 	t.Run("Advisors disabled error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("StartChecks", []string(nil)).Return(services.ErrAdvisorsDisabled)
 
@@ -300,7 +303,9 @@ func TestListFailedServices(t *testing.T) {
 }
 
 func TestListAdvisorChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("GetDisabledChecks", mock.Anything).Return([]string{"two"}, nil)
 		checksService.On("GetChecks", mock.Anything).
@@ -328,6 +333,7 @@ func TestListAdvisorChecks(t *testing.T) {
 	})
 
 	t.Run("get disabled checks error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("GetDisabledChecks", mock.Anything).Return(nil, errors.New("random error"))
 
@@ -340,7 +346,9 @@ func TestListAdvisorChecks(t *testing.T) {
 }
 
 func TestUpdateAdvisorChecks(t *testing.T) {
+	t.Parallel()
 	t.Run("enable advisor checks error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("EnableChecks", mock.Anything).Return(errors.New("random error"))
 
@@ -352,6 +360,7 @@ func TestUpdateAdvisorChecks(t *testing.T) {
 	})
 
 	t.Run("disable advisor checks error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("EnableChecks", mock.Anything).Return(nil)
 		checksService.On("DisableChecks", mock.Anything).Return(errors.New("random error"))
@@ -364,6 +373,7 @@ func TestUpdateAdvisorChecks(t *testing.T) {
 	})
 
 	t.Run("change interval error", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("ChangeInterval", mock.Anything).Return(errors.New("random error"))
 
@@ -380,6 +390,7 @@ func TestUpdateAdvisorChecks(t *testing.T) {
 	})
 
 	t.Run("ChangeInterval success", func(t *testing.T) {
+		t.Parallel()
 		var checksService mockChecksService
 		checksService.On("ChangeInterval", mock.Anything).Return(nil)
 		checksService.On("EnableChecks", mock.Anything).Return(nil)

--- a/managed/services/management/node_test.go
+++ b/managed/services/management/node_test.go
@@ -41,7 +41,9 @@ import (
 )
 
 func TestNodeService(t *testing.T) {
+	t.Parallel()
 	t.Run("NodeRegistration", func(t *testing.T) {
+		t.Parallel()
 		getTestNodeName := func() string {
 			return "test-node"
 		}
@@ -96,6 +98,7 @@ func TestNodeService(t *testing.T) {
 		defer teardown(t)
 
 		t.Run("New", func(t *testing.T) {
+			t.Parallel()
 			nodeName := getTestNodeName()
 
 			res, err := s.RegisterNode(ctx, &managementv1.RegisterNodeRequest{
@@ -123,6 +126,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("Exist", func(t *testing.T) {
+			t.Parallel()
 			res, err := s.RegisterNode(ctx, &managementv1.RegisterNodeRequest{
 				NodeType: inventoryv1.NodeType_NODE_TYPE_GENERIC_NODE,
 				NodeName: getTestNodeName(),
@@ -132,6 +136,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("Reregister", func(t *testing.T) {
+			t.Parallel()
 			serviceAccountID := int(0)
 			nodeName := "test-node-new"
 			reregister := false
@@ -153,6 +158,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("Reregister-force", func(t *testing.T) {
+			t.Parallel()
 			serviceAccountID := int(0)
 			nodeName := "test-node-new"
 			reregister := true
@@ -188,6 +194,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("Register/Unregister", func(t *testing.T) {
+			t.Parallel()
 			serviceAccountID := int(0)
 			nodeName := getTestNodeName()
 			reregister := true
@@ -231,6 +238,7 @@ func TestNodeService(t *testing.T) {
 	})
 
 	t.Run("ListNodes", func(t *testing.T) {
+		t.Parallel()
 		now = models.Now()
 
 		setup := func(t *testing.T) (context.Context, *ManagementService, func(t *testing.T)) {
@@ -298,6 +306,7 @@ func TestNodeService(t *testing.T) {
 		)
 
 		t.Run("should output an unfiltered list of all nodes", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -365,6 +374,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("should output an empty list of nodes when filter condition is not satisfied", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -381,6 +391,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("should output a list of nodes when filter condition is satisfied", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -451,6 +462,7 @@ func TestNodeService(t *testing.T) {
 	})
 
 	t.Run("GetNode", func(t *testing.T) {
+		t.Parallel()
 		now := models.Now()
 
 		setup := func(t *testing.T) (context.Context, *ManagementService, func(t *testing.T)) {
@@ -513,6 +525,7 @@ func TestNodeService(t *testing.T) {
 		}
 
 		t.Run("should query the node by its id", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -557,6 +570,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("should return an error if such node_id doesn't exist", func(t *testing.T) {
+			t.Parallel()
 			const nodeID = "00000000-0000-4000-8000-000000000000"
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
@@ -570,6 +584,7 @@ func TestNodeService(t *testing.T) {
 		})
 
 		t.Run("should return an error if the node_id parameter is empty", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown := setup(t)
 			t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/management/rds_test.go
+++ b/managed/services/management/rds_test.go
@@ -44,7 +44,9 @@ import (
 )
 
 func TestRDSService(t *testing.T) {
+	t.Parallel(
 	// logrus.SetLevel(logrus.DebugLevel)
+	)
 
 	uuid.SetRand(&tests.IDReader{})
 	defer uuid.SetRand(nil)
@@ -83,7 +85,9 @@ func TestRDSService(t *testing.T) {
 	s := NewManagementService(db, ar, state, cc, sib, vmdb, vc, grafanaClient, vmClient)
 
 	t.Run("DiscoverRDS", func(t *testing.T) {
+		t.Parallel()
 		t.Run("ListRegions", func(t *testing.T) {
+			t.Parallel()
 			expected := []string{
 				"af-south-1",
 				"ap-east-1",
@@ -127,6 +131,7 @@ func TestRDSService(t *testing.T) {
 		})
 
 		t.Run("InvalidClientTokenId", func(t *testing.T) {
+			t.Parallel()
 			ctx := logger.Set(context.Background(), t.Name())
 			accessKey, secretKey := "EXAMPLE_ACCESS_KEY", "EXAMPLE_SECRET_KEY"
 
@@ -140,6 +145,7 @@ func TestRDSService(t *testing.T) {
 		})
 
 		t.Run("DeadlineExceeded", func(t *testing.T) {
+			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 			defer cancel()
 			ctx = logger.Set(ctx, t.Name())
@@ -155,6 +161,7 @@ func TestRDSService(t *testing.T) {
 		})
 
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			ctx := logger.Set(context.Background(), t.Name())
 			accessKey, secretKey := tests.GetAWSKeys(t)
 
@@ -222,6 +229,7 @@ func TestRDSService(t *testing.T) {
 			{"us-west-2", []instance{{"us-west-2b", "autotest-aurora-psql-11"}, {"us-west-2c", "autotest-mysql-57"}}},
 		} {
 			t.Run(fmt.Sprintf("discoverRDSRegion %s", tt.region), func(t *testing.T) {
+				t.Parallel()
 				ctx := logger.Set(context.Background(), t.Name())
 				accessKey, secretKey := tests.GetAWSKeys(t)
 				creds := credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")
@@ -251,6 +259,7 @@ func TestRDSService(t *testing.T) {
 	})
 
 	t.Run("AddRDS", func(t *testing.T) {
+		t.Parallel()
 		ctx := logger.Set(context.Background(), t.Name())
 		accessKey, secretKey := "EXAMPLE_ACCESS_KEY", "EXAMPLE_SECRET_KEY"
 
@@ -343,6 +352,7 @@ func TestRDSService(t *testing.T) {
 	})
 
 	t.Run("AddRDSPostgreSQL", func(t *testing.T) {
+		t.Parallel()
 		ctx := logger.Set(context.Background(), t.Name())
 		accessKey, secretKey := "EXAMPLE_ACCESS_KEY", "EXAMPLE_SECRET_KEY"
 

--- a/managed/services/management/service_test.go
+++ b/managed/services/management/service_test.go
@@ -40,7 +40,9 @@ import (
 )
 
 func TestServiceService(t *testing.T) {
+	t.Parallel()
 	t.Run("Remove", func(t *testing.T) {
+		t.Parallel()
 		setup := func(t *testing.T) (context.Context, *ManagementService, func(t *testing.T), *mockPrometheusService) { //nolint:unparam
 			t.Helper()
 
@@ -94,6 +96,7 @@ func TestServiceService(t *testing.T) {
 			return ctx, s, teardown, vmdb
 		}
 		t.Run("No params", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -103,6 +106,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("Not found", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -112,6 +116,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("Wrong service type", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -129,6 +134,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -167,6 +173,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("RDS", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -221,6 +228,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("Azure", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			defer teardown(t)
 
@@ -276,6 +284,7 @@ func TestServiceService(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
+		t.Parallel()
 		setup := func(t *testing.T) (context.Context, *ManagementService, func(t *testing.T), *mockPrometheusService) { //nolint:unparam
 			t.Helper()
 
@@ -337,6 +346,7 @@ func TestServiceService(t *testing.T) {
 		)
 
 		t.Run("Basic", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -352,6 +362,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("RDS", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			t.Cleanup(func() { teardown(t) })
 
@@ -405,6 +416,7 @@ func TestServiceService(t *testing.T) {
 		})
 
 		t.Run("Azure", func(t *testing.T) {
+			t.Parallel()
 			ctx, s, teardown, _ := setup(t)
 			t.Cleanup(func() { teardown(t) })
 

--- a/managed/services/preconditions_test.go
+++ b/managed/services/preconditions_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestCheckMongoDBBackupPreconditions(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	t.Cleanup(func() {
@@ -78,6 +79,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("unable to create snapshot backup for cluster with enabled PITR backup", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.Snapshot, "cluster1", "", "")
 		})
@@ -85,6 +87,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("unable to create second PITR backup for cluster", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.PITR, "cluster1", "", "")
 		})
@@ -92,6 +95,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("able to update existing PITR backup for cluster", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.PITR, "cluster1", "", schedule1.ID)
 		})
@@ -99,6 +103,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("unable to create second PITR backup for service", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.Snapshot, "", "service1", "")
 		})
@@ -106,6 +111,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("able to update existing PITR backup for service", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.PITR, "", "service1", schedule1.ID)
 		})
@@ -113,6 +119,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("unable to create PITR backup for cluster with scheduled snapshot backup", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.PITR, "cluster2", "", "")
 		})
@@ -120,6 +127,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("able to create second snapshot backup for cluster", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.Snapshot, "cluster2", "", "")
 		})
@@ -127,6 +135,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("unable to create PITR backup for service with scheduled snapshot backup", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.PITR, "", "service2", "")
 		})
@@ -134,6 +143,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("able to create second snapshot backup for service", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.Snapshot, "", "service2", "")
 		})
@@ -141,6 +151,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 	})
 
 	t.Run("incremental backups are not supported", func(t *testing.T) {
+		t.Parallel()
 		err := db.InTransactionContext(context.Background(), &sql.TxOptions{Isolation: sql.LevelSerializable}, func(_ *reform.TX) error {
 			return CheckMongoDBBackupPreconditions(db.Querier, models.Incremental, "cluster1", "", "")
 		})
@@ -149,6 +160,7 @@ func TestCheckMongoDBBackupPreconditions(t *testing.T) {
 }
 
 func TestCheckArtifactOverlapping(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 	t.Cleanup(func() {

--- a/managed/services/qan/client_test.go
+++ b/managed/services/qan/client_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SetupFixtures, nil)
 	reformL := sqlmetrics.NewReform("test", "test", t.Logf)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)
@@ -124,6 +125,7 @@ func TestClient(t *testing.T) {
 	}
 
 	t.Run("Test MySQL Metrics conversion", func(t *testing.T) {
+		t.Parallel()
 		c := &mockQanCollectorClient{}
 		c.Test(t)
 		defer c.AssertExpectations(t)
@@ -210,6 +212,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Test MongoDB Metrics conversion", func(t *testing.T) {
+		t.Parallel()
 		c := &mockQanCollectorClient{}
 		c.Test(t)
 		defer c.AssertExpectations(t)
@@ -276,6 +279,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Test PostgreSQL Metrics conversion", func(t *testing.T) {
+		t.Parallel()
 		c := &mockQanCollectorClient{}
 		c.Test(t)
 		defer c.AssertExpectations(t)
@@ -411,6 +415,7 @@ func TestClient(t *testing.T) {
 	})
 
 	t.Run("Test conversion skips bad buckets", func(t *testing.T) {
+		t.Parallel()
 		c := &mockQanCollectorClient{}
 		c.Test(t)
 		defer c.AssertExpectations(t)
@@ -437,6 +442,7 @@ func TestClient(t *testing.T) {
 }
 
 func TestClientPerformance(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SetupFixtures, nil)
 	reformL := sqlmetrics.NewReform("test", "test", t.Logf)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)

--- a/managed/services/scheduler/scheduler_test.go
+++ b/managed/services/scheduler/scheduler_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	setup := func(t *testing.T, ctx context.Context, serviceType models.ServiceType, serviceName string) (*Service, *models.Service, *models.BackupLocation) {
 		t.Helper()
 		sqlDB := testdb.Open(t, models.SkipFixtures, nil)
@@ -79,6 +80,7 @@ func TestService(t *testing.T) {
 	}
 
 	t.Run("invalid cron expression", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		scheduler, service, location := setup(t, ctx, models.MongoDBServiceType, "mongo_service")
@@ -106,6 +108,7 @@ func TestService(t *testing.T) {
 	})
 
 	t.Run("normal", func(t *testing.T) {
+		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		scheduler, service, location := setup(t, ctx, models.MongoDBServiceType, "mongo_service")

--- a/managed/services/server/logs_test.go
+++ b/managed/services/server/logs_test.go
@@ -65,6 +65,7 @@ var commonExpectedFiles = []string{
 }
 
 func TestReadLog(t *testing.T) {
+	t.Parallel()
 	f, err := os.CreateTemp("", "pmm-managed-supervisord-tests-")
 	require.NoError(t, err)
 	fNoNewLineEnding, err := os.CreateTemp("", "pmm-managed-supervisord-tests-")
@@ -82,6 +83,7 @@ func TestReadLog(t *testing.T) {
 	defer os.Remove(fNoNewLineEnding.Name()) //nolint:errcheck
 
 	t.Run("LimitByLines", func(t *testing.T) {
+		t.Parallel()
 		b, m, err := readLog(f.Name(), 5)
 		require.NoError(t, err)
 		assert.WithinDuration(t, time.Now(), m, 5*time.Second)
@@ -91,6 +93,7 @@ func TestReadLog(t *testing.T) {
 	})
 
 	t.Run("LimitByLines - no new line ending", func(t *testing.T) {
+		t.Parallel()
 		b, m, err := readLog(fNoNewLineEnding.Name(), 5)
 		require.NoError(t, err)
 		assert.WithinDuration(t, time.Now(), m, 5*time.Second)
@@ -101,6 +104,7 @@ func TestReadLog(t *testing.T) {
 }
 
 func TestReadLogUnlimited(t *testing.T) {
+	t.Parallel()
 	f, err := os.CreateTemp("", "pmm-managed-supervisord-tests-")
 	require.NoError(t, err)
 	fNoNewLineEnding, err := os.CreateTemp("", "pmm-managed-supervisord-tests-")
@@ -118,6 +122,7 @@ func TestReadLogUnlimited(t *testing.T) {
 	defer os.Remove(fNoNewLineEnding.Name()) //nolint:errcheck
 
 	t.Run("UnlimitedLineCount", func(t *testing.T) {
+		t.Parallel()
 		b, m, err := readLogUnlimited(f.Name())
 		require.NoError(t, err)
 		assert.WithinDuration(t, time.Now(), m, 5*time.Second)
@@ -127,6 +132,7 @@ func TestReadLogUnlimited(t *testing.T) {
 	})
 
 	t.Run("UnlimitedLineCount - no new line ending", func(t *testing.T) {
+		t.Parallel()
 		b, m, err := readLogUnlimited(fNoNewLineEnding.Name())
 		require.NoError(t, err)
 		assert.WithinDuration(t, time.Now(), m, 5*time.Second)
@@ -137,6 +143,7 @@ func TestReadLogUnlimited(t *testing.T) {
 }
 
 func TestAddAdminSummary(t *testing.T) {
+	t.Parallel()
 	t.Skip("FIXME")
 
 	zipfile, err := os.CreateTemp("", "*-test.zip")
@@ -162,6 +169,7 @@ func TestAddAdminSummary(t *testing.T) {
 }
 
 func TestFiles(t *testing.T) {
+	t.Parallel()
 	updater := &Updater{}
 	params, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 	require.NoError(t, err)
@@ -193,6 +201,7 @@ func TestFiles(t *testing.T) {
 }
 
 func TestZip(t *testing.T) {
+	t.Parallel()
 	t.Skip("FIXME")
 
 	updater := &Updater{}

--- a/managed/services/server/server_test.go
+++ b/managed/services/server/server_test.go
@@ -38,6 +38,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 
 	newServer := func(t *testing.T) *Server {
@@ -95,7 +96,9 @@ func TestServer(t *testing.T) {
 	}
 
 	t.Run("UpdateSettingsFromEnv", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Typical", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_ENABLE_UPDATES=true",
@@ -119,6 +122,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("Untypical", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_ENABLE_TELEMETRY=TrUe",
@@ -132,6 +136,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("NoValue", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_ENABLE_TELEMETRY",
@@ -142,6 +147,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("InvalidValue", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_ENABLE_TELEMETRY=",
@@ -152,6 +158,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("MetricsLessThenMin", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_METRICS_RESOLUTION=5ns",
@@ -164,6 +171,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("DataRetentionLessThenMin", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_DATA_RETENTION=12h",
@@ -176,6 +184,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("Data retention is not a natural number of days", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_DATA_RETENTION=30h",
@@ -188,6 +197,7 @@ func TestServer(t *testing.T) {
 		})
 
 		t.Run("Data retention without suffix", func(t *testing.T) {
+			t.Parallel()
 			s := newServer(t)
 			errs := s.UpdateSettingsFromEnv(context.TODO(), []string{
 				"PMM_DATA_RETENTION=30",
@@ -199,6 +209,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("ValidateChangeSettingsRequest", func(t *testing.T) {
+		t.Parallel()
 		s := newServer(t)
 
 		ctx := context.TODO()
@@ -248,6 +259,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("ChangeSettings", func(t *testing.T) {
+		t.Parallel()
 		server := newServer(t)
 
 		server.UpdateSettingsFromEnv(context.TODO(), []string{
@@ -271,6 +283,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("ChangeSettings Alerting", func(t *testing.T) {
+		t.Parallel()
 		server := newServer(t)
 		server.UpdateSettingsFromEnv(context.TODO(), []string{})
 

--- a/managed/services/server/updater_test.go
+++ b/managed/services/server/updater_test.go
@@ -42,6 +42,7 @@ import (
 )
 
 func TestUpdater(t *testing.T) {
+	t.Parallel()
 	gRPCMessageMaxSize := uint32(100 * 1024 * 1024)
 	watchtowerURL, _ := url.Parse("http://watchtower:8080")
 	const tmpDistributionFile = "/tmp/distribution"
@@ -50,6 +51,7 @@ func TestUpdater(t *testing.T) {
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("TestNextVersion", func(t *testing.T) {
+		t.Parallel()
 		type args struct {
 			currentVersion string
 			results        []result
@@ -264,6 +266,7 @@ func TestUpdater(t *testing.T) {
 	})
 
 	t.Run("TestSortedVersionList", func(t *testing.T) {
+		t.Parallel()
 		versions := version.DockerVersionsInfo{
 			{Version: *version.MustParse("3.0.0")},
 			{Version: *version.MustParse("3.1.0")},
@@ -279,10 +282,12 @@ func TestUpdater(t *testing.T) {
 	})
 
 	t.Run("TestLatest", func(t *testing.T) {
+		t.Parallel()
 		version.Version = "2.41.0"
 		u := NewUpdater(watchtowerURL, gRPCMessageMaxSize, db)
 
 		t.Run("LatestFromProduction", func(t *testing.T) {
+			t.Parallel()
 			_, latest, err := u.latest(context.Background())
 			require.NoError(t, err)
 			if latest != nil {
@@ -291,6 +296,7 @@ func TestUpdater(t *testing.T) {
 			}
 		})
 		t.Run("LatestFromStaging", func(t *testing.T) {
+			t.Parallel()
 			versionServiceURL, err := envvars.GetPlatformAddress() // defaults to production
 			require.NoError(t, err)
 			defer func() {
@@ -305,6 +311,7 @@ func TestUpdater(t *testing.T) {
 	})
 
 	t.Run("TestParseFile", func(t *testing.T) {
+		t.Parallel()
 		fileBody := `{ "version": "2.41.1" , "docker_image": "2.41.1" , "build_time": "2024-03-20T15:48:07.14562Z" }`
 		oldFileName := fileName
 		fileName = filepath.Join(os.TempDir(), "pmm-update.json")
@@ -322,6 +329,7 @@ func TestUpdater(t *testing.T) {
 	})
 
 	t.Run("with disabled updates check", func(t *testing.T) {
+		t.Parallel()
 		_, err := models.UpdateSettings(db.Querier, &models.ChangeSettingsParams{
 			EnableUpdates: pointer.ToBool(false),
 		})
@@ -337,6 +345,7 @@ func TestUpdater(t *testing.T) {
 	})
 
 	t.Run("TestUpdateEnvFile", func(t *testing.T) {
+		t.Parallel()
 		u := NewUpdater(watchtowerURL, gRPCMessageMaxSize, db)
 		tmpFile := filepath.Join(os.TempDir(), "pmm-service.env")
 		content := `PMM_WATCHTOWER_HOST=http://watchtower:8080

--- a/managed/services/supervisord/devcontainer_test.go
+++ b/managed/services/supervisord/devcontainer_test.go
@@ -30,8 +30,12 @@ import (
 
 // TODO move tests to other files and remove this one.
 func TestDevContainer(t *testing.T) {
+	t.Parallel()
 	t.Run("UpdateConfiguration", func(t *testing.T) {
+		t.Parallel(
 		// logrus.SetLevel(logrus.DebugLevel)
+		)
+
 		vmParams, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 		require.NoError(t, err)
 

--- a/managed/services/supervisord/supervisord_test.go
+++ b/managed/services/supervisord/supervisord_test.go
@@ -71,6 +71,7 @@ func TestConfig(t *testing.T) {
 }
 
 func TestConfigVictoriaMetricsEnvvars(t *testing.T) {
+	t.Parallel()
 	configDir := filepath.Join("..", "..", "testdata", "supervisord.d")
 	vmParams, err := models.NewVictoriaMetricsParams(models.BasePrometheusConfigPath, models.VMBaseURL)
 	require.NoError(t, err)
@@ -108,6 +109,7 @@ func TestConfigVictoriaMetricsEnvvars(t *testing.T) {
 		}
 
 		t.Run(tmpl.Name(), func(t *testing.T) {
+			t.Parallel()
 			expected, err := os.ReadFile(filepath.Join(configDir, tmpl.Name()+"_envvars.ini")) //nolint:gosec
 			require.NoError(t, err)
 			actual, err := s.marshalConfig(tmpl, settings, nil)

--- a/managed/services/telemetry/config_test.go
+++ b/managed/services/telemetry/config_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestServiceConfigUnmarshal(t *testing.T) {
+	t.Parallel()
 	input := `
 enabled: true
 saas_hostname: "check.localhost"

--- a/managed/services/telemetry/transform_test.go
+++ b/managed/services/telemetry/transform_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestTransformToJSON(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		config  *Config
 		metrics []*telemetryv1.GenericReport_Metric
@@ -151,6 +152,7 @@ func TestTransformToJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := transformToJSON(tt.args.config, tt.args.metrics)
 			if !tt.wantErr(t, err) {
 				t.Logf("config: %v", tt.args.config)
@@ -162,6 +164,7 @@ func TestTransformToJSON(t *testing.T) {
 }
 
 func TestTransformExportValues(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		config  *Config
 		metrics []*telemetryv1.GenericReport_Metric
@@ -242,6 +245,7 @@ func TestTransformExportValues(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := transformExportValues(tt.args.config, tt.args.metrics)
 			if !tt.wantErr(t, err) {
 				t.Logf("config: %v", tt.args.config)
@@ -299,6 +303,7 @@ func (c *Config) changeData(d []ConfigData) *Config {
 }
 
 func TestRemoveEmpty(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		metrics []*telemetryv1.GenericReport_Metric
 	}
@@ -362,6 +367,7 @@ func TestRemoveEmpty(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			assert.Equalf(t, tt.want, removeEmpty(tt.args.metrics), "removeEmpty(%v)", tt.args.metrics)
 		})
 	}

--- a/managed/services/types_test.go
+++ b/managed/services/types_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestTarget_Copy(t1 *testing.T) {
+	t1.Parallel()
 	target := Target{
 		AgentID:     "agent_id",
 		ServiceID:   "service_id",

--- a/managed/services/user/user_test.go
+++ b/managed/services/user/user_test.go
@@ -43,6 +43,7 @@ func (m *mockGrafanaClient) GetUserID(ctx context.Context) (int, error) {
 }
 
 func TestSnoozeUpdate(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 
 	defer func() {
@@ -72,6 +73,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	}
 
 	t.Run("user info returns snooze information", func(t *testing.T) {
+		t.Parallel()
 		service, _, cleanup := setup(t)
 		defer cleanup()
 
@@ -86,6 +88,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("user info support snooze", func(t *testing.T) {
+		t.Parallel()
 		service, _, cleanup := setup(t)
 		defer cleanup()
 
@@ -106,6 +109,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("user info supports incrementing snooze count", func(t *testing.T) {
+		t.Parallel()
 		service, _, cleanup := setup(t)
 		defer cleanup()
 
@@ -128,6 +132,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("user info resets counts on version change", func(t *testing.T) {
+		t.Parallel()
 		service, _, cleanup := setup(t)
 		defer cleanup()
 
@@ -159,6 +164,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("snooze the same update to increase snooze count", func(t *testing.T) {
+		t.Parallel()
 		service, mockClient, cleanup := setup(t)
 		defer cleanup()
 
@@ -205,6 +211,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("resets snooze count when called with different version", func(t *testing.T) {
+		t.Parallel()
 		service, mockClient, cleanup := setup(t)
 		defer cleanup()
 
@@ -252,6 +259,7 @@ func TestSnoozeUpdate(t *testing.T) {
 	})
 
 	t.Run("multiple subsequent snoozes with same version", func(t *testing.T) {
+		t.Parallel()
 		service, mockClient, cleanup := setup(t)
 		defer cleanup()
 

--- a/managed/services/versioncache/versioncache_test.go
+++ b/managed/services/versioncache/versioncache_test.go
@@ -33,10 +33,12 @@ import (
 )
 
 func TestVersionCache(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	db := reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
 
 	t.Run("success", func(t *testing.T) {
+		t.Parallel()
 		versionerMock := &MockVersioner{}
 		versionerMock.Test(t)
 
@@ -169,6 +171,7 @@ func TestVersionCache(t *testing.T) {
 	})
 
 	t.Run("no version request if no backup software declared", func(t *testing.T) {
+		t.Parallel()
 		nodeID1 := "node_id_1"
 		serviceID1 := "service_id_1"
 		agentID1, agentID2 := "agent_id_1", "agent_id_2"

--- a/managed/services/victoriametrics/scrape_configs_test.go
+++ b/managed/services/victoriametrics/scrape_configs_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestScrapeConfig(t *testing.T) {
+	t.Parallel()
 	s := &models.MetricsResolutions{
 		HR: 5 * time.Second,
 		MR: 5 * time.Second,
@@ -39,7 +40,9 @@ func TestScrapeConfig(t *testing.T) {
 	}
 
 	t.Run("scrapeConfigsForNodeExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -176,6 +179,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("MacOS", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -243,7 +247,9 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForMySQLdExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -400,6 +406,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("DisabledCollectors", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -553,6 +560,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("ManyTables", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:   "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName: "node_name",
@@ -693,6 +701,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{}
 			service := &models.Service{}
 			agent := &models.Agent{
@@ -713,7 +722,9 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForMongoDBExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -814,6 +825,7 @@ func TestScrapeConfig(t *testing.T) {
 			}
 		})
 		t.Run("Without enable-all option on v2.43+", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -916,6 +928,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{}
 			service := &models.Service{}
 			agent := &models.Agent{
@@ -937,7 +950,9 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForPostgresExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -1068,6 +1083,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{}
 			service := &models.Service{}
 			agent := &models.Agent{
@@ -1088,7 +1104,9 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForProxySQLExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{
 				NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 				NodeName:     "node_name",
@@ -1152,6 +1170,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			node := &models.Node{}
 			service := &models.Service{}
 			agent := &models.Agent{
@@ -1171,7 +1190,9 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForRDSExporter", func(t *testing.T) {
+		t.Parallel()
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			params := []*scrapeConfigParams{
 				// two RDS configs on the same host/port combination: single pmm-agent, single rds_exporter process
 				{
@@ -1275,6 +1296,7 @@ func TestScrapeConfig(t *testing.T) {
 	})
 
 	t.Run("scrapeConfigsForExternalExporter", func(t *testing.T) {
+		t.Parallel()
 		node := &models.Node{
 			NodeID:       "cc663f36-18ca-40a1-aea9-c6310bb4738d",
 			NodeName:     "node_name",
@@ -1289,6 +1311,7 @@ func TestScrapeConfig(t *testing.T) {
 			ExternalGroup: "rabbitmq",
 		}
 		t.Run("Normal", func(t *testing.T) {
+			t.Parallel()
 			agent := &models.Agent{
 				AgentID:         "75bb30d3-ef4a-4147-97a8-621a996611dd",
 				AgentType:       models.ExternalExporterType,
@@ -1334,6 +1357,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("WithExtraParams", func(t *testing.T) {
+			t.Parallel()
 			agent := &models.Agent{
 				AgentID:      "75bb30d3-ef4a-4147-97a8-621a996611dd",
 				AgentType:    models.ExternalExporterType,
@@ -1396,6 +1420,7 @@ func TestScrapeConfig(t *testing.T) {
 		})
 
 		t.Run("BadCustomLabels", func(t *testing.T) {
+			t.Parallel()
 			agent := &models.Agent{
 				CustomLabels:    []byte("{"),
 				ListenPort:      pointer.ToUint16(12345),

--- a/managed/services/victoriametrics/victoriametrics_test.go
+++ b/managed/services/victoriametrics/victoriametrics_test.go
@@ -67,7 +67,9 @@ func teardown(t *testing.T, db *reform.DB, svc *Service, original []byte) {
 }
 
 func TestVictoriaMetrics(t *testing.T) {
+	t.Parallel()
 	t.Run("Default", func(t *testing.T) {
+		t.Parallel()
 		check := require.New(t)
 		db, svc, original := setup(t)
 		defer teardown(t, db, svc, original)
@@ -80,6 +82,7 @@ func TestVictoriaMetrics(t *testing.T) {
 	})
 
 	t.Run("Normal", func(t *testing.T) {
+		t.Parallel()
 		check := require.New(t)
 		db, svc, original := setup(t)
 		defer teardown(t, db, svc, original)
@@ -834,9 +837,11 @@ scrape_configs:
 }
 
 func TestConfigReload(t *testing.T) {
+	t.Parallel()
 	db, svc, original := setup(t)
 	defer teardown(t, db, svc, original)
 	t.Run("Good file, reload ok", func(t *testing.T) {
+		t.Parallel()
 		err := svc.configAndReload(context.TODO(), []byte(strings.TrimSpace(`
 # Managed by pmm-managed. DO NOT EDIT.
 ---
@@ -870,11 +875,13 @@ scrape_configs:
 	})
 
 	t.Run("Bad scrape config file", func(t *testing.T) {
+		t.Parallel()
 		err := svc.configAndReload(context.TODO(), []byte(`unexpected input`))
 		assert.Errorf(t, err, "error when checking Prometheus config")
 	})
 
 	t.Run("Scrape config file with unknown params", func(t *testing.T) {
+		t.Parallel()
 		err := svc.configAndReload(context.TODO(), []byte(strings.TrimSpace(`
 # Managed by pmm-managed. DO NOT EDIT.
 ---
@@ -892,6 +899,7 @@ unknown_filed: unknown_value
 }
 
 func TestBaseConfig(t *testing.T) {
+	t.Parallel()
 	db, svc, original := setup(t)
 	defer teardown(t, db, svc, original)
 

--- a/managed/services/vmalert/vmalert_test.go
+++ b/managed/services/vmalert/vmalert_test.go
@@ -54,7 +54,9 @@ func teardownVMAlert(t *testing.T, rules *ExternalRules, db *reform.DB) {
 }
 
 func TestVMAlert(t *testing.T) {
+	t.Parallel()
 	t.Run("Default", func(t *testing.T) {
+		t.Parallel()
 		check := require.New(t)
 		db, rules, svc := setupVMAlert(t)
 		defer teardownVMAlert(t, rules, db)
@@ -62,6 +64,7 @@ func TestVMAlert(t *testing.T) {
 	})
 
 	t.Run("Normal", func(t *testing.T) {
+		t.Parallel()
 		check := require.New(t)
 		db, rules, svc := setupVMAlert(t)
 		defer teardownVMAlert(t, rules, db)

--- a/managed/utils/clean/clean_test.go
+++ b/managed/utils/clean/clean_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestCleaner(t *testing.T) {
+	t.Parallel()
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -79,6 +80,7 @@ func TestCleaner(t *testing.T) {
 	}
 
 	t.Run("CheckActionResultByID", func(t *testing.T) {
+		t.Parallel()
 		db, q, teardown := setup(t)
 		defer teardown(t)
 

--- a/managed/utils/collectors/collectors_test.go
+++ b/managed/utils/collectors/collectors_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestDisableDefaultEnabledCollectors(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		prefix             string
 		defaultCollectors  []string
@@ -71,6 +72,7 @@ func TestDisableDefaultEnabledCollectors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			actual := DisableDefaultEnabledCollectors(tt.args.prefix, tt.args.defaultCollectors, tt.args.disabledCollectors)
 			require.Equal(t, tt.want, actual, "DisableDefaultEnabledCollectors() = %v, want %v", actual, tt.want)
 		})

--- a/managed/utils/depstests/protobuf_test.go
+++ b/managed/utils/depstests/protobuf_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 func TestDuration(t *testing.T) {
+	t.Parallel(
 	// https://github.com/golang/protobuf/issues/883
 	// https://github.com/golang/protobuf/issues/1219
 	// https://jira.percona.com/browse/PMM-6760
+	)
 
 	s, err := protojson.Marshal(durationpb.New(-time.Nanosecond))
 	require.NoError(t, err)

--- a/managed/utils/pprof/pprof_test.go
+++ b/managed/utils/pprof/pprof_test.go
@@ -47,7 +47,10 @@ func TestHeap(t *testing.T) {
 func TestProfile(t *testing.T) {
 	t.Parallel()
 	t.Run("Profile test", func(t *testing.T) {
+		t.Parallel(
 		// Create a new context
+		)
+
 		ctx := context.Background()
 		profileBytes, err := Profile(ctx, 1*time.Second)
 
@@ -84,7 +87,10 @@ func TestProfile(t *testing.T) {
 func TestTrace(t *testing.T) {
 	t.Parallel()
 	t.Run("Trace test", func(t *testing.T) {
+		t.Parallel(
 		// Create a new context
+		)
+
 		ctx := context.Background()
 		traceBytes, err := Trace(ctx, 1*time.Second)
 

--- a/qan-api2/db_test.go
+++ b/qan-api2/db_test.go
@@ -71,6 +71,7 @@ func cleanup() {
 }
 
 func TestDropOldPartition(t *testing.T) {
+	t.Parallel()
 	db := setup()
 
 	const query = `SELECT DISTINCT partition FROM system.parts WHERE database = 'pmm_test_parts' and visible = 1 ORDER BY partition`
@@ -83,6 +84,7 @@ func TestDropOldPartition(t *testing.T) {
 	daysNewestPartition := uint(math.Abs(difference.Hours()) / 24)
 
 	t.Run("no so old partition", func(t *testing.T) {
+		t.Parallel()
 		partitions := []string{}
 		days := daysNewestPartition + 1
 		DropOldPartition(db, "pmm_test_parts", days)
@@ -96,6 +98,7 @@ func TestDropOldPartition(t *testing.T) {
 	})
 
 	t.Run("delete one day old partition", func(t *testing.T) {
+		t.Parallel()
 		partitions := []string{}
 		days := daysNewestPartition
 		DropOldPartition(db, "pmm_test_parts", days)
@@ -110,7 +113,9 @@ func TestDropOldPartition(t *testing.T) {
 }
 
 func TestCreateDbIfNotExists(t *testing.T) {
+	t.Parallel()
 	t.Run("connect to db that doesnt exist", func(t *testing.T) {
+		t.Parallel()
 		dsn, ok := os.LookupEnv("QANAPI_DSN_TEST")
 
 		dsn = strings.Replace(dsn, "/pmm_test", "/pmm_created_db", 1)

--- a/qan-api2/models/reporter_test.go
+++ b/qan-api2/models/reporter_test.go
@@ -37,7 +37,9 @@ func setup(t *testing.T, filter string) context.Context {
 }
 
 func TestParseFilters(t *testing.T) {
+	t.Parallel()
 	t.Run("empty filters", func(t *testing.T) {
+		t.Parallel()
 		result, err := parseFilters(nil)
 		require.NoError(t, err)
 		require.Nil(t, result)
@@ -48,6 +50,7 @@ func TestParseFilters(t *testing.T) {
 	})
 
 	t.Run("valid filters", func(t *testing.T) {
+		t.Parallel()
 		filters := []string{"abc", "def"}
 		encoded := base64.StdEncoding.EncodeToString([]byte(`["abc", "def"]`))
 		result, err := parseFilters([]string{encoded})
@@ -56,12 +59,14 @@ func TestParseFilters(t *testing.T) {
 	})
 
 	t.Run("invalid base64", func(t *testing.T) {
+		t.Parallel()
 		_, err := parseFilters([]string{"invalid-base64"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to decode filters")
 	})
 
 	t.Run("invalid JSON", func(t *testing.T) {
+		t.Parallel()
 		encoded := base64.StdEncoding.EncodeToString([]byte("invalid-json"))
 		_, err := parseFilters([]string{encoded})
 		require.Error(t, err)
@@ -70,8 +75,12 @@ func TestParseFilters(t *testing.T) {
 }
 
 func TestHeadersToLbacFilter(t *testing.T) {
+	t.Parallel(
 	// Selector example: `[{service_type=~"mysql|mongodb", environment!~"prod"}, {service_type="postgresql", az!="us-east-1"}]`
+	)
+
 	t.Run("no metadata in context", func(t *testing.T) {
+		t.Parallel()
 		filter, err := headersToLbacFilter(context.TODO())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to extract metadata from context")
@@ -79,6 +88,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("empty filter", func(t *testing.T) {
+		t.Parallel()
 		md := metadata.New(make(map[string]string))
 		ctx := metadata.NewIncomingContext(context.TODO(), md)
 		filter, err := headersToLbacFilter(ctx)
@@ -87,6 +97,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("invalid base64 in filter", func(t *testing.T) {
+		t.Parallel()
 		md := metadata.New(map[string]string{
 			LBACHeaderName: "invalid-base64",
 		})
@@ -99,6 +110,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("invalid JSON after decoding", func(t *testing.T) {
+		t.Parallel()
 		invalidJSON := base64.StdEncoding.EncodeToString([]byte("invalid-json"))
 		md := metadata.New(map[string]string{
 			LBACHeaderName: invalidJSON,
@@ -112,6 +124,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("single dimension filter", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{service_type=\"mysql\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -119,6 +132,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("multiple dimension filters with OR", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{service_type=\"mysql\"}", "{service_type=\"postgresql\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -126,6 +140,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("complex filter with multiple conditions", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{service_type=\"mysql\", environment!=\"dev\"}", "{service_type=\"postgresql\", environment!=\"prod\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -133,6 +148,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("regex match", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{service_type=~\"mysql|postgresql\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -140,6 +156,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("custom label", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{custom_label=\"value\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -147,6 +164,7 @@ func TestHeadersToLbacFilter(t *testing.T) {
 	})
 
 	t.Run("complex filter with custom label and dimension", func(t *testing.T) {
+		t.Parallel()
 		ctx := setup(t, `["{custom_label=\"value\",service_type=\"mysql\"}"]`)
 		filter, err := headersToLbacFilter(ctx)
 		require.NoError(t, err)
@@ -155,7 +173,9 @@ func TestHeadersToLbacFilter(t *testing.T) {
 }
 
 func TestMatchersToSQL(t *testing.T) {
+	t.Parallel()
 	t.Run("standard dimension matchers", func(t *testing.T) {
+		t.Parallel()
 		testCases := []struct {
 			name     string
 			matchers []*labels.Matcher
@@ -208,6 +228,7 @@ func TestMatchersToSQL(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				result, err := matchersToSQL(tc.matchers)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, result)
@@ -216,6 +237,7 @@ func TestMatchersToSQL(t *testing.T) {
 	})
 
 	t.Run("custom label matchers", func(t *testing.T) {
+		t.Parallel()
 		testCases := []struct {
 			name     string
 			matchers []*labels.Matcher
@@ -253,6 +275,7 @@ func TestMatchersToSQL(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
 				result, err := matchersToSQL(tc.matchers)
 				require.NoError(t, err)
 				require.Equal(t, tc.expected, result)
@@ -261,6 +284,7 @@ func TestMatchersToSQL(t *testing.T) {
 	})
 
 	t.Run("mixed dimension and custom label matchers", func(t *testing.T) {
+		t.Parallel()
 		matchers := []*labels.Matcher{
 			labels.MustNewMatcher(labels.MatchEqual, "service_type", "mysql"),
 			labels.MustNewMatcher(labels.MatchEqual, "custom_label", "value"),
@@ -271,7 +295,10 @@ func TestMatchersToSQL(t *testing.T) {
 	})
 
 	t.Run("unsupported matcher type", func(t *testing.T) {
+		t.Parallel(
 		// Create a custom matcher with an invalid type (5)
+		)
+
 		invalidMatcher := &labels.Matcher{
 			Type:  5, // Invalid type
 			Name:  "service_type",

--- a/qan-api2/services/analytics/filters_test.go
+++ b/qan-api2/services/analytics/filters_test.go
@@ -53,6 +53,7 @@ type testValuesUnmarshal struct {
 }
 
 func TestService_GetFilters(t *testing.T) {
+	t.Parallel()
 	dsn, ok := os.LookupEnv("QANAPI_DSN_TEST")
 	if !ok {
 		dsn = "clickhouse://default:clickhouse@0.0.0.0:19000/pmm_test"
@@ -179,6 +180,7 @@ func TestService_GetFilters(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := &Service{
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,

--- a/qan-api2/services/analytics/metrics_names_test.go
+++ b/qan-api2/services/analytics/metrics_names_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestService_GetMetricsNames(t *testing.T) {
+	t.Parallel()
 	type fields struct {
 		rm models.Reporter
 		mm models.Metrics
@@ -46,6 +47,7 @@ func TestService_GetMetricsNames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := &Service{
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,

--- a/qan-api2/services/analytics/object_details_test.go
+++ b/qan-api2/services/analytics/object_details_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestService_GetQueryExample(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -123,6 +124,7 @@ func TestService_GetQueryExample(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := &Service{
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
@@ -148,6 +150,7 @@ func TestService_GetQueryExample(t *testing.T) {
 }
 
 func TestService_GetMetricsError(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -257,6 +260,7 @@ func TestService_GetMetricsError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := &Service{
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
@@ -270,6 +274,7 @@ func TestService_GetMetricsError(t *testing.T) {
 }
 
 func TestService_GetMetrics(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -277,6 +282,7 @@ func TestService_GetMetrics(t *testing.T) {
 	t2, _ := time.Parse(time.RFC3339, "2019-01-01T10:00:00Z")
 
 	t.Run("group_by_queryid", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -301,6 +307,7 @@ func TestService_GetMetrics(t *testing.T) {
 
 	t3, _ := time.Parse(time.RFC3339, "2019-01-01T01:30:00Z")
 	t.Run("sparklines_90_points", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -324,6 +331,7 @@ func TestService_GetMetrics(t *testing.T) {
 	})
 
 	t.Run("total", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -349,6 +357,7 @@ func TestService_GetMetrics(t *testing.T) {
 }
 
 func TestService_GetLabels(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -382,6 +391,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -412,6 +422,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -434,6 +445,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -457,6 +469,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -480,6 +493,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -511,6 +525,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,
@@ -534,6 +549,7 @@ func TestService_GetLabels(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: tt.fields.rm,
 			mm: tt.fields.mm,

--- a/qan-api2/services/analytics/profile_test.go
+++ b/qan-api2/services/analytics/profile_test.go
@@ -78,6 +78,7 @@ func getExpectedJSON(t *testing.T, got proto.Message, filename string) []byte {
 }
 
 func TestService_GetReport(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -145,6 +146,7 @@ func TestService_GetReport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := &Service{
 				rm: tt.fields.rm,
 				mm: tt.fields.mm,
@@ -171,6 +173,7 @@ func TestService_GetReport(t *testing.T) {
 }
 
 func TestService_GetReport_Mix(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -211,6 +214,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 		false,
 	}
 	t.Run("reverse_order", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -231,6 +235,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 	})
 
 	t.Run("correct_load", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -251,6 +256,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 	})
 
 	t.Run("correct_latency", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -271,6 +277,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 	})
 
 	t.Run("no error on limit is 0", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -285,6 +292,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 	})
 
 	t.Run("Limit is 0", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -301,6 +309,7 @@ func TestService_GetReport_Mix(t *testing.T) {
 }
 
 func TestService_GetReport_Groups(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -308,6 +317,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	t2, _ := time.Parse(time.RFC3339, "2019-01-01T10:00:00Z")
 
 	t.Run("group_by_queryid", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -346,6 +356,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	})
 
 	t.Run("group_by_service_name", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -384,6 +395,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	})
 
 	t.Run("group_by_database", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -422,6 +434,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	})
 
 	t.Run("group_by_schema", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -460,6 +473,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	})
 
 	t.Run("group_by_username", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -498,6 +512,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 	})
 
 	t.Run("group_by_client_host", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -537,6 +552,7 @@ func TestService_GetReport_Groups(t *testing.T) {
 }
 
 func TestService_GetReport_AllLabels(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -632,6 +648,7 @@ func TestService_GetReport_AllLabels(t *testing.T) {
 		false,
 	}
 	t.Run("Use all label keys", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: test.fields.rm,
 			mm: test.fields.mm,
@@ -652,6 +669,7 @@ func TestService_GetReport_AllLabels(t *testing.T) {
 }
 
 func TestService_GetReport_Sparklines(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -659,6 +677,7 @@ func TestService_GetReport_Sparklines(t *testing.T) {
 	t2, _ := time.Parse(time.RFC3339, "2019-01-01T01:00:00Z")
 
 	t.Run("sparklines_60_points", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -698,6 +717,7 @@ func TestService_GetReport_Sparklines(t *testing.T) {
 
 	t3, _ := time.Parse(time.RFC3339, "2019-01-01T01:30:00Z")
 	t.Run("sparklines_90_points", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -737,6 +757,7 @@ func TestService_GetReport_Sparklines(t *testing.T) {
 }
 
 func TestService_GetReport_Search(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -744,6 +765,7 @@ func TestService_GetReport_Search(t *testing.T) {
 	t2, _ := time.Parse(time.RFC3339, "2019-01-01T10:00:00Z")
 
 	t.Run("search_queryid", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -775,6 +797,7 @@ func TestService_GetReport_Search(t *testing.T) {
 	})
 
 	t.Run("search_fingerprint", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -806,6 +829,7 @@ func TestService_GetReport_Search(t *testing.T) {
 	})
 
 	t.Run("search_service_name", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,
@@ -838,6 +862,7 @@ func TestService_GetReport_Search(t *testing.T) {
 }
 
 func TestServiceGetReportSpecialMetrics(t *testing.T) {
+	t.Parallel()
 	db := setup()
 	rm := models.NewReporter(db)
 	mm := models.NewMetrics(db)
@@ -845,6 +870,7 @@ func TestServiceGetReportSpecialMetrics(t *testing.T) {
 	t2, _ := time.Parse(time.RFC3339, "2019-01-01T10:00:00Z")
 
 	t.Run("num_queries_with_errors", func(t *testing.T) {
+		t.Parallel()
 		s := &Service{
 			rm: rm,
 			mm: mm,

--- a/utils/depstests/protobuf_test.go
+++ b/utils/depstests/protobuf_test.go
@@ -26,9 +26,11 @@ import (
 )
 
 func TestDuration(t *testing.T) {
+	t.Parallel(
 	// https://google.golang.org/protobuf/issues/883
 	// https://google.golang.org/protobuf/issues/1219
 	// https://jira.percona.com/browse/PMM-6760
+	)
 
 	s, err := protojson.Marshal(durationpb.New(-time.Nanosecond))
 	require.NoError(t, err)

--- a/utils/grafana/serviceaccounts_test.go
+++ b/utils/grafana/serviceaccounts_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func Test_sanitizeSAName(t *testing.T) {
+	t.Parallel(
 	// max possible length without hashing
+	)
+
 	len180, err := stringsgen.GenerateRandomString(180)
 	require.NoError(t, err)
 	require.Equal(t, len180, SanitizeSAName(len180))

--- a/version/parsed_test.go
+++ b/version/parsed_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 func TestParsed(t *testing.T) {
+	t.Parallel()
 	t.Run("PMM", func(t *testing.T) {
+		t.Parallel()
 		data := []struct {
 			s string
 			p *Parsed
@@ -59,6 +61,7 @@ func TestParsed(t *testing.T) {
 		}
 		for i, expected := range data {
 			t.Run(expected.s, func(t *testing.T) {
+				t.Parallel()
 				actual, err := Parse(expected.s)
 				require.NoError(t, err)
 				assert.Equal(t, *expected.p, *actual)
@@ -75,6 +78,7 @@ func TestParsed(t *testing.T) {
 	})
 
 	t.Run("MySQL", func(t *testing.T) {
+		t.Parallel()
 		data := []struct {
 			s string
 			p *Parsed
@@ -101,6 +105,7 @@ func TestParsed(t *testing.T) {
 		}
 		for i, expected := range data {
 			t.Run(expected.s, func(t *testing.T) {
+				t.Parallel()
 				actual, err := Parse(expected.s)
 				require.NoError(t, err)
 				assert.Equal(t, *expected.p, *actual)

--- a/version/release_test.go
+++ b/version/release_test.go
@@ -40,6 +40,7 @@ func setupDataForExporter() {
 }
 
 func TestShortInfoManaged(t *testing.T) {
+	t.Parallel()
 	setupDataForManaged()
 
 	expected := fmt.Sprintf("%s v%s", ProjectName, PMMVersion)
@@ -50,6 +51,7 @@ func TestShortInfoManaged(t *testing.T) {
 }
 
 func TestFullInfoPlainManaged(t *testing.T) {
+	t.Parallel()
 	setupDataForManaged()
 
 	expected := strings.Join([]string{
@@ -67,6 +69,7 @@ func TestFullInfoPlainManaged(t *testing.T) {
 }
 
 func TestFullInfoJsonManaged(t *testing.T) {
+	t.Parallel()
 	setupDataForManaged()
 
 	expected := "{" + strings.Join([]string{
@@ -85,6 +88,7 @@ func TestFullInfoJsonManaged(t *testing.T) {
 }
 
 func TestShortInfoExporter(t *testing.T) {
+	t.Parallel()
 	setupDataForExporter()
 
 	expected := fmt.Sprintf("external_exporter v%s (PMM v%s)", Version, PMMVersion)
@@ -95,6 +99,7 @@ func TestShortInfoExporter(t *testing.T) {
 }
 
 func TestFullInfoPlainExporter(t *testing.T) {
+	t.Parallel()
 	setupDataForExporter()
 
 	expected := strings.Join([]string{
@@ -113,6 +118,7 @@ func TestFullInfoPlainExporter(t *testing.T) {
 }
 
 func TestFullInfoJsonExporter(t *testing.T) {
+	t.Parallel()
 	setupDataForExporter()
 
 	expected := "{" + strings.Join([]string{


### PR DESCRIPTION
Fixes #2342

## Changes
- Enable paralleltest linter by removing it from the disabled list in .golangci.yml
- Add t.Parallel() calls to test functions and subtests across 194 test files
- Fix test isolation by ensuring proper parallel test execution patterns