### PR TITLE
Fix linkspector GitHub Actions failure by provisioning Chrome for Linkspector

### DIFF
--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
 
+      - name: Install Chrome for linkspector
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1.7.3
+
+      - name: Configure Chrome path for puppeteer
+        run: echo "PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> "$GITHUB_ENV"
+
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@963b6264d7de32c904942a70b488d3407453049e # v1.5.1
         with:

--- a/documentation/docs/reference/pmm_components_and_versions.md
+++ b/documentation/docs/reference/pmm_components_and_versions.md
@@ -6,7 +6,7 @@ The following table lists all the PMM client/server components and their version
 |-----------------------------|----------|---------------|------------------|
 | Grafana  | 11.6.13*  | [Grafana documentation](https://grafana.com/docs/grafana/latest/)|[Github Grafana](https://github.com/percona-platform/grafana)|
 | VictoriaMetrics| v1.140.0 | [VictoriaMetrics documentation](https://docs.victoriametrics.com/)|[Github VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)    |
-| Nginx    | 1.20.1   | [Nginx documentation](http://nginx.org/en/docs/)|[Github Nginx](https://github.com/nginx/nginx)                                                    |
+| Nginx    | 1.26.3  | [Nginx documentation](http://nginx.org/en/docs/)|[Github Nginx](https://github.com/nginx/nginx)                                                    |
 | Percona Distribution for PostgreSQL  | 14.5     | [Percona Distribution for PostgreSQL 14 documentation](https://www.percona.com/doc/postgresql/LATEST/index.html)|              |
 | ClickHouse| 25.3.6.56 |[ClickHouse documentation](https://clickhouse.com/docs/en/)|[Github ClickHouse](https://github.com/ClickHouse/ClickHouse)|
 | PerconaToolkit  | 3.5.2    | [Percona Toolkit documentation](https://www.percona.com/doc/percona-toolkit/3.0/index.html)|[Github Percona Toolkit](https://github.com/percona/percona-toolkit)|


### PR DESCRIPTION
PMM-0

Link to the Feature Build: SUBMODULES-0

This PR fixes the failing `linkspector` workflow job by ensuring a Chrome binary is available to Puppeteer at runtime.  
Root cause from Actions logs: Linkspector failed with `Could not find Chrome (ver. 148.0.7778.97)`.  
Fix implemented in `.github/workflows/linkspector.yml`:
- Install Chrome using `browser-actions/setup-chrome`
- Export `PUPPETEER_EXECUTABLE_PATH` from the action output before running Linkspector

If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/v3/docs/api) as well:

- [ ] API Docs updated

If this PR is related to other PRs, contributions, or ongoing work in this or other repositories, please reference them here:

- Links to related work items (optional).