### PR TITLE
PMM-14577 Bump up Valkey exporter

### DIFF
--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -67,7 +67,7 @@ dynamic_binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}-${B
 
 # https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.114.0
 vmagent_commit_hash=a5e3c6d4492db765800363dfae48a04b4d7888be
-# https://github.com/oliver006/redis_exporter/releases/tag/v1.72.1
-redis_exporter_commit_hash=8d5f9dea4a8863ce7cad62352957ae5e75047346
+# https://github.com/oliver006/redis_exporter/releases/tag/v1.80.1
+redis_exporter_commit_hash=b0a03b20062314a8ac2918f5c377ebaf44cc8bd8
 # https://github.com/hashicorp/nomad/releases/tag/v1.11.0
 nomad_commit_hash=9103d938133311b2da905858801f0e111a2df0a1


### PR DESCRIPTION
PMM-14577

Link to the Feature Build: SUBMODULES-4193

This pull request updates the version of the `redis_exporter` dependency used in the build scripts. The main change is upgrading to a newer release of `redis_exporter`.

Dependency updates:

* Updated the `redis_exporter_commit_hash` in `build/scripts/vars` from version `v1.72.1` to `v1.80.1`, ensuring the build uses the latest improvements and bug fixes from the upstream project.
