### PR TITLE
PMM-14829 Bump Go to 1.25.8

### DIFF
--- a/api-tests/tools/go.mod
+++ b/api-tests/tools/go.mod
@@ -1,5 +1,5 @@
 module tools
 
-go 1.25.7
+go 1.25.8
 
 require github.com/jstemmer/go-junit-report v1.0.0

--- a/build/docker/rpmbuild/Dockerfile.el8
+++ b/build/docker/rpmbuild/Dockerfile.el8
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/build/docker/rpmbuild/Dockerfile.hetzner-el9
+++ b/build/docker/rpmbuild/Dockerfile.hetzner-el9
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/build/packer/ansible/agent-aws.yml
+++ b/build/packer/ansible/agent-aws.yml
@@ -107,12 +107,6 @@
         dest: /usr/local/bin/kubectl
         mode: "u+x,g+x,o+x"
 
-    - name: Install lacework
-      get_url:
-        url: "https://github.com/lacework/lacework-vulnerability-scanner/releases/latest/download/lw-scanner-linux-{{ ansible_architecture_alt }}"
-        dest: /usr/local/bin/lw-scanner
-        mode: "u+x,g+x,o+x"
-
     - name: Install doctl client for digital ocean
       get_url:
         url: https://github.com/digitalocean/doctl/releases/download/v{{ doctl_version }}/doctl-{{ doctl_version }}-linux-{{ ansible_architecture_alt }}.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm
 
-go 1.25.7
+go 1.25.8
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.0.0-20260107142235-15cbcf569b9f
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm/tools
 
-go 1.25.7
+go 1.25.8
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.21.0-percona
 


### PR DESCRIPTION
PMM-14829

Link to the Feature Build: SUBMODULES-4258

This pull request primarily updates the Go version used across the project from 1.25.7 to 1.25.8, ensuring consistency in builds and dependencies. Additionally, it removes the installation step for the Lacework vulnerability scanner from the AWS agent provisioning process.

Go version upgrade:

* Updated the Go version from 1.25.7 to 1.25.8.

Provisioning changes:

* Removed the Lacework vulnerability scanner installation step from the `agent-aws.yml` Ansible playbook.
