### PR TITLE
Update Valkey_CommandDetails.json

### DIFF
--- a/dashboards/dashboards/Valkey/Valkey_CommandDetails.json
+++ b/dashboards/dashboards/Valkey/Valkey_CommandDetails.json
@@ -2250,7 +2250,7 @@
                     ]
                 },
                 "datasource": "Metrics",
-                "definition": "label_values(redis_up{node_name=~\"$node_name\", role!=\"sentinel\"},service_name)",
+                "definition": "label_values(redis_up{node_name=~\"$node_name\", role!=\"sentinel\", service_name=~\"$service_name\"},service_name)",
                 "hide": 2,
                 "includeAll": true,
                 "label": "Service Name",
@@ -2259,7 +2259,7 @@
                 "options": [],
                 "query": {
                     "qryType": 1,
-                    "query": "label_values(redis_up{node_name=~\"$node_name\", role!=\"sentinel\"},service_name)",
+                    "query": "label_values(redis_up{node_name=~\"$node_name\", role!=\"sentinel\", service_name=~\"$service_name\"},service_name)",
                     "refId": "PrometheusVariableQueryEditor-VariableQuery"
                 },
                 "refresh": 2,

--- a/dashboards/dashboards/Valkey/Valkey_CommandDetails.json
+++ b/dashboards/dashboards/Valkey/Valkey_CommandDetails.json
@@ -377,7 +377,7 @@
                 {
                     "datasource": "Metrics",
                     "editorMode": "code",
-                    "expr": "sum(rate(redis_commands_total{service_name=~\"$service_name\"} [1m])) by (service_name,cmd)",
+                    "expr": "sum(rate(redis_commands_total{service_name=~\"$ns_service_name\"} [1m])) by (service_name,cmd)",
                     "format": "time_series",
                     "interval": "",
                     "intervalFactor": 2,


### PR DESCRIPTION
Since the dashboard repeat is configured by "ns_service_name" variable, the expression must use the same variable name. Otherwise, the identical panels between multiple Redis instances are generating. Tested on PMM 3.7.1

PMM-0

Link to the Feature Build: SUBMODULES-0


If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/v3/docs/api) as well:

- [ ] API Docs updated

If this PR is related to other PRs, contributions, or ongoing work in this or other repositories, please reference them here:

- Links to related work items (optional).
