### PR TITLE
PMM-7 - Add Jira bug ticket templates for Cursor and Claude Code AI agents

### DIFF
--- a/.claude/skills/jira-bug-ticket/SKILL.md
+++ b/.claude/skills/jira-bug-ticket/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: jira-bug-ticket
+description: Draft a PMM Jira bug ticket in the team's standard format. Use when filing a bug report, describing a defect, or when the user mentions "bug ticket" or "Jira bug".
+argument-hint: "[optional bug description or context]"
+---
+
+Draft a PMM Jira bug ticket using the template below. All sections are mandatory — write "N/A" if a section genuinely does not apply. Use context from the current conversation, codebase, or `$ARGUMENTS` to fill in as much detail as possible.
+
+## Title
+
+Short, specific summary: `[Component] Brief description of the defect`
+
+PMM components: QAN, Alerting, Backup, Inventory, UI, pmm-agent, pmm-managed, pmm-admin, vmproxy, Grafana, ClickHouse, VictoriaMetrics, Exporters, API.
+
+## Description Fields
+
+**Steps to reproduce:**
+Numbered, minimal steps to reliably trigger the bug. Include PMM version, database type/version, and deployment method (Docker/OVF/AMI) when relevant.
+
+**Actual result:**
+What happens — include error messages, HTTP status codes, or log snippets verbatim.
+
+**Expected result:**
+What should happen according to documentation or intended behavior.
+
+**User impact:**
+Who is affected (all users, specific DB type, specific deployment), severity (data loss, degraded monitoring, cosmetic), and whether it blocks a workflow.
+
+**Workaround:**
+Temporary steps users can take to avoid the issue, or "None known."
+
+**Details (+screenshots, whole logs):**
+Attach screenshots, full log excerpts (not truncated) including PMM components logs, relevant config, and `pmm-admin status` / `pmm-admin list` output.
+
+## Additional Fields
+
+**How to document:**
+Brief note for the technical writer — does this need a Known Issues entry, a docs update, or a release note? Reference the affected docs page if known.
+
+**How to test:**
+Concrete verification steps for QA. Include: preconditions, test data setup, exact actions, and pass/fail criteria. Mention if it's automatable and which test suite it belongs to (api-tests, pmm-ui-tests, pmm-qa).
+
+## Classification
+
+Determine the issue type:
+
+- **Regression** — functionality that worked in a previous release but is now broken. Always fill in the `Affects version` field with the last known working version. Example: "Regression from 3.0.0 — worked in 2.x."
+- **Defect** — new or changed functionality in the current release that was broken during development. `Affects version` is the current release only.
+
+State the classification explicitly in the ticket (e.g., "Regression from 3.0.0" or "Defect introduced in 3.1.0").
+
+## Example
+
+For the expected output format, see [example.md](example.md).

--- a/.claude/skills/jira-bug-ticket/example.md
+++ b/.claude/skills/jira-bug-ticket/example.md
@@ -1,0 +1,38 @@
+# Example Bug Ticket
+
+```
+Title: [Alerting] Custom alerting rule silently dropped after PMM Server restart
+
+Steps to reproduce:
+1. Deploy PMM 3.1.0 via Docker
+2. Navigate to Alerting > Alert Rules > New Alert Rule
+3. Create a custom rule with a PromQL expression
+4. Restart the PMM Server container (`docker restart pmm-server`)
+5. Navigate back to Alerting > Alert Rules
+
+Actual result:
+The custom rule is no longer listed. No error in the UI. Server logs show:
+`level=error msg="failed to restore rule" err="rule file not found"`
+
+Expected result:
+Custom alerting rules persist across PMM Server restarts.
+
+User impact:
+All users who create custom alerting rules lose them on restart. High severity — silent data loss of monitoring configuration.
+
+Workaround:
+Export rules via API (`GET /v1/alerting/rules`) before restart and re-import after.
+
+Details:
+- PMM 3.1.0, Docker deployment
+- See attached pmm-managed.log and screenshot of empty rules page
+
+How to document:
+Add to Known Issues for 3.1.0. Update "Alerting" docs page with a note about backup/export before restart.
+
+How to test:
+1. Create 3 alert rules (1 built-in template, 1 custom PromQL, 1 with labels)
+2. Restart PMM Server
+3. Verify all 3 rules are present and functional
+Automatable: yes, extend api-tests/alerting suite.
+```

--- a/.cursor/rules/jira-bug-ticket.mdc
+++ b/.cursor/rules/jira-bug-ticket.mdc
@@ -1,0 +1,89 @@
+---
+description: Format for creating PMM Jira bug tickets. Use when drafting or reviewing bug reports.
+alwaysApply: false
+---
+
+# PMM Jira Bug Ticket Format
+
+When asked to create, draft, or review a Jira bug ticket, use this template. All sections are mandatory — write "N/A" if a section genuinely does not apply.
+
+## Title
+
+Short, specific summary: `[Component] Brief description of the defect`
+Examples: `[QAN] Filter by service name returns empty results for MongoDB`, `[Backup] Scheduled backup fails silently when S3 bucket is unreachable`
+
+## Description Fields
+
+**Steps to reproduce:**
+Numbered, minimal steps to reliably trigger the bug. Include PMM version, database type/version, and deployment method (Docker/OVF/AMI) when relevant.
+
+**Actual result:**
+What happens — include error messages, HTTP status codes, or log snippets verbatim.
+
+**Expected result:**
+What should happen according to documentation or intended behavior.
+
+**User impact:**
+Who is affected (all users, specific DB type, specific deployment), severity (data loss, degraded monitoring, cosmetic), and whether it blocks a workflow.
+
+**Workaround:**
+Temporary steps users can take to avoid the issue, or "None known."
+
+**Details (+screenshots, whole logs):**
+Attach screenshots, full log excerpts (not truncated) including PMM components logs, relevant config, and `pmm-admin status` / `pmm-admin list` output.
+
+## Additional Fields
+
+**How to document:**
+Brief note for the technical writer — does this need a Known Issues entry, a docs update, or a release note? Reference the affected docs page if known.
+
+**How to test:**
+Concrete verification steps for QA. Include: preconditions, test data setup, exact actions, and pass/fail criteria. Mention if it's automatable and which test suite it belongs to (API tests, E2E UI tests, etc.).
+
+## Classification
+
+Determine the issue type:
+
+- **Regression** — functionality that worked in a previous release but is now broken. Always fill in the `Affects version` field with the last known working version. Example: "Regression from 3.0.0 — worked in 2.x."
+- **Defect** — new or changed functionality in the current release that was broken during development. `Affects version` is the current release only.
+
+State the classification explicitly in the ticket (e.g., "Regression from 3.0.0" or "Defect introduced in 3.1.0").
+
+## Example
+
+```text
+Title: [Alerting] Custom alerting rule silently dropped after PMM Server restart
+
+Steps to reproduce:
+1. Deploy PMM 3.x via Docker
+2. Navigate to Alerting > Alert Rules > New Alert Rule
+3. Create a custom rule with a PromQL expression
+4. Restart the PMM Server container (`docker restart pmm-server`)
+5. Navigate back to Alerting > Alert Rules
+
+Actual result:
+The custom rule is no longer listed. No error in the UI. Server logs show:
+`level=error msg="failed to restore rule" err="rule file not found"`
+
+Expected result:
+Custom alerting rules persist across PMM Server restarts.
+
+User impact:
+All users who create custom alerting rules lose them on restart. High severity — silent data loss of monitoring configuration.
+
+Workaround:
+Export rules via API (`GET /v1/alerting/rules`) before restart and re-import after.
+
+Details:
+- PMM 3.1.0, Docker deployment
+- See attached pmm-managed.log and screenshot of empty rules page
+
+How to document:
+Add to Known Issues for 3.1.0. Update "Alerting" docs page with a note about backup/export before restart.
+
+How to test:
+1. Create 3 alert rules (1 built-in template, 1 custom PromQL, 1 with labels)
+2. Restart PMM Server
+3. Verify all 3 rules are present and functional
+Automatable: yes, extend api-tests/alerting suite.
+```


### PR DESCRIPTION
## Summary
- Add a Cursor rule (`.cursor/rules/jira-bug-ticket.mdc`) and a Claude Code
  skill (`.claude/skills/jira-bug-ticket/`) that teach AI agents the PMM team's
  standard Jira bug ticket format.
- The templates enforce mandatory Jira tickets sections

## Details
**Cursor rule skill** (`.cursor/rules/jira-bug-ticket.mdc`):
- Scoped with `alwaysApply: false` — auto-attached by the agent when bug
  ticket context is detected, or manually via `@jira-bug-ticket`.
- Self-contained with an inline example.

**Claude Code skill** (`.claude/skills/jira-bug-ticket/SKILL.md`):
- Invocable via `/jira-bug-ticket` slash command or auto-loaded when relevant.
- Supports `$ARGUMENTS` for passing bug context directly.
- Example output kept in a separate `example.md` to reduce context usage.

