### PR TITLE
PMM-7 Fix API tests

### DIFF
--- a/api-tests/inventory/agents_test.go
+++ b/api-tests/inventory/agents_test.go
@@ -174,7 +174,7 @@ func TestAgents(t *testing.T) {
 		assertPMMAgentNotExists(t, res, pmmAgentID)
 		assertNodeExporterNotExists(t, res, nodeExporterID)
 
-		// Filter by agent type, scoped to this test's pmm-agent to avoid the TOCTOU 404
+		// Filter by agent type, scoped to this test's pmm-agent to avoid the 404
 		// race an unscoped type filter hits (see the List subtest).
 		res, err = client.Default.AgentsService.ListAgents(
 			&agents.ListAgentsParams{

--- a/api-tests/inventory/agents_test.go
+++ b/api-tests/inventory/agents_test.go
@@ -174,11 +174,13 @@ func TestAgents(t *testing.T) {
 		assertPMMAgentNotExists(t, res, pmmAgentID)
 		assertNodeExporterNotExists(t, res, nodeExporterID)
 
-		// Filter by service ID.
+		// Filter by agent type, scoped to this test's pmm-agent to avoid the TOCTOU 404
+		// race an unscoped type filter hits (see the List subtest).
 		res, err = client.Default.AgentsService.ListAgents(
 			&agents.ListAgentsParams{
-				AgentType: new(types.AgentTypeMySQLdExporter),
-				Context:   pmmapitests.Context,
+				PMMAgentID: new(pmmAgentID),
+				AgentType:  new(types.AgentTypeMySQLdExporter),
+				Context:    pmmapitests.Context,
 			},
 		)
 		require.NoError(t, err)

--- a/api-tests/inventory/services_test.go
+++ b/api-tests/inventory/services_test.go
@@ -1218,10 +1218,9 @@ func TestExternalService(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, noFilterServicesList)
-		assert.Empty(t, noFilterServicesList.Payload.Mysql)
-		assert.Empty(t, noFilterServicesList.Payload.Mongodb)
+		// No filter returns the shared inventory; parallel tests may add other
+		// service types, so only assert on what this test guarantees.
 		assert.NotEmpty(t, noFilterServicesList.Payload.Postgresql)
-		assert.Empty(t, noFilterServicesList.Payload.Proxysql)
 		assert.NotEmpty(t, noFilterServicesList.Payload.External)
 		assert.Conditionf(t, containsExternalWithGroup(noFilterServicesList.Payload.External, "redis"), "list does not contain external group %s", "redis")
 


### PR DESCRIPTION
PMM-7

We observe the following errors when running the API tests:

```
  00:08:22.000  === NAME  TestAgents/FilterList
  00:08:22.000      agents_test.go:185:
  00:08:22.000              Error Trace:    /go/pmm/api-tests/inventory/agents_test.go:185
  00:08:22.000              Error:          Received unexpected error:
  00:08:22.000                              [GET /v1/inventory/agents][404] ListAgents default {"code":5,"message":"Service with ID \"97a27633-7ab6-4295-9f10-664aeee5d761\" not
  found.","details":[]}
  00:08:22.000              Test:           TestAgents/FilterList/exit
```

and 

```
  00:09:23.669  === NAME  TestExternalService/Basic
  00:09:23.669      services_test.go:1222:
  00:09:23.669              Error Trace:    /go/pmm/api-tests/inventory/services_test.go:1222
  00:09:23.669              Error:          Should be empty, but was [0xc000998e60 0xc000998f00 0xc000998fa0]
  00:09:23.669              Test:           TestExternalService/Basic
```

Link to the Feature Build: SUBMODULES-4382 ✅ 

