### PR TITLE
Cert-based internal service authentication

### DIFF
--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -100,6 +100,16 @@
         - absent
         - directory
 
+    - name: Remove Ansible build artifacts from production image
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /opt/ansible/roles/grafana/files/grafana.ini
+        - /opt/ansible/roles/grafana/files/datasources.yml
+        - /opt/ansible/roles/cloud-node/tasks/main.yml
+        - /opt/ansible/pmm-docker/post-build.yml
+
     - name: Remove auto-generated config files
       file:
         path: "/etc/supervisord.d/{{ item }}"

--- a/build/ansible/roles/clickhouse/files/default-config.xml
+++ b/build/ansible/roles/clickhouse/files/default-config.xml
@@ -155,7 +155,7 @@
          You have to configure certificate to enable this interface.
          See the openSSL section below.
     -->
-    <!-- <tcp_port_secure>9440</tcp_port_secure> -->
+    <tcp_port_secure>9440</tcp_port_secure>
 
     <!-- Native interface wrapped with PROXYv1 protocol
          PROXYv1 header sent for every connection.
@@ -271,37 +271,26 @@
     <!-- Used with https_port and tcp_port_secure. Full ssl options list: https://github.com/ClickHouse-Extras/poco/blob/master/NetSSL_OpenSSL/include/Poco/Net/SSLManager.h#L71 -->
     <openSSL>
         <server> <!-- Used for https server AND secure tcp port -->
-            <!-- openssl req -subj "/CN=localhost" -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout /etc/clickhouse-server/server.key -out /etc/clickhouse-server/server.crt -->
-            <certificateFile>/etc/clickhouse-server/server.crt</certificateFile>
-            <privateKeyFile>/etc/clickhouse-server/server.key</privateKeyFile>
-            <!-- dhparams are optional. You can delete the <dhParamsFile> element.
-                 To generate dhparams, use the following command:
-                  openssl dhparam -out /etc/clickhouse-server/dhparam.pem 4096
-                 Only file format with BEGIN DH PARAMETERS is supported.
-              -->
-            <dhParamsFile>/etc/clickhouse-server/dhparam.pem</dhParamsFile>
-            <verificationMode>none</verificationMode>
-            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <certificateFile>/srv/certs/ch-server.crt</certificateFile>
+            <privateKeyFile>/srv/certs/ch-server.key</privateKeyFile>
+            <caConfig>/srv/certs/ca.crt</caConfig>
+            <verificationMode>strict</verificationMode>
+            <loadDefaultCAFile>false</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>
             <disableProtocols>sslv2,sslv3</disableProtocols>
             <preferServerCiphers>true</preferServerCiphers>
-
             <invalidCertificateHandler>
-                <!-- The server, in contrast to the client, cannot ask about the certificate interactively.
-                     The only reasonable option is to reject.
-                -->
                 <name>RejectCertificateHandler</name>
             </invalidCertificateHandler>
         </server>
 
-        <client> <!-- Used for connecting to https dictionary source and secured Zookeeper communication -->
-            <loadDefaultCAFile>true</loadDefaultCAFile>
+        <client>
+            <caConfig>/srv/certs/ca.crt</caConfig>
+            <loadDefaultCAFile>false</loadDefaultCAFile>
             <cacheSessions>true</cacheSessions>
             <disableProtocols>sslv2,sslv3</disableProtocols>
             <preferServerCiphers>true</preferServerCiphers>
-            <!-- Use for self-signed: <verificationMode>none</verificationMode> -->
             <invalidCertificateHandler>
-                <!-- Use for self-signed: <name>AcceptCertificateHandler</name> -->
                 <name>RejectCertificateHandler</name>
             </invalidCertificateHandler>
         </client>

--- a/build/ansible/roles/clickhouse/files/default-users.xml
+++ b/build/ansible/roles/clickhouse/files/default-users.xml
@@ -52,7 +52,10 @@
                  Execute: PASSWORD=$(base64 < /dev/urandom | head -c8); echo "$PASSWORD"; echo -n "$PASSWORD" | sha1sum | tr -d '-' | xxd -r -p | sha1sum | tr -d '-'
                  In first line will be password and in second - corresponding double SHA1.
             -->
-            <password_sha256_hex>7e099f39b84ea79559b3e85ea046804e63725fd1f46b37f281276aae20f86dc3</password_sha256_hex>
+            <!-- Certificate-based authentication: client must present a cert with matching CN -->
+            <ssl_certificates>
+                <common_name>clickhouse-client</common_name>
+            </ssl_certificates>
 
             <!-- List of networks with open access.
 

--- a/build/ansible/roles/grafana/files/datasources.yml
+++ b/build/ansible/roles/grafana/files/datasources.yml
@@ -2,6 +2,8 @@ apiVersion: 1
 deleteDatasources:
   - name: ClickHouse
     orgId: 1
+  - name: PostgreSQL
+    orgId: 1
 
 datasources:
 - name: Metrics
@@ -15,23 +17,6 @@ datasources:
     httpMethod: POST
     keepCookies: []
     timeInterval: 1s
-
-- name: PostgreSQL
-  version: 2
-  orgId: 1
-  type: postgres
-  access: proxy
-  url: ${PMM_POSTGRES_ADDR}
-  user: ${PMM_POSTGRES_USERNAME}
-  database: ${PMM_POSTGRES_DBNAME}
-  jsonData:
-    sslRootCertFile: ${PMM_POSTGRES_SSL_CA_PATH}
-    sslKeyFile: ${PMM_POSTGRES_SSL_KEY_PATH}
-    sslCertFile: ${PMM_POSTGRES_SSL_CERT_PATH}
-    postgresVersion: "1100"
-    sslmode: ${PMM_POSTGRES_SSL_MODE}
-  secureJsonData:
-    password: ${PMM_POSTGRES_DBPASSWORD}
 
 - name: PTSummary
   version: 2
@@ -48,6 +33,10 @@ datasources:
     username: ${PMM_CLICKHOUSE_USER}
     port: ${PMM_CLICKHOUSE_PORT}
     host: ${PMM_CLICKHOUSE_HOST}
+    secure: true
     tlsSkipVerify: false
+    tlsAuthWithCACert: true
   secureJsonData:
-    password: ${PMM_CLICKHOUSE_PASSWORD}
+    tlsCACert: ${PMM_CLICKHOUSE_SSL_CA_CERT}
+    tlsClientCert: ${PMM_CLICKHOUSE_SSL_CLIENT_CERT}
+    tlsClientKey: ${PMM_CLICKHOUSE_SSL_CLIENT_KEY}

--- a/build/ansible/roles/grafana/files/grafana.ini
+++ b/build/ansible/roles/grafana/files/grafana.ini
@@ -7,8 +7,11 @@
 type = postgres
 host = localhost
 user = grafana
-# If the password contains # or ; you have to wrap it with triple quotes. Ex """#password;"""
-password = grafana
+# Certificate-based authentication — no password needed
+ssl_mode = verify-ca
+ca_cert_path = /srv/certs/ca.crt
+client_cert_path = /srv/certs/grafana.crt
+client_key_path = /srv/certs/grafana.key
 
 [paths]
 # Directory where grafana will automatically scan and look for plugins

--- a/build/ansible/roles/initialization/tasks/main.yml
+++ b/build/ansible/roles/initialization/tasks/main.yml
@@ -41,6 +41,11 @@
   debug:
     msg: "Need upgrade: {{ need_upgrade }}"
 
+- name: Generate internal TLS certificates
+  include_role:
+    name: internal-certs
+  when: need_initialization or need_upgrade
+
 - name: Execute PMM upgrade & initialization tasks
   block: # when need_initialization or need_upgrade
   - name: Enable maintenance mode before upgrade
@@ -73,7 +78,6 @@
         postgresql_user:
           db: grafana
           name: grafana
-          password: grafana
           priv: 'ALL'
           expires: infinity
           login_user: postgres

--- a/build/ansible/roles/internal-certs/defaults/main.yml
+++ b/build/ansible/roles/internal-certs/defaults/main.yml
@@ -1,0 +1,29 @@
+---
+# Internal certificate configuration for PMM service-to-service auth
+pmm_certs_dir: /srv/certs
+pmm_certs_ca_validity_days: 3650  # 10 years
+pmm_certs_service_validity_days: 3650  # 10 years
+pmm_certs_owner: pmm
+pmm_certs_group: root
+pmm_certs_key_mode: "0600"
+pmm_certs_cert_mode: "0644"
+
+# Services that need client certificates (CN must match PostgreSQL/ClickHouse username)
+pmm_cert_services:
+  - name: pmm-managed
+    cn: pmm-managed
+  - name: grafana
+    cn: grafana
+  - name: qan-api2
+    cn: qan-api2
+  - name: clickhouse-client
+    cn: clickhouse-client
+
+# Server certificates
+pmm_cert_servers:
+  - name: pg-server
+    cn: localhost
+    san: "DNS:localhost,IP:127.0.0.1"
+  - name: ch-server
+    cn: localhost
+    san: "DNS:localhost,IP:127.0.0.1"

--- a/build/ansible/roles/internal-certs/tasks/main.yml
+++ b/build/ansible/roles/internal-certs/tasks/main.yml
@@ -1,0 +1,187 @@
+---
+# Generate internal CA and per-service certificates for PMM
+# This role is idempotent — it only generates certs if the CA doesn't already exist.
+# Certs are stored on the persistent /srv volume and survive container restarts.
+
+- name: Create certificates directory
+  file:
+    path: "{{ pmm_certs_dir }}"
+    state: directory
+    owner: "{{ pmm_certs_owner }}"
+    group: "{{ pmm_certs_group }}"
+    mode: "0755"
+
+- name: Check if CA certificate already exists
+  stat:
+    path: "{{ pmm_certs_dir }}/ca.crt"
+  register: ca_cert_stat
+
+- name: Generate internal CA and service certificates
+  when: not ca_cert_stat.stat.exists
+  block:
+    # --- CA ---
+    - name: Generate CA private key
+      command: >
+        openssl genrsa -out {{ pmm_certs_dir }}/ca.key 4096
+      args:
+        creates: "{{ pmm_certs_dir }}/ca.key"
+
+    - name: Generate CA certificate
+      command: >
+        openssl req -new -x509
+        -key {{ pmm_certs_dir }}/ca.key
+        -out {{ pmm_certs_dir }}/ca.crt
+        -days {{ pmm_certs_ca_validity_days }}
+        -subj "/CN=PMM Internal CA/O=Percona/OU=PMM"
+        -addext "basicConstraints=critical,CA:TRUE"
+        -addext "keyUsage=critical,keyCertSign,cRLSign"
+      args:
+        creates: "{{ pmm_certs_dir }}/ca.crt"
+
+    - name: Set CA key permissions
+      file:
+        path: "{{ pmm_certs_dir }}/ca.key"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_key_mode }}"
+
+    - name: Set CA cert permissions
+      file:
+        path: "{{ pmm_certs_dir }}/ca.crt"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_cert_mode }}"
+
+    # --- Server certificates (PostgreSQL, ClickHouse) ---
+    - name: Generate server private keys
+      command: >
+        openssl genrsa -out {{ pmm_certs_dir }}/{{ item.name }}.key 2048
+      loop: "{{ pmm_cert_servers }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.key"
+
+    - name: Generate server CSRs
+      command: >
+        openssl req -new
+        -key {{ pmm_certs_dir }}/{{ item.name }}.key
+        -out {{ pmm_certs_dir }}/{{ item.name }}.csr
+        -subj "/CN={{ item.cn }}/O=Percona/OU=PMM"
+        -addext "subjectAltName={{ item.san }}"
+      loop: "{{ pmm_cert_servers }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.csr"
+
+    - name: Create server cert extension file
+      copy:
+        content: |
+          basicConstraints=CA:FALSE
+          keyUsage=critical,digitalSignature,keyEncipherment
+          extendedKeyUsage=serverAuth
+          subjectAltName={{ item.san }}
+        dest: "{{ pmm_certs_dir }}/{{ item.name }}.ext"
+      loop: "{{ pmm_cert_servers }}"
+
+    - name: Sign server certificates with CA
+      command: >
+        openssl x509 -req
+        -in {{ pmm_certs_dir }}/{{ item.name }}.csr
+        -CA {{ pmm_certs_dir }}/ca.crt
+        -CAkey {{ pmm_certs_dir }}/ca.key
+        -CAcreateserial
+        -out {{ pmm_certs_dir }}/{{ item.name }}.crt
+        -days {{ pmm_certs_service_validity_days }}
+        -extfile {{ pmm_certs_dir }}/{{ item.name }}.ext
+      loop: "{{ pmm_cert_servers }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.crt"
+
+    - name: Set server key permissions
+      file:
+        path: "{{ pmm_certs_dir }}/{{ item.name }}.key"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_key_mode }}"
+      loop: "{{ pmm_cert_servers }}"
+
+    - name: Set server cert permissions
+      file:
+        path: "{{ pmm_certs_dir }}/{{ item.name }}.crt"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_cert_mode }}"
+      loop: "{{ pmm_cert_servers }}"
+
+    # --- Client certificates (per-service) ---
+    - name: Generate client private keys
+      command: >
+        openssl genrsa -out {{ pmm_certs_dir }}/{{ item.name }}.key 2048
+      loop: "{{ pmm_cert_services }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.key"
+
+    - name: Generate client CSRs
+      command: >
+        openssl req -new
+        -key {{ pmm_certs_dir }}/{{ item.name }}.key
+        -out {{ pmm_certs_dir }}/{{ item.name }}.csr
+        -subj "/CN={{ item.cn }}/O=Percona/OU=PMM"
+      loop: "{{ pmm_cert_services }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.csr"
+
+    - name: Create client cert extension file
+      copy:
+        content: |
+          basicConstraints=CA:FALSE
+          keyUsage=critical,digitalSignature
+          extendedKeyUsage=clientAuth
+        dest: "{{ pmm_certs_dir }}/{{ item.name }}.ext"
+      loop: "{{ pmm_cert_services }}"
+
+    - name: Sign client certificates with CA
+      command: >
+        openssl x509 -req
+        -in {{ pmm_certs_dir }}/{{ item.name }}.csr
+        -CA {{ pmm_certs_dir }}/ca.crt
+        -CAkey {{ pmm_certs_dir }}/ca.key
+        -CAcreateserial
+        -out {{ pmm_certs_dir }}/{{ item.name }}.crt
+        -days {{ pmm_certs_service_validity_days }}
+        -extfile {{ pmm_certs_dir }}/{{ item.name }}.ext
+      loop: "{{ pmm_cert_services }}"
+      args:
+        creates: "{{ pmm_certs_dir }}/{{ item.name }}.crt"
+
+    - name: Set client key permissions
+      file:
+        path: "{{ pmm_certs_dir }}/{{ item.name }}.key"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_key_mode }}"
+      loop: "{{ pmm_cert_services }}"
+
+    - name: Set client cert permissions
+      file:
+        path: "{{ pmm_certs_dir }}/{{ item.name }}.crt"
+        owner: "{{ pmm_certs_owner }}"
+        group: "{{ pmm_certs_group }}"
+        mode: "{{ pmm_certs_cert_mode }}"
+      loop: "{{ pmm_cert_services }}"
+
+    # --- Cleanup temporary files ---
+    - name: Remove CSR and extension files
+      file:
+        path: "{{ pmm_certs_dir }}/{{ item }}"
+        state: absent
+      loop: "{{ (pmm_cert_servers + pmm_cert_services) | map(attribute='name') | product(['.csr', '.ext']) | map('join') | list }}"
+
+    - name: Remove CA serial file
+      file:
+        path: "{{ pmm_certs_dir }}/ca.srl"
+        state: absent
+
+- name: Verify CA certificate exists
+  stat:
+    path: "{{ pmm_certs_dir }}/ca.crt"
+  register: ca_cert_final
+  failed_when: not ca_cert_final.stat.exists

--- a/build/ansible/roles/postgres/tasks/main.yml
+++ b/build/ansible/roles/postgres/tasks/main.yml
@@ -63,6 +63,40 @@
   become_user: pmm
   become_method: su
 
+- name: Configure PostgreSQL for SSL with internal certificates
+  blockinfile:
+    path: /srv/postgres14/postgresql.conf
+    marker: "# {mark} PMM INTERNAL SSL CONFIGURATION"
+    block: |
+      ssl = on
+      ssl_cert_file = '/srv/certs/pg-server.crt'
+      ssl_key_file = '/srv/certs/pg-server.key'
+      ssl_ca_file = '/srv/certs/ca.crt'
+
+- name: Configure pg_hba.conf for certificate-based authentication
+  copy:
+    content: |
+      # PMM Internal Certificate-Based Authentication
+      # TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+      # Local socket connections for init/admin tasks (no password needed)
+      local   all             all                                     trust
+
+      # SSL certificate authentication for internal services
+      hostssl pmm-managed     pmm-managed     127.0.0.1/32            cert clientcert=verify-full
+      hostssl grafana         grafana         127.0.0.1/32            cert clientcert=verify-full
+
+      # Superuser via password for backward compatibility (localhost only)
+      host    all             postgres        127.0.0.1/32            scram-sha-256
+      host    all             postgres        ::1/128                 scram-sha-256
+
+      # Replication (local only)
+      local   replication     all                                     trust
+    dest: /srv/postgres14/pg_hba.conf
+    owner: pmm
+    group: root
+    mode: 0600
+
 - name: Start Postgres database without supervisor
   command: /usr/pgsql-14/bin/pg_ctl start -D /srv/postgres14 -o "-c logging_collector=off"
   become: true
@@ -82,7 +116,6 @@
   postgresql_user:
     db: pmm-managed
     name: pmm-managed
-    password: pmm-managed
     priv: "ALL"
     expires: infinity
     state: present
@@ -108,7 +141,6 @@
   postgresql_user:
     db: grafana
     name: grafana
-    password: grafana
     priv: 'ALL'
     expires: infinity
     state: present

--- a/build/ansible/roles/supervisord/files/pmm.ini
+++ b/build/ansible/roles/supervisord/files/pmm.ini
@@ -1,11 +1,7 @@
 [unix_http_server]
 chmod = 0700
-username = dummy
-password = dummy
-
-[supervisorctl]
-username = dummy
-password = dummy
+; supervisord socket auth — access restricted by file permissions (0700)
+; no credentials needed since only root/pmm can access the socket
 
 ; we rewrite autostart to true during update or build.
 [program:pmm-init]
@@ -87,7 +83,14 @@ command =
         --victoriametrics-url=http://127.0.0.1:9090/prometheus
         --postgres-name=pmm-managed
         --postgres-username=pmm-managed
-        --postgres-password=pmm-managed
+        --postgres-password=
+        --postgres-ssl-mode=verify-ca
+        --postgres-ssl-ca-path=/srv/certs/ca.crt
+        --postgres-ssl-cert-path=/srv/certs/pmm-managed.crt
+        --postgres-ssl-key-path=/srv/certs/pmm-managed.key
+        --clickhouse-ssl-ca-path=/srv/certs/ca.crt
+        --clickhouse-ssl-cert-path=/srv/certs/clickhouse-client.crt
+        --clickhouse-ssl-key-path=/srv/certs/clickhouse-client.key
         --supervisord-config-dir=/etc/supervisord.d
 autorestart = true
 autostart = true

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	_ "expvar" // register /debug/vars
 	"fmt"
@@ -35,7 +37,7 @@ import (
 	"sync"
 	"time"
 
-	_ "github.com/ClickHouse/clickhouse-go/v2"
+	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/alecthomas/kingpin/v2"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
@@ -625,13 +627,42 @@ func migrateDB(ctx context.Context, sqlDB *sql.DB, params models.SetupDBParams) 
 	}
 }
 
-// newClickhouseDB return a new Clickhouse db.
-func newClickhouseDB(dsn string, maxIdleConns, maxOpenConns int) (*sql.DB, error) {
-	db, err := sql.Open("clickhouse", dsn)
+// buildTLSConfig creates a *tls.Config from CA cert, client cert, and client key file paths.
+func buildTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
+	caCert, err := os.ReadFile(caPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to open connection to QAN DB")
+		return nil, fmt.Errorf("failed to read CA cert %s: %w", caPath, err)
 	}
 
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA cert from %s", caPath)
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client cert/key (%s, %s): %w", certPath, keyPath, err)
+	}
+
+	return &tls.Config{
+		RootCAs:      caCertPool,
+		Certificates: []tls.Certificate{clientCert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// newClickhouseDB creates a new ClickHouse database connection using TLS certificate authentication.
+func newClickhouseDB(addr, database, username string, tlsConfig *tls.Config, maxIdleConns, maxOpenConns int) (*sql.DB, error) {
+	opts := &clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: database,
+			Username: username,
+		},
+		TLS: tlsConfig,
+	}
+
+	db := sql.OpenDB(clickhouse.Connector(opts))
 	db.SetConnMaxLifetime(0)
 	db.SetMaxIdleConns(maxIdleConns)
 	db.SetMaxOpenConns(maxOpenConns)
@@ -723,9 +754,17 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	traceF := kingpin.Flag("trace", "[DEPRECATED] Enable trace logging (implies debug)").Envar("PMM_TRACE").Bool()
 
 	clickHouseDatabaseF := kingpin.Flag("clickhouse-name", "Clickhouse database name").Default("pmm").Envar("PMM_CLICKHOUSE_DATABASE").String()
-	clickhouseAddrF := kingpin.Flag("clickhouse-addr", "Clickhouse database address").Default("127.0.0.1:9000").Envar("PMM_CLICKHOUSE_ADDR").String()
+	clickhouseAddrF := kingpin.Flag("clickhouse-addr", "Clickhouse database address").Default("127.0.0.1:9440").Envar("PMM_CLICKHOUSE_ADDR").String()
 	clickhouseUsernameF := kingpin.Flag("clickhouse-username", "Clickhouse database user").Default("default").Envar("PMM_CLICKHOUSE_USER").String()
-	clickhousePasswordF := kingpin.Flag("clickhouse-password", "Clickhouse database user password").Default("clickhouse").Envar("PMM_CLICKHOUSE_PASSWORD").String()
+	clickhouseSSLCAPathF := kingpin.Flag("clickhouse-ssl-ca-path", "ClickHouse SSL CA root certificate path").
+		Envar("PMM_CLICKHOUSE_SSL_CA_PATH").
+		String()
+	clickhouseSSLCertPathF := kingpin.Flag("clickhouse-ssl-cert-path", "ClickHouse SSL client certificate path").
+		Envar("PMM_CLICKHOUSE_SSL_CERT_PATH").
+		String()
+	clickhouseSSLKeyPathF := kingpin.Flag("clickhouse-ssl-key-path", "ClickHouse SSL client key path").
+		Envar("PMM_CLICKHOUSE_SSL_KEY_PATH").
+		String()
 
 	watchtowerHostF := kingpin.Flag("watchtower-host", "Watchtower host").Default("http://watchtower:8080").Envar("PMM_WATCHTOWER_HOST").URL()
 
@@ -821,11 +860,23 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	grafanadb.DSN.DB = "grafana"
 	grafanadb.DSN.Params = q.Encode()
 
+	// Build ClickHouse TLS config for cert-based auth
+	var chTLSConfig *tls.Config
+	if *clickhouseSSLCAPathF != "" {
+		var err error
+		chTLSConfig, err = buildTLSConfig(*clickhouseSSLCAPathF, *clickhouseSSLCertPathF, *clickhouseSSLKeyPathF)
+		if err != nil {
+			l.Panicf("Failed to build ClickHouse TLS config: %+v", err)
+		}
+	}
+
+	// Build ClickHouse DSN for qan-api2 and dump service (tcp:// format with secure=true)
 	chURI := url.URL{
-		Scheme: "tcp",
-		User:   url.UserPassword(*clickhouseUsernameF, *clickhousePasswordF),
-		Host:   *clickhouseAddrF,
-		Path:   *clickHouseDatabaseF,
+		Scheme:   "tcp",
+		User:     url.User(*clickhouseUsernameF),
+		Host:     *clickhouseAddrF,
+		Path:     *clickHouseDatabaseF,
+		RawQuery: "secure=true&skip_verify=true",
 	}
 
 	qanDB := ds.QanDBSelect
@@ -992,7 +1043,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		l.Fatalf("Could not create Victoria Metrics client: %s", err)
 	}
 
-	clickhouseClient, err := newClickhouseDB(qanDB.DSN, clickhouseMaxIdleConns, clickhouseMaxOpenConns)
+	clickhouseClient, err := newClickhouseDB(*clickhouseAddrF, *clickHouseDatabaseF, *clickhouseUsernameF, chTLSConfig, clickhouseMaxIdleConns, clickhouseMaxOpenConns)
 	if err != nil {
 		l.Fatalf("Could not create Clickhouse client: %s", err)
 	}

--- a/managed/services/supervisord/pmm_config.go
+++ b/managed/services/supervisord/pmm_config.go
@@ -82,12 +82,8 @@ func saveConfig(path string, cfg []byte) (err error) {
 
 var pmmTemplate = template.Must(template.New("").Option("missingkey=error").Parse(`[unix_http_server]
 chmod = 0700
-username = dummy
-password = dummy
-
-[supervisorctl]
-username = dummy
-password = dummy
+; supervisord socket auth — access restricted by file permissions (0700)
+; no credentials needed since only root/pmm can access the socket
 
 [program:pmm-init]
 command = /usr/bin/ansible-playbook /opt/ansible/pmm-docker/init.yml

--- a/managed/services/supervisord/supervisord.go
+++ b/managed/services/supervisord/supervisord.go
@@ -46,9 +46,8 @@ import (
 
 const (
 	defaultClickhouseDatabase           = "pmm"
-	defaultClickhouseAddr               = "127.0.0.1:9000"
+	defaultClickhouseAddr               = "127.0.0.1:9440"
 	defaultClickhouseUser               = "default"
-	defaultClickhousePassword           = "clickhouse"
 	defaultVMSearchMaxQueryLen          = "1MB"
 	defaultVMSearchLatencyOffset        = "5s"
 	defaultVMSearchMaxUniqueTimeseries  = "100000000"
@@ -225,7 +224,9 @@ func (s *Service) marshalConfig(tmpl *template.Template, settings *models.Settin
 	clickhouseAddr := envvars.GetEnv("PMM_CLICKHOUSE_ADDR", defaultClickhouseAddr)
 	clickhouseAddrPair := strings.SplitN(clickhouseAddr, ":", 2) //nolint:mnd
 	clickhouseUser := envvars.GetEnv("PMM_CLICKHOUSE_USER", defaultClickhouseUser)
-	clickhousePassword := envvars.GetEnv("PMM_CLICKHOUSE_PASSWORD", defaultClickhousePassword)
+	clickhouseSSLCAPath := envvars.GetEnv("PMM_CLICKHOUSE_SSL_CA_PATH", "")
+	clickhouseSSLCertPath := envvars.GetEnv("PMM_CLICKHOUSE_SSL_CERT_PATH", "")
+	clickhouseSSLKeyPath := envvars.GetEnv("PMM_CLICKHOUSE_SSL_KEY_PATH", "")
 	vmSearchDisableCache := envvars.GetEnv("VM_search_disableCache", strconv.FormatBool(!settings.IsVictoriaMetricsCacheEnabled()))
 	vmSearchMaxQueryLen := envvars.GetEnv("VM_search_maxQueryLen", defaultVMSearchMaxQueryLen)
 	vmSearchLatencyOffset := envvars.GetEnv("VM_search_latencyOffset", defaultVMSearchLatencyOffset)
@@ -258,7 +259,9 @@ func (s *Service) marshalConfig(tmpl *template.Template, settings *models.Settin
 		"ClickhouseHost":               clickhouseAddrPair[0],
 		"ClickhousePort":               clickhouseAddrPair[1],
 		"ClickhouseUser":               clickhouseUser,
-		"ClickhousePassword":           clickhousePassword,
+		"ClickhouseSSLCAPath":          clickhouseSSLCAPath,
+		"ClickhouseSSLCertPath":        clickhouseSSLCertPath,
+		"ClickhouseSSLKeyPath":         clickhouseSSLKeyPath,
 		"PMMServerHost":                "",
 	}
 
@@ -517,7 +520,9 @@ environment =
 	PMM_CLICKHOUSE_ADDR="{{ .ClickhouseAddr }}",
 	PMM_CLICKHOUSE_DATABASE="{{ .ClickhouseDatabase }}",
 	PMM_CLICKHOUSE_USER="{{ .ClickhouseUser }}",
-	PMM_CLICKHOUSE_PASSWORD="{{ .ClickhousePassword }}",
+	PMM_CLICKHOUSE_SSL_CA_PATH="{{ .ClickhouseSSLCAPath }}",
+	PMM_CLICKHOUSE_SSL_CERT_PATH="{{ .ClickhouseSSLCertPath }}",
+	PMM_CLICKHOUSE_SSL_KEY_PATH="{{ .ClickhouseSSLKeyPath }}",
 
 
 autorestart = true
@@ -546,7 +551,6 @@ environment =
     PMM_POSTGRES_ADDR="{{ .PostgresAddr }}",
     PMM_POSTGRES_DBNAME="{{ .PostgresDBName }}",
     PMM_POSTGRES_USERNAME="{{ .PostgresDBUsername }}",
-    PMM_POSTGRES_DBPASSWORD="{{ .PostgresDBPassword }}",
     PMM_POSTGRES_SSL_MODE="{{ .PostgresSSLMode }}",
     PMM_POSTGRES_SSL_CA_PATH="{{ .PostgresSSLCAPath }}",
     PMM_POSTGRES_SSL_KEY_PATH="{{ .PostgresSSLKeyPath }}",
@@ -554,7 +558,9 @@ environment =
     PMM_CLICKHOUSE_HOST="{{ .ClickhouseHost }}",
     PMM_CLICKHOUSE_PORT="{{ .ClickhousePort }}",
     PMM_CLICKHOUSE_USER="{{ .ClickhouseUser }}",
-    PMM_CLICKHOUSE_PASSWORD="{{ .ClickhousePassword }}",
+    PMM_CLICKHOUSE_SSL_CA_PATH="{{ .ClickhouseSSLCAPath }}",
+    PMM_CLICKHOUSE_SSL_CERT_PATH="{{ .ClickhouseSSLCertPath }}",
+    PMM_CLICKHOUSE_SSL_KEY_PATH="{{ .ClickhouseSSLKeyPath }}",
     {{- if .HAEnabled}}
     GF_UNIFIED_ALERTING_HA_LISTEN_ADDRESS="0.0.0.0:{{ .GrafanaGossipPort }}",
     GF_UNIFIED_ALERTING_HA_ADVERTISE_ADDRESS="{{ .HAAdvertiseAddress }}:{{ .GrafanaGossipPort }}",

--- a/qan-api2/db.go
+++ b/qan-api2/db.go
@@ -16,15 +16,17 @@
 package main
 
 import (
+	"crypto/tls"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
-	clickhouse "github.com/ClickHouse/clickhouse-go/v2"          // register database/sql driver
+	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/golang-migrate/migrate/v4/database/clickhouse" // register golang-migrate driver
-	"github.com/jmoiron/sqlx"                                    // TODO: research alternatives. Ex.: https://github.com/go-reform/reform
+	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/reflectx"
 	"github.com/sirupsen/logrus"
 
@@ -36,13 +38,13 @@ const (
 	databaseNotExistErrorCode = 81
 )
 
-// NewDB return updated db.
-func NewDB(dsn string, maxIdleConns, maxOpenConns int, isCluster bool, clusterName string) *sqlx.DB {
+// NewDB creates a new ClickHouse database connection using TLS certificate authentication.
+func NewDB(addr, database, username string, tlsConfig *tls.Config, maxIdleConns, maxOpenConns int, isCluster bool, clusterName string, migrationDSN string) *sqlx.DB {
 	l := logrus.WithField("component", "db")
 	// If ClickHouse is a cluster, wait until the cluster is ready.
 	if isCluster {
 		l.Info("PMM_CLICKHOUSE_IS_CLUSTER is set to 1")
-		dsnURL, err := url.Parse(dsn)
+		dsnURL, err := url.Parse(migrationDSN)
 		if err != nil {
 			l.Fatalf("Error parsing DSN: %v", err)
 		}
@@ -65,20 +67,33 @@ func NewDB(dsn string, maxIdleConns, maxOpenConns int, isCluster bool, clusterNa
 		}
 	}
 
-	l.Infof("New connection with DSN: %s", dsnutils.RedactDSN(dsn))
-	db, err := sqlx.Connect("clickhouse", dsn)
-	if err != nil {
+	// Connect using TLS cert-based auth via clickhouse.Connector
+	opts := &clickhouse.Options{
+		Addr: []string{addr},
+		Auth: clickhouse.Auth{
+			Database: database,
+			Username: username,
+		},
+		TLS: tlsConfig,
+	}
+
+	sqlDB := sql.OpenDB(clickhouse.Connector(opts))
+	db := sqlx.NewDb(sqlDB, "clickhouse")
+
+	// Verify connection
+	if err := db.Ping(); err != nil {
 		l.Errorf("Error connecting to ClickHouse: %v", err)
 		var exception *clickhouse.Exception
 		if errors.As(err, &exception) && exception.Code == databaseNotExistErrorCode {
-			err = createDB(dsn, clusterName)
+			err = createDB(migrationDSN, clusterName)
 			if err != nil {
 				l.Fatalf("Database wasn't created: %v", err)
 			}
-			l.Infof("Connecting again to %s", dsnutils.RedactDSN(dsn))
-			db, err = sqlx.Connect("clickhouse", dsn)
-			if err != nil {
-				l.Fatalf("Connection: %v", err)
+			// Reconnect after creating database
+			sqlDB = sql.OpenDB(clickhouse.Connector(opts))
+			db = sqlx.NewDb(sqlDB, "clickhouse")
+			if err := db.Ping(); err != nil {
+				l.Fatalf("Connection after DB creation: %v", err)
 			}
 		} else {
 			l.Fatalf("Connection: %v", err)
@@ -100,7 +115,7 @@ func NewDB(dsn string, maxIdleConns, maxOpenConns int, isCluster bool, clusterNa
 	data := map[string]any{
 		"engine": migrations.GetEngine(isCluster),
 	}
-	if err := migrations.Run(dsn, data, isCluster, clusterName); err != nil {
+	if err := migrations.Run(migrationDSN, data, isCluster, clusterName); err != nil {
 		l.Fatalf("migrations: %v", err)
 	}
 	l.Info("Migrations applied successfully")

--- a/qan-api2/main.go
+++ b/qan-api2/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	_ "expvar" // register /debug/vars
 	"fmt"
@@ -65,7 +67,7 @@ import (
 const (
 	shutdownTimeout                 = 3 * time.Second
 	defaultDropOldPartitionInterval = 24 * time.Hour
-	defaultDsnF                     = "clickhouse://%s:%s@%s/%s"
+	defaultDsnF                     = "clickhouse://%s@%s/%s"
 	maxIdleConns                    = 5
 	maxOpenConns                    = 10
 )
@@ -252,6 +254,30 @@ func runDebugServer(ctx context.Context, debugBindF string) {
 	cancel()
 }
 
+// buildTLSConfig creates a *tls.Config from CA cert, client cert, and client key file paths.
+func buildTLSConfig(caPath, certPath, keyPath string) (*tls.Config, error) {
+	caCert, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA cert %s: %w", caPath, err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to parse CA cert from %s", caPath)
+	}
+
+	clientCert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client cert/key (%s, %s): %w", certPath, keyPath, err)
+	}
+
+	return &tls.Config{
+		RootCAs:      caCertPool,
+		Certificates: []tls.Certificate{clientCert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
 func main() {
 	log.SetFlags(0)
 
@@ -263,9 +289,14 @@ func main() {
 	dataRetentionF := kingpin.Flag("data-retention", "QAN data Retention (in days)").Default("30").Uint()
 	dsnF := kingpin.Flag("dsn", "ClickHouse database DSN. Can be overridden with database/host/port options").Default(defaultDsnF).String()
 	clickhouseDatabaseF := kingpin.Flag("clickhouse-name", "ClickHouse database name").Default("pmm").Envar("PMM_CLICKHOUSE_DATABASE").String()
-	clickhouseAddrF := kingpin.Flag("clickhouse-addr", "ClickHouse database address").Default("127.0.0.1:9000").Envar("PMM_CLICKHOUSE_ADDR").String()
+	clickhouseAddrF := kingpin.Flag("clickhouse-addr", "ClickHouse database address").Default("127.0.0.1:9440").Envar("PMM_CLICKHOUSE_ADDR").String()
 	clickhouseUserF := kingpin.Flag("clickhouse-user", "ClickHouse database user").Default("default").Envar("PMM_CLICKHOUSE_USER").String()
-	clickhousePasswordF := kingpin.Flag("clickhouse-password", "ClickHouse database user password").Default("clickhouse").Envar("PMM_CLICKHOUSE_PASSWORD").String()
+	clickhouseSSLCAPathF := kingpin.Flag("clickhouse-ssl-ca-path", "ClickHouse SSL CA root certificate path").
+		Envar("PMM_CLICKHOUSE_SSL_CA_PATH").String()
+	clickhouseSSLCertPathF := kingpin.Flag("clickhouse-ssl-cert-path", "ClickHouse SSL client certificate path").
+		Envar("PMM_CLICKHOUSE_SSL_CERT_PATH").String()
+	clickhouseSSLKeyPathF := kingpin.Flag("clickhouse-ssl-key-path", "ClickHouse SSL client key path").
+		Envar("PMM_CLICKHOUSE_SSL_KEY_PATH").String()
 
 	clickhouseIsClusterF := kingpin.Flag("clickhouse-cluster", "Is ClickHouse a cluster").Default("false").Envar("PMM_CLICKHOUSE_IS_CLUSTER").Bool()
 	clickhouseClusterNameF := kingpin.Flag("clickhouse-cluster-name", "ClickHouse cluster name").Default("").Envar("PMM_CLICKHOUSE_CLUSTER_NAME").String()
@@ -295,15 +326,26 @@ func main() {
 	ctx = logger.Set(ctx, "main")
 	defer l.Info("Done.")
 
+	// Build ClickHouse TLS config for cert-based auth
+	var chTLSConfig *tls.Config
+	if *clickhouseSSLCAPathF != "" {
+		var err error
+		chTLSConfig, err = buildTLSConfig(*clickhouseSSLCAPathF, *clickhouseSSLCertPathF, *clickhouseSSLKeyPathF)
+		if err != nil {
+			l.Fatalf("Failed to build ClickHouse TLS config: %+v", err)
+		}
+	}
+
+	// Build DSN for migrations (which still use DSN-based connection)
 	var dsn string
 	if *dsnF == defaultDsnF {
-		dsn = fmt.Sprintf(defaultDsnF, *clickhouseUserF, *clickhousePasswordF, *clickhouseAddrF, *clickhouseDatabaseF)
+		dsn = fmt.Sprintf("clickhouse://%s@%s/%s?secure=true&skip_verify=true", *clickhouseUserF, *clickhouseAddrF, *clickhouseDatabaseF)
 	} else {
 		dsn = *dsnF
 	}
 	l.Info("DSN: ", dsnutils.RedactDSN(dsn))
 
-	db := NewDB(dsn, maxIdleConns, maxOpenConns, *clickhouseIsClusterF, *clickhouseClusterNameF)
+	db := NewDB(*clickhouseAddrF, *clickhouseDatabaseF, *clickhouseUserF, chTLSConfig, maxIdleConns, maxOpenConns, *clickhouseIsClusterF, *clickhouseClusterNameF, dsn)
 	prom.MustRegister(sqlmetrics.NewCollector("clickhouse", "qan-api2", db.DB))
 
 	// handle termination signals


### PR DESCRIPTION
- Generate per-instance CA and service certs at first init
- PostgreSQL and ClickHouse use SSL with client cert auth
- Grafana internal DB switched to cert auth
- ClickHouse connector uses TLS config, new --clickhouse-ssl-* flags
- Dynamic supervisord templates updated
- PostgreSQL datasource removed from provisioning

