### PR TITLE
PMM-14833 Add support for deprecated tiers attribute

### DIFF
--- a/managed/AGENT.md
+++ b/managed/AGENT.md
@@ -105,6 +105,7 @@ Multiple code generation tools are used:
 - Prefer modern Go idioms (context, error wrapping)
 - Prefer modern slice helpers (e.g., `slices.Contains`), range loops
 - Use `any` instead of `interface{}`
+- Prefer `len(varN) != 0` over `len(varN) > 0` for non-empty checks
 
 ### Don't
 - Don't use `gorm` or other ORMs - only `reform`

--- a/managed/pi/alert/template.go
+++ b/managed/pi/alert/template.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/percona/promconfig"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
 	"github.com/percona/pmm/managed/pi/common"
@@ -98,6 +99,8 @@ type Template struct {
 	Severity    common.Severity     `yaml:"severity"`              // required
 	Labels      map[string]string   `yaml:"labels,omitempty"`      // optional
 	Annotations map[string]string   `yaml:"annotations,omitempty"` // optional
+	// TODO: Tiers field is deprecated and must be removed in PMM v4.
+	Tiers []string `yaml:"tiers,omitempty"` // optional
 }
 
 // Validate validates template.
@@ -118,6 +121,15 @@ func (r *Template) Validate() error {
 
 	if r.Expr == "" {
 		return errors.New("template expression is empty")
+	}
+
+	// Log deprecation warning for tiers field
+	if len(r.Tiers) > 0 {
+		logrus.WithFields(logrus.Fields{
+			"component": "alert/template",
+			"template":  r.Name,
+			"tiers":     r.Tiers,
+		}).Warn("The 'tiers' field in alert templates is deprecated and will be removed in PMM v4. Please update your templates.")
 	}
 
 	err = r.validateParams()

--- a/managed/pi/alert/template.go
+++ b/managed/pi/alert/template.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/percona/promconfig"
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,8 @@ import (
 
 	"github.com/percona/pmm/managed/pi/common"
 )
+
+var tiersDeprecationWarned sync.Map
 
 type templates struct {
 	Templates []Template `yaml:"templates"`
@@ -123,13 +126,15 @@ func (r *Template) Validate() error {
 		return errors.New("template expression is empty")
 	}
 
-	// Log deprecation warning for tiers field
-	if len(r.Tiers) > 0 {
-		logrus.WithFields(logrus.Fields{
-			"component": "alert/template",
-			"template":  r.Name,
-			"tiers":     r.Tiers,
-		}).Warn("The 'tiers' field in alert templates is deprecated and will be removed in PMM v4. Please update your templates.")
+	// Log deprecation warning for tiers field (once per template name)
+	if len(r.Tiers) != 0 {
+		if _, warned := tiersDeprecationWarned.LoadOrStore(r.Name, true); !warned {
+			logrus.WithFields(logrus.Fields{
+				"component": "alert/template",
+				"template":  r.Name,
+				"tiers":     r.Tiers,
+			}).Warn("The 'tiers' field in alert templates is deprecated and will be removed in PMM v4. Please update your templates.")
+		}
 	}
 
 	err = r.validateParams()

--- a/managed/services/grafana/auth_server.go
+++ b/managed/services/grafana/auth_server.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -350,7 +351,14 @@ func (s *AuthServer) getLBACFilters(ctx context.Context, userID int) ([]string, 
 			return models.AssignDefaultRole(tx, userID)
 		})
 		if err != nil {
-			return nil, err
+			// Handle race condition: if another concurrent request already assigned the default role,
+			// we'll get a duplicate key error. In this case, just go fetch the roles.
+			var pgErr *pq.Error
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.Constraint == "user_roles_pkey" {
+				s.l.Debugf("Default role already assigned to user ID %d by another request", userID)
+			} else {
+				return nil, err
+			}
 		}
 
 		// Reload roles


### PR DESCRIPTION
PMM-14833

Link to the Feature Build: SUBMODULES-4228

This pull request introduces a deprecation warning for the `tiers` field in alert templates and prepares for its removal in a future release. It also logs a deprecation warning.

Deprecation handling and logging:

* Added a deprecation warning in the `Validate` method of the `Template` struct to log a warning message if the deprecated `tiers` field is used, informing users that it will be removed in PMM v4.
* Added the `logrus` logging library import to support structured logging for deprecation warnings.

Template struct changes:

* Added a comment to the `Tiers` field in the `Template` struct indicating that it is deprecated and will be removed in PMM v4.
