### PR TITLE
PMM-14944 Bump up Go to 1.25.9

### DIFF
--- a/api-tests/tools/go.mod
+++ b/api-tests/tools/go.mod
@@ -1,5 +1,5 @@
 module tools
 
-go 1.25.8
+go 1.25.9
 
 require github.com/jstemmer/go-junit-report v1.0.0

--- a/build/docker/rpmbuild/Dockerfile.el8
+++ b/build/docker/rpmbuild/Dockerfile.el8
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/build/docker/rpmbuild/Dockerfile.el9
+++ b/build/docker/rpmbuild/Dockerfile.el9
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/build/docker/rpmbuild/Dockerfile.hetzner-el9
+++ b/build/docker/rpmbuild/Dockerfile.hetzner-el9
@@ -1,5 +1,5 @@
 # keep that format for easier search
-ARG GO_VERSION=1.25.8
+ARG GO_VERSION=1.25.9
 
 FROM golang:${GO_VERSION} AS golang
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm
 
-go 1.25.8
+go 1.25.9
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.0.0-20260107142235-15cbcf569b9f
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm/tools
 
-go 1.25.8
+go 1.25.9
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.21.0-percona
 


### PR DESCRIPTION
PMM-14944

Link to the Feature Build: SUBMODULES-4306

This PR addresses the CVE-2026-32280, which is fixed in Go 1.25.9.
