### PR TITLE
PMM-14550 Small UI fixes

### DIFF
--- a/ui/apps/pmm/src/hooks/useLiveTimestamp.ts
+++ b/ui/apps/pmm/src/hooks/useLiveTimestamp.ts
@@ -1,0 +1,9 @@
+import { useEffect, useState } from 'react';
+
+export const useLiveTimestamp = (intervalMs = 1000) => {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+};

--- a/ui/apps/pmm/src/pages/rta/overview/RealtimeOverview.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/RealtimeOverview.tsx
@@ -83,7 +83,6 @@ const RealtimeOverviewPage: FC = () => {
       <OverviewTable
         queries={queries || []}
         onQuerySelected={handleQueryChange}
-        onRowHover={() => setFetching(false)}
         actions={() => (
           <Stack
             direction="row"

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.constants.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.constants.tsx
@@ -8,7 +8,7 @@ import UnavailableText from 'components/unavailable-text';
 
 export const OVERVIEW_TABLE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
   {
-    size: 400,
+    size: 500,
     header: Messages.columns.queryText,
     accessorKey: 'queryText',
     filterFn: 'contains',
@@ -19,8 +19,10 @@ export const OVERVIEW_TABLE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
     accessorKey: 'serviceName',
   },
   {
+    size: 150,
     header: Messages.columns.operationId,
     accessorKey: 'queryId',
+    enableColumnFilter: false,
   },
   {
     size: 150,
@@ -28,6 +30,9 @@ export const OVERVIEW_TABLE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
     accessorKey: 'queryExecutionDurationMs',
     filterVariant: 'range',
     filterFn: 'timeRangeFilterFn',
+    muiTableHeadCellFilterTextFieldProps: {
+      inputProps: { step: 0.25, type: 'number' },
+    },
     Cell: ({ cell }) =>
       cell.getValue() ? (
         `${formatDuration(

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.tsx
@@ -1,3 +1,4 @@
+import { type MRT_Row } from 'material-react-table';
 import { MaterialReactTableProps } from 'material-react-table';
 import { Table } from '@percona/ui-lib';
 import { FC } from 'react';
@@ -6,6 +7,7 @@ import { OVERVIEW_TABLE_COLUMNS } from './OverviewTable.constants';
 import { RealtimeTableWrapper } from 'pages/rta/components/rta-table-wrapper';
 import { boxClasses } from '@mui/material/Box';
 import { Messages } from './OverviewTable.messages';
+import { filterElapsedTime } from './OverviewTable.utils';
 
 interface Props {
   queries: QueryData[];
@@ -48,33 +50,8 @@ const OverviewTable: FC<Props> = ({
       renderTopToolbarCustomActions={actions}
       filterFns={{
         // default 'betweenInclusive' filter fails on values like '1.50', discarding the row that has 1.5 seconds
-        timeRangeFilterFn: (row, id, filterValue) => {
-          const [min, max] = filterValue;
-          if (
-            min === '' ||
-            max === '' ||
-            min === null ||
-            max === null ||
-            min === undefined ||
-            max === undefined
-          ) {
-            return true;
-          }
-
-          if (Number.isNaN(min) || Number.isNaN(max)) {
-            return false;
-          }
-
-          const minSeconds = parseFloat(min);
-          const maxSeconds = parseFloat(max);
-
-          const valueSeconds = row.getValue<number>(id);
-          if (valueSeconds === null || valueSeconds === undefined) {
-            return false;
-          }
-
-          return valueSeconds >= minSeconds && valueSeconds <= maxSeconds;
-        },
+        timeRangeFilterFn: (row, id, filterValue) =>
+          filterElapsedTime(row as MRT_Row<QueryData>, id, filterValue),
       }}
       muiTableBodyRowProps={{
         onMouseEnter: onRowHover,

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.utils.ts
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.utils.ts
@@ -1,0 +1,22 @@
+import { type MRT_Row } from 'material-react-table';
+import { QueryData } from 'types/rta.types';
+
+export const filterElapsedTime = (
+  row: MRT_Row<QueryData>,
+  id: string,
+  filterValue: [string, string]
+) => {
+  const [min, max] = filterValue;
+  const valueSeconds = row.getValue<number>(id);
+  if (valueSeconds === null || valueSeconds === undefined) return false;
+
+  const minSet = min !== '' && min != null && !Number.isNaN(parseFloat(min));
+  const maxSet = max !== '' && max != null && !Number.isNaN(parseFloat(max));
+
+  if (!minSet && !maxSet) return true;
+
+  if (minSet && !maxSet) return valueSeconds >= parseFloat(min);
+  if (!minSet && maxSet) return valueSeconds <= parseFloat(max);
+
+  return valueSeconds >= parseFloat(min) && valueSeconds <= parseFloat(max);
+};

--- a/ui/apps/pmm/src/pages/rta/sessions/sessions-table/SessionsTable.tsx
+++ b/ui/apps/pmm/src/pages/rta/sessions/sessions-table/SessionsTable.tsx
@@ -20,6 +20,7 @@ import { ModalType, SessionRow } from './SessionsTable.types';
 import { enqueueSnackbar } from 'notistack';
 import { RealtimeTableWrapper } from 'pages/rta/components/rta-table-wrapper';
 import { useUser } from 'contexts/user';
+import { Navigate } from 'react-router-dom';
 
 const SessionsTable: FC = () => {
   const { user } = useUser();
@@ -104,6 +105,10 @@ const SessionsTable: FC = () => {
 
   if (isLoading) {
     return <Skeleton variant="rounded" height="100%" />;
+  }
+
+  if (sessions.length === 0) {
+    return <Navigate to="/rta/selection" />;
   }
 
   return (

--- a/ui/apps/pmm/src/pages/rta/sessions/sessions-table/cell-session-status/SessionStatus.tsx
+++ b/ui/apps/pmm/src/pages/rta/sessions/sessions-table/cell-session-status/SessionStatus.tsx
@@ -9,6 +9,7 @@ import { diffFromNow, formatDuration } from 'utils/datetime.utils';
 import { Messages } from './SessionStatus.messages';
 import { getSessionStatusText } from 'utils/status.utils';
 import { SessionRow } from '../SessionsTable.types';
+import { useLiveTimestamp } from 'hooks/useLiveTimestamp';
 
 interface Props {
   session: SessionRow;
@@ -17,6 +18,7 @@ interface Props {
 const SessionStatus: FC<Props> = ({ session }) => {
   const theme = useTheme();
   const styles = getStyles(theme);
+  useLiveTimestamp(30_000);
 
   if (session.status === RealtimeSessionStatus.running) {
     return Messages.runningFor(formatDuration(diffFromNow(session.startTime)));


### PR DESCRIPTION
PMM-14550

- Live update of "Running for"
- Navigate to selection if running sessions is empty
- Don't pause on row hover
- Disable column filter for "Operation ID"
- Allow just min/max for elapsed time column
- Increase space for “Query text”