### PR TITLE
PMM-14800 Upgrade VictoriaMetrics to v1.134.0

### DIFF
--- a/build/packages/rpm/server/SPECS/victoriametrics.spec
+++ b/build/packages/rpm/server/SPECS/victoriametrics.spec
@@ -9,10 +9,10 @@
 
 %global repo            VictoriaMetrics
 %global provider        github.com/VictoriaMetrics/%{repo}
-%global commit          pmm-6401-v1.114.0
+%global commit          pmm-6401-v1.134.0
 
 Name:           percona-victoriametrics
-Version:        1.114.0
+Version:        1.134.0
 Release:        1%{?dist}
 Summary:        VictoriaMetrics monitoring solution and time series database
 License:        Apache-2.0
@@ -50,6 +50,9 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 
 %changelog
+* Fri Jan 30 2026 Alex Demidoff <alexander.demidoff@percona.com> - 1.134.0-1
+- upgrade victoriametrics to 1.134.0 release
+
 * Mon Apr 7 2025 Nurlan Moldomurov <nurlan.moldomurov@percona.com> - 1.114.0-1
 - upgrade victoriametrics to 1.114.0 release
 

--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -65,8 +65,8 @@ source_tarball=${root_dir}/results/source_tarball/pmm-client-${pmm_version}.tar.
 binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}.tar.gz
 dynamic_binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}-${BUILD_TYPE}-${OS_VARIANT}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.114.0
-vmagent_commit_hash=a5e3c6d4492db765800363dfae48a04b4d7888be
+# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.134.0
+vmagent_commit_hash=8fb6f74a739dc9d433274906fd69d1b2edca6951
 # https://github.com/oliver006/redis_exporter/releases/tag/v1.80.1
 redis_exporter_commit_hash=b0a03b20062314a8ac2918f5c377ebaf44cc8bd8
 # https://github.com/hashicorp/nomad/releases/tag/v1.11.0

--- a/documentation/docs/reference/pmm_components_and_versions.md
+++ b/documentation/docs/reference/pmm_components_and_versions.md
@@ -5,7 +5,7 @@ The following table lists all the PMM client/server components and their version
 | PMM client/server component | Version  | Documentation |Location on GitHub|
 |-----------------------------|----------|---------------|------------------|
 | Grafana  | 11.6.3*  | [Grafana documentation](https://grafana.com/docs/grafana/latest/)|[Github Grafana](https://github.com/percona-platform/grafana)|
-| VictoriaMetrics| 1.114.0  | [VictoriaMetrics documentation](https://docs.victoriametrics.com/)|[Github VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)    |
+| VictoriaMetrics| 1.134.0  | [VictoriaMetrics documentation](https://docs.victoriametrics.com/)|[Github VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)    |
 | Nginx    | 1.20.1   | [Nginx documentation](http://nginx.org/en/docs/)|[Github Nginx](https://github.com/nginx/nginx)                                                    |
 | Percona Distribution for PostgreSQL  | 14.5     | [Percona Distribution for PostgreSQL 14 documentation](https://www.percona.com/doc/postgresql/LATEST/index.html)|              |
 | Clickhouse| 25.3.6.56 |[ClickHouse documentation](https://clickhouse.com/docs/en/)|[Github ClickHouse](https://github.com/ClickHouse/ClickHouse)|


### PR DESCRIPTION
PMM-14800

Link to the Feature Build: SUBMODULES-4209

This pull request updates the VictoriaMetrics component to version 1.134.0 across the codebase, ensuring that both the build scripts and documentation reflect the new version. The most important changes are:

**VictoriaMetrics version upgrade:**

* Updated the VictoriaMetrics version from 1.114.0 to 1.134.0 in the RPM spec file (`victoriametrics.spec`) and the documentation (`pmm_components_and_versions.md`). [[1]](diffhunk://#diff-dd0b0d2296dc4410fbc99e0556e1717c5296559bb4bf916f8c259719e105af23L12-R15) [[2]](diffhunk://#diff-a70885d5d4e4e1af7d8f55f896547848fa87de1a7beeac4cb30a814d3be4b232L8-R8)
* Changed the `vmagent_commit_hash` in the build variables script to match the new VictoriaMetrics release (`vars`).

**Changelog update:**

* Added a new changelog entry in `victoriametrics.spec` for the 1.134.0 release, documenting the upgrade.