### PR TITLE
PMM-14670 Fix QAN data purge failure

### DIFF
--- a/qan-api2/db.go
+++ b/qan-api2/db.go
@@ -153,19 +153,24 @@ func DropOldPartition(db *sqlx.DB, dbName string, days uint) {
 	const query = `
 		SELECT DISTINCT partition
 		FROM system.parts
-		WHERE toUInt32OrZero(partition) < toYYYYMMDD(now() - toIntervalDay(?)) AND database = ? and visible = 1 ORDER BY partition
+		WHERE database = ?
+		AND table = 'metrics'
+		AND visible = 1
+		AND match(partition, '^[0-9]{8}$')
+		AND toUInt32(partition) < toYYYYMMDD(now() - toIntervalDay(?))
+		ORDER BY partition
 	`
 	err := db.Select(
 		&partitions,
 		query,
-		days,
-		dbName)
+		dbName,
+		days)
 	if err != nil {
 		l.Infof("Select %d days old partitions of system.parts. Result: %v, Error: %v", days, partitions, err)
 		return
 	}
 	for _, part := range partitions {
-		result, err := db.Exec(fmt.Sprintf(`ALTER TABLE metrics DROP PARTITION %s`, part))
-		l.Infof("Drop %s partitions of metrics. Result: %v, Error: %v", part, result, err)
+		result, err := db.Exec(fmt.Sprintf(`ALTER TABLE %s.metrics DROP PARTITION %s`, dbName, part))
+		l.Infof("Drop partition %s of %s.metrics. Result: %v, Error: %v", part, dbName, result, err)
 	}
 }

--- a/qan-api2/db.go
+++ b/qan-api2/db.go
@@ -154,10 +154,10 @@ func DropOldPartition(db *sqlx.DB, dbName string, days uint) {
 		SELECT DISTINCT partition
 		FROM system.parts
 		WHERE database = ?
-		AND table = 'metrics'
-		AND visible = 1
-		AND match(partition, '^[0-9]{8}$')
-		AND toUInt32(partition) < toYYYYMMDD(now() - toIntervalDay(?))
+			AND table = 'metrics'
+			AND visible = 1
+			AND match(partition, '^[0-9]{8}$')
+			AND toUInt32(partition) < toYYYYMMDD(now() - toIntervalDay(?))
 		ORDER BY partition
 	`
 	err := db.Select(


### PR DESCRIPTION
PMM-14670

Link to the Feature Build: SUBMODULES-4189

This pull request refines the logic for dropping old partitions in the `DropOldPartition` function in `qan-api2/db.go`. The changes improve partition selection accuracy and ensure the correct table is targeted during partition deletion.

Partition selection improvements:
* The query now filters partitions by table name (`metrics`), enforces a stricter partition format (8-digit date), and corrects the ordering of query parameters for clarity and correctness.

Partition deletion accuracy:
* The partition drop command now explicitly specifies the database name in `ALTER TABLE`, ensuring the correct table is targeted, and improves logging to clearly indicate which partition and database are affected.


