### PR TITLE
PMM-7 Introduce PR branch auto update

### DIFF
--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -134,7 +134,7 @@ jobs:
             }
 
             if (errorEncountered) {
-              core.setFailed(`[ERROR] One or more PR base updates failed. Check logs for details.`);
+              core.setFailed('One or more PR branch updates failed. Check logs for details.');
             } else if (warningEncountered) {
               core.warning('Max attempts reached for one or more PRs; some mergeability states remained unknown. See workflow logs for details.');
             } else {

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -1,8 +1,8 @@
 ---
-# This workflow automatically updates PR's base branch once it is updated
-# (new commit is merged).
+# This workflow automatically updates a PR branch with the latest changes from its base branch
+# (i.e. performs the equivalent of the GitHub UI "Update branch" action).
 # To make it work it is required to set "auto-update-base" label on PR.
-# There will be max 10 attempts to update base branch.
+# There will be max 10 attempts to update branches.
 name: Auto-Update PR Base
 
 on:

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -11,6 +11,10 @@ on:
       - main
       - pmm-*
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   auto-update-base:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -1,0 +1,118 @@
+---
+# This workflow automatically updates PR's base branch once it is updated
+# (new commit is merged).
+# To make it work it is required to set "auto-update-base" label on PR.
+# There will be max 1- attempts to update base branch.
+name: Auto-Update PR Base
+
+on:
+  push:
+    branches:
+      - main
+      - pmm-*
+
+jobs:
+  auto-update-base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.ROBOT_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            let retriesNeeded = true;
+            let attemptCount = 0;
+            const maxAttempts = 10;  // Set a limit for the maximum number of attempts
+            let errorEncountered = false; // Track if any errors occur
+
+            while (retriesNeeded && attemptCount < maxAttempts) {
+              retriesNeeded = false;  // Assume no retries needed, unless 'unknown' state is found.
+              attemptCount += 1;
+
+              try {
+                const { data: pulls } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: "open",
+                });
+
+                for (const pull of pulls) {
+                  const hasAutoUpdateLabel = pull.labels.some(label => label.name === "auto-update-base");
+
+                  if (!hasAutoUpdateLabel) {
+                    continue;
+                  }
+
+                  try {
+                    const { data: pr } = await github.rest.pulls.get({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: pull.number,
+                    });
+
+                    switch (pr.mergeable) {
+                      case null:
+                        console.log(`[INFO] PR #${pull.number}: "${pull.title}" - GitHub is still computing the mergeability. Will retry later.`);
+                        retriesNeeded = true;
+                        break;
+                      case false:
+                        console.log(`[INFO] PR #${pull.number}: "${pull.title}" - Skipping update due to merge conflict.`);
+                        break;
+                      case true:
+                        try {
+                          const { data: baseBranch } = await github.rest.repos.getBranch({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            branch: pr.base.ref,
+                          });
+
+                          if (pr.base.sha === baseBranch.commit.sha) {
+                            console.log(`[INFO] PR #${pull.number}: "${pull.title}" - Base branch is already up-to-date.`);
+                            break;
+                          }
+
+                          console.log(`[UPDATE] PR #${pull.number}: "${pull.title}" - Updating base branch...`);
+                          try {
+                            await github.rest.pulls.updateBranch({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              pull_number: pull.number,
+                            });
+                            console.log(`[SUCCESS] PR #${pull.number}: "${pull.title}" - Base branch updated.`);
+                          } catch (updateError) {
+                            console.error(`[ERROR] PR #${pull.number}: Failed to update base branch - ${updateError.message}`);
+                            errorEncountered = true;
+                          }
+
+                          break;
+                        } catch (baseError) {
+                          console.error(`[ERROR] PR #${pull.number}: Failed to get base branch - ${baseError.message}`);
+                          errorEncountered = true;
+                          break;
+                        }
+                    }
+                  } catch (prError) {
+                    console.error(`[ERROR] Failed to get PR #${pull.number} - ${prError.message}`);
+                    errorEncountered = true;
+                  }
+                }
+              } catch (error) {
+                console.error(`[ERROR] Failed to list pull requests - ${error.message}`);
+                errorEncountered = true;
+              }
+
+              if (retriesNeeded && attemptCount < maxAttempts) {
+                console.log(`[INFO] Retrying for PRs with 'unknown' mergeable state (Attempt ${attemptCount}/${maxAttempts})...`);
+                await new Promise(resolve => setTimeout(resolve, 5000));
+              }
+            }
+
+            if (attemptCount >= maxAttempts) {
+              console.error(`[ERROR] Maximum attempts (${maxAttempts}) reached. Some PRs may still have 'unknown' mergeable state.`);
+              errorEncountered = true;
+            }
+
+            if (errorEncountered) {
+              core.setFailed(`[ERROR] Some PRs failed to update base branch.`);
+            } else {
+              console.log(`[INFO] All PRs with 'auto-update-base' label have been processed.`);
+            }

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -1,9 +1,9 @@
 ---
-# This workflow automatically updates a PR branch with the latest changes from its base branch
-# (i.e. performs the equivalent of the GitHub UI "Update branch" action).
-# To make it work it is required to set "auto-update-base" label on PR.
+# This workflow automatically updates a PR branch with the latest changes from
+#  its base branch (i.e. performs the equivalent of the GitHub UI "Update branch" action).
+# To make it work it is required to set "auto-update-branch" label on PR.
 # There will be max 10 attempts to update branches.
-name: Auto-Update PR Base
+name: Auto-Update PR Branch
 
 on:
   push:
@@ -30,6 +30,7 @@ jobs:
             const pushedBranch = context.ref.replace('refs/heads/', '');
             const maxAttempts = 10;
             let errorEncountered = false;
+            let warningEncountered = false;
 
             console.log(`[INFO] Workflow triggered by push to: ${pushedBranch} (SHA: ${context.sha})`);
 
@@ -41,11 +42,12 @@ jobs:
                 base: pushedBranch,
                 repo: context.repo.repo,
                 state: "open",
+                per_page: 100,
               });
 
               // 2. Filter in-memory: Only care about PRs having the label.
               let pendingPRs = pulls.filter(pr => 
-                pr.labels.some(label => label.name === "auto-update-base")
+                pr.labels.some(label => label.name === "auto-update-branch")
               );
 
               console.log(`[INFO] Found ${pendingPRs.length} PR(s) targeting ${pushedBranch} requiring updates.`);
@@ -121,8 +123,8 @@ jobs:
               }
 
               if (pendingPRs.length > 0) {
-                console.error(`[ERROR] Max attempts reached. ${pendingPRs.length} PR(s) still have 'unknown' mergeable state.`);
-                errorEncountered = true;
+                console.log(`[WARN] Max attempts reached. ${pendingPRs.length} PR(s) still have 'unknown' mergeable state.`);
+                warningEncountered = true;
               }
 
             } catch (globalError) {
@@ -132,6 +134,8 @@ jobs:
 
             if (errorEncountered) {
               core.setFailed(`[ERROR] One or more PR base updates failed. Check logs for details.`);
+            } else if (warningEncountered) {
+              core.warning(`[WARN] `;)
             } else {
               console.log(`[INFO] All eligible PRs processed successfully.`);
             }

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -81,16 +81,16 @@ jobs:
                             break;
                           }
 
-                          console.log(`[UPDATE] PR #${pull.number}: "${pull.title}" - Updating base branch...`);
+                          console.log(`[UPDATE] PR #${pull.number}: "${pull.title}" - Updating PR branch from base...`);
                           try {
                             await github.rest.pulls.updateBranch({
                               owner: context.repo.owner,
                               repo: context.repo.repo,
                               pull_number: pull.number,
                             });
-                            console.log(`[SUCCESS] PR #${pull.number}: "${pull.title}" - Base branch updated.`);
+                            console.log(`[SUCCESS] PR #${pull.number}: "${pull.title}" - PR branch updated from base.`);
                           } catch (updateError) {
-                            console.error(`[ERROR] PR #${pull.number}: Failed to update base branch - ${updateError.message}`);
+                            console.error(`[ERROR] PR #${pull.number}: Failed to update PR branch from base - ${updateError.message}`);
                             errorEncountered = true;
                           }
 

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -2,7 +2,7 @@
 # This workflow automatically updates PR's base branch once it is updated
 # (new commit is merged).
 # To make it work it is required to set "auto-update-base" label on PR.
-# There will be max 1- attempts to update base branch.
+# There will be max 10 attempts to update base branch.
 name: Auto-Update PR Base
 
 on:

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -135,7 +135,7 @@ jobs:
             if (errorEncountered) {
               core.setFailed(`[ERROR] One or more PR base updates failed. Check logs for details.`);
             } else if (warningEncountered) {
-              core.warning(`[WARN] `;)
+              core.warning('Max attempts reached for one or more PRs; some mergeability states remained unknown. See workflow logs for details.');
             } else {
               console.log(`[INFO] All eligible PRs processed successfully.`);
             }

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -11,6 +11,9 @@ on:
       - main
       - pmm-*
 
+concurrency:
+  group: auto-update-base-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -99,6 +99,7 @@ jobs:
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       pull_number: pull.number,
+                      expected_head_sha: pr.head.sha,
                     });
                     console.log(`[SUCCESS] PR #${pull.number}: Branch successfully updated.`);
 

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -35,7 +35,7 @@ jobs:
 
             try {
               // 1. Fetch all open PRs using the native pagination helper.
-             // Only care about PRs targeting the branch that was just pushed.
+              // Only care about PRs targeting the branch that was just pushed.
               const pulls = await github.paginate(github.rest.pulls.list, {
                 owner: context.repo.owner,
                 base: pushedBranch,

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -63,24 +63,28 @@ jobs:
                       pull_number: pull.number,
                     });
 
-                    if (pr.mergeable === null) {
+                    // 1. Check if GitHub is still calculating the state
+                    if (pr.mergeable === null || pr.mergeable_state === "unknown") {
                       console.log(`[INFO] PR #${pull.number}: GitHub is computing mergeability. Queuing for retry.`);
                       retryList.push(pull);
                       continue;
                     }
 
-                    if (pr.mergeable === false) {
+                    // 2. Check for conflicts
+                    if (pr.mergeable === false || pr.mergeable_state === "dirty") {
                       console.log(`[INFO] PR #${pull.number}: Skipping due to existing merge conflicts.`);
                       continue;
                     }
 
-                    // Compare against context.sha to save an API call
-                    if (pr.base.sha === context.sha) {
-                      console.log(`[INFO] PR #${pull.number}: Already up-to-date with base branch.`);
+                    // 3. Check if it actually needs an update
+                    if (pr.mergeable_state !== "behind") {
+                      console.log(`[INFO] PR #${pull.number}: Not behind base branch (state: ${pr.mergeable_state}).`);
                       continue;
                     }
 
+                    // 4. Proceed with update
                     console.log(`[UPDATE] PR #${pull.number}: Updating branch from base...`);
+
                     await github.rest.pulls.updateBranch({
                       owner: context.repo.owner,
                       repo: context.repo.repo,

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -33,11 +33,18 @@ jobs:
               attemptCount += 1;
 
               try {
-                const { data: pulls } = await github.rest.pulls.list({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  state: "open",
-                });
+                const pulls = [];
+                for (let page = 1; ; page += 1) {
+                  const { data } = await github.rest.pulls.list({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: "open",
+                    per_page: 100,
+                    page,
+                  });
+                  pulls.push(...data);
+                  if (data.length < 100) break;
+                }
 
                 for (const pull of pulls) {
                   const hasAutoUpdateLabel = pull.labels.some(label => label.name === "auto-update-base");

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -3,7 +3,7 @@
 #  its base branch (i.e. performs the equivalent of the GitHub UI "Update branch" action).
 # To make it work it is required to set "auto-update-branch" label on PR.
 # There will be max 10 attempts to update branches.
-name: Auto-Update PR Branch
+name: Auto-Update PR Branch (from base)
 
 on:
   push:

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -101,7 +101,12 @@ jobs:
                     console.log(`[SUCCESS] PR #${pull.number}: Branch successfully updated.`);
 
                   } catch (prError) {
-                    console.error(`[ERROR] Failed processing PR #${pull.number} - ${prError.message}`);
+                    const status = prError.status ?? prError.statusCode;
+                    if (status === 409 || status === 422) {
+                      console.log(`[INFO] PR #${pull.number}: Update skipped (${status}) - ${prError.message}`);
+                      continue;
+                    }
+                    console.error(`[ERROR] Failed processing PR #${pull.number} (${status ?? "unknown"}): ${prError.message}`);
                     errorEncountered = true;
                   }
                 }

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -66,6 +66,11 @@ jobs:
                       pull_number: pull.number,
                     });
 
+                    const baseRepoFullName = `${context.repo.owner}/${context.repo.repo}`;
+                    if (pr.head?.repo?.full_name !== baseRepoFullName) {
+                      console.log(`[INFO] PR #${pull.number}: Skipping because head branch is in a fork (${pr.head?.repo?.full_name}).`);
+                      continue;
+                    }
                     // 1. Check if GitHub is still calculating the state
                     if (pr.mergeable === null || pr.mergeable_state === "unknown") {
                       console.log(`[INFO] PR #${pull.number}: GitHub is computing mergeability. Queuing for retry.`);

--- a/.github/workflows/auto-update-base.yaml
+++ b/.github/workflows/auto-update-base.yaml
@@ -23,107 +23,98 @@ jobs:
         with:
           github-token: ${{ secrets.ROBOT_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            let retriesNeeded = true;
-            let attemptCount = 0;
-            const maxAttempts = 10;  // Set a limit for the maximum number of attempts
-            let errorEncountered = false; // Track if any errors occur
+            // Extract the branch name that triggered this workflow (e.g., 'main' or 'pmm-3.9')
+            const pushedBranch = context.ref.replace('refs/heads/', '');
+            const maxAttempts = 10;
+            let errorEncountered = false;
 
-            while (retriesNeeded && attemptCount < maxAttempts) {
-              retriesNeeded = false;  // Assume no retries needed, unless 'unknown' state is found.
-              attemptCount += 1;
+            console.log(`[INFO] Workflow triggered by push to: ${pushedBranch} (SHA: ${context.sha})`);
 
-              try {
-                const pulls = [];
-                for (let page = 1; ; page += 1) {
-                  const { data } = await github.rest.pulls.list({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    state: "open",
-                    per_page: 100,
-                    page,
-                  });
-                  pulls.push(...data);
-                  if (data.length < 100) break;
-                }
+            try {
+              // 1. Fetch all open PRs using the native pagination helper.
+             // Only care about PRs targeting the branch that was just pushed.
+              const pulls = await github.paginate(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                base: pushedBranch,
+                repo: context.repo.repo,
+                state: "open",
+              });
 
-                for (const pull of pulls) {
-                  const hasAutoUpdateLabel = pull.labels.some(label => label.name === "auto-update-base");
+              // 2. Filter in-memory: Only care about PRs having the label.
+              let pendingPRs = pulls.filter(pr => 
+                pr.labels.some(label => label.name === "auto-update-base")
+              );
 
-                  if (!hasAutoUpdateLabel) {
-                    continue;
-                  }
+              console.log(`[INFO] Found ${pendingPRs.length} PR(s) targeting ${pushedBranch} requiring updates.`);
 
+              let attemptCount = 0;
+
+              // 3. Process PRs, retrying ONLY the specific PRs that are stuck in 'mergeability computing' state
+              while (pendingPRs.length > 0 && attemptCount < maxAttempts) {
+                attemptCount++;
+                const retryList = [];
+
+                for (const pull of pendingPRs) {
                   try {
+                    // We must fetch the specific PR to get the accurate 'mergeable' status
                     const { data: pr } = await github.rest.pulls.get({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       pull_number: pull.number,
                     });
 
-                    switch (pr.mergeable) {
-                      case null:
-                        console.log(`[INFO] PR #${pull.number}: "${pull.title}" - GitHub is still computing the mergeability. Will retry later.`);
-                        retriesNeeded = true;
-                        break;
-                      case false:
-                        console.log(`[INFO] PR #${pull.number}: "${pull.title}" - Skipping update due to merge conflict.`);
-                        break;
-                      case true:
-                        try {
-                          const { data: baseBranch } = await github.rest.repos.getBranch({
-                            owner: context.repo.owner,
-                            repo: context.repo.repo,
-                            branch: pr.base.ref,
-                          });
-
-                          if (pr.base.sha === baseBranch.commit.sha) {
-                            console.log(`[INFO] PR #${pull.number}: "${pull.title}" - Base branch is already up-to-date.`);
-                            break;
-                          }
-
-                          console.log(`[UPDATE] PR #${pull.number}: "${pull.title}" - Updating PR branch from base...`);
-                          try {
-                            await github.rest.pulls.updateBranch({
-                              owner: context.repo.owner,
-                              repo: context.repo.repo,
-                              pull_number: pull.number,
-                            });
-                            console.log(`[SUCCESS] PR #${pull.number}: "${pull.title}" - PR branch updated from base.`);
-                          } catch (updateError) {
-                            console.error(`[ERROR] PR #${pull.number}: Failed to update PR branch from base - ${updateError.message}`);
-                            errorEncountered = true;
-                          }
-
-                          break;
-                        } catch (baseError) {
-                          console.error(`[ERROR] PR #${pull.number}: Failed to get base branch - ${baseError.message}`);
-                          errorEncountered = true;
-                          break;
-                        }
+                    if (pr.mergeable === null) {
+                      console.log(`[INFO] PR #${pull.number}: GitHub is computing mergeability. Queuing for retry.`);
+                      retryList.push(pull);
+                      continue;
                     }
+
+                    if (pr.mergeable === false) {
+                      console.log(`[INFO] PR #${pull.number}: Skipping due to existing merge conflicts.`);
+                      continue;
+                    }
+
+                    // Compare against context.sha to save an API call
+                    if (pr.base.sha === context.sha) {
+                      console.log(`[INFO] PR #${pull.number}: Already up-to-date with base branch.`);
+                      continue;
+                    }
+
+                    console.log(`[UPDATE] PR #${pull.number}: Updating branch from base...`);
+                    await github.rest.pulls.updateBranch({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: pull.number,
+                    });
+                    console.log(`[SUCCESS] PR #${pull.number}: Branch successfully updated.`);
+
                   } catch (prError) {
-                    console.error(`[ERROR] Failed to get PR #${pull.number} - ${prError.message}`);
+                    console.error(`[ERROR] Failed processing PR #${pull.number} - ${prError.message}`);
                     errorEncountered = true;
                   }
                 }
-              } catch (error) {
-                console.error(`[ERROR] Failed to list pull requests - ${error.message}`);
+
+                // Re-assign pendingPRs to only those that needed retries
+                pendingPRs = retryList;
+
+                if (pendingPRs.length > 0 && attemptCount < maxAttempts) {
+                  console.log(`[INFO] Waiting 5 seconds before retrying ${pendingPRs.length} PR(s) (Attempt ${attemptCount}/${maxAttempts})...`);
+                  await new Promise(resolve => setTimeout(resolve, 5000));
+                }
+              }
+
+              if (pendingPRs.length > 0) {
+                console.error(`[ERROR] Max attempts reached. ${pendingPRs.length} PR(s) still have 'unknown' mergeable state.`);
                 errorEncountered = true;
               }
 
-              if (retriesNeeded && attemptCount < maxAttempts) {
-                console.log(`[INFO] Retrying for PRs with 'unknown' mergeable state (Attempt ${attemptCount}/${maxAttempts})...`);
-                await new Promise(resolve => setTimeout(resolve, 5000));
-              }
-            }
-
-            if (attemptCount >= maxAttempts) {
-              console.error(`[ERROR] Maximum attempts (${maxAttempts}) reached. Some PRs may still have 'unknown' mergeable state.`);
+            } catch (globalError) {
+              console.error(`[ERROR] Workflow encountered a fatal error: ${globalError.message}`);
               errorEncountered = true;
             }
 
             if (errorEncountered) {
-              core.setFailed(`[ERROR] Some PRs failed to update base branch.`);
+              core.setFailed(`[ERROR] One or more PR base updates failed. Check logs for details.`);
             } else {
-              console.log(`[INFO] All PRs with 'auto-update-base' label have been processed.`);
+              console.log(`[INFO] All eligible PRs processed successfully.`);
             }


### PR DESCRIPTION
Ticket number: PMM-7

This workflow automatically updates PR branch once its base branch is updated (new commit is merged).
To make it work it is required to set `auto-update-branch` label on PR.
There will be max 10 attempts to update PR branch.