### PR TITLE
PMM-15006 Upgrade VictoriaMetrics to version 1.140.0 and fix Go toolchain

### DIFF
--- a/build/packages/rpm/server/SPECS/victoriametrics.spec
+++ b/build/packages/rpm/server/SPECS/victoriametrics.spec
@@ -2,10 +2,10 @@
 
 %global repo            VictoriaMetrics
 %global provider        github.com/VictoriaMetrics/%{repo}
-%global commit          pmm-6401-v1.139.0
+%global commit          pmm-6401-v1.140.0
 
 Name:           percona-victoriametrics
-Version:        1.139.0
+Version:        1.140.0
 Release:        1%{?dist}
 Summary:        VictoriaMetrics monitoring solution and time series database
 License:        Apache-2.0
@@ -26,8 +26,8 @@ export PKG_TAG=%{commit}
 export BUILDINFO_TAG=%{commit}
 export USER=builder
 
-make victoria-metrics-pure
-make vmalert-pure
+GOTOOLCHAIN=local make victoria-metrics-pure
+GOTOOLCHAIN=local make vmalert-pure
 
 
 %install
@@ -43,6 +43,9 @@ install -D -p -m 0755 ./bin/vmalert-pure %{buildroot}%{_sbindir}/vmalert
 
 
 %changelog
+* Wed Apr 22 2026 Alex Demidoff <alexander.demidoff@percona.com> - 1.140.0-1
+- upgrade victoriametrics to 1.140.0 release
+
 * Mon Apr 6 2026 Alex Demidoff <alexander.demidoff@percona.com> - 1.139.0-1
 - upgrade victoriametrics to 1.139.0 release
 

--- a/build/packages/rpm/server/SPECS/victoriametrics.spec
+++ b/build/packages/rpm/server/SPECS/victoriametrics.spec
@@ -26,8 +26,8 @@ export PKG_TAG=%{commit}
 export BUILDINFO_TAG=%{commit}
 export USER=builder
 
-GOTOOLCHAIN=local make victoria-metrics-pure
-GOTOOLCHAIN=local make vmalert-pure
+make victoria-metrics-pure
+make vmalert-pure
 
 
 %install

--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -64,8 +64,8 @@ source_tarball=${root_dir}/results/source_tarball/pmm-client-${pmm_version}.tar.
 binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}.tar.gz
 dynamic_binary_tarball=${root_dir}/results/tarball/pmm-client-${pmm_version}-${BUILD_TYPE}-${OS_VARIANT}.tar.gz
 
-# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.139.0
-vmagent_commit_hash=74d803aaf9182e8fecaa5c7ba9703d3c29437c10
+# https://github.com/VictoriaMetrics/VictoriaMetrics/releases/tag/pmm-6401-v1.140.0
+vmagent_commit_hash=de590f71fe078c197e32cc873995965161bcedc8
 # https://github.com/oliver006/redis_exporter/releases/tag/v1.82.0
 redis_exporter_commit_hash=1f3d89a11af0f0fd10f4f6e56b24a1687ae85776
 # https://github.com/hashicorp/nomad/releases/tag/v1.11.3


### PR DESCRIPTION
PMM-15006

Link to the Feature Build: SUBMODULES-4312

