### PR TITLE
PMM-7 Prevent dependabot automerge on major versions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,6 +20,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
PMM-7

This pull request updates the Dependabot workflow to improve automation for merging pull requests. The main change ensures that auto-merge is only enabled for safe, non-breaking updates.

**Dependabot workflow improvements:**

* Added a condition to the "Enable auto-merge for Dependabot PRs" step in `.github/workflows/dependabot.yml` so that auto-merge is only triggered for `semver-minor` and `semver-patch` updates, reducing the risk of unintended breaking changes being merged automatically.