### PR TITLE
Improve the Essential Ports sections

### DIFF
--- a/documentation/docs/install-pmm/plan-pmm-installation/network_and_firewall.md
+++ b/documentation/docs/install-pmm/plan-pmm-installation/network_and_firewall.md
@@ -20,8 +20,9 @@ These ports must be accessible for basic PMM functionality:
 
 | PMM component | TCP port      | Direction     | Description
 |---------------|---------------|---------------|------------------------------------------------------------------------------------------
-| PMM Server    |   80          | both          | HTTP server, used for gRPC over HTTP and web interface (**insecure**, use with caution).
 | PMM Server    |  443          | both          | HTTPS server, used for gRPC over HTTPS and web interface (secure, use of SSL certificates is highly encouraged).
+
+It must be noted that some systems may disallow the use of ports below 1024 for non-root processes. If you encounter issues with PMM Server binding to port 443, consider using a higher port (e.g., 8443) and configuring your firewall to redirect traffic from port 443 to the chosen port.
 
 ### Internal component ports 
 These ports are used for communication between PMM components:


### PR DESCRIPTION
This pull request updates the PMM installation documentation to clarify network and firewall requirements. The most important change is the addition of a note about potential issues with binding to ports below 1024, such as 443, and guidance on using higher ports with firewall redirection if needed.

Documentation improvements:

* Added a note explaining that some systems may prevent non-root processes from binding to ports below 1024 (like 443), and provided instructions to use a higher port (e.g., 8443) with firewall redirection if binding fails.