### PR TITLE
PMM-14934 Adjust the server container healthcheck

### DIFF
--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -47,6 +47,6 @@ VOLUME [ "/srv" ]
 
 EXPOSE 8080 8443
 
-HEALTHCHECK --interval=4s --timeout=2s --start-period=10s --retries=3 CMD curl -sf http://127.0.0.1:8080/v1/server/readyz
+HEALTHCHECK --interval=4s --timeout=2s --start-period=25s --retries=3 CMD curl -sf http://127.0.0.1:8080/v1/server/readyz
 
 CMD ["/opt/entrypoint.sh"]


### PR DESCRIPTION
PMM-14934

Link to the Feature Build: SUBMODULES-4365


`--start-period` applies any time the container starts (or restarts), not just the initial creation. It defines a grace period after the container process begins during which healthcheck failures don't count toward the `--retries` threshold — Docker won't mark the container unhealthy until the start period has elapsed.

Since we are now shipping an empty "/srv" directory, all components need time to initialize. Grafana needs at least 20 to 30 seconds (depends on CPU and disk performance) to perform the initial DB migration. Therefore, to prevent Docker/Podman from reporting PMM Server as unhealthy, we want to increase the `--start-period` from 10s to 25s, which should fix the false positive.