### PR TITLE
Update isolated_hosts.md - wrong pmm3 download link

### DIFF
--- a/documentation/docs/install-pmm/install-pmm-server/deployment-options/docker/isolated_hosts.md
+++ b/documentation/docs/install-pmm/install-pmm-server/deployment-options/docker/isolated_hosts.md
@@ -6,8 +6,8 @@ To deploy [PMM Server][Docker image] in air-gapped or isolated environments with
 1. On an internet-connected host, download the [Docker][Docker] image and its checksum file:
 
     ```sh
-    wget https://downloads.percona.com/downloads/pmm/{{release}}/docker/pmm-server-{{release}}.docker
-    wget https://downloads.percona.com/downloads/pmm/{{release}}/docker/pmm-server-{{release}}.sha256sum
+    wget https://downloads.percona.com/downloads/pmm3/{{release}}/docker/pmm-server-{{release}}.docker
+    wget https://downloads.percona.com/downloads/pmm3/{{release}}/docker/pmm-server-{{release}}.sha256sum
     ```
 
 2. Transfer both files to the target host where you'll run PMM Server using a secure method (such as `scp`, physical media, or your organization's approved file transfer mechanism).


### PR DESCRIPTION
The correct link per the download page is https://downloads.percona.com/downloads/pmm3/3.5.0/docker/pmm-server-3.5.0.docker  The link supplied here https://downloads.percona.com/downloads/pmm3/3.5.0/docker/pmm-server-3.5.0.docker  is broken

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds, removes or alters one or more API endpoints, please review and add or update the relevant [API documentation](https://github.com/percona/pmm/tree/v3/docs/api) as well:

- [ ] API Docs updated

If this PR is related to some other PRs in this or other repositories, please provide links to those PRs:

- Links to related pull requests (optional).
