### PR TITLE
PMM-14829 Bump VictoriaMetrics to 1.138.0

### DIFF
--- a/build/packages/rpm/server/SPECS/victoriametrics.spec
+++ b/build/packages/rpm/server/SPECS/victoriametrics.spec
@@ -1,18 +1,11 @@
 %undefine _missing_build_ids_terminate_build
 
-%define copying() \
-%if 0%{?fedora} >= 21 || 0%{?rhel} >= 7 \
-%license %{*} \
-%else \
-%doc %{*} \
-%endif
-
 %global repo            VictoriaMetrics
 %global provider        github.com/VictoriaMetrics/%{repo}
-%global commit          pmm-6401-v1.137.0
+%global commit          pmm-6401-v1.138.0
 
 Name:           percona-victoriametrics
-Version:        1.137.0
+Version:        1.138.0
 Release:        1%{?dist}
 Summary:        VictoriaMetrics monitoring solution and time series database
 License:        Apache-2.0
@@ -50,6 +43,9 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 
 %changelog
+* Wed Mar 18 2026 Alex Demidoff <alexander.demidoff@percona.com> - 1.138.0-1
+- upgrade victoriametrics to 1.138.0 release
+
 * Thu Mar 12 2026 Alex Demidoff <alexander.demidoff@percona.com> - 1.137.0-1
 - upgrade victoriametrics to 1.137.0 release
 

--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -64,8 +64,8 @@ source_tarball=${root_dir}/results/source_tarball/pmm-client-${pmm_version}.tar.
 binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}.tar.gz
 dynamic_binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}-${BUILD_TYPE}-${OS_VARIANT}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.137.0
-vmagent_commit_hash=0e2f3b13bde9a9724223752f5cfb875fc7e8c495
+# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.138.0
+vmagent_commit_hash=bcd5d31b54598dfb3c43420c2b3abe4f0a812493
 # https://github.com/oliver006/redis_exporter/releases/tag/v1.82.0
 redis_exporter_commit_hash=1f3d89a11af0f0fd10f4f6e56b24a1687ae85776
 # https://github.com/hashicorp/nomad/releases/tag/v1.11.3


### PR DESCRIPTION
PMM-14829

Link to the Feature Build: [SUBMODULES-4269](https://github.com/Percona-Lab/pmm-submodules/pull/4269)
