### PR TITLE
PMM-14980 Fix the healthcheck

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -21,7 +21,7 @@ on:
     inputs:
       BRANCH:
         description: "The branch to pull API tests from"
-        default: "main"
+        default: "v3"
         required: true
         type: string      
       PMM_SERVER_IMAGE:
@@ -40,7 +40,7 @@ jobs:
     env:
       PMM_URL: https://admin:admin@127.0.0.1
       BRANCH: ${{ github.event.inputs.BRANCH || 'v3' }}
-      PMM_SERVER_IMAGE: ${{ github.event.inputs.PMM_SERVER_IMAGE || 'ghcr.io/percona/pmm:3-dev-container' }}
+      PMM_SERVER_IMAGE: ${{ github.event.inputs.PMM_SERVER_IMAGE || 'perconalab/pmm-server:3-dev-latest' }}
 
     steps:
       - name: Check out code
@@ -57,7 +57,6 @@ jobs:
 
       - name: Run PMM Server
         run: |
-          docker volume create pmm-data
           cat <<-EOF > compose.yml
           services:
             pmm-server:
@@ -65,14 +64,15 @@ jobs:
               container_name: pmm-server
               environment:
                 - PMM_DEBUG=1
-                - PMM_ENABLE_TELEMETRY=0
                 - PMM_DEV_PERCONA_PLATFORM_ADDRESS=https://check-dev.percona.com
-                - PMM_DEV_PERCONA_PLATFORM_PUBLIC_KEY=RWTg+ZmCCjt7O8eWeAmTLAqW+1ozUbpRSKSwNTmO+exlS5KEIPYWuYdX
               ports:
                 - 443:8443
               volumes:
                 - pmm-data:/srv
                 - ./managed/testdata/checks:/srv/checks
+          volumes:
+            pmm-data:
+              name: pmm-data
           EOF
 
           # Run it and wait until it's healthy

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -9,21 +9,18 @@ build:
 	go test -c -v ./backup
 	go test -c -v ./inventory
 	go test -c -v ./management
-	go test -c -v -tags settings ./server
+	go test -c -v ./server
 	go test -c -v ./user
 
 run:
 	go test -count=1 -p 1 -v ./... 2>&1 | tee pmm-api-tests-output.txt
-	go test -count=1 -p 1 -v -tags settings ./server -run TestSettings 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 run-dev:
 	go test -count=1 -p 1 -v ./...
-	go test -count=1 -p 1 -v -tags settings ./server -run TestSettings
 
 run-race:
 	go test -count=1 -p 1 -v -race ./... 2>&1 | tee pmm-api-tests-output.txt
-	go test -count=1 -p 1 -v -race -tags settings ./server -run TestSettings 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 clean:

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -9,18 +9,21 @@ build:
 	go test -c -v ./backup
 	go test -c -v ./inventory
 	go test -c -v ./management
-	go test -c -v ./server
+	go test -c -v -tags settings ./server
 	go test -c -v ./user
 
 run:
 	go test -count=1 -p 1 -v ./... 2>&1 | tee pmm-api-tests-output.txt
+	go test -count=1 -p 1 -v -tags settings ./server/... 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 run-dev:
 	go test -count=1 -p 1 -v ./...
+	go test -count=1 -p 1 -v -tags settings ./server/...
 
 run-race:
 	go test -count=1 -p 1 -v -race ./... 2>&1 | tee pmm-api-tests-output.txt
+	go test -count=1 -p 1 -v -race -tags settings ./server/... 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 clean:

--- a/api-tests/Makefile
+++ b/api-tests/Makefile
@@ -14,16 +14,16 @@ build:
 
 run:
 	go test -count=1 -p 1 -v ./... 2>&1 | tee pmm-api-tests-output.txt
-	go test -count=1 -p 1 -v -tags settings ./server/... 2>&1 | tee -a pmm-api-tests-output.txt
+	go test -count=1 -p 1 -v -tags settings ./server -run TestSettings 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 run-dev:
 	go test -count=1 -p 1 -v ./...
-	go test -count=1 -p 1 -v -tags settings ./server/...
+	go test -count=1 -p 1 -v -tags settings ./server -run TestSettings
 
 run-race:
 	go test -count=1 -p 1 -v -race ./... 2>&1 | tee pmm-api-tests-output.txt
-	go test -count=1 -p 1 -v -race -tags settings ./server/... 2>&1 | tee -a pmm-api-tests-output.txt
+	go test -count=1 -p 1 -v -race -tags settings ./server -run TestSettings 2>&1 | tee -a pmm-api-tests-output.txt
 	cat pmm-api-tests-output.txt | bin/go-junit-report > pmm-api-tests-junit-report.xml
 
 clean:

--- a/api-tests/server/settings_test.go
+++ b/api-tests/server/settings_test.go
@@ -1,3 +1,5 @@
+//go:build settings
+
 // Copyright (C) 2023 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify

--- a/api-tests/server/settings_test.go
+++ b/api-tests/server/settings_test.go
@@ -1,5 +1,3 @@
-//go:build settings
-
 // Copyright (C) 2023 Percona LLC
 //
 // This program is free software: you can redistribute it and/or modify
@@ -39,6 +37,7 @@ import (
 )
 
 func TestSettings(t *testing.T) {
+	t.Cleanup(func() { restoreSettingsDefaults(t) })
 	t.Run("GetSettings", func(t *testing.T) {
 		res, err := serverClient.Default.ServerService.GetSettings(nil)
 		require.NoError(t, err)
@@ -727,19 +726,19 @@ func TestSettings(t *testing.T) {
 							t.Logf("Response:\n%s", b)
 						}
 						b, err = io.ReadAll(resp.Body)
-						assert.NoError(t, err)
+						require.NoError(t, err)
 						resp.Body.Close() //nolint:errcheck
 
 						if get == "" {
-							assert.Equal(t, 400, resp.StatusCode, "response:\n%s", b)
+							require.Equal(t, 400, resp.StatusCode, "response:\n%s", b)
 							return
 						}
-						assert.Equal(t, 200, resp.StatusCode, "response:\n%s", b)
+						require.Equal(t, 200, resp.StatusCode, "response:\n%s", b)
 
 						p.Settings.MetricsResolutions.LR = ""
 						err = json.Unmarshal(b, &p)
 						require.NoError(t, err)
-						assert.Equal(t, get, p.Settings.MetricsResolutions.LR, "Change")
+						require.Equal(t, get, p.Settings.MetricsResolutions.LR, "Change")
 
 						req, err = http.NewRequestWithContext(pmmapitests.Context, http.MethodGet, getURI.String(), nil)
 						require.NoError(t, err)

--- a/managed/services/grafana/client.go
+++ b/managed/services/grafana/client.go
@@ -814,14 +814,11 @@ type grafanaHealthResponse struct {
 func (c *Client) IsReady(ctx context.Context) error {
 	var status grafanaHealthResponse
 	if err := c.do(ctx, http.MethodGet, "/api/health", "", nil, nil, &status); err != nil {
-		// since we don't return the error to the user, log it to help debugging
-		logrus.Errorf("grafana status check failed: %s", err)
-		return fmt.Errorf("cannot reach Grafana API")
+		return fmt.Errorf("grafana health check failed: %v", err)
 	}
 
 	if strings.ToLower(status.Database) != "ok" {
-		logrus.Errorf("grafana is up but the database is not ok. Database status is %s", status.Database)
-		return fmt.Errorf("grafana is running with errors")
+		return fmt.Errorf("grafana health check failure: database status is %s", status.Database)
 	}
 
 	return nil

--- a/managed/services/grafana/client.go
+++ b/managed/services/grafana/client.go
@@ -814,7 +814,7 @@ type grafanaHealthResponse struct {
 func (c *Client) IsReady(ctx context.Context) error {
 	var status grafanaHealthResponse
 	if err := c.do(ctx, http.MethodGet, "/api/health", "", nil, nil, &status); err != nil {
-		return fmt.Errorf("grafana health check failed: %v", err)
+		return fmt.Errorf("grafana health check failed: %w", err)
 	}
 
 	if strings.ToLower(status.Database) != "ok" {


### PR DESCRIPTION
PMM-14980

Link to the Feature Build: SUBMODULES-4296

This is an attempt to investigate what can be the reason of failing API `server/settings_test.go`. 

```
00:05:35.855              --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway (0.06s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/60s (0.01s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/61s (0.03s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/61 (0.00s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/2m (0.00s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/1h (0.00s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/1d (0.00s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/1w (0.00s)
00:05:35.855                  --- FAIL: TestSettings/GetSettings/ChangeSettings/grpc-gateway/59s (0.01s)
```

> [!NOTE]
> There is no guarantee this will fix the tests, but it should definitely help identify the root cause. 
