### PR TITLE
PMM-7 Update documentation and pmm-agent configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+# IDE
 /.idea/
 /.vscode/
 *.iml
+*.sw[o,p]
+settings.json
 
 /api/nginx/*.pem
 bin/
@@ -8,6 +11,27 @@ bin/
 
 # System Files
 .DS_Store
+
+# Temporary (build, config, etc)
+/tmp/
+
+.env
+.netrc
+.modules
+build.log
+build/.cache/
+packer.log
+ci.yml
+
+
+# PMM specific
+/dev/clickhouse-backups/
+encryption.key
+backoff.png
+pmm-agent-dev.yaml
+compose.yml
+api-tests/*.txt
+api-tests/*.xml
 
 cover.out
 crosscover.out
@@ -23,35 +47,10 @@ fuzzing/
 *-fuzz.zip
 *.bench
 
-backoff.png
-pmm-agent-dev.yaml
-compose.yml
-
+# QAN
 /qan-api2/logs/
 
-# ViM temporary files
-*.sw[o,p]
-
-.env
-.netrc
-.modules
-build.log
-build/.cache/
-packer.log
-ci.yml
-
-api-tests/*.txt
-api-tests/*.xml
-
-
-/tmp/
-settings.json
-
-# PMM specific
-/dev/clickhouse-backups/
-encryption.key
-
-# Exclude AI skills to support fast local experimentation
+# Ignore AI-related files to support fast local experimentation
 .claude/
 .cursor/
 .cursorrules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,13 +122,13 @@ Since PMM has a lot of components, we will mention only three big parts of it.
 * Clone [pmm repository](https://github.com/percona/pmm).
 * Navigate to the `/agent` folder in the root of the repository.
 * Run `make setup-dev` to connect pmm-agent to PMM Server.
-  * This command will register local pmm-agent to PMM Server and generate config file `pmm-agent-dev.yaml`
+  * This command will rebuild the local pmm-agent and register it to PMM Server
 * Once it's connected just use `make run` to run pmm-agent.
 * To work correctly, pmm-agent needs vmagent and exporters installed on the system.
   * The first option is to install pmm-client using this instruction https://docs.percona.com/percona-monitoring-and-management/3/install-pmm/install-pmm-client/index.html. It will install all exporters as well.
   * Another option is to do it manually
-    * vmagent and exporters can be installed by building each of them or by downloading the pmm-client tarball from [percona.com](https://www.percona.com/downloads/pmm2/) and copying binaries to the exporters_base directory configured in `pmm-agent-dev.yaml` file.
-    * All paths to exporter binaries are configured in `pmm-agent-dev.yaml`, so they can be changed manually if necessary.
+    * vmagent and exporters can be installed by building each of them or by downloading the pmm-client tarball from [percona.com](https://www.percona.com/downloads) and copying binaries to the exporters_base directory configured in `pmm-agent.yaml` file.
+    * All paths to exporter binaries are configured in `pmm-agent.yaml`, so they can be changed manually if necessary.
 
 ### Exporters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ Since PMM has a lot of components, we will mention only three big parts of it.
 * Clone [pmm repository](https://github.com/percona/pmm).
 * Navigate to the `/agent` folder in the root of the repository.
 * Run `make setup-dev` to connect pmm-agent to PMM Server.
-  * This command will rebuild the local pmm-agent and register it to PMM Server
+  * This command will rebuild the local pmm-agent, register it to PMM Server and generate `pmm-agent.yaml` configuration file.
 * Once it's connected just use `make run` to run pmm-agent.
 * To work correctly, pmm-agent needs vmagent and exporters installed on the system.
   * The first option is to install pmm-client using this instruction https://docs.percona.com/percona-monitoring-and-management/3/install-pmm/install-pmm-client/index.html. It will install all exporters as well.

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -92,7 +92,7 @@ bench:                          ## Run benchmarks
 	go test -bench=. -benchtime=1s -count=5 -cpu=1 -timeout=30m -failfast github.com/percona/pmm/agent/agents/postgres/parser | tee postgres_parser_new.bench
 	go tool benchstat postgres_parser_old.bench postgres_parser_new.bench
 
-RUN_FLAGS = --config-file=pmm-agent-dev.yaml
+RUN_FLAGS = --config-file=pmm-agent.yaml
 
 run: install _run               ## Run pmm-agent
 

--- a/documentation/docs/install-pmm/HA-clustered.md
+++ b/documentation/docs/install-pmm/HA-clustered.md
@@ -148,7 +148,6 @@ PMM HA uses several mechanisms to ensure continuous operation:
 - **[PMM-14665](https://perconadev.atlassian.net/browse/PMM-14665)**: When adding a service, the node list incorrectly includes PostgreSQL database instance nodes alongside PMM HA nodes.
 - **[PMM-14678](https://perconadev.atlassian.net/browse/PMM-14678)**: Database dashboards don't display metrics for services added via pmm-admin, though they work correctly for services added through the UI.
 - **[PMM-14680](https://perconadev.atlassian.net/browse/PMM-14680)**: PostgreSQL database instance nodes and services display with an incorrect 'pmm-' prefix in their names.
-- **[PMM-14696](https://perconadev.atlassian.net/browse/PMM-14696)**: PostgreSQL database instance services show "UNSPECIFIED" status and "FAILED" monitoring with "UNKNOWN" external exporter status.
 - **[PMM-14734](https://perconadev.atlassian.net/browse/PMM-14734)**: HA cluster status always displays as "Healthy" even when follower or leader pods are deleted or not ready.
 - **[PMM-14742](https://perconadev.atlassian.net/browse/PMM-14742)**: The Inventory page shows inconsistent numbers of PostgreSQL services (4-5 instead of the expected 6 services).
 - **[PMM-14787](https://perconadev.atlassian.net/browse/PMM-14787)**: Data retention settings are not applied correctly, allowing metrics older than the configured retention period to remain visible.

--- a/documentation/docs/install-pmm/HA-kubernetes-single-instance.md
+++ b/documentation/docs/install-pmm/HA-kubernetes-single-instance.md
@@ -432,11 +432,7 @@ resources:
 To monitor your databases, install PMM Client on each database host and connect it to PMM Server:
 {.power-number}
 
-1. [Install PMM Client](../install-pmm/install-pmm-client/index.md) on your database hosts:
-  ```sh
-  # Install PMM Client
-  curl -fsSL https://www.percona.com/downloads/pmm3/pmm-client.sh | sh
-  ```
+1. [Install PMM Client](../install-pmm/install-pmm-client/index.md) on your database hosts.
 
 2. Get the PMM Server address:
   ```sh

--- a/documentation/docs/use/commands/pmm-agent.md
+++ b/documentation/docs/use/commands/pmm-agent.md
@@ -90,7 +90,7 @@ Since 2.23.0 this flag could be used for easier setup of PMM agent. With this fl
 - **Case 1:** There are no root permissions for `/usr/local/percona/pmm` folder or there is a need to change default folder for PMM files.
 Command:
 ````
-pmm-agent setup --paths-base=/home/user/custom/pmm --config-file=pmm-agent-dev.yaml --server-insecure-tls --server-address=127.0.0.1:443 --server-username=admin --server-password=admin
+pmm-agent setup --paths-base=/home/user/custom/pmm --config-file=pmm-agent.yaml --server-insecure-tls --server-address=127.0.0.1:443 --server-username=admin --server-password=admin
 ````
 Config output:
 ````
@@ -132,7 +132,7 @@ As could be seen above, base for all exporters and tools was changed only by set
 - **Case 2:** The older `--paths-exporters_base` flag could be passed along with the `--paths-base`
 Command:
 ````
-pmm-agent setup --paths-base=/home/user/custom/pmm --paths-exporters_base=/home/user/exporters --config-file=pmm-agent-dev.yaml --server-insecure-tls --server-address=127.0.0.1:443 --server-username=admin --server-password=admin
+pmm-agent setup --paths-base=/home/user/custom/pmm --paths-exporters_base=/home/user/exporters --config-file=pmm-agent.yaml --server-insecure-tls --server-address=127.0.0.1:443 --server-username=admin --server-password=admin
 ````
 Config output:
 ````


### PR DESCRIPTION
This pull request updates configuration file references and documentation to standardize on the use of `pmm-agent.yaml` instead of `pmm-agent-dev.yaml`. It also removes obsolete installation instructions and cleans up an outdated bug reference from the documentation.

**Configuration and Documentation Updates:**

* Updated all references to the agent config file from `pmm-agent-dev.yaml` to `pmm-agent.yaml` in `CONTRIBUTING.md`, `agent/Makefile`, and `documentation/docs/use/commands/pmm-agent.md` to ensure consistency in setup and usage instructions.
* Changed exporter binary paths documentation to refer to `pmm-agent.yaml` instead of the deprecated `pmm-agent-dev.yaml` in `CONTRIBUTING.md`.

**Documentation Cleanup:**

* Removed obsolete shell-based installation instructions for PMM Client from `documentation/docs/install-pmm/HA-kubernetes-single-instance.md`, directing users to the main installation guide instead.
* Removed a resolved bug reference ([PMM-14696]) from the list of known issues in `documentation/docs/install-pmm/HA-clustered.md`.

[PMM-14696]: https://perconadev.atlassian.net/browse/PMM-14696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ