### PR TITLE
PMM-14952 Avoid sending RTA agent status with each RTA bucket

### DIFF
--- a/agent/agents/mongodb/realtimeanalytics/mongodb.go
+++ b/agent/agents/mongodb/realtimeanalytics/mongodb.go
@@ -150,15 +150,12 @@ func (m *MongoDBRTA) Run(ctx context.Context) {
 					// If context is done, we don't send anything to the channel.
 					return
 				default:
-					change := agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING}
 					if len(rtaQueryBucket) != 0 {
 						// If we have data, send it to the channel.
 						// If not, send only status without data to avoid triggering
 						// unnecessary processing in the receiver.
-						change.RTAQueriesBucket = rtaQueryBucket
+						m.changes <- agents.Change{RTAQueriesBucket: rtaQueryBucket}
 					}
-
-					m.changes <- change
 				}
 			}(ctx)
 		}


### PR DESCRIPTION
PMM-14952

Link to the Feature Build: https://github.com/Percona-Lab/pmm-submodules/pull/4284


PMM Agent sent to PMM Server the fetched RTA queries bucket and current rta-agent status `AgentStatus_AGENT_STATUS_RUNNING`. This status triggered status update logic on PMM Server side that resulted into triggering agent configuration update. And we observed the high CPU usage
