### PR TITLE
PMM-14759 Fix the dashboards build task

### DIFF
--- a/build/ansible/roles/dashboards/tasks/main.yml
+++ b/build/ansible/roles/dashboards/tasks/main.yml
@@ -32,9 +32,9 @@
     mode: 0664
     remote_src: yes
 
-- name: Restart Grafana service with new plugins 
-  shell: "supervisorctl {{ item }} grafana"
-  loop:
-    - stop
-    - remove
-    - add
+# - name: Restart Grafana service with new plugins 
+#   shell: "supervisorctl {{ item }} grafana"
+#   loop:
+#     - stop
+#     - remove
+#     - add

--- a/build/ansible/roles/dashboards/tasks/main.yml
+++ b/build/ansible/roles/dashboards/tasks/main.yml
@@ -31,10 +31,3 @@
     dest: /srv/grafana/PERCONA_DASHBOARDS_VERSION
     mode: 0664
     remote_src: yes
-
-# - name: Restart Grafana service with new plugins 
-#   shell: "supervisorctl {{ item }} grafana"
-#   loop:
-#     - stop
-#     - remove
-#     - add


### PR DESCRIPTION
PMM-14759

Link to the Feature Build: SUBMODULES-4199

This pull request makes a minor update to the Grafana dashboard deployment process in the Ansible configuration. The change removes the step that restarts the Grafana service using `supervisorctl` after updating plugins.

* Removed the task from `build/ansible/roles/dashboards/tasks/main.yml` that restarted the Grafana service with `supervisorctl` after plugin updates.
