### PR TITLE
Fix/pmm-4971

### DIFF
--- a/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.provider.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate, useNavigationType } from 'react-router';
 import { GrafanaContext } from './grafana.context';
 import {
   GRAFANA_SUB_PATH,
+  PMM_BASE_PATH,
   PMM_NEW_NAV_GRAFANA_PATH,
   PMM_NEW_NAV_PATH,
 } from 'lib/constants';
@@ -15,7 +16,7 @@ import type {
 import { updateDocumentTitle } from 'utils/document.utils';
 import { useKioskMode } from 'hooks/utils/useKioskMode';
 import { useColorMode } from 'hooks/theme';
-import { getLocationUrl } from './grafana.utils';
+import { getLocationUrl, isGrafanaLoginPath } from './grafana.utils';
 import messenger from 'lib/messenger';
 import { useSettings } from 'hooks/api/useSettings';
 import { useServiceTypes } from 'hooks/api/useServices';
@@ -93,7 +94,18 @@ export const GrafanaProvider: FC<PropsWithChildren> = ({ children }) => {
           return;
         }
 
-        navigate(getLocationUrl(location), {
+        const nextPath = getLocationUrl(location);
+
+        // Full top-level navigation: SPA route still mounts MainWithNav for /graph/*,
+        // which would keep the PMM sidebar visible next to Grafana login (PMM-14971).
+        if (isGrafanaLoginPath(nextPath)) {
+          window.location.replace(
+            new URL(`${PMM_BASE_PATH}${nextPath}`, window.location.origin).href
+          );
+          return;
+        }
+
+        navigate(nextPath, {
           state: { fromGrafana: true },
           replace: true,
         });

--- a/ui/apps/pmm/src/contexts/grafana/grafana.utils.test.ts
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getLocationUrl, isGrafanaLoginPath } from './grafana.utils';
+
+describe('getLocationUrl', () => {
+  it('maps Grafana-relative /login to /graph/login', () => {
+    expect(
+      getLocationUrl({
+        pathname: '/login',
+        search: '',
+        hash: '',
+        key: 'k',
+      })
+    ).toBe('/graph/login');
+  });
+
+  it('keeps /graph/login when Grafana already uses full graph path', () => {
+    expect(
+      getLocationUrl({
+        pathname: '/graph/login',
+        search: '',
+        hash: '',
+        key: 'k',
+      })
+    ).toBe('/graph/login');
+  });
+
+  it('strips /pmm-ui prefix when present', () => {
+    expect(
+      getLocationUrl({
+        pathname: '/pmm-ui/graph/d/x',
+        search: '?a=1',
+        hash: '',
+        key: 'k',
+      })
+    ).toBe('/graph/d/x?a=1');
+  });
+});
+
+describe('isGrafanaLoginPath', () => {
+  it('detects /graph/login', () => {
+    expect(isGrafanaLoginPath('/graph/login')).toBe(true);
+    expect(isGrafanaLoginPath('/graph/login?redirect=/')).toBe(true);
+  });
+
+  it('rejects other graph routes', () => {
+    expect(isGrafanaLoginPath('/graph/d/pmm-home')).toBe(false);
+    expect(isGrafanaLoginPath('/graph/admin/users')).toBe(false);
+  });
+});

--- a/ui/apps/pmm/src/contexts/grafana/grafana.utils.test.ts
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.utils.test.ts
@@ -8,7 +8,6 @@ describe('getLocationUrl', () => {
         pathname: '/login',
         search: '',
         hash: '',
-        key: 'k',
       })
     ).toBe('/graph/login');
   });
@@ -19,7 +18,6 @@ describe('getLocationUrl', () => {
         pathname: '/graph/login',
         search: '',
         hash: '',
-        key: 'k',
       })
     ).toBe('/graph/login');
   });
@@ -30,7 +28,6 @@ describe('getLocationUrl', () => {
         pathname: '/pmm-ui/graph/d/x',
         search: '?a=1',
         hash: '',
-        key: 'k',
       })
     ).toBe('/graph/d/x?a=1');
   });

--- a/ui/apps/pmm/src/contexts/grafana/grafana.utils.ts
+++ b/ui/apps/pmm/src/contexts/grafana/grafana.utils.ts
@@ -1,10 +1,25 @@
-import { PMM_NEW_NAV_GRAFANA_PATH, PMM_NEW_NAV_PATH } from 'lib/constants';
+import {
+  GRAFANA_SUB_PATH,
+  PMM_LOGIN_URL,
+  PMM_NEW_NAV_GRAFANA_PATH,
+  PMM_NEW_NAV_PATH,
+} from 'lib/constants';
 import { Path } from 'react-router-dom';
 
-export const getLocationUrl = (location: Path) => {
-  const pathname = location.pathname.startsWith('/pmm-ui')
-    ? location.pathname.replace('/pmm-ui', PMM_NEW_NAV_PATH)
-    : PMM_NEW_NAV_GRAFANA_PATH + location.pathname;
+/** True when the PMM URL (pathname + optional search/hash) is the Grafana login route. */
+export const isGrafanaLoginPath = (pathnameSearchHash: string) => {
+  const path = pathnameSearchHash.split(/[?#]/)[0].replace(/\/$/, '') || '/';
+  return path === PMM_LOGIN_URL || path.endsWith(PMM_LOGIN_URL);
+};
 
-  return pathname + location.search + location.hash;
+export const getLocationUrl = (location: Path) => {
+  const { pathname: rawPath, search, hash } = location;
+
+  const pathname = rawPath.startsWith('/pmm-ui')
+    ? rawPath.replace('/pmm-ui', PMM_NEW_NAV_PATH)
+    : rawPath.startsWith(GRAFANA_SUB_PATH)
+      ? rawPath
+      : PMM_NEW_NAV_GRAFANA_PATH + rawPath;
+
+  return pathname + search + hash;
 };

--- a/ui/apps/pmm/src/pages/grafana/GrafanaFullPageLogin.tsx
+++ b/ui/apps/pmm/src/pages/grafana/GrafanaFullPageLogin.tsx
@@ -1,0 +1,33 @@
+import { CircularProgress, Stack } from '@mui/material';
+import { GrafanaPage } from 'pages/grafana';
+import { useBootstrap } from 'hooks/utils/useBootstrap';
+
+/**
+ * Full-viewport Grafana iframe without PMM shell (sidebar/header).
+ * Used for /graph/login so session expiry after password change does not show duplicate nav (PMM-14971).
+ */
+export const GrafanaFullPageLogin = () => {
+  const { isReady } = useBootstrap();
+
+  if (!isReady) {
+    return (
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        sx={{
+          flex: 1,
+          minHeight: '100vh',
+          padding: 10,
+        }}
+      >
+        <CircularProgress data-testid="pmm-grafana-login-fullpage-loading" />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack direction="column" flex={1} sx={{ minHeight: '100vh' }}>
+      <GrafanaPage />
+    </Stack>
+  );
+};

--- a/ui/apps/pmm/src/pages/grafana/GrafanaFullPageLogin.tsx
+++ b/ui/apps/pmm/src/pages/grafana/GrafanaFullPageLogin.tsx
@@ -1,5 +1,5 @@
 import { CircularProgress, Stack } from '@mui/material';
-import { GrafanaPage } from 'pages/grafana';
+import { GrafanaPage } from './GrafanaPage';
 import { useBootstrap } from 'hooks/utils/useBootstrap';
 
 /**

--- a/ui/apps/pmm/src/pages/grafana/index.ts
+++ b/ui/apps/pmm/src/pages/grafana/index.ts
@@ -1,1 +1,2 @@
 export { GrafanaPage } from './GrafanaPage';
+export { GrafanaFullPageLogin } from './GrafanaFullPageLogin';

--- a/ui/apps/pmm/src/router.tsx
+++ b/ui/apps/pmm/src/router.tsx
@@ -12,6 +12,7 @@ import { RealtimeSessionsPage } from 'pages/rta/sessions';
 import { Redirect } from 'components/redirect';
 import RealtimeOverviewPage from 'pages/rta/overview/RealtimeOverview';
 import RealtimeTab from 'pages/rta/tab/RealtimeTab';
+import { GrafanaFullPageLogin } from 'pages/grafana';
 
 const router = createBrowserRouter(
   [
@@ -19,6 +20,10 @@ const router = createBrowserRouter(
       path: '',
       element: <Providers />,
       children: [
+        {
+          path: 'graph/login',
+          element: <GrafanaFullPageLogin />,
+        },
         {
           path: PMM_NEW_NAV_PATH,
           element: <MainWithNav />,


### PR DESCRIPTION
When the iframe session expires (e.g. after password change), Grafana posts
LOCATION_CHANGE to /graph/login. SPA navigate kept MainWithNav, so the
sidebar stayed visible next to the login form.

Use a top-level document navigation to /[pmm-ui](https://perconadev.atlassian.net/browse/PMM-ui)/graph/login and a dedicated
route that renders only the Grafana iframe (no sidebar/header). Harden
getLocationUrl so Grafana paths already under /graph are not doubled.

- [ ] API Docs updated

If this PR is related to other PRs, contributions, or ongoing work in this or other repositories, please reference them here:

- Links to related work items (optional).
