### PR TITLE
PMM-14154 Rename default branch from v3 to main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 ---
 version: 2
 updates:
-# V3 branch
+# main branch
   - package-ecosystem: "gomod"
     directory: "/"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"
     ignore:
@@ -13,30 +13,30 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/build/docker/client"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/build/docker/rpmbuild"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "docker"
     directory: "/build/docker/server"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "v3"
+    target-branch: "main"
     schedule:
       interval: "daily"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Ticket number: PMM-0
 Feature build: SUBMODULES-0
 
 
-If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/v3/documentation/api) as well:
+If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/main/documentation/api) as well:
 
 - [ ] API Docs updated
 

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -21,7 +21,7 @@ on:
     inputs:
       BRANCH:
         description: "The branch to pull API tests from"
-        default: "v3"
+        default: "main"
         required: true
         type: string
       PMM_SERVER_IMAGE:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PMM_URL: https://admin:admin@127.0.0.1
-      BRANCH: ${{ github.event.inputs.BRANCH || 'v3' }}
+      BRANCH: ${{ github.event.inputs.BRANCH || 'main' }}
       PMM_SERVER_IMAGE: ${{ github.event.inputs.PMM_SERVER_IMAGE }}
 
     steps:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v3
     paths:
       - "api/**"
       - "documentation/api/**"

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -4,14 +4,14 @@ on:
     inputs:
       branch:
         description: "The branch to build the devcontainer from"
-        default: "v3"
+        default: "main"
         required: true
         type: string
   workflow_call:
     inputs:
       branch:
         description: "The branch to build the devcontainer from"
-        default: "v3"
+        default: "main"
         required: true
         type: string
 

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -2,7 +2,7 @@ name: Update Docker Hub Readme
 on:
   push:
     branches:
-      - v3
+      - main
     paths:
       - build/docker/server/README.md
   workflow_dispatch:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: PMM Docs 3.x
 on:
   push:
     branches:
-      - v3
+      - main
     paths:
       - "documentation/**"
       - "!documentation/api/**"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/percona-intelligence.yml
+++ b/.github/workflows/percona-intelligence.yml
@@ -2,7 +2,7 @@ name: 'Percona Intelligence'
 on:
   push:
     branches:
-      - v3
+      - main
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
     paths:

--- a/.github/workflows/qan-api2.yml
+++ b/.github/workflows/qan-api2.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -16,9 +16,9 @@ on:
         default: ''
         type: string
       target_docs_branch:
-        description: 'Target docs branch (default: v3)'
+        description: 'Target docs branch (default: main)'
         required: false
-        default: 'v3'
+        default: 'main'
         type: string
 
 permissions:
@@ -46,7 +46,7 @@ jobs:
             version="${version/refs\/tags\/v/}"
             echo "version=$version" >> $GITHUB_OUTPUT
             echo "source_branch=" >> $GITHUB_OUTPUT
-            echo "target_docs_branch=v3" >> $GITHUB_OUTPUT
+            echo "target_docs_branch=main" >> $GITHUB_OUTPUT
             echo "Release with version: $version"
           fi
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,7 +6,7 @@ on:
     - cron: "24 3 * * 1"
   push:
     branches:
-      - v3
+      - main
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/vmproxy.yml
+++ b/.github/workflows/vmproxy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v3
       - pmm-*
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,19 +23,19 @@ This project is built from several repositories:
 
 #### Backends
 
-* [percona/pmm-managed](https://github.com/percona/pmm/tree/v3/managed) manages configuration of PMM server components (VictoriaMetrics, Grafana, etc.) and exposes API for that. APIs are used by [pmm-admin](https://github.com/percona/pmm/tree/v3/admin)
-* [percona/qan-api](https://github.com/percona/pmm/tree/v3/qan-api2) query analytics API
+* [percona/pmm-managed](https://github.com/percona/pmm/tree/main/managed) manages configuration of PMM server components (VictoriaMetrics, Grafana, etc.) and exposes API for that. APIs are used by [pmm-admin](https://github.com/percona/pmm/tree/main/admin)
+* [percona/qan-api](https://github.com/percona/pmm/tree/main/qan-api2) query analytics API
 
 #### Frontends
 
 * [percona/grafana](https://github.com/percona/grafana) user interface for PMM (Grafana-based)
-* [percona/ui](https://github.com/percona/pmm/tree/v3/ui) user interface for PMM (own)
-* [percona/dashboards](https://github.com/percona/pmm/tree/v3/dashboards) PMM dashboards for database monitoring
+* [percona/ui](https://github.com/percona/pmm/tree/main/ui) user interface for PMM (own)
+* [percona/dashboards](https://github.com/percona/pmm/tree/main/dashboards) PMM dashboards for database monitoring
 
 ### PMM Client
 
-* [percona/pmm-agent](https://github.com/percona/pmm/tree/v3/agent) monitoring agent for PMM. Runs exporters, and VMAgent that collects data from exporters and send to VictoriaMetrics
-* [percona/pmm-admin](https://github.com/percona/pmm/tree/v3/admin) admin tool for PMM to manage service that should be monitored by PMM
+* [percona/pmm-agent](https://github.com/percona/pmm/tree/main/agent) monitoring agent for PMM. Runs exporters, and VMAgent that collects data from exporters and send to VictoriaMetrics
+* [percona/pmm-admin](https://github.com/percona/pmm/tree/main/admin) admin tool for PMM to manage service that should be monitored by PMM
 * [percona/node_exporter](https://github.com/percona/node_exporter) exports machine's metrics
 * [percona/mysqld_exporter](https://github.com/percona/mysqld_exporter) exports MySQL server's metrics
 * [percona/mongodb_exporter](https://github.com/percona/mongodb_exporter) exports MongoDB server's metrics
@@ -136,7 +136,7 @@ Exporters by themselves are independent applications, so each of them contains i
 
 ### UI
 
-See [Grafana Dashboards Contribution Guide](https://github.com/percona/pmm/tree/v3/dashboards/CONTRIBUTING.md).
+See [Grafana Dashboards Contribution Guide](https://github.com/percona/pmm/tree/main/dashboards/CONTRIBUTING.md).
 
 ## Tests
 

--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -1,7 +1,5 @@
 bin_dir=$(cd $(dirname $0); pwd -P)
-# TODO: refactor to pass ${WORKSPACE} as ROOT_DIR from either Jenkins or, if relevant, from GH actions
-# NOTE: in most cases, this evaluates to Jenkins ${WORKSPACE} directory when called from pipelines
-# Example: /home/ec2-user/workspace/ol9-build-server/, see how it's used in ol9-build-server.groovy
+# NOTE: in most cases, `root_dir` evaluates to Jenkins ${WORKSPACE} directory when called from pipelines
 root_dir_tmp=$(cd $(dirname $0)/../../../../../../../..; pwd -P)
 root_dir=${ROOT_DIR:-$root_dir_tmp}
 tmp_dir=${root_dir}/tmp
@@ -22,10 +20,7 @@ full_pmm_version=${pmm_base_version}-${pmm_branch}-$(git rev-parse --short HEAD)
 # Replace '/' with '-' to prevent sed from failing on dependabot-authored PRs
 full_pmm_version=${full_pmm_version//\//-}
 
-# TODO Maybe it makes sense to use variable from job here
-if [[ ${pmm_branch} =~ release-* || \
-      ${pmm_branch} =~ pmm-3.* || \
-      ${pmm_branch} == "main" ]]; then
+if [[ ${pmm_branch} =~ pmm-3.* || ${pmm_branch} == "main" ]]; then
     full_pmm_version=${pmm_base_version}
 fi
 

--- a/build/scripts/vars
+++ b/build/scripts/vars
@@ -25,7 +25,6 @@ full_pmm_version=${full_pmm_version//\//-}
 # TODO Maybe it makes sense to use variable from job here
 if [[ ${pmm_branch} =~ release-* || \
       ${pmm_branch} =~ pmm-3.* || \
-      ${pmm_branch} == v3 || \
       ${pmm_branch} == "main" ]]; then
     full_pmm_version=${pmm_base_version}
 fi

--- a/dev/docs/managed/access-control.md
+++ b/dev/docs/managed/access-control.md
@@ -1,7 +1,7 @@
 # Access Control
 
 PMM Server supports managing access to individual metrics in VictoriaMetrics.  
-[vmproxy](https://github.com/percona/pmm/tree/v3/vmproxy) is placed in front of VictoriaMetrics and helps add extra filters to each query to filter access to metrics, such as `{env=~"prod|staging"}`.
+[vmproxy](https://github.com/percona/pmm/tree/main/vmproxy) is placed in front of VictoriaMetrics and helps add extra filters to each query to filter access to metrics, such as `{env=~"prod|staging"}`.
 
 Each Grafana user can be assigned multiple roles in PMM Server. A PMM Server role is different from Grafana roles (viewer, editor, admin).  
 A PMM Server role defines extra filters to be applied to a query. This way access to metrics can be limited per role.

--- a/documentation/docs-contributing.md
+++ b/documentation/docs-contributing.md
@@ -20,7 +20,7 @@ Create a Jira ticket for formal tracking: [Create PMM documentation issue](https
 
 ## Edit the documentation
 
-Ready to make changes? The docs are written in [Markdown](https://www.markdownguide.org/) and live on [Github](https://github.com/percona/pmm/tree/v3/documentation/docs).
+Ready to make changes? The docs are written in [Markdown](https://www.markdownguide.org/) and live on [Github](https://github.com/percona/pmm/tree/main/documentation/docs).
 
 ### Quick edits online
 
@@ -33,7 +33,7 @@ Want more details? Check out [GitHub's guide to editing files](https://docs.gith
 
 ### Work locally
 
-1. Fork and clone the repository:
+1. Clone the repository:
 
     ```shell
     git clone https://github.com/<your_github_name>/pmm.git
@@ -44,8 +44,8 @@ Want more details? Check out [GitHub's guide to editing files](https://docs.gith
 
     ```shell
     git remote add upstream https://github.com/percona/pmm.git
-    git checkout v3
-    git pull upstream v3
+    git checkout main
+    git pull upstream main
     ```
 
 3. Create a branch and make your changes:
@@ -73,17 +73,16 @@ Before submitting your changes, you can build and preview the documentation loca
 
 ```shell
 # Build the documentation
-make docs-build
+make doc-build
 
 # Preview the documentation with live reload (recommended)
-make docs-serve
+make doc-build-preview
 
 # Build the PDF (Percona staff only — update the version in mkdocs-base.yml first)
-make docs-pdf
-pdf
+make doc-build-pdf
 ```
 
-That's it! The `make docs-serve` command will start a local server at `http://127.0.0.1:8000/` that automatically reloads when you save changes.
+That's it! The `make doc-build-preview` command will start a local server at `http://127.0.0.1:8000/` that automatically reloads when you save changes.
 
 ## What happens next
 

--- a/documentation/docs/quickstart/quickstart.md
+++ b/documentation/docs/quickstart/quickstart.md
@@ -32,13 +32,13 @@ The Easy-install script only runs on Linux-compatible systems. To use it, run th
     === "cURL"
 
         ```sh
-        curl -fsSL https://raw.githubusercontent.com/percona/pmm/refs/heads/v3/get-pmm.sh | /bin/bash
+        curl -fsSL https://raw.githubusercontent.com/percona/pmm/refs/heads/main/get-pmm.sh | /bin/bash
         ```
 
     === "wget"
 
         ```sh
-        wget -qO - https://raw.githubusercontent.com/percona/pmm/refs/heads/v3/get-pmm.sh | /bin/bash    
+        wget -qO - https://raw.githubusercontent.com/percona/pmm/refs/heads/main/get-pmm.sh | /bin/bash    
         ```
 
 2. After the installation is complete, log into PMM with the default `admin:admin` credentials.

--- a/documentation/docs/reference/index.md
+++ b/documentation/docs/reference/index.md
@@ -50,7 +50,7 @@ PMM Server includes the following tools:
   - [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics) is a scalable time-series database. 
   - [ClickHouse](https://clickhouse.com) is a third-party column-oriented database that facilitates the Query Analytics functionality.
   - [Grafana](http://docs.grafana.org) is a third-party dashboard and graph engine for visualizing data aggregated in an intuitive web interface.
-  - [PMM Dashboards](https://github.com/percona/pmm/tree/v3/dashboards) is a set of monitoring dashboards developed by Percona.
+  - [PMM Dashboards](https://github.com/percona/pmm/tree/main/dashboards) is a set of monitoring dashboards developed by Percona.
 
 ### PMM Client
 

--- a/documentation/mkdocs-base.yml
+++ b/documentation/mkdocs-base.yml
@@ -9,7 +9,7 @@ site_url: ""
 use_directory_urls: false
 repo_name: percona/pmm
 repo_url: https://github.com/percona/pmm/
-edit_uri: edit/v3/documentation/docs/
+edit_uri: edit/main/documentation/docs/
 
 theme:
   name: material

--- a/documentation/overrides/partials/edit.html
+++ b/documentation/overrides/partials/edit.html
@@ -13,7 +13,7 @@
     <div class="banner-divider"></div>
 
     <!-- Contributing Guide below, smaller -->
-    <a href="https://github.com/percona/pmm/blob/v3/documentation/docs-contributing.md"
+    <a href="https://github.com/percona/pmm/blob/main/documentation/docs-contributing.md"
        title="Contributing guide"
        class="contrib-link"
        target="_blank"

--- a/get-pmm.sh
+++ b/get-pmm.sh
@@ -6,7 +6,7 @@
 # if PMM 2 is running, it will be stopped and data will be migrated to PMM 3.
 #
 # Usage example:
-# curl -fsSL https://raw.githubusercontent.com/percona/pmm/v3/get-pmm.sh -o get-pmm.sh; chmod +x get-pmm.sh; ./get-pmm.sh -b
+# curl -fsSL https://raw.githubusercontent.com/percona/pmm/main/get-pmm.sh -o get-pmm.sh; chmod +x get-pmm.sh; ./get-pmm.sh -b
 #
 #################################
 


### PR DESCRIPTION
PMM-14154

SUBMODULES-4416

> [!IMPORTANT]
> The feature build does not apply to this PR. A separate feature build will have to be done after merge. 

## Summary

Updates all **in-repo references** to the repository's default branch from `v3` to `main`, in preparation for renaming the default branch on GitHub. Scope is limited to branch references — the PMM product version (`3.x`) is untouched.

This satisfies the two requirements for the migration:

### 1. GitHub Actions continue to work, keyed off the new default branch
- Workflow `push` triggers now fire on `main`

### 2. Build scripts still build PMM as before
- `build/scripts/vars`: removed the now-redundant `${pmm_branch} == v3` check
- `build/scripts/build-client-packages` is intentionally left on `v3`

### Docs / URLs
In-repo links have been updated. Links to `Percona-Lab/pmm-submodules` are left on `v3`.

## Out of scope / manual follow-up (cannot be done in a PR)
1. Rename the branch on GitHub (Settings → Branches): `v3` → `main`. **Recommended order:** merge this PR into `v3` first, then perform the rename (if the rename is done first, GitHub will auto-retarget this PR to `main`).
2. Update `percona-lab/jenkins-pipelines`.
