### PR TITLE
PMM-14934 Revert removal of rpm directory

### DIFF
--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -27,7 +27,6 @@
         - /var/log/clickhouse-keeper
         - /var/log/nginx
         - /var/lib/pgsql
-        - /var/lib/rpm
         - /var/cache/dnf
         - /var/cache/yum
         - /usr/local/percona/pmm/config/pmm-agent.yaml


### PR DESCRIPTION
PMM-14934

SUBMODULES-4360

Initially this removal was meant to save some disk space, but we realized a few tests would fail.

* Removed `/var/lib/rpm` from the list of directories to be cleaned up.


