### PR TITLE
PMM-15054 Disable unused ClickHouse system logs

### DIFF
--- a/build/ansible/roles/clickhouse/files/default-config.xml
+++ b/build/ansible/roles/clickhouse/files/default-config.xml
@@ -740,33 +740,6 @@
     <!-- Reallocate memory for machine code ("text") using huge pages. Highly experimental. -->
     <remap_executable>false</remap_executable>
 
-    <![CDATA[
-         Uncomment below in order to use JDBC table engine and function.
-
-         To install and run JDBC bridge in background:
-         * [Debian/Ubuntu]
-           export MVN_URL=https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc-bridge/
-           export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-           wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-           apt install --no-install-recommends -f ./clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-           clickhouse-jdbc-bridge &
-
-         * [CentOS/RHEL]
-           export MVN_URL=https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc-bridge/
-           export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-           wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-           dnf install -y ./clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-           clickhouse-jdbc-bridge &
-
-         Please refer to https://github.com/ClickHouse/clickhouse-jdbc-bridge#usage for more information.
-    ]]>
-    <!--
-    <jdbc_bridge>
-        <host>127.0.0.1</host>
-        <port>9019</port>
-    </jdbc_bridge>
-    -->
-
     <!-- Configuration of clusters that could be used in Distributed tables.
          https://clickhouse.com/docs/en/operations/table_engines/distributed/
       -->
@@ -1004,11 +977,13 @@
 
         <!-- example of using a different storage policy for a system table -->
         <!-- storage_policy>local_ssd</storage_policy -->
-        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
     </query_log>
 
     <!-- Trace log. Stores stack traces collected by query profilers.
          See query_profiler_real_time_period_ns and query_profiler_cpu_time_period_ns settings. -->
+    <!-- PMM: trace_log disabled — used only for ClickHouse-internal CPU profiling, not read by PMM (PMM-15054). -->
+    <!--
     <trace_log>
         <database>system</database>
         <table>trace_log</table>
@@ -1018,10 +993,10 @@
         <max_size_rows>1048576</max_size_rows>
         <reserved_size_rows>8192</reserved_size_rows>
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
-        <!-- Indication whether logs should be dumped to the disk in case of a crash -->
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
     </trace_log>
+    -->
 
     <!-- Query thread log. Has information about all threads participated in query execution.
          Used only for queries with setting log_query_threads = 1. -->
@@ -1077,6 +1052,8 @@
     -->
 
     <!-- Metric log contains rows with current values of ProfileEvents, CurrentMetrics collected with "collect_interval_milliseconds" interval. -->
+    <!-- PMM: metric_log disabled — CH self-monitoring is redundant; PMM monitors CH via VictoriaMetrics (PMM-15054). -->
+    <!--
     <metric_log>
         <database>system</database>
         <table>metric_log</table>
@@ -1088,11 +1065,14 @@
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
     </metric_log>
+    -->
 
     <!--
         Asynchronous metric log contains values of metrics from
         system.asynchronous_metrics.
     -->
+    <!-- PMM: asynchronous_metric_log disabled — current values remain available in system.asynchronous_metrics (PMM-15054). -->
+    <!--
     <asynchronous_metric_log>
         <database>system</database>
         <table>asynchronous_metric_log</table>
@@ -1103,21 +1083,14 @@
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
     </asynchronous_metric_log>
+    -->
 
     <!--
         OpenTelemetry log contains OpenTelemetry trace spans.
     -->
+    <!-- PMM: opentelemetry_span_log disabled — PMM does not emit OTel spans (PMM-15054). -->
+    <!--
     <opentelemetry_span_log>
-        <!--
-            The default table creation code is insufficient, this <engine> spec
-            is a workaround. There is no 'event_time' for this log, but two times,
-            start and finish. It is sorted by finish time, to avoid inserting
-            data too far away in the past (probably we can sometimes insert a span
-            that is seconds earlier than the last span in the table, due to a race
-            between several spans inserted in parallel). This gives the spans a
-            global order that we can use to e.g. retry insertion into some external
-            system.
-        -->
         <engine>
             engine MergeTree
             partition by toYYYYMM(finish_date)
@@ -1131,6 +1104,7 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
     </opentelemetry_span_log>
+    -->
 
 
     <!-- Crash log. Stores stack traces for fatal errors.
@@ -1152,7 +1126,8 @@
 
         Note: session log has known security issues and should not be used in production.
     -->
-    <!-- <session_log>
+    <!--
+    <session_log>
         <database>system</database>
         <table>session_log</table>
 
@@ -1162,10 +1137,12 @@
         <reserved_size_rows>8192</reserved_size_rows>
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
-    </session_log> -->
+    </session_log>
+    -->
 
     <!-- Profiling on Processors level. -->
-    <processors_profile_log>
+    <!-- PMM: processors_profile_log disabled — pipeline-level CH dev profiling, not used by PMM (PMM-15054). -->
+    <!-- <processors_profile_log>
         <database>system</database>
         <table>processors_profile_log</table>
 
@@ -1176,11 +1153,13 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
     </processors_profile_log>
+    -->
 
     <!-- Log of asynchronous inserts. It allows to check status
          of insert query in fire-and-forget mode.
     -->
-    <asynchronous_insert_log>
+    <!-- PMM: asynchronous_insert_log disabled — PMM does not use async inserts (PMM-15054). -->
+    <!-- <asynchronous_insert_log>
         <database>system</database>
         <table>asynchronous_insert_log</table>
 
@@ -1192,6 +1171,7 @@
         <partition_by>event_date</partition_by>
         <ttl>event_date + INTERVAL 3 DAY</ttl>
     </asynchronous_insert_log>
+    -->
 
     <!-- <top_level_domains_path>/var/lib/clickhouse/top_level_domains/</top_level_domains_path> -->
     <!-- Custom TLD lists.
@@ -1462,4 +1442,31 @@
     <!-- On Linux systems this can control the behavior of OOM killer.
     <oom_score>-1000</oom_score>
     -->
+
+    <!--
+        PMM-15054: drop ClickHouse system log tables PMM does not consume,
+        plus orphan "*_log_0" tables left over from past CH schema upgrades.
+        Runs on every server start; DROP IF EXISTS makes each call idempotent.
+        Per-script errors are non-fatal (startup_scripts.throw_on_error is set to false).
+    -->
+    <startup_scripts>
+        <throw_on_error>false</throw_on_error>
+        <scripts><query>DROP TABLE IF EXISTS system.trace_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.trace_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.metric_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.metric_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_metric_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_metric_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.opentelemetry_span_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.opentelemetry_span_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.processors_profile_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.processors_profile_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_insert_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_insert_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.text_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.text_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.query_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.query_thread_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.part_log_0 SYNC</query></scripts>
+    </startup_scripts>
 </clickhouse>

--- a/build/ansible/roles/clickhouse/files/default-config.xml
+++ b/build/ansible/roles/clickhouse/files/default-config.xml
@@ -1142,7 +1142,8 @@
 
     <!-- Profiling on Processors level. -->
     <!-- PMM: processors_profile_log disabled — pipeline-level CH dev profiling, not used by PMM (PMM-15054). -->
-    <!-- <processors_profile_log>
+    <!--
+    <processors_profile_log>
         <database>system</database>
         <table>processors_profile_log</table>
 
@@ -1159,7 +1160,8 @@
          of insert query in fire-and-forget mode.
     -->
     <!-- PMM: asynchronous_insert_log disabled — PMM does not use async inserts (PMM-15054). -->
-    <!-- <asynchronous_insert_log>
+    <!--
+    <asynchronous_insert_log>
         <database>system</database>
         <table>asynchronous_insert_log</table>
 
@@ -1200,7 +1202,7 @@
 
     <!-- Uncomment if you want data to be compressed 30-100% better.
          Don't do that if you just started using ClickHouse.
-      -->
+    -->
     <!--
     <compression>
         <!- - Set of variants. Checked in order. Last matching case wins. If nothing matches, lz4 will be used. - ->
@@ -1288,6 +1290,7 @@
     <!-- <max_partition_size_to_drop>0</max_partition_size_to_drop> -->
 
     <!-- Example of parameters for GraphiteMergeTree table engine -->
+    <!--
     <graphite_rollup_example>
         <pattern>
             <regexp>click_cost</regexp>
@@ -1317,6 +1320,7 @@
             </retention>
         </default>
     </graphite_rollup_example>
+    -->
 
     <!-- Directory in <clickhouse-path> containing schema files for various input formats.
          The directory will be created if it doesn't exist.

--- a/build/ansible/roles/clickhouse/files/default-config.xml
+++ b/build/ansible/roles/clickhouse/files/default-config.xml
@@ -1451,10 +1451,10 @@
         PMM-15054: drop ClickHouse system log tables PMM does not consume,
         plus orphan "*_log_0" tables left over from past CH schema upgrades.
         Runs on every server start; DROP IF EXISTS makes each call idempotent.
-        Per-script errors are non-fatal (startup_scripts.throw_on_error is set to false).
+        Per-script errors are non-fatal: ClickHouse catches exceptions inside
+        loadStartupScripts and only logs them.
     -->
     <startup_scripts>
-        <throw_on_error>false</throw_on_error>
         <scripts><query>DROP TABLE IF EXISTS system.trace_log SYNC</query></scripts>
         <scripts><query>DROP TABLE IF EXISTS system.trace_log_0 SYNC</query></scripts>
         <scripts><query>DROP TABLE IF EXISTS system.metric_log SYNC</query></scripts>

--- a/build/ansible/roles/clickhouse/files/low-memory-config.xml
+++ b/build/ansible/roles/clickhouse/files/low-memory-config.xml
@@ -995,7 +995,8 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
-    </trace_log> -->
+    </trace_log>
+    -->
 
     <!-- Query thread log. Has information about all threads participated in query execution.
          Used only for queries with setting log_query_threads = 1. -->
@@ -1063,7 +1064,8 @@
         <collect_interval_milliseconds>1000</collect_interval_milliseconds>
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
-    </metric_log> -->
+    </metric_log>
+    -->
 
     <!--
         Asynchronous metric log contains values of metrics from
@@ -1080,7 +1082,8 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
         <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
-    </asynchronous_metric_log> -->
+    </asynchronous_metric_log>
+    -->
 
     <!--
         OpenTelemetry log contains OpenTelemetry trace spans.
@@ -1138,7 +1141,8 @@
 
     <!-- Profiling on Processors level. -->
     <!-- PMM: processors_profile_log disabled — pipeline-level CH dev profiling, not used by PMM (PMM-15054). -->
-    <!-- <processors_profile_log>
+    <!--
+    <processors_profile_log>
         <database>system</database>
         <table>processors_profile_log</table>
 
@@ -1285,6 +1289,7 @@
     <!-- <max_partition_size_to_drop>0</max_partition_size_to_drop> -->
 
     <!-- Example of parameters for GraphiteMergeTree table engine -->
+    <!--
     <graphite_rollup_example>
         <pattern>
             <regexp>click_cost</regexp>
@@ -1314,6 +1319,7 @@
             </retention>
         </default>
     </graphite_rollup_example>
+    -->
 
     <!-- Directory in <clickhouse-path> containing schema files for various input formats.
          The directory will be created if it doesn't exist.

--- a/build/ansible/roles/clickhouse/files/low-memory-config.xml
+++ b/build/ansible/roles/clickhouse/files/low-memory-config.xml
@@ -1450,10 +1450,10 @@
         PMM-15054: drop ClickHouse system log tables PMM does not consume,
         plus orphan "*_log_0" tables left over from past CH schema upgrades.
         Runs on every server start; DROP IF EXISTS makes each call idempotent.
-        Per-script errors are non-fatal (startup_scripts.throw_on_error is set to false).
+        Per-script errors are non-fatal: ClickHouse catches exceptions inside
+        loadStartupScripts and only logs them.
     -->
     <startup_scripts>
-        <throw_on_error>false</throw_on_error>
         <scripts><query>DROP TABLE IF EXISTS system.trace_log SYNC</query></scripts>
         <scripts><query>DROP TABLE IF EXISTS system.trace_log_0 SYNC</query></scripts>
         <scripts><query>DROP TABLE IF EXISTS system.metric_log SYNC</query></scripts>

--- a/build/ansible/roles/clickhouse/files/low-memory-config.xml
+++ b/build/ansible/roles/clickhouse/files/low-memory-config.xml
@@ -740,33 +740,6 @@
     <!-- Reallocate memory for machine code ("text") using huge pages. Highly experimental. -->
     <remap_executable>false</remap_executable>
 
-    <![CDATA[
-         Uncomment below in order to use JDBC table engine and function.
-
-         To install and run JDBC bridge in background:
-         * [Debian/Ubuntu]
-           export MVN_URL=https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc-bridge/
-           export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-           wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-           apt install --no-install-recommends -f ./clickhouse-jdbc-bridge_$PKG_VER-1_all.deb
-           clickhouse-jdbc-bridge &
-
-         * [CentOS/RHEL]
-           export MVN_URL=https://repo1.maven.org/maven2/com/clickhouse/clickhouse-jdbc-bridge/
-           export PKG_VER=$(curl -sL $MVN_URL/maven-metadata.xml | grep '<release>' | sed -e 's|.*>\(.*\)<.*|\1|')
-           wget https://github.com/ClickHouse/clickhouse-jdbc-bridge/releases/download/v$PKG_VER/clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-           dnf install -y ./clickhouse-jdbc-bridge-$PKG_VER-1.noarch.rpm
-           clickhouse-jdbc-bridge &
-
-         Please refer to https://github.com/ClickHouse/clickhouse-jdbc-bridge#usage for more information.
-    ]]>
-    <!--
-    <jdbc_bridge>
-        <host>127.0.0.1</host>
-        <port>9019</port>
-    </jdbc_bridge>
-    -->
-
     <!-- Configuration of clusters that could be used in Distributed tables.
          https://clickhouse.com/docs/en/operations/table_engines/distributed/
       -->
@@ -1004,13 +977,14 @@
 
         <!-- example of using a different storage policy for a system table -->
         <!-- storage_policy>local_ssd</storage_policy -->
-        <ttl>event_date + INTERVAL 30 DAY DELETE</ttl>
+        <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
     </query_log>
 
     <!-- Trace log. Stores stack traces collected by query profilers.
          See query_profiler_real_time_period_ns and query_profiler_cpu_time_period_ns settings. -->
     <!-- PMM: Default enabled, now disabled -->
-    <!-- <trace_log>
+    <!--
+    <trace_log>
         <database>system</database>
         <table>trace_log</table>
 
@@ -1078,7 +1052,8 @@
 
     <!-- Metric log contains rows with current values of ProfileEvents, CurrentMetrics collected with "collect_interval_milliseconds" interval. -->
     <!-- PMM: Default enabled, now disabled -->
-    <!-- <metric_log>
+    <!--
+    <metric_log>
         <database>system</database>
         <table>metric_log</table>
         <flush_interval_milliseconds>7500</flush_interval_milliseconds>
@@ -1095,7 +1070,8 @@
         system.asynchronous_metrics.
     -->
     <!-- PMM: Default enabled, now disabled -->
-    <!-- <asynchronous_metric_log>
+    <!--
+    <asynchronous_metric_log>
         <database>system</database>
         <table>asynchronous_metric_log</table>
         <flush_interval_milliseconds>7000</flush_interval_milliseconds>
@@ -1109,17 +1085,9 @@
     <!--
         OpenTelemetry log contains OpenTelemetry trace spans.
     -->
+    <!-- PMM: opentelemetry_span_log disabled — PMM does not emit OTel spans (PMM-15054). -->
+    <!--
     <opentelemetry_span_log>
-        <!--
-            The default table creation code is insufficient, this <engine> spec
-            is a workaround. There is no 'event_time' for this log, but two times,
-            start and finish. It is sorted by finish time, to avoid inserting
-            data too far away in the past (probably we can sometimes insert a span
-            that is seconds earlier than the last span in the table, due to a race
-            between several spans inserted in parallel). This gives the spans a
-            global order that we can use to e.g. retry insertion into some external
-            system.
-        -->
         <engine>
             engine MergeTree
             partition by toYYYYMM(finish_date)
@@ -1133,6 +1101,7 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
     </opentelemetry_span_log>
+    -->
 
 
     <!-- Crash log. Stores stack traces for fatal errors.
@@ -1154,7 +1123,8 @@
 
         Note: session log has known security issues and should not be used in production.
     -->
-    <!-- <session_log>
+    <!--
+    <session_log>
         <database>system</database>
         <table>session_log</table>
 
@@ -1167,7 +1137,8 @@
     </session_log> -->
 
     <!-- Profiling on Processors level. -->
-    <processors_profile_log>
+    <!-- PMM: processors_profile_log disabled — pipeline-level CH dev profiling, not used by PMM (PMM-15054). -->
+    <!-- <processors_profile_log>
         <database>system</database>
         <table>processors_profile_log</table>
 
@@ -1178,10 +1149,13 @@
         <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
         <flush_on_crash>false</flush_on_crash>
     </processors_profile_log>
+    -->
 
     <!-- Log of asynchronous inserts. It allows to check status
          of insert query in fire-and-forget mode.
     -->
+    <!-- PMM: asynchronous_insert_log disabled — PMM does not use async inserts (PMM-15054). -->
+    <!--
     <asynchronous_insert_log>
         <database>system</database>
         <table>asynchronous_insert_log</table>
@@ -1194,6 +1168,7 @@
         <partition_by>event_date</partition_by>
         <ttl>event_date + INTERVAL 3 DAY</ttl>
     </asynchronous_insert_log>
+    -->
 
     <!-- <top_level_domains_path>/var/lib/clickhouse/top_level_domains/</top_level_domains_path> -->
     <!-- Custom TLD lists.
@@ -1464,4 +1439,31 @@
     <!-- On Linux systems this can control the behavior of OOM killer.
     <oom_score>-1000</oom_score>
     -->
+
+    <!--
+        PMM-15054: drop ClickHouse system log tables PMM does not consume,
+        plus orphan "*_log_0" tables left over from past CH schema upgrades.
+        Runs on every server start; DROP IF EXISTS makes each call idempotent.
+        Per-script errors are non-fatal (startup_scripts.throw_on_error is set to false).
+    -->
+    <startup_scripts>
+        <throw_on_error>false</throw_on_error>
+        <scripts><query>DROP TABLE IF EXISTS system.trace_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.trace_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.metric_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.metric_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_metric_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_metric_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.opentelemetry_span_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.opentelemetry_span_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.processors_profile_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.processors_profile_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_insert_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.asynchronous_insert_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.text_log SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.text_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.query_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.query_thread_log_0 SYNC</query></scripts>
+        <scripts><query>DROP TABLE IF EXISTS system.part_log_0 SYNC</query></scripts>
+    </startup_scripts>
 </clickhouse>


### PR DESCRIPTION
PMM-15054

Link to the Feature Build: SUBMODULES-4375

On low-memory PMM Server installs (e.g. 8 GB), ClickHouse RSS pins at its configured cap as the system log tables grow — `trace_log` alone can reach hundreds of gigabytes (and occupy billions of rows) on long-running installs — starving the merge executor and producing "Code: 241. (total) memory limit exceeded" errors during background merges.

Actions implemented to counter memory exhaustion:

1. Comment out the `<…_log>` blocks for log tables PMM does not consume (trace_log, metric_log, asynchronous_metric_log, opentelemetry_span_log, processors_profile_log, asynchronous_insert_log, plus the long-disabled text_log) in both `default-config.xml` and `low-memory-config.xml`.

2. Add a <startup_scripts> block that issues `DROP TABLE IF EXISTS … SYNC` for each of those tables and for the orphan `*_log_0` tables left over from past ClickHouse schema upgrades, reclaiming disk and merge-memory budget on every server start. Per-script errors are non-fatal, but log-only.

3. `query_log`'s retention was reduced to a more reasonnable 7-day interval.

The Prometheus endpoint, `system.metrics`, and `system.asynchronous_metrics` are unaffected — they read from the in-memory metric sources, not from the dropped `MergeTree` log tables.
