### PR TITLE
[PMM-15167] Real-Time Query Analytics for PostgreSQL

### DIFF
--- a/agent/agents/postgres/realtimeanalytics/collector.go
+++ b/agent/agents/postgres/realtimeanalytics/collector.go
@@ -1,0 +1,317 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+const (
+	activityQuery = `
+SELECT pid, datname, usename, application_name,
+       COALESCE(host(client_addr), '') AS client_host,
+       client_port, state, query,
+       query_id, backend_start, xact_start, query_start,
+       wait_event_type, wait_event, leader_pid
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND backend_type = 'client backend'
+  AND state <> 'idle'`
+
+	locksQuery = `
+SELECT blocked_locks.pid AS blocked_pid,
+       blocking_locks.pid AS blocker_pid,
+       blocked_locks.mode AS lock_mode,
+       COALESCE(blocked_relation.relname, '') AS relation_name,
+       blocking_activity.query AS blocker_query,
+       blocking_activity.query_start AS blocker_query_start
+FROM pg_catalog.pg_locks blocked_locks
+JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+JOIN pg_catalog.pg_locks blocking_locks
+  ON blocking_locks.locktype = blocked_locks.locktype
+ AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+ AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+ AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+ AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+ AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+ AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+ AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+ AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+ AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+ AND blocking_locks.pid != blocked_locks.pid
+JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+LEFT JOIN pg_catalog.pg_class blocked_relation ON blocked_relation.oid = blocked_locks.relation
+WHERE NOT blocked_locks.granted`
+
+	trackActivityQuerySizeSQL = `SELECT current_setting('track_activity_query_size')::int`
+)
+
+var errMissingPgReadAllStats = errors.New("monitoring user lacks pg_read_all_stats role; grant pg_read_all_stats or use a superuser account")
+
+func collectSessions(ctx context.Context, db *sql.DB) ([]*rtav1.QueryData, error) {
+	trackSize, err := readTrackActivityQuerySize(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions, err := readActivityRows(ctx, db, trackSize)
+	if err != nil {
+		if isPermissionError(err) {
+			return nil, errMissingPgReadAllStats
+		}
+		return nil, err
+	}
+
+	lockRows, err := readLockRows(ctx, db)
+	if err != nil && !isPermissionError(err) {
+		return nil, err
+	}
+
+	sessionMap := make(map[int32]*sessionRow, len(sessions))
+	for i := range sessions {
+		sessionMap[sessions[i].PID] = &sessions[i]
+	}
+
+	lockChains := buildLockChains(lockRows, sessionMap)
+	now := time.Now()
+
+	results := make([]*rtav1.QueryData, 0, len(sessions))
+	for _, session := range sessions {
+		queryID := sessionQueryID(session)
+		duration := sessionDuration(session, now)
+
+		payload := &rtav1.QueryPostgreSQLData{
+			DatabaseName:            session.DatabaseName,
+			Username:                session.Username,
+			ApplicationName:         session.ApplicationName,
+			SessionState:            session.State,
+			WaitEventType:           session.WaitEventType,
+			WaitEvent:               session.WaitEvent,
+			BackendPid:              session.PID,
+			LeaderPid:               session.LeaderPID,
+			QueryTextTruncated:      session.QueryTextTruncated,
+			TrackActivityQuerySize:  session.TrackActivitySize,
+			LockChain:               lockChains[session.PID],
+		}
+
+		if !session.TransactionStart.IsZero() {
+			payload.TransactionStartTime = timestamppb.New(session.TransactionStart)
+		}
+		if !session.QueryStart.IsZero() {
+			payload.QueryStartTime = timestamppb.New(session.QueryStart)
+		}
+		if session.ClientAddress != "" {
+			payload.DbInstanceAddress = session.ClientAddress
+		}
+
+		results = append(results, &rtav1.QueryData{
+			QueryId:                 queryID,
+			QueryText:               strings.TrimSpace(session.Query),
+			QueryRawJson:            session.RawJSON,
+			QueryExecutionDuration:  durationpb.New(duration),
+			ClientAddress:           session.ClientAddress,
+			Payload:                 &rtav1.QueryData_PostgresPayload{PostgresPayload: payload},
+		})
+	}
+
+	return results, nil
+}
+
+func readTrackActivityQuerySize(ctx context.Context, db *sql.DB) (int32, error) {
+	var size int32
+	err := db.QueryRowContext(ctx, trackActivityQuerySizeSQL).Scan(&size)
+	if err != nil {
+		return 1024, nil //nolint:mnd
+	}
+	return size, nil
+}
+
+func readActivityRows(ctx context.Context, db *sql.DB, trackSize int32) ([]sessionRow, error) {
+	rows, err := db.QueryContext(ctx, activityQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var sessions []sessionRow
+	for rows.Next() {
+		var (
+			session       sessionRow
+			clientHost    sql.NullString
+			clientPort    sql.NullInt64
+			queryID       sql.NullInt64
+			backendStart  sql.NullTime
+			xactStart     sql.NullTime
+			queryStart    sql.NullTime
+			waitEventType sql.NullString
+			waitEvent     sql.NullString
+			leaderPID     sql.NullInt64
+		)
+
+		err = rows.Scan(
+			&session.PID,
+			&session.DatabaseName,
+			&session.Username,
+			&session.ApplicationName,
+			&clientHost,
+			&clientPort,
+			&session.State,
+			&session.Query,
+			&queryID,
+			&backendStart,
+			&xactStart,
+			&queryStart,
+			&waitEventType,
+			&waitEvent,
+			&leaderPID,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if clientHost.Valid {
+			if clientPort.Valid && clientPort.Int64 > 0 {
+				session.ClientAddress = fmt.Sprintf("%s:%d", clientHost.String, clientPort.Int64)
+			} else {
+				session.ClientAddress = clientHost.String
+			}
+		}
+
+		if queryID.Valid {
+			session.QueryID = queryID.Int64
+			session.HasQueryID = true
+		}
+		if backendStart.Valid {
+			session.BackendStart = backendStart.Time
+		}
+		if xactStart.Valid {
+			session.TransactionStart = xactStart.Time
+		}
+		if queryStart.Valid {
+			session.QueryStart = queryStart.Time
+		}
+		if waitEventType.Valid {
+			session.WaitEventType = waitEventType.String
+		}
+		if waitEvent.Valid {
+			session.WaitEvent = waitEvent.String
+		}
+		if leaderPID.Valid {
+			session.LeaderPID = int32(leaderPID.Int64) //nolint:gosec
+		}
+
+		session.TrackActivitySize = trackSize
+		if trackSize > 0 && len(session.Query) >= int(trackSize) {
+			session.QueryTextTruncated = true
+		}
+
+		raw, _ := json.Marshal(map[string]any{
+			"pid":              session.PID,
+			"datname":          session.DatabaseName,
+			"usename":          session.Username,
+			"application_name": session.ApplicationName,
+			"client_addr":      session.ClientAddress,
+			"state":            session.State,
+			"query":            session.Query,
+			"query_id":         session.QueryID,
+			"xact_start":       session.TransactionStart,
+			"query_start":      session.QueryStart,
+			"wait_event_type":  session.WaitEventType,
+			"wait_event":       session.WaitEvent,
+			"leader_pid":       session.LeaderPID,
+		})
+		session.RawJSON = string(raw)
+
+		sessions = append(sessions, session)
+	}
+
+	return sessions, rows.Err()
+}
+
+func readLockRows(ctx context.Context, db *sql.DB) ([]lockRow, error) {
+	rows, err := db.QueryContext(ctx, locksQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var result []lockRow
+	for rows.Next() {
+		var row lockRow
+		var blockerQueryStart sql.NullTime
+		err = rows.Scan(
+			&row.BlockedPID,
+			&row.BlockerPID,
+			&row.LockMode,
+			&row.RelationName,
+			&row.BlockerQuery,
+			&blockerQueryStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if blockerQueryStart.Valid {
+			row.BlockerQueryAt = blockerQueryStart.Time
+		}
+		result = append(result, row)
+	}
+
+	return result, rows.Err()
+}
+
+func sessionQueryID(session sessionRow) string {
+	if session.HasQueryID {
+		return strconv.FormatInt(session.QueryID, 10)
+	}
+
+	sum := sha256.Sum256([]byte(strings.TrimSpace(session.Query)))
+	return hex.EncodeToString(sum[:8])
+}
+
+func sessionDuration(session sessionRow, now time.Time) time.Duration {
+	if session.State == "idle in transaction" && !session.TransactionStart.IsZero() {
+		return now.Sub(session.TransactionStart)
+	}
+	if !session.QueryStart.IsZero() {
+		return now.Sub(session.QueryStart)
+	}
+	if !session.BackendStart.IsZero() {
+		return now.Sub(session.BackendStart)
+	}
+	return 0
+}
+
+func isPermissionError(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "42501" // insufficient_privilege
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "permission denied")
+}

--- a/agent/agents/postgres/realtimeanalytics/locks.go
+++ b/agent/agents/postgres/realtimeanalytics/locks.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+type lockRow struct {
+	BlockedPID     int32
+	BlockerPID     int32
+	LockMode       string
+	RelationName   string
+	BlockerQuery   string
+	BlockerQueryAt time.Time
+}
+
+type sessionRow struct {
+	PID                  int32
+	DatabaseName         string
+	Username             string
+	ApplicationName      string
+	ClientAddress        string
+	State                string
+	Query                string
+	QueryID              int64
+	HasQueryID           bool
+	BackendStart         time.Time
+	TransactionStart     time.Time
+	QueryStart           time.Time
+	WaitEventType        string
+	WaitEvent            string
+	LeaderPID            int32
+	TrackActivitySize    int32
+	QueryTextTruncated   bool
+	RawJSON              string
+}
+
+func buildLockChains(rows []lockRow, sessions map[int32]*sessionRow) map[int32][]*rtav1.LockChainLink {
+	chains := make(map[int32][]*rtav1.LockChainLink)
+	now := time.Now()
+
+	for _, row := range rows {
+		link := &rtav1.LockChainLink{
+			BlockerPid:       row.BlockerPID,
+			BlockedPid:       row.BlockedPID,
+			LockMode:         row.LockMode,
+			RelationName:     row.RelationName,
+			BlockerQueryText: row.BlockerQuery,
+		}
+
+		if blocker, ok := sessions[row.BlockerPID]; ok && !blocker.QueryStart.IsZero() {
+			link.BlockerDuration = durationpb.New(now.Sub(blocker.QueryStart))
+		} else if !row.BlockerQueryAt.IsZero() {
+			link.BlockerDuration = durationpb.New(now.Sub(row.BlockerQueryAt))
+		}
+
+		chains[row.BlockedPID] = append(chains[row.BlockedPID], link)
+	}
+
+	return chains
+}

--- a/agent/agents/postgres/realtimeanalytics/postgresql.go
+++ b/agent/agents/postgres/realtimeanalytics/postgresql.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package realtimeanalytics runs built-in Real-Time Analytics Agent for PostgreSQL.
+package realtimeanalytics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	_ "github.com/lib/pq" // register postgres driver
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/percona/pmm/agent/agents"
+	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+const changesBufferSize = 10
+
+// PostgreSQLRTA extracts Real-Time Analytics data from PostgreSQL.
+type PostgreSQLRTA struct {
+	agentID         string
+	serviceID       string
+	serviceName     string
+	l               *logrus.Entry
+	changes         chan agents.Change
+	dsn             string
+	collectInterval time.Duration
+}
+
+// Params represent Agent parameters.
+type Params struct {
+	AgentID         string
+	DSN             string
+	ServiceID       string
+	ServiceName     string
+	CollectInterval time.Duration
+}
+
+// New creates new PostgreSQLRTA service.
+func New(params *Params, l *logrus.Entry) (*PostgreSQLRTA, error) {
+	if params.DSN == "" {
+		return nil, fmt.Errorf("empty DSN")
+	}
+
+	return &PostgreSQLRTA{
+		agentID:         params.AgentID,
+		serviceID:       params.ServiceID,
+		serviceName:     params.ServiceName,
+		dsn:             params.DSN,
+		collectInterval: params.CollectInterval,
+		l:               l,
+		changes:         make(chan agents.Change, changesBufferSize),
+	}, nil
+}
+
+// Run extracts currently running DB sessions from PostgreSQL until ctx is canceled.
+func (p *PostgreSQLRTA) Run(ctx context.Context) {
+	p.l.Info("Starting PostgreSQL RTA agent")
+
+	p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STARTING}
+
+	defer func() {
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_DONE}
+		close(p.changes)
+	}()
+
+	db, err := sql.Open("postgres", p.dsn)
+	if err != nil {
+		p.l.Errorf("Can't run Real-Time Analytics agent, reason: %v", err)
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+		return
+	}
+	defer db.Close() //nolint:errcheck
+
+	db.SetMaxOpenConns(2)
+	db.SetConnMaxLifetime(5 * time.Minute) //nolint:mnd
+
+	if err = db.PingContext(ctx); err != nil {
+		p.l.Errorf("Can't connect to PostgreSQL for RTA: %v", err)
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+		return
+	}
+
+	p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING}
+
+	ticker := time.NewTicker(p.collectInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.l.Info("Stopping PostgreSQL RTA agent")
+			p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+			return
+		case <-ticker.C:
+			go func(curCtx context.Context) {
+				bucket, collectErr := p.collect(curCtx, db)
+				if collectErr != nil {
+					if collectErr == errMissingPgReadAllStats {
+						p.l.Error(collectErr.Error())
+						p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_WAITING}
+						return
+					}
+					p.l.Warnf("pg_stat_activity collection failed: %v", collectErr)
+					return
+				}
+
+				select {
+				case <-curCtx.Done():
+					return
+				default:
+					if len(bucket) != 0 {
+						p.changes <- agents.Change{RTAQueriesBucket: bucket}
+					}
+				}
+			}(ctx)
+		}
+	}
+}
+
+func (p *PostgreSQLRTA) collect(ctx context.Context, db *sql.DB) ([]*rtav1.QueryData, error) {
+	results, err := collectSessions(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	collectTime := timestamppb.New(time.Now())
+	for _, query := range results {
+		query.ServiceId = p.serviceID
+		query.ServiceName = p.serviceName
+		query.QueryCollectTime = collectTime
+	}
+
+	return results, nil
+}
+
+// Changes returns channel that should be read until it is closed.
+func (p *PostgreSQLRTA) Changes() <-chan agents.Change {
+	return p.changes
+}
+
+// Describe implements prometheus.Collector.
+func (p *PostgreSQLRTA) Describe(_ chan<- *prometheus.Desc) {}
+
+// Collect implement prometheus.Collector.
+func (p *PostgreSQLRTA) Collect(_ chan<- prometheus.Metric) {}
+
+var _ prometheus.Collector = (*PostgreSQLRTA)(nil)

--- a/agent/agents/postgres/realtimeanalytics/postgresql_test.go
+++ b/agent/agents/postgres/realtimeanalytics/postgresql_test.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLockChains(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	sessions := map[int32]*sessionRow{
+		100: {PID: 100, QueryStart: now.Add(-30 * time.Second)},
+		200: {PID: 200, QueryStart: now.Add(-10 * time.Second)},
+	}
+
+	rows := []lockRow{{
+		BlockedPID:   200,
+		BlockerPID:   100,
+		LockMode:     "ShareLock",
+		RelationName: "orders",
+		BlockerQuery: "UPDATE orders SET status = 1",
+	}}
+
+	chains := buildLockChains(rows, sessions)
+	require.Len(t, chains[200], 1)
+	assert.Equal(t, int32(100), chains[200][0].BlockerPid)
+	assert.Equal(t, "ShareLock", chains[200][0].LockMode)
+	assert.Equal(t, "orders", chains[200][0].RelationName)
+}
+
+func TestSessionQueryID(t *testing.T) {
+	t.Parallel()
+
+	withID := sessionRow{HasQueryID: true, QueryID: 42}
+	assert.Equal(t, "42", sessionQueryID(withID))
+
+	withoutID := sessionRow{Query: "SELECT 1"}
+	assert.NotEmpty(t, sessionQueryID(withoutID))
+}
+
+func TestSessionDurationIdleInTransaction(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := sessionRow{
+		State:            "idle in transaction",
+		TransactionStart: now.Add(-45 * time.Second),
+		QueryStart:       now.Add(-5 * time.Second),
+	}
+
+	duration := sessionDuration(session, now)
+	assert.InDelta(t, 45.0, duration.Seconds(), 0.1)
+}
+
+func TestSessionDurationActiveQuery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := sessionRow{
+		State:      "active",
+		QueryStart: now.Add(-12 * time.Second),
+	}
+
+	duration := sessionDuration(session, now)
+	assert.InDelta(t, 12.0, duration.Seconds(), 0.1)
+}
+
+func TestQueryTextTruncation(t *testing.T) {
+	t.Parallel()
+
+	session := sessionRow{Query: "SELECT 1", TrackActivitySize: 8}
+	assert.True(t, len(session.Query) >= int(session.TrackActivitySize))
+	session.QueryTextTruncated = len(session.Query) >= int(session.TrackActivitySize)
+	assert.True(t, session.QueryTextTruncated)
+}

--- a/agent/agents/supervisor/supervisor.go
+++ b/agent/agents/supervisor/supervisor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/percona/pmm/agent/agents/mongodb/mongolog"
 	mongoprofiler "github.com/percona/pmm/agent/agents/mongodb/profiler"
 	mongorta "github.com/percona/pmm/agent/agents/mongodb/realtimeanalytics"
+	postgresrta "github.com/percona/pmm/agent/agents/postgres/realtimeanalytics"
 	"github.com/percona/pmm/agent/agents/mysql/perfschema"
 	"github.com/percona/pmm/agent/agents/mysql/slowlog"
 	"github.com/percona/pmm/agent/agents/noop"
@@ -672,6 +673,16 @@ func (s *Supervisor) startBuiltin(agentID string, builtinAgent *agentv1.SetState
 			CollectInterval: builtinAgent.RtaOptions.GetCollectInterval().AsDuration(),
 		}
 		agent, err = mongorta.New(params, l)
+
+	case inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT:
+		params := &postgresrta.Params{
+			DSN:             dsn,
+			AgentID:         agentID,
+			ServiceID:       builtinAgent.ServiceId,
+			ServiceName:     builtinAgent.ServiceName,
+			CollectInterval: builtinAgent.RtaOptions.GetCollectInterval().AsDuration(),
+		}
+		agent, err = postgresrta.New(params, l)
 
 	case type_TEST_NOOP:
 		agent = noop.New()

--- a/api/accesscontrol/v1beta1/accesscontrol.pb.go
+++ b/api/accesscontrol/v1beta1/accesscontrol.pb.go
@@ -7,15 +7,14 @@
 package accesscontrolv1beta1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -824,27 +823,24 @@ func file_accesscontrol_v1beta1_accesscontrol_proto_rawDescGZIP() []byte {
 	return file_accesscontrol_v1beta1_accesscontrol_proto_rawDescData
 }
 
-var (
-	file_accesscontrol_v1beta1_accesscontrol_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
-	file_accesscontrol_v1beta1_accesscontrol_proto_goTypes  = []any{
-		(*CreateRoleRequest)(nil),          // 0: accesscontrol.v1beta1.CreateRoleRequest
-		(*CreateRoleResponse)(nil),         // 1: accesscontrol.v1beta1.CreateRoleResponse
-		(*UpdateRoleRequest)(nil),          // 2: accesscontrol.v1beta1.UpdateRoleRequest
-		(*UpdateRoleResponse)(nil),         // 3: accesscontrol.v1beta1.UpdateRoleResponse
-		(*DeleteRoleRequest)(nil),          // 4: accesscontrol.v1beta1.DeleteRoleRequest
-		(*DeleteRoleResponse)(nil),         // 5: accesscontrol.v1beta1.DeleteRoleResponse
-		(*GetRoleRequest)(nil),             // 6: accesscontrol.v1beta1.GetRoleRequest
-		(*GetRoleResponse)(nil),            // 7: accesscontrol.v1beta1.GetRoleResponse
-		(*SetDefaultRoleRequest)(nil),      // 8: accesscontrol.v1beta1.SetDefaultRoleRequest
-		(*SetDefaultRoleResponse)(nil),     // 9: accesscontrol.v1beta1.SetDefaultRoleResponse
-		(*AssignRolesRequest)(nil),         // 10: accesscontrol.v1beta1.AssignRolesRequest
-		(*AssignRolesResponse)(nil),        // 11: accesscontrol.v1beta1.AssignRolesResponse
-		(*ListRolesRequest)(nil),           // 12: accesscontrol.v1beta1.ListRolesRequest
-		(*ListRolesResponse)(nil),          // 13: accesscontrol.v1beta1.ListRolesResponse
-		(*ListRolesResponse_RoleData)(nil), // 14: accesscontrol.v1beta1.ListRolesResponse.RoleData
-	}
-)
-
+var file_accesscontrol_v1beta1_accesscontrol_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_accesscontrol_v1beta1_accesscontrol_proto_goTypes = []any{
+	(*CreateRoleRequest)(nil),          // 0: accesscontrol.v1beta1.CreateRoleRequest
+	(*CreateRoleResponse)(nil),         // 1: accesscontrol.v1beta1.CreateRoleResponse
+	(*UpdateRoleRequest)(nil),          // 2: accesscontrol.v1beta1.UpdateRoleRequest
+	(*UpdateRoleResponse)(nil),         // 3: accesscontrol.v1beta1.UpdateRoleResponse
+	(*DeleteRoleRequest)(nil),          // 4: accesscontrol.v1beta1.DeleteRoleRequest
+	(*DeleteRoleResponse)(nil),         // 5: accesscontrol.v1beta1.DeleteRoleResponse
+	(*GetRoleRequest)(nil),             // 6: accesscontrol.v1beta1.GetRoleRequest
+	(*GetRoleResponse)(nil),            // 7: accesscontrol.v1beta1.GetRoleResponse
+	(*SetDefaultRoleRequest)(nil),      // 8: accesscontrol.v1beta1.SetDefaultRoleRequest
+	(*SetDefaultRoleResponse)(nil),     // 9: accesscontrol.v1beta1.SetDefaultRoleResponse
+	(*AssignRolesRequest)(nil),         // 10: accesscontrol.v1beta1.AssignRolesRequest
+	(*AssignRolesResponse)(nil),        // 11: accesscontrol.v1beta1.AssignRolesResponse
+	(*ListRolesRequest)(nil),           // 12: accesscontrol.v1beta1.ListRolesRequest
+	(*ListRolesResponse)(nil),          // 13: accesscontrol.v1beta1.ListRolesResponse
+	(*ListRolesResponse_RoleData)(nil), // 14: accesscontrol.v1beta1.ListRolesResponse.RoleData
+}
 var file_accesscontrol_v1beta1_accesscontrol_proto_depIdxs = []int32{
 	14, // 0: accesscontrol.v1beta1.ListRolesResponse.roles:type_name -> accesscontrol.v1beta1.ListRolesResponse.RoleData
 	0,  // 1: accesscontrol.v1beta1.AccessControlService.CreateRole:input_type -> accesscontrol.v1beta1.CreateRoleRequest

--- a/api/accesscontrol/v1beta1/accesscontrol.pb.validate.go
+++ b/api/accesscontrol/v1beta1/accesscontrol.pb.validate.go
@@ -139,8 +139,7 @@ func (e CreateRoleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateRoleRequestValidationError{}
@@ -244,8 +243,7 @@ func (e CreateRoleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateRoleResponseValidationError{}
@@ -292,6 +290,7 @@ func (m *UpdateRoleRequest) validate(all bool) error {
 	}
 
 	if m.Title != nil {
+
 		if utf8.RuneCountInString(m.GetTitle()) < 1 {
 			err := UpdateRoleRequestValidationError{
 				field:  "Title",
@@ -302,6 +301,7 @@ func (m *UpdateRoleRequest) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.Filter != nil {
@@ -379,8 +379,7 @@ func (e UpdateRoleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateRoleRequestValidationError{}
@@ -482,8 +481,7 @@ func (e UpdateRoleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateRoleResponseValidationError{}
@@ -598,8 +596,7 @@ func (e DeleteRoleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteRoleRequestValidationError{}
@@ -701,8 +698,7 @@ func (e DeleteRoleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteRoleResponseValidationError{}
@@ -813,8 +809,7 @@ func (e GetRoleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetRoleRequestValidationError{}
@@ -922,8 +917,7 @@ func (e GetRoleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetRoleResponseValidationError{}
@@ -1036,8 +1030,7 @@ func (e SetDefaultRoleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetDefaultRoleRequestValidationError{}
@@ -1139,8 +1132,7 @@ func (e SetDefaultRoleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetDefaultRoleResponseValidationError{}
@@ -1253,8 +1245,7 @@ func (e AssignRolesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AssignRolesRequestValidationError{}
@@ -1356,8 +1347,7 @@ func (e AssignRolesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AssignRolesResponseValidationError{}
@@ -1457,8 +1447,7 @@ func (e ListRolesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListRolesRequestValidationError{}
@@ -1594,8 +1583,7 @@ func (e ListRolesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListRolesResponseValidationError{}
@@ -1705,8 +1693,7 @@ func (e ListRolesResponse_RoleDataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListRolesResponse_RoleDataValidationError{}

--- a/api/accesscontrol/v1beta1/accesscontrol.swagger.json
+++ b/api/accesscontrol/v1beta1/accesscontrol.swagger.json
@@ -1,0 +1,410 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "accesscontrol/v1beta1/accesscontrol.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AccessControlService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/accesscontrol/roles": {
+      "get": {
+        "summary": "List Roles",
+        "description": "Lists all roles.",
+        "operationId": "ListRoles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1ListRolesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "AccessControlService"
+        ]
+      },
+      "post": {
+        "summary": "Create a Role",
+        "description": "Creates a new role.",
+        "operationId": "CreateRole",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1CreateRoleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1CreateRoleRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      }
+    },
+    "/v1/accesscontrol/roles/{role_id}": {
+      "get": {
+        "summary": "Get a Role",
+        "description": "Retrieves a role by ID.",
+        "operationId": "GetRole",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1GetRoleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "role_id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      },
+      "delete": {
+        "summary": "Delete a Role",
+        "description": "Deletes a role.",
+        "operationId": "DeleteRole",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1DeleteRoleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "role_id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "replacement_role_id",
+            "description": "Role ID to be used as a replacement for the role. Additional logic applies.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      },
+      "put": {
+        "summary": "Update a Role",
+        "description": "Updates an existing role.",
+        "operationId": "UpdateRole",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1UpdateRoleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "role_id",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AccessControlServiceUpdateRoleBody"
+            }
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      }
+    },
+    "/v1/accesscontrol/roles:assign": {
+      "post": {
+        "summary": "Assign Roles to a User",
+        "description": "Replaces all existing roles for a user.",
+        "operationId": "AssignRoles",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1AssignRolesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1AssignRolesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      }
+    },
+    "/v1/accesscontrol/roles:setDefault": {
+      "post": {
+        "summary": "Set a Default Role",
+        "description": "Configures a default role assigned to users.",
+        "operationId": "SetDefaultRole",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1SetDefaultRoleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1SetDefaultRoleRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AccessControlService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "AccessControlServiceUpdateRoleBody": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "filter": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "x-nullable": true
+        }
+      }
+    },
+    "ListRolesResponseRoleData": {
+      "type": "object",
+      "properties": {
+        "role_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "title": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1beta1AssignRolesRequest": {
+      "type": "object",
+      "properties": {
+        "role_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "user_id": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "v1beta1AssignRolesResponse": {
+      "type": "object"
+    },
+    "v1beta1CreateRoleRequest": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1CreateRoleResponse": {
+      "type": "object",
+      "properties": {
+        "role_id": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "v1beta1DeleteRoleResponse": {
+      "type": "object"
+    },
+    "v1beta1GetRoleResponse": {
+      "type": "object",
+      "properties": {
+        "role_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "title": {
+          "type": "string"
+        },
+        "filter": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1ListRolesResponse": {
+      "type": "object",
+      "properties": {
+        "roles": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ListRolesResponseRoleData"
+          }
+        }
+      }
+    },
+    "v1beta1SetDefaultRoleRequest": {
+      "type": "object",
+      "properties": {
+        "role_id": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "v1beta1SetDefaultRoleResponse": {
+      "type": "object"
+    },
+    "v1beta1UpdateRoleResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/accesscontrol/v1beta1/accesscontrol_grpc.pb.go
+++ b/api/accesscontrol/v1beta1/accesscontrol_grpc.pb.go
@@ -8,7 +8,6 @@ package accesscontrolv1beta1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -162,27 +161,21 @@ type UnimplementedAccessControlServiceServer struct{}
 func (UnimplementedAccessControlServiceServer) CreateRole(context.Context, *CreateRoleRequest) (*CreateRoleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateRole not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) UpdateRole(context.Context, *UpdateRoleRequest) (*UpdateRoleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateRole not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) DeleteRole(context.Context, *DeleteRoleRequest) (*DeleteRoleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteRole not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) GetRole(context.Context, *GetRoleRequest) (*GetRoleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetRole not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) ListRoles(context.Context, *ListRolesRequest) (*ListRolesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListRoles not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) AssignRoles(context.Context, *AssignRolesRequest) (*AssignRolesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AssignRoles not implemented")
 }
-
 func (UnimplementedAccessControlServiceServer) SetDefaultRole(context.Context, *SetDefaultRoleRequest) (*SetDefaultRoleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetDefaultRole not implemented")
 }

--- a/api/actions/v1/actions.pb.go
+++ b/api/actions/v1/actions.pb.go
@@ -7,15 +7,14 @@
 package actionsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -2610,46 +2609,43 @@ func file_actions_v1_actions_proto_rawDescGZIP() []byte {
 	return file_actions_v1_actions_proto_rawDescData
 }
 
-var (
-	file_actions_v1_actions_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_actions_v1_actions_proto_msgTypes  = make([]protoimpl.MessageInfo, 32)
-	file_actions_v1_actions_proto_goTypes   = []any{
-		ActionType(0),                                        // 0: actions.v1.ActionType
-		(*GetActionRequest)(nil),                             // 1: actions.v1.GetActionRequest
-		(*GetActionResponse)(nil),                            // 2: actions.v1.GetActionResponse
-		(*StartMySQLExplainActionParams)(nil),                // 3: actions.v1.StartMySQLExplainActionParams
-		(*StartMySQLExplainActionResult)(nil),                // 4: actions.v1.StartMySQLExplainActionResult
-		(*StartMySQLExplainJSONActionParams)(nil),            // 5: actions.v1.StartMySQLExplainJSONActionParams
-		(*StartMySQLExplainJSONActionResult)(nil),            // 6: actions.v1.StartMySQLExplainJSONActionResult
-		(*StartMySQLExplainTraditionalJSONActionParams)(nil), // 7: actions.v1.StartMySQLExplainTraditionalJSONActionParams
-		(*StartMySQLExplainTraditionalJSONActionResult)(nil), // 8: actions.v1.StartMySQLExplainTraditionalJSONActionResult
-		(*StartMySQLShowCreateTableActionParams)(nil),        // 9: actions.v1.StartMySQLShowCreateTableActionParams
-		(*StartMySQLShowCreateTableActionResult)(nil),        // 10: actions.v1.StartMySQLShowCreateTableActionResult
-		(*StartMySQLShowTableStatusActionParams)(nil),        // 11: actions.v1.StartMySQLShowTableStatusActionParams
-		(*StartMySQLShowTableStatusActionResult)(nil),        // 12: actions.v1.StartMySQLShowTableStatusActionResult
-		(*StartMySQLShowIndexActionParams)(nil),              // 13: actions.v1.StartMySQLShowIndexActionParams
-		(*StartMySQLShowIndexActionResult)(nil),              // 14: actions.v1.StartMySQLShowIndexActionResult
-		(*StartPostgreSQLShowCreateTableActionParams)(nil),   // 15: actions.v1.StartPostgreSQLShowCreateTableActionParams
-		(*StartPostgreSQLShowCreateTableActionResult)(nil),   // 16: actions.v1.StartPostgreSQLShowCreateTableActionResult
-		(*StartPostgreSQLShowIndexActionParams)(nil),         // 17: actions.v1.StartPostgreSQLShowIndexActionParams
-		(*StartPostgreSQLShowIndexActionResult)(nil),         // 18: actions.v1.StartPostgreSQLShowIndexActionResult
-		(*StartMongoDBExplainActionParams)(nil),              // 19: actions.v1.StartMongoDBExplainActionParams
-		(*StartMongoDBExplainActionResult)(nil),              // 20: actions.v1.StartMongoDBExplainActionResult
-		(*StartPTPgSummaryActionParams)(nil),                 // 21: actions.v1.StartPTPgSummaryActionParams
-		(*StartPTPgSummaryActionResult)(nil),                 // 22: actions.v1.StartPTPgSummaryActionResult
-		(*StartPTMongoDBSummaryActionParams)(nil),            // 23: actions.v1.StartPTMongoDBSummaryActionParams
-		(*StartPTMongoDBSummaryActionResult)(nil),            // 24: actions.v1.StartPTMongoDBSummaryActionResult
-		(*StartPTMySQLSummaryActionParams)(nil),              // 25: actions.v1.StartPTMySQLSummaryActionParams
-		(*StartPTMySQLSummaryActionResult)(nil),              // 26: actions.v1.StartPTMySQLSummaryActionResult
-		(*StartPTSummaryActionRequest)(nil),                  // 27: actions.v1.StartPTSummaryActionRequest
-		(*StartPTSummaryActionResponse)(nil),                 // 28: actions.v1.StartPTSummaryActionResponse
-		(*CancelActionRequest)(nil),                          // 29: actions.v1.CancelActionRequest
-		(*CancelActionResponse)(nil),                         // 30: actions.v1.CancelActionResponse
-		(*StartServiceActionRequest)(nil),                    // 31: actions.v1.StartServiceActionRequest
-		(*StartServiceActionResponse)(nil),                   // 32: actions.v1.StartServiceActionResponse
-	}
-)
-
+var file_actions_v1_actions_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_actions_v1_actions_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_actions_v1_actions_proto_goTypes = []any{
+	(ActionType)(0),                                      // 0: actions.v1.ActionType
+	(*GetActionRequest)(nil),                             // 1: actions.v1.GetActionRequest
+	(*GetActionResponse)(nil),                            // 2: actions.v1.GetActionResponse
+	(*StartMySQLExplainActionParams)(nil),                // 3: actions.v1.StartMySQLExplainActionParams
+	(*StartMySQLExplainActionResult)(nil),                // 4: actions.v1.StartMySQLExplainActionResult
+	(*StartMySQLExplainJSONActionParams)(nil),            // 5: actions.v1.StartMySQLExplainJSONActionParams
+	(*StartMySQLExplainJSONActionResult)(nil),            // 6: actions.v1.StartMySQLExplainJSONActionResult
+	(*StartMySQLExplainTraditionalJSONActionParams)(nil), // 7: actions.v1.StartMySQLExplainTraditionalJSONActionParams
+	(*StartMySQLExplainTraditionalJSONActionResult)(nil), // 8: actions.v1.StartMySQLExplainTraditionalJSONActionResult
+	(*StartMySQLShowCreateTableActionParams)(nil),        // 9: actions.v1.StartMySQLShowCreateTableActionParams
+	(*StartMySQLShowCreateTableActionResult)(nil),        // 10: actions.v1.StartMySQLShowCreateTableActionResult
+	(*StartMySQLShowTableStatusActionParams)(nil),        // 11: actions.v1.StartMySQLShowTableStatusActionParams
+	(*StartMySQLShowTableStatusActionResult)(nil),        // 12: actions.v1.StartMySQLShowTableStatusActionResult
+	(*StartMySQLShowIndexActionParams)(nil),              // 13: actions.v1.StartMySQLShowIndexActionParams
+	(*StartMySQLShowIndexActionResult)(nil),              // 14: actions.v1.StartMySQLShowIndexActionResult
+	(*StartPostgreSQLShowCreateTableActionParams)(nil),   // 15: actions.v1.StartPostgreSQLShowCreateTableActionParams
+	(*StartPostgreSQLShowCreateTableActionResult)(nil),   // 16: actions.v1.StartPostgreSQLShowCreateTableActionResult
+	(*StartPostgreSQLShowIndexActionParams)(nil),         // 17: actions.v1.StartPostgreSQLShowIndexActionParams
+	(*StartPostgreSQLShowIndexActionResult)(nil),         // 18: actions.v1.StartPostgreSQLShowIndexActionResult
+	(*StartMongoDBExplainActionParams)(nil),              // 19: actions.v1.StartMongoDBExplainActionParams
+	(*StartMongoDBExplainActionResult)(nil),              // 20: actions.v1.StartMongoDBExplainActionResult
+	(*StartPTPgSummaryActionParams)(nil),                 // 21: actions.v1.StartPTPgSummaryActionParams
+	(*StartPTPgSummaryActionResult)(nil),                 // 22: actions.v1.StartPTPgSummaryActionResult
+	(*StartPTMongoDBSummaryActionParams)(nil),            // 23: actions.v1.StartPTMongoDBSummaryActionParams
+	(*StartPTMongoDBSummaryActionResult)(nil),            // 24: actions.v1.StartPTMongoDBSummaryActionResult
+	(*StartPTMySQLSummaryActionParams)(nil),              // 25: actions.v1.StartPTMySQLSummaryActionParams
+	(*StartPTMySQLSummaryActionResult)(nil),              // 26: actions.v1.StartPTMySQLSummaryActionResult
+	(*StartPTSummaryActionRequest)(nil),                  // 27: actions.v1.StartPTSummaryActionRequest
+	(*StartPTSummaryActionResponse)(nil),                 // 28: actions.v1.StartPTSummaryActionResponse
+	(*CancelActionRequest)(nil),                          // 29: actions.v1.CancelActionRequest
+	(*CancelActionResponse)(nil),                         // 30: actions.v1.CancelActionResponse
+	(*StartServiceActionRequest)(nil),                    // 31: actions.v1.StartServiceActionRequest
+	(*StartServiceActionResponse)(nil),                   // 32: actions.v1.StartServiceActionResponse
+}
 var file_actions_v1_actions_proto_depIdxs = []int32{
 	3,  // 0: actions.v1.StartServiceActionRequest.mysql_explain:type_name -> actions.v1.StartMySQLExplainActionParams
 	5,  // 1: actions.v1.StartServiceActionRequest.mysql_explain_json:type_name -> actions.v1.StartMySQLExplainJSONActionParams

--- a/api/actions/v1/actions.pb.validate.go
+++ b/api/actions/v1/actions.pb.validate.go
@@ -133,8 +133,7 @@ func (e GetActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetActionRequestValidationError{}
@@ -246,8 +245,7 @@ func (e GetActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetActionResponseValidationError{}
@@ -367,8 +365,7 @@ func (e StartMySQLExplainActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainActionParamsValidationError{}
@@ -475,8 +472,7 @@ func (e StartMySQLExplainActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainActionResultValidationError{}
@@ -598,8 +594,7 @@ func (e StartMySQLExplainJSONActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainJSONActionParamsValidationError{}
@@ -708,8 +703,7 @@ func (e StartMySQLExplainJSONActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainJSONActionResultValidationError{}
@@ -833,8 +827,7 @@ func (e StartMySQLExplainTraditionalJSONActionParamsValidationError) Error() str
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainTraditionalJSONActionParamsValidationError{}
@@ -945,8 +938,7 @@ func (e StartMySQLExplainTraditionalJSONActionResultValidationError) Error() str
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLExplainTraditionalJSONActionResultValidationError{}
@@ -1077,8 +1069,7 @@ func (e StartMySQLShowCreateTableActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowCreateTableActionParamsValidationError{}
@@ -1187,8 +1178,7 @@ func (e StartMySQLShowCreateTableActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowCreateTableActionResultValidationError{}
@@ -1319,8 +1309,7 @@ func (e StartMySQLShowTableStatusActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowTableStatusActionParamsValidationError{}
@@ -1429,8 +1418,7 @@ func (e StartMySQLShowTableStatusActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowTableStatusActionResultValidationError{}
@@ -1559,8 +1547,7 @@ func (e StartMySQLShowIndexActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowIndexActionParamsValidationError{}
@@ -1667,8 +1654,7 @@ func (e StartMySQLShowIndexActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMySQLShowIndexActionResultValidationError{}
@@ -1800,8 +1786,7 @@ func (e StartPostgreSQLShowCreateTableActionParamsValidationError) Error() strin
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPostgreSQLShowCreateTableActionParamsValidationError{}
@@ -1911,8 +1896,7 @@ func (e StartPostgreSQLShowCreateTableActionResultValidationError) Error() strin
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPostgreSQLShowCreateTableActionResultValidationError{}
@@ -2043,8 +2027,7 @@ func (e StartPostgreSQLShowIndexActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPostgreSQLShowIndexActionParamsValidationError{}
@@ -2153,8 +2136,7 @@ func (e StartPostgreSQLShowIndexActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPostgreSQLShowIndexActionResultValidationError{}
@@ -2281,8 +2263,7 @@ func (e StartMongoDBExplainActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMongoDBExplainActionParamsValidationError{}
@@ -2389,8 +2370,7 @@ func (e StartMongoDBExplainActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartMongoDBExplainActionResultValidationError{}
@@ -2497,8 +2477,7 @@ func (e StartPTPgSummaryActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTPgSummaryActionParamsValidationError{}
@@ -2605,8 +2584,7 @@ func (e StartPTPgSummaryActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTPgSummaryActionResultValidationError{}
@@ -2715,8 +2693,7 @@ func (e StartPTMongoDBSummaryActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTMongoDBSummaryActionParamsValidationError{}
@@ -2825,8 +2802,7 @@ func (e StartPTMongoDBSummaryActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTMongoDBSummaryActionResultValidationError{}
@@ -2933,8 +2909,7 @@ func (e StartPTMySQLSummaryActionParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTMySQLSummaryActionParamsValidationError{}
@@ -3041,8 +3016,7 @@ func (e StartPTMySQLSummaryActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTMySQLSummaryActionResultValidationError{}
@@ -3149,8 +3123,7 @@ func (e StartPTSummaryActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTSummaryActionRequestValidationError{}
@@ -3257,8 +3230,7 @@ func (e StartPTSummaryActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartPTSummaryActionResponseValidationError{}
@@ -3371,8 +3343,7 @@ func (e CancelActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CancelActionRequestValidationError{}
@@ -3474,8 +3445,7 @@ func (e CancelActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CancelActionResponseValidationError{}
@@ -4074,8 +4044,7 @@ func (e StartServiceActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartServiceActionRequestValidationError{}
@@ -4674,8 +4643,7 @@ func (e StartServiceActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartServiceActionResponseValidationError{}

--- a/api/actions/v1/actions.swagger.json
+++ b/api/actions/v1/actions.swagger.json
@@ -1,0 +1,737 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "actions/v1/actions.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "ActionsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/actions/{action_id}": {
+      "get": {
+        "summary": "Get Action",
+        "description": "Gets the result of a given Action.",
+        "operationId": "GetAction",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetActionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "action_id",
+            "description": "Unique Action ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ActionsService"
+        ]
+      }
+    },
+    "/v1/actions:cancelAction": {
+      "post": {
+        "summary": "Cancel an Action",
+        "description": "Stops an Action.",
+        "operationId": "CancelAction",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CancelActionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CancelActionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ActionsService"
+        ]
+      }
+    },
+    "/v1/actions:startNodeAction": {
+      "post": {
+        "summary": "Start 'PT Summary' Action",
+        "description": "Starts 'Percona Toolkit Summary' Action.",
+        "operationId": "StartPTSummaryAction",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartPTSummaryActionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartPTSummaryActionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ActionsService"
+        ]
+      }
+    },
+    "/v1/actions:startServiceAction": {
+      "post": {
+        "summary": "Start a Service Action",
+        "description": "Starts a Service Action.",
+        "operationId": "StartServiceAction",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartServiceActionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartServiceActionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ActionsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1CancelActionRequest": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID. Required."
+        }
+      }
+    },
+    "v1CancelActionResponse": {
+      "type": "object"
+    },
+    "v1GetActionResponse": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where this Action is running / was run."
+        },
+        "output": {
+          "type": "string",
+          "description": "Current Action output; may be partial if Action is still running."
+        },
+        "done": {
+          "type": "boolean",
+          "description": "True if Action is finished."
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message if Action failed."
+        }
+      }
+    },
+    "v1StartMongoDBExplainActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "query": {
+          "type": "string",
+          "description": "Query. Required."
+        }
+      }
+    },
+    "v1StartMongoDBExplainActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLExplainActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "query_id": {
+          "type": "string",
+          "description": "Query ID of query."
+        },
+        "placeholders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Array of placeholder values"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if it can't be deduced from the query ID."
+        }
+      }
+    },
+    "v1StartMySQLExplainActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLExplainJSONActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "query_id": {
+          "type": "string",
+          "description": "Query ID of query."
+        },
+        "placeholders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Array of placeholder values"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if it can't be deduced from the query ID."
+        }
+      }
+    },
+    "v1StartMySQLExplainJSONActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLExplainTraditionalJSONActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "query_id": {
+          "type": "string",
+          "description": "Query ID of query."
+        },
+        "placeholders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Array of placeholder values"
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if it can't be deduced from the query ID."
+        }
+      }
+    },
+    "v1StartMySQLExplainTraditionalJSONActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLShowCreateTableActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "table_name": {
+          "type": "string",
+          "description": "Table name. Required. May additionally contain a database name."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if not given in the table_name field."
+        }
+      }
+    },
+    "v1StartMySQLShowCreateTableActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLShowIndexActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "table_name": {
+          "type": "string",
+          "description": "Table name. Required. May additionally contain a database name."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if not given in the table_name field."
+        }
+      }
+    },
+    "v1StartMySQLShowIndexActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartMySQLShowTableStatusActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "table_name": {
+          "type": "string",
+          "description": "Table name. Required. May additionally contain a database name."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if not given in the table_name field."
+        }
+      }
+    },
+    "v1StartMySQLShowTableStatusActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartPTMongoDBSummaryActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action."
+        }
+      },
+      "title": "Message to prepare pt-mongodb-summary data"
+    },
+    "v1StartPTMongoDBSummaryActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      },
+      "title": "Message to retrieve the prepared pt-mongodb-summary data"
+    },
+    "v1StartPTMySQLSummaryActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action."
+        }
+      },
+      "title": "Message to prepare pt-mysql-summary data"
+    },
+    "v1StartPTMySQLSummaryActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      },
+      "title": "Message to retrieve the prepared pt-mysql-summary data"
+    },
+    "v1StartPTPgSummaryActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action."
+        }
+      },
+      "title": "Message to prepare pt-pg-summary data"
+    },
+    "v1StartPTPgSummaryActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      },
+      "title": "Message to retrieve the prepared pt-pg-summary data"
+    },
+    "v1StartPTSummaryActionRequest": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node ID for this Action."
+        }
+      }
+    },
+    "v1StartPTSummaryActionResponse": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartPostgreSQLShowCreateTableActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "table_name": {
+          "type": "string",
+          "description": "Table name. Required. May additionally contain a database name."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if not given in the table_name field."
+        }
+      }
+    },
+    "v1StartPostgreSQLShowCreateTableActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartPostgreSQLShowIndexActionParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to run this Action."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service ID for this Action. Required."
+        },
+        "table_name": {
+          "type": "string",
+          "description": "Table name. Required. May additionally contain a database name."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name. Required if not given in the table_name field."
+        }
+      }
+    },
+    "v1StartPostgreSQLShowIndexActionResult": {
+      "type": "object",
+      "properties": {
+        "action_id": {
+          "type": "string",
+          "description": "Unique Action ID."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "pmm-agent ID where to this Action was started."
+        }
+      }
+    },
+    "v1StartServiceActionRequest": {
+      "type": "object",
+      "properties": {
+        "mysql_explain": {
+          "$ref": "#/definitions/v1StartMySQLExplainActionParams"
+        },
+        "mysql_explain_json": {
+          "$ref": "#/definitions/v1StartMySQLExplainJSONActionParams"
+        },
+        "mysql_explain_traditional_json": {
+          "$ref": "#/definitions/v1StartMySQLExplainTraditionalJSONActionParams"
+        },
+        "mysql_show_index": {
+          "$ref": "#/definitions/v1StartMySQLShowIndexActionParams"
+        },
+        "mysql_show_create_table": {
+          "$ref": "#/definitions/v1StartMySQLShowCreateTableActionParams"
+        },
+        "mysql_show_table_status": {
+          "$ref": "#/definitions/v1StartMySQLShowTableStatusActionParams"
+        },
+        "postgres_show_create_table": {
+          "$ref": "#/definitions/v1StartPostgreSQLShowCreateTableActionParams"
+        },
+        "postgres_show_index": {
+          "$ref": "#/definitions/v1StartPostgreSQLShowIndexActionParams"
+        },
+        "mongodb_explain": {
+          "$ref": "#/definitions/v1StartMongoDBExplainActionParams"
+        },
+        "pt_mongodb_summary": {
+          "$ref": "#/definitions/v1StartPTMongoDBSummaryActionParams"
+        },
+        "pt_mysql_summary": {
+          "$ref": "#/definitions/v1StartPTMySQLSummaryActionParams"
+        },
+        "pt_postgres_summary": {
+          "$ref": "#/definitions/v1StartPTPgSummaryActionParams"
+        }
+      }
+    },
+    "v1StartServiceActionResponse": {
+      "type": "object",
+      "properties": {
+        "mysql_explain": {
+          "$ref": "#/definitions/v1StartMySQLExplainActionResult"
+        },
+        "mysql_explain_json": {
+          "$ref": "#/definitions/v1StartMySQLExplainJSONActionResult"
+        },
+        "mysql_explain_traditional_json": {
+          "$ref": "#/definitions/v1StartMySQLExplainTraditionalJSONActionResult"
+        },
+        "mysql_show_index": {
+          "$ref": "#/definitions/v1StartMySQLShowIndexActionResult"
+        },
+        "mysql_show_create_table": {
+          "$ref": "#/definitions/v1StartMySQLShowCreateTableActionResult"
+        },
+        "mysql_show_table_status": {
+          "$ref": "#/definitions/v1StartMySQLShowTableStatusActionResult"
+        },
+        "postgresql_show_create_table": {
+          "$ref": "#/definitions/v1StartPostgreSQLShowCreateTableActionResult"
+        },
+        "postgresql_show_index": {
+          "$ref": "#/definitions/v1StartPostgreSQLShowIndexActionResult"
+        },
+        "mongodb_explain": {
+          "$ref": "#/definitions/v1StartMongoDBExplainActionResult"
+        },
+        "pt_mongodb_summary": {
+          "$ref": "#/definitions/v1StartPTMongoDBSummaryActionResult"
+        },
+        "pt_mysql_summary": {
+          "$ref": "#/definitions/v1StartPTMySQLSummaryActionResult"
+        },
+        "pt_postgres_summary": {
+          "$ref": "#/definitions/v1StartPTPgSummaryActionResult"
+        }
+      }
+    }
+  }
+}

--- a/api/actions/v1/actions_grpc.pb.go
+++ b/api/actions/v1/actions_grpc.pb.go
@@ -8,7 +8,6 @@ package actionsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -117,15 +116,12 @@ type UnimplementedActionsServiceServer struct{}
 func (UnimplementedActionsServiceServer) GetAction(context.Context, *GetActionRequest) (*GetActionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAction not implemented")
 }
-
 func (UnimplementedActionsServiceServer) StartServiceAction(context.Context, *StartServiceActionRequest) (*StartServiceActionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartServiceAction not implemented")
 }
-
 func (UnimplementedActionsServiceServer) StartPTSummaryAction(context.Context, *StartPTSummaryActionRequest) (*StartPTSummaryActionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartPTSummaryAction not implemented")
 }
-
 func (UnimplementedActionsServiceServer) CancelAction(context.Context, *CancelActionRequest) (*CancelActionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CancelAction not implemented")
 }

--- a/api/advisors/v1/advisors.pb.go
+++ b/api/advisors/v1/advisors.pb.go
@@ -7,17 +7,15 @@
 package advisorsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	v1 "github.com/percona/pmm/api/management/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	v1 "github.com/percona/pmm/api/management/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1358,36 +1356,33 @@ func file_advisors_v1_advisors_proto_rawDescGZIP() []byte {
 	return file_advisors_v1_advisors_proto_rawDescData
 }
 
-var (
-	file_advisors_v1_advisors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_advisors_v1_advisors_proto_msgTypes  = make([]protoimpl.MessageInfo, 20)
-	file_advisors_v1_advisors_proto_goTypes   = []any{
-		AdvisorCheckInterval(0),             // 0: advisors.v1.AdvisorCheckInterval
-		AdvisorCheckFamily(0),               // 1: advisors.v1.AdvisorCheckFamily
-		(*AdvisorCheckResult)(nil),          // 2: advisors.v1.AdvisorCheckResult
-		(*CheckResultSummary)(nil),          // 3: advisors.v1.CheckResultSummary
-		(*CheckResult)(nil),                 // 4: advisors.v1.CheckResult
-		(*AdvisorCheck)(nil),                // 5: advisors.v1.AdvisorCheck
-		(*Advisor)(nil),                     // 6: advisors.v1.Advisor
-		(*ChangeAdvisorCheckParams)(nil),    // 7: advisors.v1.ChangeAdvisorCheckParams
-		(*StartAdvisorChecksRequest)(nil),   // 8: advisors.v1.StartAdvisorChecksRequest
-		(*StartAdvisorChecksResponse)(nil),  // 9: advisors.v1.StartAdvisorChecksResponse
-		(*ListAdvisorChecksRequest)(nil),    // 10: advisors.v1.ListAdvisorChecksRequest
-		(*ListAdvisorChecksResponse)(nil),   // 11: advisors.v1.ListAdvisorChecksResponse
-		(*ListAdvisorsRequest)(nil),         // 12: advisors.v1.ListAdvisorsRequest
-		(*ListAdvisorsResponse)(nil),        // 13: advisors.v1.ListAdvisorsResponse
-		(*ChangeAdvisorChecksRequest)(nil),  // 14: advisors.v1.ChangeAdvisorChecksRequest
-		(*ChangeAdvisorChecksResponse)(nil), // 15: advisors.v1.ChangeAdvisorChecksResponse
-		(*ListFailedServicesRequest)(nil),   // 16: advisors.v1.ListFailedServicesRequest
-		(*ListFailedServicesResponse)(nil),  // 17: advisors.v1.ListFailedServicesResponse
-		(*GetFailedChecksRequest)(nil),      // 18: advisors.v1.GetFailedChecksRequest
-		(*GetFailedChecksResponse)(nil),     // 19: advisors.v1.GetFailedChecksResponse
-		nil,                                 // 20: advisors.v1.AdvisorCheckResult.LabelsEntry
-		nil,                                 // 21: advisors.v1.CheckResult.LabelsEntry
-		v1.Severity(0),                      // 22: management.v1.Severity
-	}
-)
-
+var file_advisors_v1_advisors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_advisors_v1_advisors_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_advisors_v1_advisors_proto_goTypes = []any{
+	(AdvisorCheckInterval)(0),           // 0: advisors.v1.AdvisorCheckInterval
+	(AdvisorCheckFamily)(0),             // 1: advisors.v1.AdvisorCheckFamily
+	(*AdvisorCheckResult)(nil),          // 2: advisors.v1.AdvisorCheckResult
+	(*CheckResultSummary)(nil),          // 3: advisors.v1.CheckResultSummary
+	(*CheckResult)(nil),                 // 4: advisors.v1.CheckResult
+	(*AdvisorCheck)(nil),                // 5: advisors.v1.AdvisorCheck
+	(*Advisor)(nil),                     // 6: advisors.v1.Advisor
+	(*ChangeAdvisorCheckParams)(nil),    // 7: advisors.v1.ChangeAdvisorCheckParams
+	(*StartAdvisorChecksRequest)(nil),   // 8: advisors.v1.StartAdvisorChecksRequest
+	(*StartAdvisorChecksResponse)(nil),  // 9: advisors.v1.StartAdvisorChecksResponse
+	(*ListAdvisorChecksRequest)(nil),    // 10: advisors.v1.ListAdvisorChecksRequest
+	(*ListAdvisorChecksResponse)(nil),   // 11: advisors.v1.ListAdvisorChecksResponse
+	(*ListAdvisorsRequest)(nil),         // 12: advisors.v1.ListAdvisorsRequest
+	(*ListAdvisorsResponse)(nil),        // 13: advisors.v1.ListAdvisorsResponse
+	(*ChangeAdvisorChecksRequest)(nil),  // 14: advisors.v1.ChangeAdvisorChecksRequest
+	(*ChangeAdvisorChecksResponse)(nil), // 15: advisors.v1.ChangeAdvisorChecksResponse
+	(*ListFailedServicesRequest)(nil),   // 16: advisors.v1.ListFailedServicesRequest
+	(*ListFailedServicesResponse)(nil),  // 17: advisors.v1.ListFailedServicesResponse
+	(*GetFailedChecksRequest)(nil),      // 18: advisors.v1.GetFailedChecksRequest
+	(*GetFailedChecksResponse)(nil),     // 19: advisors.v1.GetFailedChecksResponse
+	nil,                                 // 20: advisors.v1.AdvisorCheckResult.LabelsEntry
+	nil,                                 // 21: advisors.v1.CheckResult.LabelsEntry
+	(v1.Severity)(0),                    // 22: management.v1.Severity
+}
 var file_advisors_v1_advisors_proto_depIdxs = []int32{
 	22, // 0: advisors.v1.AdvisorCheckResult.severity:type_name -> management.v1.Severity
 	20, // 1: advisors.v1.AdvisorCheckResult.labels:type_name -> advisors.v1.AdvisorCheckResult.LabelsEntry

--- a/api/advisors/v1/advisors.pb.validate.go
+++ b/api/advisors/v1/advisors.pb.validate.go
@@ -140,8 +140,7 @@ func (e AdvisorCheckResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorCheckResultValidationError{}
@@ -263,8 +262,7 @@ func (e CheckResultSummaryValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckResultSummaryValidationError{}
@@ -381,8 +379,7 @@ func (e CheckResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckResultValidationError{}
@@ -493,8 +490,7 @@ func (e AdvisorCheckValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorCheckValidationError{}
@@ -636,8 +632,7 @@ func (e AdvisorValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorValidationError{}
@@ -747,8 +742,7 @@ func (e ChangeAdvisorCheckParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAdvisorCheckParamsValidationError{}
@@ -850,8 +844,7 @@ func (e StartAdvisorChecksRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartAdvisorChecksRequestValidationError{}
@@ -953,8 +946,7 @@ func (e StartAdvisorChecksResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartAdvisorChecksResponseValidationError{}
@@ -1056,8 +1048,7 @@ func (e ListAdvisorChecksRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAdvisorChecksRequestValidationError{}
@@ -1193,8 +1184,7 @@ func (e ListAdvisorChecksResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAdvisorChecksResponseValidationError{}
@@ -1296,8 +1286,7 @@ func (e ListAdvisorsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAdvisorsRequestValidationError{}
@@ -1433,8 +1422,7 @@ func (e ListAdvisorsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAdvisorsResponseValidationError{}
@@ -1570,8 +1558,7 @@ func (e ChangeAdvisorChecksRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAdvisorChecksRequestValidationError{}
@@ -1674,8 +1661,7 @@ func (e ChangeAdvisorChecksResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAdvisorChecksResponseValidationError{}
@@ -1777,8 +1763,7 @@ func (e ListFailedServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListFailedServicesRequestValidationError{}
@@ -1914,8 +1899,7 @@ func (e ListFailedServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListFailedServicesResponseValidationError{}
@@ -1953,6 +1937,7 @@ func (m *GetFailedChecksRequest) validate(all bool) error {
 	// no validation rules for ServiceId
 
 	if m.PageSize != nil {
+
 		if m.GetPageSize() < 1 {
 			err := GetFailedChecksRequestValidationError{
 				field:  "PageSize",
@@ -1963,9 +1948,11 @@ func (m *GetFailedChecksRequest) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.PageIndex != nil {
+
 		if m.GetPageIndex() < 0 {
 			err := GetFailedChecksRequestValidationError{
 				field:  "PageIndex",
@@ -1976,6 +1963,7 @@ func (m *GetFailedChecksRequest) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if len(errors) > 0 {
@@ -2045,8 +2033,7 @@ func (e GetFailedChecksRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetFailedChecksRequestValidationError{}
@@ -2186,8 +2173,7 @@ func (e GetFailedChecksResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetFailedChecksResponseValidationError{}

--- a/api/advisors/v1/advisors.swagger.json
+++ b/api/advisors/v1/advisors.swagger.json
@@ -1,0 +1,539 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "advisors/v1/advisors.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AdvisorService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/advisors": {
+      "get": {
+        "summary": "List Advisors",
+        "description": "List advisors available to the user.",
+        "operationId": "ListAdvisors",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAdvisorsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    },
+    "/v1/advisors/checks": {
+      "get": {
+        "summary": "List Advisor Checks",
+        "description": "List advisor checks available to the user.",
+        "operationId": "ListAdvisorChecks",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAdvisorChecksResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    },
+    "/v1/advisors/checks/failed": {
+      "get": {
+        "summary": "Get Failed Advisor Checks",
+        "description": "Returns the latest check results for a given service.",
+        "operationId": "GetFailedChecks",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetFailedChecksResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_size",
+            "description": "Maximum number of results per page.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "page_index",
+            "description": "Index of the requested page, starts from 0.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "service_id",
+            "description": "Service ID.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    },
+    "/v1/advisors/checks:batchChange": {
+      "post": {
+        "summary": "Change Advisor Checks",
+        "description": "Enables/disables advisor checks or changes their exec interval.",
+        "operationId": "ChangeAdvisorChecks",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeAdvisorChecksResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ChangeAdvisorChecksRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    },
+    "/v1/advisors/checks:start": {
+      "post": {
+        "summary": "Start Advisor Checks",
+        "description": "Executes Advisor checks and returns when all checks are executed. All available checks will be started if check names aren't specified.",
+        "operationId": "StartAdvisorChecks",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartAdvisorChecksResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartAdvisorChecksRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    },
+    "/v1/advisors/failedServices": {
+      "get": {
+        "summary": "List Failed Services",
+        "description": "Returns a list of services with failed checks and a summary of check results.",
+        "operationId": "ListFailedServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListFailedServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "AdvisorService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1Advisor": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable name (ID) that is used in expression."
+        },
+        "description": {
+          "type": "string",
+          "description": "Long human-readable description."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short human-readable summary."
+        },
+        "comment": {
+          "type": "string",
+          "description": "Comment."
+        },
+        "category": {
+          "type": "string",
+          "description": "Category."
+        },
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AdvisorCheck"
+          },
+          "description": "Advisor checks."
+        }
+      }
+    },
+    "v1AdvisorCheck": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable name (ID) that is used in expression."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "True if that check is enabled."
+        },
+        "description": {
+          "type": "string",
+          "description": "Long human-readable description."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short human-readable summary."
+        },
+        "interval": {
+          "$ref": "#/definitions/v1AdvisorCheckInterval",
+          "description": "Check execution interval."
+        },
+        "family": {
+          "$ref": "#/definitions/v1AdvisorCheckFamily",
+          "description": "DB family."
+        }
+      },
+      "description": "AdvisorCheck contains check name and status."
+    },
+    "v1AdvisorCheckFamily": {
+      "type": "string",
+      "enum": [
+        "ADVISOR_CHECK_FAMILY_UNSPECIFIED",
+        "ADVISOR_CHECK_FAMILY_MYSQL",
+        "ADVISOR_CHECK_FAMILY_POSTGRESQL",
+        "ADVISOR_CHECK_FAMILY_MONGODB"
+      ],
+      "default": "ADVISOR_CHECK_FAMILY_UNSPECIFIED"
+    },
+    "v1AdvisorCheckInterval": {
+      "type": "string",
+      "enum": [
+        "ADVISOR_CHECK_INTERVAL_UNSPECIFIED",
+        "ADVISOR_CHECK_INTERVAL_STANDARD",
+        "ADVISOR_CHECK_INTERVAL_FREQUENT",
+        "ADVISOR_CHECK_INTERVAL_RARE"
+      ],
+      "default": "ADVISOR_CHECK_INTERVAL_UNSPECIFIED",
+      "description": "AdvisorCheckInterval represents possible execution interval values for checks."
+    },
+    "v1ChangeAdvisorCheckParams": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the check to change."
+        },
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "interval": {
+          "$ref": "#/definitions/v1AdvisorCheckInterval",
+          "description": "check execution interval."
+        }
+      },
+      "description": "ChangeAdvisorCheckParams specifies a single check parameters."
+    },
+    "v1ChangeAdvisorChecksRequest": {
+      "type": "object",
+      "properties": {
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ChangeAdvisorCheckParams"
+          }
+        }
+      }
+    },
+    "v1ChangeAdvisorChecksResponse": {
+      "type": "object"
+    },
+    "v1CheckResult": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "severity": {
+          "$ref": "#/definitions/v1Severity"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "read_more_url": {
+          "type": "string",
+          "description": "URL containing information on how to resolve an issue detected by an Advisor check."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Name of the monitored service on which the check ran."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "ID of the monitored service on which the check ran."
+        },
+        "check_name": {
+          "type": "string",
+          "title": "Name of the check that failed"
+        },
+        "silenced": {
+          "type": "boolean",
+          "title": "Silence status of the check result"
+        }
+      },
+      "description": "CheckResult represents the check results for a given service."
+    },
+    "v1CheckResultSummary": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string"
+        },
+        "service_id": {
+          "type": "string"
+        },
+        "emergency_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"EMERGENCY\"."
+        },
+        "alert_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"ALERT\"."
+        },
+        "critical_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"CRITICAL\"."
+        },
+        "error_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"ERROR\"."
+        },
+        "warning_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"WARNING\"."
+        },
+        "notice_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"NOTICE\"."
+        },
+        "info_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"INFO\"."
+        },
+        "debug_count": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of failed checks for this service with severity level \"DEBUG\"."
+        }
+      },
+      "description": "CheckResultSummary is a summary of check results."
+    },
+    "v1GetFailedChecksResponse": {
+      "type": "object",
+      "properties": {
+        "total_items": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of results."
+        },
+        "total_pages": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of pages."
+        },
+        "results": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1CheckResult"
+          },
+          "title": "Check results"
+        }
+      }
+    },
+    "v1ListAdvisorChecksResponse": {
+      "type": "object",
+      "properties": {
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AdvisorCheck"
+          }
+        }
+      }
+    },
+    "v1ListAdvisorsResponse": {
+      "type": "object",
+      "properties": {
+        "advisors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Advisor"
+          }
+        }
+      }
+    },
+    "v1ListFailedServicesResponse": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1CheckResultSummary"
+          }
+        }
+      }
+    },
+    "v1Severity": {
+      "type": "string",
+      "enum": [
+        "SEVERITY_UNSPECIFIED",
+        "SEVERITY_EMERGENCY",
+        "SEVERITY_ALERT",
+        "SEVERITY_CRITICAL",
+        "SEVERITY_ERROR",
+        "SEVERITY_WARNING",
+        "SEVERITY_NOTICE",
+        "SEVERITY_INFO",
+        "SEVERITY_DEBUG"
+      ],
+      "default": "SEVERITY_UNSPECIFIED",
+      "description": "Severity represents severity level of the check result or alert."
+    },
+    "v1StartAdvisorChecksRequest": {
+      "type": "object",
+      "properties": {
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of the checks that should be started."
+        }
+      }
+    },
+    "v1StartAdvisorChecksResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/advisors/v1/advisors_grpc.pb.go
+++ b/api/advisors/v1/advisors_grpc.pb.go
@@ -8,7 +8,6 @@ package advisorsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -147,23 +146,18 @@ type UnimplementedAdvisorServiceServer struct{}
 func (UnimplementedAdvisorServiceServer) ListFailedServices(context.Context, *ListFailedServicesRequest) (*ListFailedServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListFailedServices not implemented")
 }
-
 func (UnimplementedAdvisorServiceServer) GetFailedChecks(context.Context, *GetFailedChecksRequest) (*GetFailedChecksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetFailedChecks not implemented")
 }
-
 func (UnimplementedAdvisorServiceServer) StartAdvisorChecks(context.Context, *StartAdvisorChecksRequest) (*StartAdvisorChecksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartAdvisorChecks not implemented")
 }
-
 func (UnimplementedAdvisorServiceServer) ListAdvisorChecks(context.Context, *ListAdvisorChecksRequest) (*ListAdvisorChecksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAdvisorChecks not implemented")
 }
-
 func (UnimplementedAdvisorServiceServer) ListAdvisors(context.Context, *ListAdvisorsRequest) (*ListAdvisorsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAdvisors not implemented")
 }
-
 func (UnimplementedAdvisorServiceServer) ChangeAdvisorChecks(context.Context, *ChangeAdvisorChecksRequest) (*ChangeAdvisorChecksResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeAdvisorChecks not implemented")
 }

--- a/api/agent/pb/agent.pb.go
+++ b/api/agent/pb/agent.pb.go
@@ -7,13 +7,11 @@
 package pb
 
 import (
-	reflect "reflect"
-	unsafe "unsafe"
-
+	v1 "github.com/percona/pmm/api/agent/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	v1 "github.com/percona/pmm/api/agent/v1"
+	reflect "reflect"
+	unsafe "unsafe"
 )
 
 const (
@@ -37,7 +35,6 @@ var file_agent_pb_agent_proto_goTypes = []any{
 	(*v1.AgentMessage)(nil),  // 0: agent.v1.AgentMessage
 	(*v1.ServerMessage)(nil), // 1: agent.v1.ServerMessage
 }
-
 var file_agent_pb_agent_proto_depIdxs = []int32{
 	0, // 0: agent.Agent.Connect:input_type -> agent.v1.AgentMessage
 	1, // 1: agent.Agent.Connect:output_type -> agent.v1.ServerMessage

--- a/api/agent/pb/agent.swagger.json
+++ b/api/agent/pb/agent.swagger.json
@@ -1,0 +1,55 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "agent/pb/agent.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "Agent"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The status code, which should be an enum value of\n[google.rpc.Code][google.rpc.Code]."
+        },
+        "message": {
+          "type": "string",
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\n[google.rpc.Status.details][google.rpc.Status.details] field, or localized\nby the client."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."
+        }
+      },
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors)."
+    }
+  }
+}

--- a/api/agent/pb/agent_grpc.pb.go
+++ b/api/agent/pb/agent_grpc.pb.go
@@ -8,12 +8,10 @@ package pb
 
 import (
 	context "context"
-
+	v1 "github.com/percona/pmm/api/agent/v1"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-
-	v1 "github.com/percona/pmm/api/agent/v1"
 )
 
 // This is a compile-time assertion to ensure that this generated file

--- a/api/agent/v1/agent.pb.go
+++ b/api/agent/v1/agent.pb.go
@@ -7,19 +7,17 @@
 package agentv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	v11 "github.com/percona/pmm/api/backup/v1"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v11 "github.com/percona/pmm/api/backup/v1"
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -7110,118 +7108,115 @@ func file_agent_v1_agent_proto_rawDescGZIP() []byte {
 	return file_agent_v1_agent_proto_rawDescData
 }
 
-var (
-	file_agent_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_agent_v1_agent_proto_msgTypes  = make([]protoimpl.MessageInfo, 92)
-	file_agent_v1_agent_proto_goTypes   = []any{
-		MysqlExplainOutputFormat(0),                                    // 0: agent.v1.MysqlExplainOutputFormat
-		StartActionRequest_RestartSystemServiceParams_SystemService(0), // 1: agent.v1.StartActionRequest.RestartSystemServiceParams.SystemService
-		(*TextFiles)(nil),                                              // 2: agent.v1.TextFiles
-		(*Ping)(nil),                                                   // 3: agent.v1.Ping
-		(*Pong)(nil),                                                   // 4: agent.v1.Pong
-		(*QANCollectRequest)(nil),                                      // 5: agent.v1.QANCollectRequest
-		(*QANCollectResponse)(nil),                                     // 6: agent.v1.QANCollectResponse
-		(*StateChangedRequest)(nil),                                    // 7: agent.v1.StateChangedRequest
-		(*StateChangedResponse)(nil),                                   // 8: agent.v1.StateChangedResponse
-		(*SetStateRequest)(nil),                                        // 9: agent.v1.SetStateRequest
-		(*SetStateResponse)(nil),                                       // 10: agent.v1.SetStateResponse
-		(*QueryActionValue)(nil),                                       // 11: agent.v1.QueryActionValue
-		(*QueryActionSlice)(nil),                                       // 12: agent.v1.QueryActionSlice
-		(*QueryActionMap)(nil),                                         // 13: agent.v1.QueryActionMap
-		(*QueryActionBinary)(nil),                                      // 14: agent.v1.QueryActionBinary
-		(*QueryActionResult)(nil),                                      // 15: agent.v1.QueryActionResult
-		(*StartActionRequest)(nil),                                     // 16: agent.v1.StartActionRequest
-		(*StartActionResponse)(nil),                                    // 17: agent.v1.StartActionResponse
-		(*StopActionRequest)(nil),                                      // 18: agent.v1.StopActionRequest
-		(*StopActionResponse)(nil),                                     // 19: agent.v1.StopActionResponse
-		(*ActionResultRequest)(nil),                                    // 20: agent.v1.ActionResultRequest
-		(*ActionResultResponse)(nil),                                   // 21: agent.v1.ActionResultResponse
-		(*PBMSwitchPITRRequest)(nil),                                   // 22: agent.v1.PBMSwitchPITRRequest
-		(*PBMSwitchPITRResponse)(nil),                                  // 23: agent.v1.PBMSwitchPITRResponse
-		(*AgentLogsRequest)(nil),                                       // 24: agent.v1.AgentLogsRequest
-		(*AgentLogsResponse)(nil),                                      // 25: agent.v1.AgentLogsResponse
-		(*CheckConnectionRequest)(nil),                                 // 26: agent.v1.CheckConnectionRequest
-		(*CheckConnectionResponse)(nil),                                // 27: agent.v1.CheckConnectionResponse
-		(*ServiceInfoRequest)(nil),                                     // 28: agent.v1.ServiceInfoRequest
-		(*ServiceInfoResponse)(nil),                                    // 29: agent.v1.ServiceInfoResponse
-		(*JobStatusRequest)(nil),                                       // 30: agent.v1.JobStatusRequest
-		(*JobStatusResponse)(nil),                                      // 31: agent.v1.JobStatusResponse
-		(*S3LocationConfig)(nil),                                       // 32: agent.v1.S3LocationConfig
-		(*FilesystemLocationConfig)(nil),                               // 33: agent.v1.FilesystemLocationConfig
-		(*StartJobRequest)(nil),                                        // 34: agent.v1.StartJobRequest
-		(*StartJobResponse)(nil),                                       // 35: agent.v1.StartJobResponse
-		(*StopJobRequest)(nil),                                         // 36: agent.v1.StopJobRequest
-		(*StopJobResponse)(nil),                                        // 37: agent.v1.StopJobResponse
-		(*JobResult)(nil),                                              // 38: agent.v1.JobResult
-		(*JobProgress)(nil),                                            // 39: agent.v1.JobProgress
-		(*GetVersionsRequest)(nil),                                     // 40: agent.v1.GetVersionsRequest
-		(*GetVersionsResponse)(nil),                                    // 41: agent.v1.GetVersionsResponse
-		(*AgentMessage)(nil),                                           // 42: agent.v1.AgentMessage
-		(*ServerMessage)(nil),                                          // 43: agent.v1.ServerMessage
-		nil,                                                            // 44: agent.v1.TextFiles.FilesEntry
-		(*SetStateRequest_AgentProcess)(nil),                           // 45: agent.v1.SetStateRequest.AgentProcess
-		nil,                                                            // 46: agent.v1.SetStateRequest.AgentProcessesEntry
-		(*SetStateRequest_BuiltinAgent)(nil),                           // 47: agent.v1.SetStateRequest.BuiltinAgent
-		nil,                                                            // 48: agent.v1.SetStateRequest.BuiltinAgentsEntry
-		nil,                                                            // 49: agent.v1.SetStateRequest.AgentProcess.TextFilesEntry
-		nil,                                                            // 50: agent.v1.SetStateRequest.BuiltinAgent.EnvEntry
-		nil,                                                            // 51: agent.v1.QueryActionMap.MapEntry
-		(*StartActionRequest_MySQLExplainParams)(nil),                  // 52: agent.v1.StartActionRequest.MySQLExplainParams
-		(*StartActionRequest_MySQLShowCreateTableParams)(nil),          // 53: agent.v1.StartActionRequest.MySQLShowCreateTableParams
-		(*StartActionRequest_MySQLShowTableStatusParams)(nil),          // 54: agent.v1.StartActionRequest.MySQLShowTableStatusParams
-		(*StartActionRequest_MySQLShowIndexParams)(nil),                // 55: agent.v1.StartActionRequest.MySQLShowIndexParams
-		(*StartActionRequest_PostgreSQLShowCreateTableParams)(nil),     // 56: agent.v1.StartActionRequest.PostgreSQLShowCreateTableParams
-		(*StartActionRequest_PostgreSQLShowIndexParams)(nil),           // 57: agent.v1.StartActionRequest.PostgreSQLShowIndexParams
-		(*StartActionRequest_MongoDBExplainParams)(nil),                // 58: agent.v1.StartActionRequest.MongoDBExplainParams
-		(*StartActionRequest_PTSummaryParams)(nil),                     // 59: agent.v1.StartActionRequest.PTSummaryParams
-		(*StartActionRequest_PTPgSummaryParams)(nil),                   // 60: agent.v1.StartActionRequest.PTPgSummaryParams
-		(*StartActionRequest_PTMongoDBSummaryParams)(nil),              // 61: agent.v1.StartActionRequest.PTMongoDBSummaryParams
-		(*StartActionRequest_PTMySQLSummaryParams)(nil),                // 62: agent.v1.StartActionRequest.PTMySQLSummaryParams
-		(*StartActionRequest_MySQLQueryShowParams)(nil),                // 63: agent.v1.StartActionRequest.MySQLQueryShowParams
-		(*StartActionRequest_MySQLQuerySelectParams)(nil),              // 64: agent.v1.StartActionRequest.MySQLQuerySelectParams
-		(*StartActionRequest_PostgreSQLQueryShowParams)(nil),           // 65: agent.v1.StartActionRequest.PostgreSQLQueryShowParams
-		(*StartActionRequest_PostgreSQLQuerySelectParams)(nil),         // 66: agent.v1.StartActionRequest.PostgreSQLQuerySelectParams
-		(*StartActionRequest_MongoDBQueryGetParameterParams)(nil),      // 67: agent.v1.StartActionRequest.MongoDBQueryGetParameterParams
-		(*StartActionRequest_MongoDBQueryBuildInfoParams)(nil),         // 68: agent.v1.StartActionRequest.MongoDBQueryBuildInfoParams
-		(*StartActionRequest_MongoDBQueryGetCmdLineOptsParams)(nil),    // 69: agent.v1.StartActionRequest.MongoDBQueryGetCmdLineOptsParams
-		(*StartActionRequest_MongoDBQueryReplSetGetStatusParams)(nil),  // 70: agent.v1.StartActionRequest.MongoDBQueryReplSetGetStatusParams
-		(*StartActionRequest_MongoDBQueryGetDiagnosticDataParams)(nil), // 71: agent.v1.StartActionRequest.MongoDBQueryGetDiagnosticDataParams
-		(*StartActionRequest_RestartSystemServiceParams)(nil),          // 72: agent.v1.StartActionRequest.RestartSystemServiceParams
-		(*CheckConnectionResponse_Stats)(nil),                          // 73: agent.v1.CheckConnectionResponse.Stats
-		(*StartJobRequest_MySQLBackup)(nil),                            // 74: agent.v1.StartJobRequest.MySQLBackup
-		(*StartJobRequest_MySQLRestoreBackup)(nil),                     // 75: agent.v1.StartJobRequest.MySQLRestoreBackup
-		(*StartJobRequest_MongoDBBackup)(nil),                          // 76: agent.v1.StartJobRequest.MongoDBBackup
-		(*StartJobRequest_MongoDBRestoreBackup)(nil),                   // 77: agent.v1.StartJobRequest.MongoDBRestoreBackup
-		(*JobResult_Error)(nil),                                        // 78: agent.v1.JobResult.Error
-		(*JobResult_MongoDBBackup)(nil),                                // 79: agent.v1.JobResult.MongoDBBackup
-		(*JobResult_MySQLBackup)(nil),                                  // 80: agent.v1.JobResult.MySQLBackup
-		(*JobResult_MySQLRestoreBackup)(nil),                           // 81: agent.v1.JobResult.MySQLRestoreBackup
-		(*JobResult_MongoDBRestoreBackup)(nil),                         // 82: agent.v1.JobResult.MongoDBRestoreBackup
-		(*JobProgress_MySQLBackup)(nil),                                // 83: agent.v1.JobProgress.MySQLBackup
-		(*JobProgress_MySQLRestoreBackup)(nil),                         // 84: agent.v1.JobProgress.MySQLRestoreBackup
-		(*JobProgress_Logs)(nil),                                       // 85: agent.v1.JobProgress.Logs
-		(*GetVersionsRequest_MySQLd)(nil),                              // 86: agent.v1.GetVersionsRequest.MySQLd
-		(*GetVersionsRequest_Xtrabackup)(nil),                          // 87: agent.v1.GetVersionsRequest.Xtrabackup
-		(*GetVersionsRequest_Xbcloud)(nil),                             // 88: agent.v1.GetVersionsRequest.Xbcloud
-		(*GetVersionsRequest_Qpress)(nil),                              // 89: agent.v1.GetVersionsRequest.Qpress
-		(*GetVersionsRequest_MongoDB)(nil),                             // 90: agent.v1.GetVersionsRequest.MongoDB
-		(*GetVersionsRequest_PBM)(nil),                                 // 91: agent.v1.GetVersionsRequest.PBM
-		(*GetVersionsRequest_Software)(nil),                            // 92: agent.v1.GetVersionsRequest.Software
-		(*GetVersionsResponse_Version)(nil),                            // 93: agent.v1.GetVersionsResponse.Version
-		(*timestamppb.Timestamp)(nil),                                  // 94: google.protobuf.Timestamp
-		(*MetricsBucket)(nil),                                          // 95: agent.v1.MetricsBucket
-		v1.AgentStatus(0),                                              // 96: inventory.v1.AgentStatus
-		(*durationpb.Duration)(nil),                                    // 97: google.protobuf.Duration
-		v1.ServiceType(0),                                              // 98: inventory.v1.ServiceType
-		(*status.Status)(nil),                                          // 99: google.rpc.Status
-		v1.AgentType(0),                                                // 100: inventory.v1.AgentType
-		(*v1.RTAOptions)(nil),                                          // 101: inventory.v1.RTAOptions
-		v11.DataModel(0),                                               // 102: backup.v1.DataModel
-		(*v11.PbmMetadata)(nil),                                        // 103: backup.v1.PbmMetadata
-		(*v11.Metadata)(nil),                                           // 104: backup.v1.Metadata
-	}
-)
-
+var file_agent_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_agent_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 92)
+var file_agent_v1_agent_proto_goTypes = []any{
+	(MysqlExplainOutputFormat)(0),                                    // 0: agent.v1.MysqlExplainOutputFormat
+	(StartActionRequest_RestartSystemServiceParams_SystemService)(0), // 1: agent.v1.StartActionRequest.RestartSystemServiceParams.SystemService
+	(*TextFiles)(nil),                             // 2: agent.v1.TextFiles
+	(*Ping)(nil),                                  // 3: agent.v1.Ping
+	(*Pong)(nil),                                  // 4: agent.v1.Pong
+	(*QANCollectRequest)(nil),                     // 5: agent.v1.QANCollectRequest
+	(*QANCollectResponse)(nil),                    // 6: agent.v1.QANCollectResponse
+	(*StateChangedRequest)(nil),                   // 7: agent.v1.StateChangedRequest
+	(*StateChangedResponse)(nil),                  // 8: agent.v1.StateChangedResponse
+	(*SetStateRequest)(nil),                       // 9: agent.v1.SetStateRequest
+	(*SetStateResponse)(nil),                      // 10: agent.v1.SetStateResponse
+	(*QueryActionValue)(nil),                      // 11: agent.v1.QueryActionValue
+	(*QueryActionSlice)(nil),                      // 12: agent.v1.QueryActionSlice
+	(*QueryActionMap)(nil),                        // 13: agent.v1.QueryActionMap
+	(*QueryActionBinary)(nil),                     // 14: agent.v1.QueryActionBinary
+	(*QueryActionResult)(nil),                     // 15: agent.v1.QueryActionResult
+	(*StartActionRequest)(nil),                    // 16: agent.v1.StartActionRequest
+	(*StartActionResponse)(nil),                   // 17: agent.v1.StartActionResponse
+	(*StopActionRequest)(nil),                     // 18: agent.v1.StopActionRequest
+	(*StopActionResponse)(nil),                    // 19: agent.v1.StopActionResponse
+	(*ActionResultRequest)(nil),                   // 20: agent.v1.ActionResultRequest
+	(*ActionResultResponse)(nil),                  // 21: agent.v1.ActionResultResponse
+	(*PBMSwitchPITRRequest)(nil),                  // 22: agent.v1.PBMSwitchPITRRequest
+	(*PBMSwitchPITRResponse)(nil),                 // 23: agent.v1.PBMSwitchPITRResponse
+	(*AgentLogsRequest)(nil),                      // 24: agent.v1.AgentLogsRequest
+	(*AgentLogsResponse)(nil),                     // 25: agent.v1.AgentLogsResponse
+	(*CheckConnectionRequest)(nil),                // 26: agent.v1.CheckConnectionRequest
+	(*CheckConnectionResponse)(nil),               // 27: agent.v1.CheckConnectionResponse
+	(*ServiceInfoRequest)(nil),                    // 28: agent.v1.ServiceInfoRequest
+	(*ServiceInfoResponse)(nil),                   // 29: agent.v1.ServiceInfoResponse
+	(*JobStatusRequest)(nil),                      // 30: agent.v1.JobStatusRequest
+	(*JobStatusResponse)(nil),                     // 31: agent.v1.JobStatusResponse
+	(*S3LocationConfig)(nil),                      // 32: agent.v1.S3LocationConfig
+	(*FilesystemLocationConfig)(nil),              // 33: agent.v1.FilesystemLocationConfig
+	(*StartJobRequest)(nil),                       // 34: agent.v1.StartJobRequest
+	(*StartJobResponse)(nil),                      // 35: agent.v1.StartJobResponse
+	(*StopJobRequest)(nil),                        // 36: agent.v1.StopJobRequest
+	(*StopJobResponse)(nil),                       // 37: agent.v1.StopJobResponse
+	(*JobResult)(nil),                             // 38: agent.v1.JobResult
+	(*JobProgress)(nil),                           // 39: agent.v1.JobProgress
+	(*GetVersionsRequest)(nil),                    // 40: agent.v1.GetVersionsRequest
+	(*GetVersionsResponse)(nil),                   // 41: agent.v1.GetVersionsResponse
+	(*AgentMessage)(nil),                          // 42: agent.v1.AgentMessage
+	(*ServerMessage)(nil),                         // 43: agent.v1.ServerMessage
+	nil,                                           // 44: agent.v1.TextFiles.FilesEntry
+	(*SetStateRequest_AgentProcess)(nil),          // 45: agent.v1.SetStateRequest.AgentProcess
+	nil,                                           // 46: agent.v1.SetStateRequest.AgentProcessesEntry
+	(*SetStateRequest_BuiltinAgent)(nil),          // 47: agent.v1.SetStateRequest.BuiltinAgent
+	nil,                                           // 48: agent.v1.SetStateRequest.BuiltinAgentsEntry
+	nil,                                           // 49: agent.v1.SetStateRequest.AgentProcess.TextFilesEntry
+	nil,                                           // 50: agent.v1.SetStateRequest.BuiltinAgent.EnvEntry
+	nil,                                           // 51: agent.v1.QueryActionMap.MapEntry
+	(*StartActionRequest_MySQLExplainParams)(nil), // 52: agent.v1.StartActionRequest.MySQLExplainParams
+	(*StartActionRequest_MySQLShowCreateTableParams)(nil),          // 53: agent.v1.StartActionRequest.MySQLShowCreateTableParams
+	(*StartActionRequest_MySQLShowTableStatusParams)(nil),          // 54: agent.v1.StartActionRequest.MySQLShowTableStatusParams
+	(*StartActionRequest_MySQLShowIndexParams)(nil),                // 55: agent.v1.StartActionRequest.MySQLShowIndexParams
+	(*StartActionRequest_PostgreSQLShowCreateTableParams)(nil),     // 56: agent.v1.StartActionRequest.PostgreSQLShowCreateTableParams
+	(*StartActionRequest_PostgreSQLShowIndexParams)(nil),           // 57: agent.v1.StartActionRequest.PostgreSQLShowIndexParams
+	(*StartActionRequest_MongoDBExplainParams)(nil),                // 58: agent.v1.StartActionRequest.MongoDBExplainParams
+	(*StartActionRequest_PTSummaryParams)(nil),                     // 59: agent.v1.StartActionRequest.PTSummaryParams
+	(*StartActionRequest_PTPgSummaryParams)(nil),                   // 60: agent.v1.StartActionRequest.PTPgSummaryParams
+	(*StartActionRequest_PTMongoDBSummaryParams)(nil),              // 61: agent.v1.StartActionRequest.PTMongoDBSummaryParams
+	(*StartActionRequest_PTMySQLSummaryParams)(nil),                // 62: agent.v1.StartActionRequest.PTMySQLSummaryParams
+	(*StartActionRequest_MySQLQueryShowParams)(nil),                // 63: agent.v1.StartActionRequest.MySQLQueryShowParams
+	(*StartActionRequest_MySQLQuerySelectParams)(nil),              // 64: agent.v1.StartActionRequest.MySQLQuerySelectParams
+	(*StartActionRequest_PostgreSQLQueryShowParams)(nil),           // 65: agent.v1.StartActionRequest.PostgreSQLQueryShowParams
+	(*StartActionRequest_PostgreSQLQuerySelectParams)(nil),         // 66: agent.v1.StartActionRequest.PostgreSQLQuerySelectParams
+	(*StartActionRequest_MongoDBQueryGetParameterParams)(nil),      // 67: agent.v1.StartActionRequest.MongoDBQueryGetParameterParams
+	(*StartActionRequest_MongoDBQueryBuildInfoParams)(nil),         // 68: agent.v1.StartActionRequest.MongoDBQueryBuildInfoParams
+	(*StartActionRequest_MongoDBQueryGetCmdLineOptsParams)(nil),    // 69: agent.v1.StartActionRequest.MongoDBQueryGetCmdLineOptsParams
+	(*StartActionRequest_MongoDBQueryReplSetGetStatusParams)(nil),  // 70: agent.v1.StartActionRequest.MongoDBQueryReplSetGetStatusParams
+	(*StartActionRequest_MongoDBQueryGetDiagnosticDataParams)(nil), // 71: agent.v1.StartActionRequest.MongoDBQueryGetDiagnosticDataParams
+	(*StartActionRequest_RestartSystemServiceParams)(nil),          // 72: agent.v1.StartActionRequest.RestartSystemServiceParams
+	(*CheckConnectionResponse_Stats)(nil),                          // 73: agent.v1.CheckConnectionResponse.Stats
+	(*StartJobRequest_MySQLBackup)(nil),                            // 74: agent.v1.StartJobRequest.MySQLBackup
+	(*StartJobRequest_MySQLRestoreBackup)(nil),                     // 75: agent.v1.StartJobRequest.MySQLRestoreBackup
+	(*StartJobRequest_MongoDBBackup)(nil),                          // 76: agent.v1.StartJobRequest.MongoDBBackup
+	(*StartJobRequest_MongoDBRestoreBackup)(nil),                   // 77: agent.v1.StartJobRequest.MongoDBRestoreBackup
+	(*JobResult_Error)(nil),                                        // 78: agent.v1.JobResult.Error
+	(*JobResult_MongoDBBackup)(nil),                                // 79: agent.v1.JobResult.MongoDBBackup
+	(*JobResult_MySQLBackup)(nil),                                  // 80: agent.v1.JobResult.MySQLBackup
+	(*JobResult_MySQLRestoreBackup)(nil),                           // 81: agent.v1.JobResult.MySQLRestoreBackup
+	(*JobResult_MongoDBRestoreBackup)(nil),                         // 82: agent.v1.JobResult.MongoDBRestoreBackup
+	(*JobProgress_MySQLBackup)(nil),                                // 83: agent.v1.JobProgress.MySQLBackup
+	(*JobProgress_MySQLRestoreBackup)(nil),                         // 84: agent.v1.JobProgress.MySQLRestoreBackup
+	(*JobProgress_Logs)(nil),                                       // 85: agent.v1.JobProgress.Logs
+	(*GetVersionsRequest_MySQLd)(nil),                              // 86: agent.v1.GetVersionsRequest.MySQLd
+	(*GetVersionsRequest_Xtrabackup)(nil),                          // 87: agent.v1.GetVersionsRequest.Xtrabackup
+	(*GetVersionsRequest_Xbcloud)(nil),                             // 88: agent.v1.GetVersionsRequest.Xbcloud
+	(*GetVersionsRequest_Qpress)(nil),                              // 89: agent.v1.GetVersionsRequest.Qpress
+	(*GetVersionsRequest_MongoDB)(nil),                             // 90: agent.v1.GetVersionsRequest.MongoDB
+	(*GetVersionsRequest_PBM)(nil),                                 // 91: agent.v1.GetVersionsRequest.PBM
+	(*GetVersionsRequest_Software)(nil),                            // 92: agent.v1.GetVersionsRequest.Software
+	(*GetVersionsResponse_Version)(nil),                            // 93: agent.v1.GetVersionsResponse.Version
+	(*timestamppb.Timestamp)(nil),                                  // 94: google.protobuf.Timestamp
+	(*MetricsBucket)(nil),                                          // 95: agent.v1.MetricsBucket
+	(v1.AgentStatus)(0),                                            // 96: inventory.v1.AgentStatus
+	(*durationpb.Duration)(nil),                                    // 97: google.protobuf.Duration
+	(v1.ServiceType)(0),                                            // 98: inventory.v1.ServiceType
+	(*status.Status)(nil),                                          // 99: google.rpc.Status
+	(v1.AgentType)(0),                                              // 100: inventory.v1.AgentType
+	(*v1.RTAOptions)(nil),                                          // 101: inventory.v1.RTAOptions
+	(v11.DataModel)(0),                                             // 102: backup.v1.DataModel
+	(*v11.PbmMetadata)(nil),                                        // 103: backup.v1.PbmMetadata
+	(*v11.Metadata)(nil),                                           // 104: backup.v1.Metadata
+}
 var file_agent_v1_agent_proto_depIdxs = []int32{
 	44,  // 0: agent.v1.TextFiles.files:type_name -> agent.v1.TextFiles.FilesEntry
 	94,  // 1: agent.v1.Pong.current_time:type_name -> google.protobuf.Timestamp

--- a/api/agent/v1/agent.pb.validate.go
+++ b/api/agent/v1/agent.pb.validate.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	backupv1 "github.com/percona/pmm/api/backup/v1"
+
 	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
 )
 
@@ -134,8 +135,7 @@ func (e TextFilesValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = TextFilesValidationError{}
@@ -233,8 +233,7 @@ func (e PingValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PingValidationError{}
@@ -361,8 +360,7 @@ func (e PongValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PongValidationError{}
@@ -498,8 +496,7 @@ func (e QANCollectRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANCollectRequestValidationError{}
@@ -601,8 +598,7 @@ func (e QANCollectResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANCollectResponseValidationError{}
@@ -714,8 +710,7 @@ func (e StateChangedRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StateChangedRequestValidationError{}
@@ -817,8 +812,7 @@ func (e StateChangedResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StateChangedResponseValidationError{}
@@ -1010,8 +1004,7 @@ func (e SetStateRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetStateRequestValidationError{}
@@ -1111,8 +1104,7 @@ func (e SetStateResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetStateResponseValidationError{}
@@ -1453,8 +1445,7 @@ func (e QueryActionValueValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryActionValueValidationError{}
@@ -1588,8 +1579,7 @@ func (e QueryActionSliceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryActionSliceValidationError{}
@@ -1735,8 +1725,7 @@ func (e QueryActionMapValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryActionMapValidationError{}
@@ -1842,8 +1831,7 @@ func (e QueryActionBinaryValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryActionBinaryValidationError{}
@@ -2013,8 +2001,7 @@ func (e QueryActionResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryActionResultValidationError{}
@@ -3013,8 +3000,7 @@ func (e StartActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequestValidationError{}
@@ -3116,8 +3102,7 @@ func (e StartActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionResponseValidationError{}
@@ -3221,8 +3206,7 @@ func (e StopActionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopActionRequestValidationError{}
@@ -3324,8 +3308,7 @@ func (e StopActionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopActionResponseValidationError{}
@@ -3435,8 +3418,7 @@ func (e ActionResultRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ActionResultRequestValidationError{}
@@ -3538,8 +3520,7 @@ func (e ActionResultResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ActionResultResponseValidationError{}
@@ -3674,8 +3655,7 @@ func (e PBMSwitchPITRRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PBMSwitchPITRRequestValidationError{}
@@ -3779,8 +3759,7 @@ func (e PBMSwitchPITRResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PBMSwitchPITRResponseValidationError{}
@@ -3884,8 +3863,7 @@ func (e AgentLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AgentLogsRequestValidationError{}
@@ -3989,8 +3967,7 @@ func (e AgentLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AgentLogsResponseValidationError{}
@@ -4158,8 +4135,7 @@ func (e CheckConnectionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckConnectionRequestValidationError{}
@@ -4263,8 +4239,7 @@ func (e CheckConnectionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckConnectionResponseValidationError{}
@@ -4432,8 +4407,7 @@ func (e ServiceInfoRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ServiceInfoRequestValidationError{}
@@ -4545,8 +4519,7 @@ func (e ServiceInfoResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ServiceInfoResponseValidationError{}
@@ -4648,8 +4621,7 @@ func (e JobStatusRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobStatusRequestValidationError{}
@@ -4753,8 +4725,7 @@ func (e JobStatusResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobStatusResponseValidationError{}
@@ -4864,8 +4835,7 @@ func (e S3LocationConfigValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = S3LocationConfigValidationError{}
@@ -4969,8 +4939,7 @@ func (e FilesystemLocationConfigValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = FilesystemLocationConfigValidationError{}
@@ -5270,8 +5239,7 @@ func (e StartJobRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobRequestValidationError{}
@@ -5373,8 +5341,7 @@ func (e StartJobResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobResponseValidationError{}
@@ -5476,8 +5443,7 @@ func (e StopJobRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopJobRequestValidationError{}
@@ -5577,8 +5543,7 @@ func (e StopJobResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopJobResponseValidationError{}
@@ -5918,8 +5883,7 @@ func (e JobResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResultValidationError{}
@@ -6177,8 +6141,7 @@ func (e JobProgressValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobProgressValidationError{}
@@ -6314,8 +6277,7 @@ func (e GetVersionsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequestValidationError{}
@@ -6451,8 +6413,7 @@ func (e GetVersionsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsResponseValidationError{}
@@ -7325,8 +7286,7 @@ func (e AgentMessageValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AgentMessageValidationError{}
@@ -8118,8 +8078,7 @@ func (e ServerMessageValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ServerMessageValidationError{}
@@ -8230,8 +8189,7 @@ func (e SetStateRequest_AgentProcessValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetStateRequest_AgentProcessValidationError{}
@@ -8414,8 +8372,7 @@ func (e SetStateRequest_BuiltinAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SetStateRequest_BuiltinAgentValidationError{}
@@ -8559,8 +8516,7 @@ func (e StartActionRequest_MySQLExplainParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLExplainParamsValidationError{}
@@ -8704,8 +8660,7 @@ func (e StartActionRequest_MySQLShowCreateTableParamsValidationError) Error() st
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLShowCreateTableParamsValidationError{}
@@ -8849,8 +8804,7 @@ func (e StartActionRequest_MySQLShowTableStatusParamsValidationError) Error() st
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLShowTableStatusParamsValidationError{}
@@ -8991,8 +8945,7 @@ func (e StartActionRequest_MySQLShowIndexParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLShowIndexParamsValidationError{}
@@ -9141,8 +9094,7 @@ func (e StartActionRequest_PostgreSQLShowCreateTableParamsValidationError) Error
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PostgreSQLShowCreateTableParamsValidationError{}
@@ -9284,8 +9236,7 @@ func (e StartActionRequest_PostgreSQLShowIndexParamsValidationError) Error() str
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PostgreSQLShowIndexParamsValidationError{}
@@ -9424,8 +9375,7 @@ func (e StartActionRequest_MongoDBExplainParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBExplainParamsValidationError{}
@@ -9530,8 +9480,7 @@ func (e StartActionRequest_PTSummaryParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PTSummaryParamsValidationError{}
@@ -9644,8 +9593,7 @@ func (e StartActionRequest_PTPgSummaryParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PTPgSummaryParamsValidationError{}
@@ -9759,8 +9707,7 @@ func (e StartActionRequest_PTMongoDBSummaryParamsValidationError) Error() string
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PTMongoDBSummaryParamsValidationError{}
@@ -9876,8 +9823,7 @@ func (e StartActionRequest_PTMySQLSummaryParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PTMySQLSummaryParamsValidationError{}
@@ -10018,8 +9964,7 @@ func (e StartActionRequest_MySQLQueryShowParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLQueryShowParamsValidationError{}
@@ -10160,8 +10105,7 @@ func (e StartActionRequest_MySQLQuerySelectParamsValidationError) Error() string
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MySQLQuerySelectParamsValidationError{}
@@ -10301,8 +10245,7 @@ func (e StartActionRequest_PostgreSQLQueryShowParamsValidationError) Error() str
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PostgreSQLQueryShowParamsValidationError{}
@@ -10446,8 +10389,7 @@ func (e StartActionRequest_PostgreSQLQuerySelectParamsValidationError) Error() s
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_PostgreSQLQuerySelectParamsValidationError{}
@@ -10591,8 +10533,7 @@ func (e StartActionRequest_MongoDBQueryGetParameterParamsValidationError) Error(
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBQueryGetParameterParamsValidationError{}
@@ -10732,8 +10673,7 @@ func (e StartActionRequest_MongoDBQueryBuildInfoParamsValidationError) Error() s
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBQueryBuildInfoParamsValidationError{}
@@ -10878,8 +10818,7 @@ func (e StartActionRequest_MongoDBQueryGetCmdLineOptsParamsValidationError) Erro
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBQueryGetCmdLineOptsParamsValidationError{}
@@ -11028,8 +10967,7 @@ func (e StartActionRequest_MongoDBQueryReplSetGetStatusParamsValidationError) Er
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBQueryReplSetGetStatusParamsValidationError{}
@@ -11178,8 +11116,7 @@ func (e StartActionRequest_MongoDBQueryGetDiagnosticDataParamsValidationError) E
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_MongoDBQueryGetDiagnosticDataParamsValidationError{}
@@ -11290,8 +11227,7 @@ func (e StartActionRequest_RestartSystemServiceParamsValidationError) Error() st
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartActionRequest_RestartSystemServiceParamsValidationError{}
@@ -11396,8 +11332,7 @@ func (e CheckConnectionResponse_StatsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckConnectionResponse_StatsValidationError{}
@@ -11560,8 +11495,7 @@ func (e StartJobRequest_MySQLBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobRequest_MySQLBackupValidationError{}
@@ -11718,8 +11652,7 @@ func (e StartJobRequest_MySQLRestoreBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobRequest_MySQLRestoreBackupValidationError{}
@@ -11948,8 +11881,7 @@ func (e StartJobRequest_MongoDBBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobRequest_MongoDBBackupValidationError{}
@@ -12234,8 +12166,7 @@ func (e StartJobRequest_MongoDBRestoreBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartJobRequest_MongoDBRestoreBackupValidationError{}
@@ -12337,8 +12268,7 @@ func (e JobResult_ErrorValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResult_ErrorValidationError{}
@@ -12471,8 +12401,7 @@ func (e JobResult_MongoDBBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResult_MongoDBBackupValidationError{}
@@ -12603,8 +12532,7 @@ func (e JobResult_MySQLBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResult_MySQLBackupValidationError{}
@@ -12707,8 +12635,7 @@ func (e JobResult_MySQLRestoreBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResult_MySQLRestoreBackupValidationError{}
@@ -12811,8 +12738,7 @@ func (e JobResult_MongoDBRestoreBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobResult_MongoDBRestoreBackupValidationError{}
@@ -12914,8 +12840,7 @@ func (e JobProgress_MySQLBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobProgress_MySQLBackupValidationError{}
@@ -13018,8 +12943,7 @@ func (e JobProgress_MySQLRestoreBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobProgress_MySQLRestoreBackupValidationError{}
@@ -13125,8 +13049,7 @@ func (e JobProgress_LogsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = JobProgress_LogsValidationError{}
@@ -13228,8 +13151,7 @@ func (e GetVersionsRequest_MySQLdValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_MySQLdValidationError{}
@@ -13332,8 +13254,7 @@ func (e GetVersionsRequest_XtrabackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_XtrabackupValidationError{}
@@ -13435,8 +13356,7 @@ func (e GetVersionsRequest_XbcloudValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_XbcloudValidationError{}
@@ -13538,8 +13458,7 @@ func (e GetVersionsRequest_QpressValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_QpressValidationError{}
@@ -13641,8 +13560,7 @@ func (e GetVersionsRequest_MongoDBValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_MongoDBValidationError{}
@@ -13744,8 +13662,7 @@ func (e GetVersionsRequest_PBMValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_PBMValidationError{}
@@ -14099,8 +14016,7 @@ func (e GetVersionsRequest_SoftwareValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsRequest_SoftwareValidationError{}
@@ -14207,8 +14123,7 @@ func (e GetVersionsResponse_VersionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetVersionsResponse_VersionValidationError{}

--- a/api/agent/v1/agent.swagger.json
+++ b/api/agent/v1/agent.swagger.json
@@ -1,0 +1,55 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "agent/v1/agent.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AgentService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The status code, which should be an enum value of\n[google.rpc.Code][google.rpc.Code]."
+        },
+        "message": {
+          "type": "string",
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\n[google.rpc.Status.details][google.rpc.Status.details] field, or localized\nby the client."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."
+        }
+      },
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors)."
+    }
+  }
+}

--- a/api/agent/v1/agent_grpc.pb.go
+++ b/api/agent/v1/agent_grpc.pb.go
@@ -8,7 +8,6 @@ package agentv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/api/agent/v1/collector.pb.go
+++ b/api/agent/v1/collector.pb.go
@@ -7,15 +7,13 @@
 package agentv1
 
 import (
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
 )
 
 const (
@@ -2811,23 +2809,20 @@ func file_agent_v1_collector_proto_rawDescGZIP() []byte {
 	return file_agent_v1_collector_proto_rawDescData
 }
 
-var (
-	file_agent_v1_collector_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_agent_v1_collector_proto_msgTypes  = make([]protoimpl.MessageInfo, 8)
-	file_agent_v1_collector_proto_goTypes   = []any{
-		ExampleType(0),                   // 0: agent.v1.ExampleType
-		(*MetricsBucket)(nil),            // 1: agent.v1.MetricsBucket
-		(*HistogramItem)(nil),            // 2: agent.v1.HistogramItem
-		(*MetricsBucket_Common)(nil),     // 3: agent.v1.MetricsBucket.Common
-		(*MetricsBucket_MySQL)(nil),      // 4: agent.v1.MetricsBucket.MySQL
-		(*MetricsBucket_MongoDB)(nil),    // 5: agent.v1.MetricsBucket.MongoDB
-		(*MetricsBucket_PostgreSQL)(nil), // 6: agent.v1.MetricsBucket.PostgreSQL
-		nil,                              // 7: agent.v1.MetricsBucket.Common.CommentsEntry
-		nil,                              // 8: agent.v1.MetricsBucket.Common.ErrorsEntry
-		v1.AgentType(0),                  // 9: inventory.v1.AgentType
-	}
-)
-
+var file_agent_v1_collector_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_agent_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_agent_v1_collector_proto_goTypes = []any{
+	(ExampleType)(0),                 // 0: agent.v1.ExampleType
+	(*MetricsBucket)(nil),            // 1: agent.v1.MetricsBucket
+	(*HistogramItem)(nil),            // 2: agent.v1.HistogramItem
+	(*MetricsBucket_Common)(nil),     // 3: agent.v1.MetricsBucket.Common
+	(*MetricsBucket_MySQL)(nil),      // 4: agent.v1.MetricsBucket.MySQL
+	(*MetricsBucket_MongoDB)(nil),    // 5: agent.v1.MetricsBucket.MongoDB
+	(*MetricsBucket_PostgreSQL)(nil), // 6: agent.v1.MetricsBucket.PostgreSQL
+	nil,                              // 7: agent.v1.MetricsBucket.Common.CommentsEntry
+	nil,                              // 8: agent.v1.MetricsBucket.Common.ErrorsEntry
+	(v1.AgentType)(0),                // 9: inventory.v1.AgentType
+}
 var file_agent_v1_collector_proto_depIdxs = []int32{
 	3, // 0: agent.v1.MetricsBucket.common:type_name -> agent.v1.MetricsBucket.Common
 	4, // 1: agent.v1.MetricsBucket.mysql:type_name -> agent.v1.MetricsBucket.MySQL

--- a/api/agent/v1/collector.pb.validate.go
+++ b/api/agent/v1/collector.pb.validate.go
@@ -242,8 +242,7 @@ func (e MetricsBucketValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucketValidationError{}
@@ -347,8 +346,7 @@ func (e HistogramItemValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HistogramItemValidationError{}
@@ -500,8 +498,7 @@ func (e MetricsBucket_CommonValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucket_CommonValidationError{}
@@ -833,8 +830,7 @@ func (e MetricsBucket_MySQLValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucket_MySQLValidationError{}
@@ -1044,8 +1040,7 @@ func (e MetricsBucket_MongoDBValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucket_MongoDBValidationError{}
@@ -1297,8 +1292,7 @@ func (e MetricsBucket_PostgreSQLValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucket_PostgreSQLValidationError{}

--- a/api/agent/v1/collector.swagger.json
+++ b/api/agent/v1/collector.swagger.json
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "agent/v1/collector.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The status code, which should be an enum value of\n[google.rpc.Code][google.rpc.Code]."
+        },
+        "message": {
+          "type": "string",
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\n[google.rpc.Status.details][google.rpc.Status.details] field, or localized\nby the client."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          },
+          "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use."
+        }
+      },
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors)."
+    }
+  }
+}

--- a/api/agentlocal/v1/agentlocal.pb.go
+++ b/api/agentlocal/v1/agentlocal.pb.go
@@ -7,16 +7,14 @@
 package agentlocalv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -244,7 +242,7 @@ func (x *StatusRequest) GetGetNetworkInfo() bool {
 type StatusResponse struct {
 	state        protoimpl.MessageState `protogen:"open.v1"`
 	AgentId      string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
-	RunsOnNodeId string                 `protobuf:"bytes,2,opt,name=runs_on_node_id,json=runsOnNodeId,proto3" json:"runs_on_node_id,omitempty"` // TODO: rename to node_id
+	RunsOnNodeId string                 `protobuf:"bytes,2,opt,name=runs_on_node_id,json=runsOnNodeId,proto3" json:"runs_on_node_id,omitempty"` //TODO: rename to node_id
 	NodeName     string                 `protobuf:"bytes,3,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
 	ServerInfo   *ServerInfo            `protobuf:"bytes,4,opt,name=server_info,json=serverInfo,proto3" json:"server_info,omitempty"`
 	AgentsInfo   []*AgentInfo           `protobuf:"bytes,5,rep,name=agents_info,json=agentsInfo,proto3" json:"agents_info,omitempty"`
@@ -471,21 +469,18 @@ func file_agentlocal_v1_agentlocal_proto_rawDescGZIP() []byte {
 	return file_agentlocal_v1_agentlocal_proto_rawDescData
 }
 
-var (
-	file_agentlocal_v1_agentlocal_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-	file_agentlocal_v1_agentlocal_proto_goTypes  = []any{
-		(*ServerInfo)(nil),          // 0: agentlocal.v1.ServerInfo
-		(*AgentInfo)(nil),           // 1: agentlocal.v1.AgentInfo
-		(*StatusRequest)(nil),       // 2: agentlocal.v1.StatusRequest
-		(*StatusResponse)(nil),      // 3: agentlocal.v1.StatusResponse
-		(*ReloadRequest)(nil),       // 4: agentlocal.v1.ReloadRequest
-		(*ReloadResponse)(nil),      // 5: agentlocal.v1.ReloadResponse
-		(*durationpb.Duration)(nil), // 6: google.protobuf.Duration
-		v1.AgentType(0),             // 7: inventory.v1.AgentType
-		v1.AgentStatus(0),           // 8: inventory.v1.AgentStatus
-	}
-)
-
+var file_agentlocal_v1_agentlocal_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_agentlocal_v1_agentlocal_proto_goTypes = []any{
+	(*ServerInfo)(nil),          // 0: agentlocal.v1.ServerInfo
+	(*AgentInfo)(nil),           // 1: agentlocal.v1.AgentInfo
+	(*StatusRequest)(nil),       // 2: agentlocal.v1.StatusRequest
+	(*StatusResponse)(nil),      // 3: agentlocal.v1.StatusResponse
+	(*ReloadRequest)(nil),       // 4: agentlocal.v1.ReloadRequest
+	(*ReloadResponse)(nil),      // 5: agentlocal.v1.ReloadResponse
+	(*durationpb.Duration)(nil), // 6: google.protobuf.Duration
+	(v1.AgentType)(0),           // 7: inventory.v1.AgentType
+	(v1.AgentStatus)(0),         // 8: inventory.v1.AgentStatus
+}
 var file_agentlocal_v1_agentlocal_proto_depIdxs = []int32{
 	6, // 0: agentlocal.v1.ServerInfo.latency:type_name -> google.protobuf.Duration
 	6, // 1: agentlocal.v1.ServerInfo.clock_drift:type_name -> google.protobuf.Duration

--- a/api/agentlocal/v1/agentlocal.pb.validate.go
+++ b/api/agentlocal/v1/agentlocal.pb.validate.go
@@ -191,8 +191,7 @@ func (e ServerInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ServerInfoValidationError{}
@@ -301,8 +300,7 @@ func (e AgentInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AgentInfoValidationError{}
@@ -404,8 +402,7 @@ func (e StatusRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StatusRequestValidationError{}
@@ -580,8 +577,7 @@ func (e StatusResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StatusResponseValidationError{}
@@ -681,8 +677,7 @@ func (e ReloadRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReloadRequestValidationError{}
@@ -782,8 +777,7 @@ func (e ReloadResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReloadResponseValidationError{}

--- a/api/agentlocal/v1/agentlocal.swagger.json
+++ b/api/agentlocal/v1/agentlocal.swagger.json
@@ -1,0 +1,296 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "agentlocal/v1/agentlocal.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AgentLocalService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/local/Reload": {
+      "post": {
+        "summary": "Reload reloads pmm-agent configuration.",
+        "operationId": "Reload",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ReloadResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ReloadRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AgentLocalService"
+        ]
+      }
+    },
+    "/local/Status": {
+      "get": {
+        "summary": "Status returns current pmm-agent status.",
+        "operationId": "Status2",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "get_network_info",
+            "description": "Returns network info (latency and clock_drift) if true.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AgentLocalService"
+        ]
+      },
+      "post": {
+        "summary": "Status returns current pmm-agent status.",
+        "operationId": "Status",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StatusRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AgentLocalService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "v1AgentInfo": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string"
+        },
+        "agent_type": {
+          "$ref": "#/definitions/v1AgentType"
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus"
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The current listen port of this Agent (exporter or vmagent).\nZero for other Agent types, or if unknown or not yet supported."
+        },
+        "process_exec_path": {
+          "type": "string"
+        }
+      },
+      "description": "AgentInfo contains information about Agent managed by pmm-agent."
+    },
+    "v1AgentStatus": {
+      "type": "string",
+      "enum": [
+        "AGENT_STATUS_UNSPECIFIED",
+        "AGENT_STATUS_STARTING",
+        "AGENT_STATUS_INITIALIZATION_ERROR",
+        "AGENT_STATUS_RUNNING",
+        "AGENT_STATUS_WAITING",
+        "AGENT_STATUS_STOPPING",
+        "AGENT_STATUS_DONE",
+        "AGENT_STATUS_UNKNOWN"
+      ],
+      "default": "AGENT_STATUS_UNSPECIFIED",
+      "description": "AgentStatus represents actual Agent status.\n\n - AGENT_STATUS_STARTING: Agent is starting.\n - AGENT_STATUS_INITIALIZATION_ERROR: Agent encountered error when starting.\n - AGENT_STATUS_RUNNING: Agent is running.\n - AGENT_STATUS_WAITING: Agent encountered error and will be restarted automatically soon.\n - AGENT_STATUS_STOPPING: Agent is stopping.\n - AGENT_STATUS_DONE: Agent has been stopped or disabled.\n - AGENT_STATUS_UNKNOWN: Agent is not connected, we don't know anything about it's state."
+    },
+    "v1AgentType": {
+      "type": "string",
+      "enum": [
+        "AGENT_TYPE_UNSPECIFIED",
+        "AGENT_TYPE_PMM_AGENT",
+        "AGENT_TYPE_VM_AGENT",
+        "AGENT_TYPE_NODE_EXPORTER",
+        "AGENT_TYPE_MYSQLD_EXPORTER",
+        "AGENT_TYPE_MONGODB_EXPORTER",
+        "AGENT_TYPE_POSTGRES_EXPORTER",
+        "AGENT_TYPE_PROXYSQL_EXPORTER",
+        "AGENT_TYPE_VALKEY_EXPORTER",
+        "AGENT_TYPE_QAN_MYSQL_PERFSCHEMA_AGENT",
+        "AGENT_TYPE_QAN_MYSQL_SLOWLOG_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_PROFILER_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_MONGOLOG_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATEMENTS_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATMONITOR_AGENT",
+        "AGENT_TYPE_EXTERNAL_EXPORTER",
+        "AGENT_TYPE_RDS_EXPORTER",
+        "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
+        "AGENT_TYPE_NOMAD_AGENT",
+        "AGENT_TYPE_RTA_MONGODB_AGENT",
+        "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
+      ],
+      "default": "AGENT_TYPE_UNSPECIFIED",
+      "description": "AgentType describes supported Agent types."
+    },
+    "v1ReloadRequest": {
+      "type": "object"
+    },
+    "v1ReloadResponse": {
+      "type": "object",
+      "description": "ReloadRequest may not be received by the client due to pmm-agent restart."
+    },
+    "v1ServerInfo": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "PMM Server URL in a form https://HOST:PORT/."
+        },
+        "insecure_tls": {
+          "type": "boolean",
+          "description": "PMM Server's TLS certificate validation should be skipped if true."
+        },
+        "connected": {
+          "type": "boolean",
+          "description": "True if pmm-agent is currently connected to the server."
+        },
+        "version": {
+          "type": "string",
+          "description": "PMM Server version (if agent is connected)."
+        },
+        "latency": {
+          "type": "string",
+          "description": "Ping time from pmm-agent to pmm-managed (if agent is connected)."
+        },
+        "clock_drift": {
+          "type": "string",
+          "description": "Clock drift from PMM Server (if agent is connected)."
+        }
+      },
+      "description": "ServerInfo contains information about the PMM Server."
+    },
+    "v1StatusRequest": {
+      "type": "object",
+      "properties": {
+        "get_network_info": {
+          "type": "boolean",
+          "description": "Returns network info (latency and clock_drift) if true."
+        }
+      }
+    },
+    "v1StatusResponse": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string"
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "title": "TODO: rename to node_id"
+        },
+        "node_name": {
+          "type": "string"
+        },
+        "server_info": {
+          "$ref": "#/definitions/v1ServerInfo"
+        },
+        "agents_info": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AgentInfo"
+          }
+        },
+        "config_filepath": {
+          "type": "string",
+          "description": "Config file path if pmm-agent was started with one."
+        },
+        "agent_version": {
+          "type": "string",
+          "description": "PMM Agent version."
+        },
+        "connection_uptime": {
+          "type": "number",
+          "format": "float",
+          "title": "Shows connection uptime in percentage between agent and server"
+        }
+      }
+    }
+  }
+}

--- a/api/agentlocal/v1/agentlocal_grpc.pb.go
+++ b/api/agentlocal/v1/agentlocal_grpc.pb.go
@@ -8,7 +8,6 @@ package agentlocalv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -87,7 +86,6 @@ type UnimplementedAgentLocalServiceServer struct{}
 func (UnimplementedAgentLocalServiceServer) Status(context.Context, *StatusRequest) (*StatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Status not implemented")
 }
-
 func (UnimplementedAgentLocalServiceServer) Reload(context.Context, *ReloadRequest) (*ReloadResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Reload not implemented")
 }

--- a/api/alerting/v1/alerting.pb.go
+++ b/api/alerting/v1/alerting.pb.go
@@ -7,18 +7,16 @@
 package alertingv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	v1 "github.com/percona/pmm/api/management/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v1 "github.com/percona/pmm/api/management/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1426,40 +1424,37 @@ func file_alerting_v1_alerting_proto_rawDescGZIP() []byte {
 	return file_alerting_v1_alerting_proto_rawDescData
 }
 
-var (
-	file_alerting_v1_alerting_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_alerting_v1_alerting_proto_msgTypes  = make([]protoimpl.MessageInfo, 20)
-	file_alerting_v1_alerting_proto_goTypes   = []any{
-		TemplateSource(0),              // 0: alerting.v1.TemplateSource
-		FilterType(0),                  // 1: alerting.v1.FilterType
-		(*BoolParamDefinition)(nil),    // 2: alerting.v1.BoolParamDefinition
-		(*FloatParamDefinition)(nil),   // 3: alerting.v1.FloatParamDefinition
-		(*StringParamDefinition)(nil),  // 4: alerting.v1.StringParamDefinition
-		(*ParamDefinition)(nil),        // 5: alerting.v1.ParamDefinition
-		(*Template)(nil),               // 6: alerting.v1.Template
-		(*ListTemplatesRequest)(nil),   // 7: alerting.v1.ListTemplatesRequest
-		(*ListTemplatesResponse)(nil),  // 8: alerting.v1.ListTemplatesResponse
-		(*CreateTemplateRequest)(nil),  // 9: alerting.v1.CreateTemplateRequest
-		(*CreateTemplateResponse)(nil), // 10: alerting.v1.CreateTemplateResponse
-		(*UpdateTemplateRequest)(nil),  // 11: alerting.v1.UpdateTemplateRequest
-		(*UpdateTemplateResponse)(nil), // 12: alerting.v1.UpdateTemplateResponse
-		(*DeleteTemplateRequest)(nil),  // 13: alerting.v1.DeleteTemplateRequest
-		(*DeleteTemplateResponse)(nil), // 14: alerting.v1.DeleteTemplateResponse
-		(*Filter)(nil),                 // 15: alerting.v1.Filter
-		(*ParamValue)(nil),             // 16: alerting.v1.ParamValue
-		(*CreateRuleRequest)(nil),      // 17: alerting.v1.CreateRuleRequest
-		(*CreateRuleResponse)(nil),     // 18: alerting.v1.CreateRuleResponse
-		nil,                            // 19: alerting.v1.Template.LabelsEntry
-		nil,                            // 20: alerting.v1.Template.AnnotationsEntry
-		nil,                            // 21: alerting.v1.CreateRuleRequest.CustomLabelsEntry
-		ParamUnit(0),                   // 22: alerting.v1.ParamUnit
-		ParamType(0),                   // 23: alerting.v1.ParamType
-		(*durationpb.Duration)(nil),    // 24: google.protobuf.Duration
-		v1.Severity(0),                 // 25: management.v1.Severity
-		(*timestamppb.Timestamp)(nil),  // 26: google.protobuf.Timestamp
-	}
-)
-
+var file_alerting_v1_alerting_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_alerting_v1_alerting_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_alerting_v1_alerting_proto_goTypes = []any{
+	(TemplateSource)(0),            // 0: alerting.v1.TemplateSource
+	(FilterType)(0),                // 1: alerting.v1.FilterType
+	(*BoolParamDefinition)(nil),    // 2: alerting.v1.BoolParamDefinition
+	(*FloatParamDefinition)(nil),   // 3: alerting.v1.FloatParamDefinition
+	(*StringParamDefinition)(nil),  // 4: alerting.v1.StringParamDefinition
+	(*ParamDefinition)(nil),        // 5: alerting.v1.ParamDefinition
+	(*Template)(nil),               // 6: alerting.v1.Template
+	(*ListTemplatesRequest)(nil),   // 7: alerting.v1.ListTemplatesRequest
+	(*ListTemplatesResponse)(nil),  // 8: alerting.v1.ListTemplatesResponse
+	(*CreateTemplateRequest)(nil),  // 9: alerting.v1.CreateTemplateRequest
+	(*CreateTemplateResponse)(nil), // 10: alerting.v1.CreateTemplateResponse
+	(*UpdateTemplateRequest)(nil),  // 11: alerting.v1.UpdateTemplateRequest
+	(*UpdateTemplateResponse)(nil), // 12: alerting.v1.UpdateTemplateResponse
+	(*DeleteTemplateRequest)(nil),  // 13: alerting.v1.DeleteTemplateRequest
+	(*DeleteTemplateResponse)(nil), // 14: alerting.v1.DeleteTemplateResponse
+	(*Filter)(nil),                 // 15: alerting.v1.Filter
+	(*ParamValue)(nil),             // 16: alerting.v1.ParamValue
+	(*CreateRuleRequest)(nil),      // 17: alerting.v1.CreateRuleRequest
+	(*CreateRuleResponse)(nil),     // 18: alerting.v1.CreateRuleResponse
+	nil,                            // 19: alerting.v1.Template.LabelsEntry
+	nil,                            // 20: alerting.v1.Template.AnnotationsEntry
+	nil,                            // 21: alerting.v1.CreateRuleRequest.CustomLabelsEntry
+	(ParamUnit)(0),                 // 22: alerting.v1.ParamUnit
+	(ParamType)(0),                 // 23: alerting.v1.ParamType
+	(*durationpb.Duration)(nil),    // 24: google.protobuf.Duration
+	(v1.Severity)(0),               // 25: management.v1.Severity
+	(*timestamppb.Timestamp)(nil),  // 26: google.protobuf.Timestamp
+}
 var file_alerting_v1_alerting_proto_depIdxs = []int32{
 	22, // 0: alerting.v1.ParamDefinition.unit:type_name -> alerting.v1.ParamUnit
 	23, // 1: alerting.v1.ParamDefinition.type:type_name -> alerting.v1.ParamType

--- a/api/alerting/v1/alerting.pb.validate.go
+++ b/api/alerting/v1/alerting.pb.validate.go
@@ -132,8 +132,7 @@ func (e BoolParamDefinitionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = BoolParamDefinitionValidationError{}
@@ -247,8 +246,7 @@ func (e FloatParamDefinitionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = FloatParamDefinitionValidationError{}
@@ -354,8 +352,7 @@ func (e StringParamDefinitionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StringParamDefinitionValidationError{}
@@ -609,8 +606,7 @@ func (e ParamDefinitionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ParamDefinitionValidationError{}
@@ -817,8 +813,7 @@ func (e TemplateValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = TemplateValidationError{}
@@ -856,6 +851,7 @@ func (m *ListTemplatesRequest) validate(all bool) error {
 	// no validation rules for Reload
 
 	if m.PageSize != nil {
+
 		if m.GetPageSize() < 1 {
 			err := ListTemplatesRequestValidationError{
 				field:  "PageSize",
@@ -866,9 +862,11 @@ func (m *ListTemplatesRequest) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.PageIndex != nil {
+
 		if m.GetPageIndex() < 0 {
 			err := ListTemplatesRequestValidationError{
 				field:  "PageIndex",
@@ -879,6 +877,7 @@ func (m *ListTemplatesRequest) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if len(errors) > 0 {
@@ -948,8 +947,7 @@ func (e ListTemplatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListTemplatesRequestValidationError{}
@@ -1089,8 +1087,7 @@ func (e ListTemplatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListTemplatesResponseValidationError{}
@@ -1203,8 +1200,7 @@ func (e CreateTemplateRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateTemplateRequestValidationError{}
@@ -1306,8 +1302,7 @@ func (e CreateTemplateResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateTemplateResponseValidationError{}
@@ -1431,8 +1426,7 @@ func (e UpdateTemplateRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateTemplateRequestValidationError{}
@@ -1534,8 +1528,7 @@ func (e UpdateTemplateResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateTemplateResponseValidationError{}
@@ -1648,8 +1641,7 @@ func (e DeleteTemplateRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteTemplateRequestValidationError{}
@@ -1751,8 +1743,7 @@ func (e DeleteTemplateResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteTemplateResponseValidationError{}
@@ -1856,8 +1847,7 @@ func (e FilterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = FilterValidationError{}
@@ -2010,8 +2000,7 @@ func (e ParamValueValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ParamValueValidationError{}
@@ -2251,8 +2240,7 @@ func (e CreateRuleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateRuleRequestValidationError{}
@@ -2354,8 +2342,7 @@ func (e CreateRuleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CreateRuleResponseValidationError{}

--- a/api/alerting/v1/alerting.swagger.json
+++ b/api/alerting/v1/alerting.swagger.json
@@ -1,0 +1,581 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "alerting/v1/alerting.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AlertingService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/alerting/rules": {
+      "post": {
+        "summary": "CreateRule creates alerting rule from the given template.",
+        "operationId": "CreateRule",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateRuleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateRuleRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AlertingService"
+        ]
+      }
+    },
+    "/v1/alerting/templates": {
+      "get": {
+        "summary": "ListTemplates returns a list of all collected alert rule templates.",
+        "operationId": "ListTemplates",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListTemplatesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page_size",
+            "description": "Maximum number of results per page.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "page_index",
+            "description": "Index of the requested page, starts from 0.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "reload",
+            "description": "If true, template files will be re-read from disk.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AlertingService"
+        ]
+      },
+      "post": {
+        "summary": "CreateTemplate creates a new template.",
+        "operationId": "CreateTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CreateTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CreateTemplateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AlertingService"
+        ]
+      }
+    },
+    "/v1/alerting/templates/{name}": {
+      "delete": {
+        "summary": "DeleteTemplate deletes existing, previously created via API.",
+        "operationId": "DeleteTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AlertingService"
+        ]
+      },
+      "put": {
+        "summary": "UpdateTemplate updates existing template, previously created via API.",
+        "operationId": "UpdateTemplate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateTemplateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "name",
+            "description": "Machine-readable name (ID).",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AlertingServiceUpdateTemplateBody"
+            }
+          }
+        ],
+        "tags": [
+          "AlertingService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "AlertingServiceUpdateTemplateBody": {
+      "type": "object",
+      "properties": {
+        "yaml": {
+          "type": "string",
+          "description": "YAML template file content."
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1BoolParamDefinition": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "boolean",
+          "x-nullable": true
+        }
+      },
+      "description": "BoolParamDefinition represents boolean parameter's default value."
+    },
+    "v1CreateRuleRequest": {
+      "type": "object",
+      "properties": {
+        "template_name": {
+          "type": "string",
+          "description": "Template name."
+        },
+        "name": {
+          "type": "string",
+          "description": "Rule name."
+        },
+        "group": {
+          "type": "string",
+          "description": "Rule group name."
+        },
+        "folder_uid": {
+          "type": "string",
+          "description": "Folder UID."
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ParamValue"
+          },
+          "description": "Rule parameters. All template parameters should be set."
+        },
+        "for": {
+          "type": "string",
+          "description": "Rule duration. Should be set."
+        },
+        "severity": {
+          "$ref": "#/definitions/v1Severity",
+          "description": "Rule severity. Should be set."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "All custom labels to add or remove (with empty values) to default labels from template."
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Filter"
+          },
+          "description": "Filters."
+        },
+        "interval": {
+          "type": "string",
+          "title": "Evaluation Interval"
+        }
+      }
+    },
+    "v1CreateRuleResponse": {
+      "type": "object"
+    },
+    "v1CreateTemplateRequest": {
+      "type": "object",
+      "properties": {
+        "yaml": {
+          "type": "string",
+          "description": "YAML template file content."
+        }
+      }
+    },
+    "v1CreateTemplateResponse": {
+      "type": "object"
+    },
+    "v1DeleteTemplateResponse": {
+      "type": "object"
+    },
+    "v1Filter": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/v1FilterType"
+        },
+        "label": {
+          "type": "string"
+        },
+        "regexp": {
+          "type": "string"
+        }
+      },
+      "description": "Filter represents a single filter condition."
+    },
+    "v1FilterType": {
+      "type": "string",
+      "enum": [
+        "FILTER_TYPE_UNSPECIFIED",
+        "FILTER_TYPE_MATCH",
+        "FILTER_TYPE_MISMATCH"
+      ],
+      "default": "FILTER_TYPE_UNSPECIFIED",
+      "description": "FilterType represents filter matching type."
+    },
+    "v1FloatParamDefinition": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true,
+          "description": "Default value."
+        },
+        "min": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true,
+          "description": "Minimum valid value (inclusive)."
+        },
+        "max": {
+          "type": "number",
+          "format": "double",
+          "x-nullable": true,
+          "description": "Maximum valid value (inclusive)."
+        }
+      },
+      "description": "FloatParamDefinition represents float parameter's default value and valid range."
+    },
+    "v1ListTemplatesResponse": {
+      "type": "object",
+      "properties": {
+        "total_items": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of results."
+        },
+        "total_pages": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of pages."
+        },
+        "templates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Template"
+          },
+          "description": "Alerting templates."
+        }
+      }
+    },
+    "v1ParamDefinition": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable name (ID) that is used in expression."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short human-readable parameter summary."
+        },
+        "unit": {
+          "$ref": "#/definitions/v1ParamUnit",
+          "description": "Parameter unit. TODO: remove this parameter."
+        },
+        "type": {
+          "$ref": "#/definitions/v1ParamType",
+          "description": "Parameter type."
+        },
+        "bool": {
+          "$ref": "#/definitions/v1BoolParamDefinition",
+          "description": "Bool value."
+        },
+        "float": {
+          "$ref": "#/definitions/v1FloatParamDefinition",
+          "description": "Float value."
+        },
+        "string": {
+          "$ref": "#/definitions/v1StringParamDefinition",
+          "description": "String value."
+        }
+      },
+      "description": "ParamDefinition represents a single query parameter."
+    },
+    "v1ParamType": {
+      "type": "string",
+      "enum": [
+        "PARAM_TYPE_UNSPECIFIED",
+        "PARAM_TYPE_BOOL",
+        "PARAM_TYPE_FLOAT",
+        "PARAM_TYPE_STRING"
+      ],
+      "default": "PARAM_TYPE_UNSPECIFIED",
+      "description": "ParamType represents template parameter type."
+    },
+    "v1ParamUnit": {
+      "type": "string",
+      "enum": [
+        "PARAM_UNIT_UNSPECIFIED",
+        "PARAM_UNIT_PERCENTAGE",
+        "PARAM_UNIT_SECONDS"
+      ],
+      "default": "PARAM_UNIT_UNSPECIFIED",
+      "description": "ParamUnit represents template parameter unit.\n\n - PARAM_UNIT_UNSPECIFIED: Invalid, unknown or absent.\n - PARAM_UNIT_PERCENTAGE: %\n - PARAM_UNIT_SECONDS: s"
+    },
+    "v1ParamValue": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable name (ID) that is used in expression."
+        },
+        "type": {
+          "$ref": "#/definitions/v1ParamType",
+          "description": "Parameter type."
+        },
+        "bool": {
+          "type": "boolean",
+          "description": "Bool value."
+        },
+        "float": {
+          "type": "number",
+          "format": "double",
+          "description": "Float value."
+        },
+        "string": {
+          "type": "string",
+          "description": "String value."
+        }
+      },
+      "description": "ParamValue represents a single rule parameter value."
+    },
+    "v1Severity": {
+      "type": "string",
+      "enum": [
+        "SEVERITY_UNSPECIFIED",
+        "SEVERITY_EMERGENCY",
+        "SEVERITY_ALERT",
+        "SEVERITY_CRITICAL",
+        "SEVERITY_ERROR",
+        "SEVERITY_WARNING",
+        "SEVERITY_NOTICE",
+        "SEVERITY_INFO",
+        "SEVERITY_DEBUG"
+      ],
+      "default": "SEVERITY_UNSPECIFIED",
+      "description": "Severity represents severity level of the check result or alert."
+    },
+    "v1StringParamDefinition": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Default value."
+        }
+      },
+      "description": "StringParamDefinition represents string parameter's default value."
+    },
+    "v1Template": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Machine-readable name (ID)."
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short human-readable summary."
+        },
+        "expr": {
+          "type": "string",
+          "description": "PromQL query expression with templating parameters."
+        },
+        "params": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ParamDefinition"
+          },
+          "description": "Query parameters definitions."
+        },
+        "for": {
+          "type": "string",
+          "description": "Default duration value."
+        },
+        "severity": {
+          "$ref": "#/definitions/v1Severity",
+          "description": "Severity."
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels."
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations."
+        },
+        "source": {
+          "$ref": "#/definitions/v1TemplateSource",
+          "description": "Template source. Only templates created via API can be updated or deleted via API."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Template creation time. Empty for built-in and SaaS templates."
+        },
+        "yaml": {
+          "type": "string",
+          "description": "YAML template file content. Empty for built-in and SaaS templates."
+        }
+      },
+      "description": "Template represents Alert Template that is used to create Alert Rule."
+    },
+    "v1TemplateSource": {
+      "type": "string",
+      "enum": [
+        "TEMPLATE_SOURCE_UNSPECIFIED",
+        "TEMPLATE_SOURCE_BUILT_IN",
+        "TEMPLATE_SOURCE_SAAS",
+        "TEMPLATE_SOURCE_USER_FILE",
+        "TEMPLATE_SOURCE_USER_API"
+      ],
+      "default": "TEMPLATE_SOURCE_UNSPECIFIED",
+      "description": "TemplateSource defines template source.\n\n - TEMPLATE_SOURCE_BUILT_IN: Template that is shipped with PMM Server releases.\n - TEMPLATE_SOURCE_SAAS: Template that is downloaded from check.percona.com.\n - TEMPLATE_SOURCE_USER_FILE: Templated loaded from user-suplied file.\n - TEMPLATE_SOURCE_USER_API: Templated created via API."
+    },
+    "v1UpdateTemplateResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/alerting/v1/alerting_grpc.pb.go
+++ b/api/alerting/v1/alerting_grpc.pb.go
@@ -8,7 +8,6 @@ package alertingv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -132,19 +131,15 @@ type UnimplementedAlertingServiceServer struct{}
 func (UnimplementedAlertingServiceServer) ListTemplates(context.Context, *ListTemplatesRequest) (*ListTemplatesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListTemplates not implemented")
 }
-
 func (UnimplementedAlertingServiceServer) CreateTemplate(context.Context, *CreateTemplateRequest) (*CreateTemplateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateTemplate not implemented")
 }
-
 func (UnimplementedAlertingServiceServer) UpdateTemplate(context.Context, *UpdateTemplateRequest) (*UpdateTemplateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateTemplate not implemented")
 }
-
 func (UnimplementedAlertingServiceServer) DeleteTemplate(context.Context, *DeleteTemplateRequest) (*DeleteTemplateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteTemplate not implemented")
 }
-
 func (UnimplementedAlertingServiceServer) CreateRule(context.Context, *CreateRuleRequest) (*CreateRuleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CreateRule not implemented")
 }

--- a/api/alerting/v1/params.pb.go
+++ b/api/alerting/v1/params.pb.go
@@ -7,12 +7,11 @@
 package alertingv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -156,14 +155,11 @@ func file_alerting_v1_params_proto_rawDescGZIP() []byte {
 	return file_alerting_v1_params_proto_rawDescData
 }
 
-var (
-	file_alerting_v1_params_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_alerting_v1_params_proto_goTypes   = []any{
-		ParamUnit(0), // 0: alerting.v1.ParamUnit
-		ParamType(0), // 1: alerting.v1.ParamType
-	}
-)
-
+var file_alerting_v1_params_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_alerting_v1_params_proto_goTypes = []any{
+	(ParamUnit)(0), // 0: alerting.v1.ParamUnit
+	(ParamType)(0), // 1: alerting.v1.ParamType
+}
 var file_alerting_v1_params_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/alerting/v1/params.swagger.json
+++ b/api/alerting/v1/params.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "alerting/v1/params.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/backup/v1/artifacts.pb.go
+++ b/api/backup/v1/artifacts.pb.go
@@ -7,14 +7,13 @@
 package backupv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -637,26 +636,23 @@ func file_backup_v1_artifacts_proto_rawDescGZIP() []byte {
 	return file_backup_v1_artifacts_proto_rawDescData
 }
 
-var (
-	file_backup_v1_artifacts_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_backup_v1_artifacts_proto_msgTypes  = make([]protoimpl.MessageInfo, 8)
-	file_backup_v1_artifacts_proto_goTypes   = []any{
-		BackupStatus(0),                    // 0: backup.v1.BackupStatus
-		(*Artifact)(nil),                   // 1: backup.v1.Artifact
-		(*ListArtifactsRequest)(nil),       // 2: backup.v1.ListArtifactsRequest
-		(*ListArtifactsResponse)(nil),      // 3: backup.v1.ListArtifactsResponse
-		(*DeleteArtifactRequest)(nil),      // 4: backup.v1.DeleteArtifactRequest
-		(*DeleteArtifactResponse)(nil),     // 5: backup.v1.DeleteArtifactResponse
-		(*PitrTimerange)(nil),              // 6: backup.v1.PitrTimerange
-		(*ListPitrTimerangesRequest)(nil),  // 7: backup.v1.ListPitrTimerangesRequest
-		(*ListPitrTimerangesResponse)(nil), // 8: backup.v1.ListPitrTimerangesResponse
-		DataModel(0),                       // 9: backup.v1.DataModel
-		(*timestamppb.Timestamp)(nil),      // 10: google.protobuf.Timestamp
-		BackupMode(0),                      // 11: backup.v1.BackupMode
-		(*Metadata)(nil),                   // 12: backup.v1.Metadata
-	}
-)
-
+var file_backup_v1_artifacts_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_backup_v1_artifacts_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_backup_v1_artifacts_proto_goTypes = []any{
+	(BackupStatus)(0),                  // 0: backup.v1.BackupStatus
+	(*Artifact)(nil),                   // 1: backup.v1.Artifact
+	(*ListArtifactsRequest)(nil),       // 2: backup.v1.ListArtifactsRequest
+	(*ListArtifactsResponse)(nil),      // 3: backup.v1.ListArtifactsResponse
+	(*DeleteArtifactRequest)(nil),      // 4: backup.v1.DeleteArtifactRequest
+	(*DeleteArtifactResponse)(nil),     // 5: backup.v1.DeleteArtifactResponse
+	(*PitrTimerange)(nil),              // 6: backup.v1.PitrTimerange
+	(*ListPitrTimerangesRequest)(nil),  // 7: backup.v1.ListPitrTimerangesRequest
+	(*ListPitrTimerangesResponse)(nil), // 8: backup.v1.ListPitrTimerangesResponse
+	(DataModel)(0),                     // 9: backup.v1.DataModel
+	(*timestamppb.Timestamp)(nil),      // 10: google.protobuf.Timestamp
+	(BackupMode)(0),                    // 11: backup.v1.BackupMode
+	(*Metadata)(nil),                   // 12: backup.v1.Metadata
+}
 var file_backup_v1_artifacts_proto_depIdxs = []int32{
 	9,  // 0: backup.v1.Artifact.data_model:type_name -> backup.v1.DataModel
 	0,  // 1: backup.v1.Artifact.status:type_name -> backup.v1.BackupStatus

--- a/api/backup/v1/artifacts.pb.validate.go
+++ b/api/backup/v1/artifacts.pb.validate.go
@@ -208,8 +208,7 @@ func (e ArtifactValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ArtifactValidationError{}
@@ -311,8 +310,7 @@ func (e ListArtifactsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListArtifactsRequestValidationError{}
@@ -448,8 +446,7 @@ func (e ListArtifactsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListArtifactsResponseValidationError{}
@@ -564,8 +561,7 @@ func (e DeleteArtifactRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteArtifactRequestValidationError{}
@@ -667,8 +663,7 @@ func (e DeleteArtifactResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteArtifactResponseValidationError{}
@@ -826,8 +821,7 @@ func (e PitrTimerangeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PitrTimerangeValidationError{}
@@ -940,8 +934,7 @@ func (e ListPitrTimerangesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListPitrTimerangesRequestValidationError{}
@@ -1077,8 +1070,7 @@ func (e ListPitrTimerangesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListPitrTimerangesResponseValidationError{}

--- a/api/backup/v1/artifacts.swagger.json
+++ b/api/backup/v1/artifacts.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/artifacts.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/backup/v1/backup.pb.go
+++ b/api/backup/v1/backup.pb.go
@@ -7,19 +7,17 @@
 package backupv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1243,40 +1241,37 @@ func file_backup_v1_backup_proto_rawDescGZIP() []byte {
 	return file_backup_v1_backup_proto_rawDescData
 }
 
-var (
-	file_backup_v1_backup_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
-	file_backup_v1_backup_proto_goTypes  = []any{
-		(*StartBackupRequest)(nil),                     // 0: backup.v1.StartBackupRequest
-		(*StartBackupResponse)(nil),                    // 1: backup.v1.StartBackupResponse
-		(*ListArtifactCompatibleServicesRequest)(nil),  // 2: backup.v1.ListArtifactCompatibleServicesRequest
-		(*ListArtifactCompatibleServicesResponse)(nil), // 3: backup.v1.ListArtifactCompatibleServicesResponse
-		(*ScheduledBackup)(nil),                        // 4: backup.v1.ScheduledBackup
-		(*ScheduleBackupRequest)(nil),                  // 5: backup.v1.ScheduleBackupRequest
-		(*ScheduleBackupResponse)(nil),                 // 6: backup.v1.ScheduleBackupResponse
-		(*ListScheduledBackupsRequest)(nil),            // 7: backup.v1.ListScheduledBackupsRequest
-		(*ListScheduledBackupsResponse)(nil),           // 8: backup.v1.ListScheduledBackupsResponse
-		(*ChangeScheduledBackupRequest)(nil),           // 9: backup.v1.ChangeScheduledBackupRequest
-		(*ChangeScheduledBackupResponse)(nil),          // 10: backup.v1.ChangeScheduledBackupResponse
-		(*RemoveScheduledBackupRequest)(nil),           // 11: backup.v1.RemoveScheduledBackupRequest
-		(*RemoveScheduledBackupResponse)(nil),          // 12: backup.v1.RemoveScheduledBackupResponse
-		(*GetLogsRequest)(nil),                         // 13: backup.v1.GetLogsRequest
-		(*GetLogsResponse)(nil),                        // 14: backup.v1.GetLogsResponse
-		(*durationpb.Duration)(nil),                    // 15: google.protobuf.Duration
-		DataModel(0),                                   // 16: backup.v1.DataModel
-		(*v1.MySQLService)(nil),                        // 17: inventory.v1.MySQLService
-		(*v1.MongoDBService)(nil),                      // 18: inventory.v1.MongoDBService
-		(*timestamppb.Timestamp)(nil),                  // 19: google.protobuf.Timestamp
-		BackupMode(0),                                  // 20: backup.v1.BackupMode
-		(*LogChunk)(nil),                               // 21: backup.v1.LogChunk
-		(*ListArtifactsRequest)(nil),                   // 22: backup.v1.ListArtifactsRequest
-		(*DeleteArtifactRequest)(nil),                  // 23: backup.v1.DeleteArtifactRequest
-		(*ListPitrTimerangesRequest)(nil),              // 24: backup.v1.ListPitrTimerangesRequest
-		(*ListArtifactsResponse)(nil),                  // 25: backup.v1.ListArtifactsResponse
-		(*DeleteArtifactResponse)(nil),                 // 26: backup.v1.DeleteArtifactResponse
-		(*ListPitrTimerangesResponse)(nil),             // 27: backup.v1.ListPitrTimerangesResponse
-	}
-)
-
+var file_backup_v1_backup_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_backup_v1_backup_proto_goTypes = []any{
+	(*StartBackupRequest)(nil),                     // 0: backup.v1.StartBackupRequest
+	(*StartBackupResponse)(nil),                    // 1: backup.v1.StartBackupResponse
+	(*ListArtifactCompatibleServicesRequest)(nil),  // 2: backup.v1.ListArtifactCompatibleServicesRequest
+	(*ListArtifactCompatibleServicesResponse)(nil), // 3: backup.v1.ListArtifactCompatibleServicesResponse
+	(*ScheduledBackup)(nil),                        // 4: backup.v1.ScheduledBackup
+	(*ScheduleBackupRequest)(nil),                  // 5: backup.v1.ScheduleBackupRequest
+	(*ScheduleBackupResponse)(nil),                 // 6: backup.v1.ScheduleBackupResponse
+	(*ListScheduledBackupsRequest)(nil),            // 7: backup.v1.ListScheduledBackupsRequest
+	(*ListScheduledBackupsResponse)(nil),           // 8: backup.v1.ListScheduledBackupsResponse
+	(*ChangeScheduledBackupRequest)(nil),           // 9: backup.v1.ChangeScheduledBackupRequest
+	(*ChangeScheduledBackupResponse)(nil),          // 10: backup.v1.ChangeScheduledBackupResponse
+	(*RemoveScheduledBackupRequest)(nil),           // 11: backup.v1.RemoveScheduledBackupRequest
+	(*RemoveScheduledBackupResponse)(nil),          // 12: backup.v1.RemoveScheduledBackupResponse
+	(*GetLogsRequest)(nil),                         // 13: backup.v1.GetLogsRequest
+	(*GetLogsResponse)(nil),                        // 14: backup.v1.GetLogsResponse
+	(*durationpb.Duration)(nil),                    // 15: google.protobuf.Duration
+	(DataModel)(0),                                 // 16: backup.v1.DataModel
+	(*v1.MySQLService)(nil),                        // 17: inventory.v1.MySQLService
+	(*v1.MongoDBService)(nil),                      // 18: inventory.v1.MongoDBService
+	(*timestamppb.Timestamp)(nil),                  // 19: google.protobuf.Timestamp
+	(BackupMode)(0),                                // 20: backup.v1.BackupMode
+	(*LogChunk)(nil),                               // 21: backup.v1.LogChunk
+	(*ListArtifactsRequest)(nil),                   // 22: backup.v1.ListArtifactsRequest
+	(*DeleteArtifactRequest)(nil),                  // 23: backup.v1.DeleteArtifactRequest
+	(*ListPitrTimerangesRequest)(nil),              // 24: backup.v1.ListPitrTimerangesRequest
+	(*ListArtifactsResponse)(nil),                  // 25: backup.v1.ListArtifactsResponse
+	(*DeleteArtifactResponse)(nil),                 // 26: backup.v1.DeleteArtifactResponse
+	(*ListPitrTimerangesResponse)(nil),             // 27: backup.v1.ListPitrTimerangesResponse
+}
 var file_backup_v1_backup_proto_depIdxs = []int32{
 	15, // 0: backup.v1.StartBackupRequest.retry_interval:type_name -> google.protobuf.Duration
 	16, // 1: backup.v1.StartBackupRequest.data_model:type_name -> backup.v1.DataModel

--- a/api/backup/v1/backup.pb.validate.go
+++ b/api/backup/v1/backup.pb.validate.go
@@ -185,8 +185,7 @@ func (e StartBackupRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartBackupRequestValidationError{}
@@ -290,8 +289,7 @@ func (e StartBackupResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartBackupResponseValidationError{}
@@ -407,8 +405,7 @@ func (e ListArtifactCompatibleServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListArtifactCompatibleServicesRequestValidationError{}
@@ -582,8 +579,7 @@ func (e ListArtifactCompatibleServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListArtifactCompatibleServicesResponseValidationError{}
@@ -829,8 +825,7 @@ func (e ScheduledBackupValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ScheduledBackupValidationError{}
@@ -1039,8 +1034,7 @@ func (e ScheduleBackupRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ScheduleBackupRequestValidationError{}
@@ -1144,8 +1138,7 @@ func (e ScheduleBackupResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ScheduleBackupResponseValidationError{}
@@ -1248,8 +1241,7 @@ func (e ListScheduledBackupsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListScheduledBackupsRequestValidationError{}
@@ -1386,8 +1378,7 @@ func (e ListScheduledBackupsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListScheduledBackupsResponseValidationError{}
@@ -1583,8 +1574,7 @@ func (e ChangeScheduledBackupRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeScheduledBackupRequestValidationError{}
@@ -1687,8 +1677,7 @@ func (e ChangeScheduledBackupResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeScheduledBackupResponseValidationError{}
@@ -1802,8 +1791,7 @@ func (e RemoveScheduledBackupRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveScheduledBackupRequestValidationError{}
@@ -1906,8 +1894,7 @@ func (e RemoveScheduledBackupResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveScheduledBackupResponseValidationError{}
@@ -2022,8 +2009,7 @@ func (e GetLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetLogsRequestValidationError{}
@@ -2159,8 +2145,7 @@ func (e GetLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetLogsResponseValidationError{}

--- a/api/backup/v1/backup.swagger.json
+++ b/api/backup/v1/backup.swagger.json
@@ -1,0 +1,1003 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/backup.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "BackupService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/backups/artifacts": {
+      "get": {
+        "summary": "List artifacts",
+        "description": "Return a list of backup artifacts.",
+        "operationId": "ListArtifacts",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListArtifactsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/artifacts/{artifact_id}": {
+      "delete": {
+        "summary": "Delete Artifact",
+        "description": "Deletes an artifact.",
+        "operationId": "DeleteArtifact",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DeleteArtifactResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "description": "Machine-readable artifact ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "remove_files",
+            "description": "Removes all the backup files associated with artifact if flag is set.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/artifacts/{artifact_id}/pitr-timeranges": {
+      "get": {
+        "summary": "List PITR Timeranges",
+        "description": "Return a list of available MongoDB point-in-time-recovery timeranges.",
+        "operationId": "ListPitrTimeranges",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListPitrTimerangesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "description": "Artifact ID represents artifact whose location has PITR timeranges to be retrieved.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/scheduled": {
+      "get": {
+        "summary": "List Scheduled Backups",
+        "description": "List all scheduled backups.",
+        "operationId": "ListScheduledBackups",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListScheduledBackupsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/{artifact_id}/compatible-services": {
+      "get": {
+        "summary": "List Compatible Services",
+        "description": "List services that are compatible with the backup artifact.",
+        "operationId": "ListArtifactCompatibleServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListArtifactCompatibleServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "description": "Artifact id used to determine restore compatibility.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/{artifact_id}/logs": {
+      "get": {
+        "summary": "Get Logs",
+        "description": "Get logs from the underlying tools for a backup/restore job.",
+        "operationId": "GetLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "artifact_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups/{scheduled_backup_id}": {
+      "delete": {
+        "summary": "Remove a Scheduled Backup",
+        "description": "Remove a scheduled backup.",
+        "operationId": "RemoveScheduledBackup",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveScheduledBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "scheduled_backup_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups:changeScheduled": {
+      "put": {
+        "summary": "Change a Scheduled Backup",
+        "description": "Change a scheduled backup.",
+        "operationId": "ChangeScheduledBackup",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeScheduledBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ChangeScheduledBackupRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups:schedule": {
+      "post": {
+        "summary": "Schedule a Backup",
+        "description": "Schedule a backup to run at a specified time.",
+        "operationId": "ScheduleBackup",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ScheduleBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ScheduleBackupRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    },
+    "/v1/backups:start": {
+      "post": {
+        "summary": "Start a Backup",
+        "description": "Could return the Error message in the details containing specific ErrorCode indicating failure reason:\nERROR_CODE_XTRABACKUP_NOT_INSTALLED - xtrabackup is not installed on the service\nERROR_CODE_INVALID_XTRABACKUP - different versions of xtrabackup and xbcloud\nERROR_CODE_INCOMPATIBLE_XTRABACKUP - xtrabackup is not compatible with MySQL for taking a backup",
+        "operationId": "StartBackup",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartBackupRequest"
+            }
+          }
+        ],
+        "tags": [
+          "BackupService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1Artifact": {
+      "type": "object",
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "description": "Machine-readable artifact ID."
+        },
+        "name": {
+          "type": "string",
+          "title": "Artifact name"
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Database vendor e.g. PostgreSQL, MongoDB, MySQL."
+        },
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable location ID."
+        },
+        "location_name": {
+          "type": "string",
+          "description": "Location name."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Machine-readable service ID."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "data_model": {
+          "$ref": "#/definitions/v1DataModel",
+          "description": "Backup data model."
+        },
+        "status": {
+          "$ref": "#/definitions/v1BackupStatus",
+          "description": "Backup status."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Artifact creation time."
+        },
+        "mode": {
+          "$ref": "#/definitions/v1BackupMode",
+          "description": "Backup mode."
+        },
+        "is_sharded_cluster": {
+          "type": "boolean",
+          "description": "Source database setup type."
+        },
+        "folder": {
+          "type": "string",
+          "description": "Folder to store artifact on a storage."
+        },
+        "metadata_list": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Metadata"
+          },
+          "description": "List of artifact metadata."
+        }
+      },
+      "description": "Artifact represents single backup artifact."
+    },
+    "v1BackupMode": {
+      "type": "string",
+      "enum": [
+        "BACKUP_MODE_UNSPECIFIED",
+        "BACKUP_MODE_SNAPSHOT",
+        "BACKUP_MODE_INCREMENTAL",
+        "BACKUP_MODE_PITR"
+      ],
+      "default": "BACKUP_MODE_UNSPECIFIED",
+      "description": "BackupMode specifies backup mode."
+    },
+    "v1BackupStatus": {
+      "type": "string",
+      "enum": [
+        "BACKUP_STATUS_UNSPECIFIED",
+        "BACKUP_STATUS_PENDING",
+        "BACKUP_STATUS_IN_PROGRESS",
+        "BACKUP_STATUS_PAUSED",
+        "BACKUP_STATUS_SUCCESS",
+        "BACKUP_STATUS_ERROR",
+        "BACKUP_STATUS_DELETING",
+        "BACKUP_STATUS_FAILED_TO_DELETE",
+        "BACKUP_STATUS_CLEANUP_IN_PROGRESS"
+      ],
+      "default": "BACKUP_STATUS_UNSPECIFIED",
+      "description": "BackupStatus shows the current status of execution of backup."
+    },
+    "v1ChangeScheduledBackupRequest": {
+      "type": "object",
+      "properties": {
+        "scheduled_backup_id": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "cron_expression": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "How often backup should be run in cron format."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "First backup wouldn't happen before this time."
+        },
+        "name": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Name of backup."
+        },
+        "description": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Human-readable description."
+        },
+        "retries": {
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "How many times to retry a failed backup before giving up."
+        },
+        "retry_interval": {
+          "type": "string",
+          "description": "Delay between each retry. Should have a suffix in JSON: 1s, 1m, 1h."
+        },
+        "retention": {
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "How many artifacts keep. 0 - unlimited."
+        }
+      }
+    },
+    "v1ChangeScheduledBackupResponse": {
+      "type": "object"
+    },
+    "v1DataModel": {
+      "type": "string",
+      "enum": [
+        "DATA_MODEL_UNSPECIFIED",
+        "DATA_MODEL_PHYSICAL",
+        "DATA_MODEL_LOGICAL"
+      ],
+      "default": "DATA_MODEL_UNSPECIFIED",
+      "description": "DataModel is a model used for performing a backup."
+    },
+    "v1DeleteArtifactResponse": {
+      "type": "object"
+    },
+    "v1File": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "is_directory": {
+          "type": "boolean"
+        }
+      },
+      "description": "File represents file or folder on a storage."
+    },
+    "v1GetLogsResponse": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1LogChunk"
+          }
+        },
+        "end": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1ListArtifactCompatibleServicesResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MySQLService"
+          }
+        },
+        "mongodb": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBService"
+          }
+        }
+      }
+    },
+    "v1ListArtifactsResponse": {
+      "type": "object",
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Artifact"
+          }
+        }
+      }
+    },
+    "v1ListPitrTimerangesResponse": {
+      "type": "object",
+      "properties": {
+        "timeranges": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PitrTimerange"
+          }
+        }
+      }
+    },
+    "v1ListScheduledBackupsResponse": {
+      "type": "object",
+      "properties": {
+        "scheduled_backups": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ScheduledBackup"
+          }
+        }
+      }
+    },
+    "v1LogChunk": {
+      "type": "object",
+      "properties": {
+        "chunk_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "data": {
+          "type": "string"
+        }
+      },
+      "description": "LogChunk represent one chunk of logs."
+    },
+    "v1Metadata": {
+      "type": "object",
+      "properties": {
+        "file_list": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1File"
+          },
+          "description": "List of files backup consists of."
+        },
+        "restore_to": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exact time DB can be restored to."
+        },
+        "pbm_metadata": {
+          "$ref": "#/definitions/v1PbmMetadata"
+        }
+      },
+      "description": "Metadata contains extra artifact data like files it consists of, tool specific data, etc."
+    },
+    "v1MongoDBService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MongoDB version."
+        }
+      },
+      "description": "MongoDBService represents a generic MongoDB instance."
+    },
+    "v1MySQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MySQL version."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra parameters to be added to the DSN."
+        }
+      },
+      "description": "MySQLService represents a generic MySQL instance."
+    },
+    "v1PbmMetadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of backup in backup tool representation."
+        }
+      },
+      "description": "PbmMetadata contains additional data for pbm cli tools."
+    },
+    "v1PitrTimerange": {
+      "type": "object",
+      "properties": {
+        "start_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "start_timestamp is the time of the first event in the PITR chunk."
+        },
+        "end_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "end_timestamp is the time of the last event in the PITR chunk."
+        }
+      }
+    },
+    "v1RemoveScheduledBackupResponse": {
+      "type": "object"
+    },
+    "v1ScheduleBackupRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier where backup should be performed."
+        },
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable location ID."
+        },
+        "folder": {
+          "type": "string",
+          "description": "How often backup should be run in cron format.\nFolder on storage for artifact."
+        },
+        "cron_expression": {
+          "type": "string"
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "First backup wouldn't happen before this time."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of backup."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "If scheduling is enabled."
+        },
+        "retries": {
+          "type": "integer",
+          "format": "int64",
+          "description": "How many times to retry a failed backup before giving up."
+        },
+        "retry_interval": {
+          "type": "string",
+          "description": "Delay between each retry. Should have a suffix in JSON: 1s, 1m, 1h."
+        },
+        "mode": {
+          "$ref": "#/definitions/v1BackupMode",
+          "description": "Backup mode."
+        },
+        "data_model": {
+          "$ref": "#/definitions/v1DataModel",
+          "description": "Backup data model (physical or logical)."
+        },
+        "retention": {
+          "type": "integer",
+          "format": "int64",
+          "description": "How many artifacts keep. 0 - unlimited."
+        }
+      }
+    },
+    "v1ScheduleBackupResponse": {
+      "type": "object",
+      "properties": {
+        "scheduled_backup_id": {
+          "type": "string"
+        }
+      }
+    },
+    "v1ScheduledBackup": {
+      "type": "object",
+      "properties": {
+        "scheduled_backup_id": {
+          "type": "string",
+          "description": "Machine-readable ID."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Machine-readable service ID."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable location ID."
+        },
+        "location_name": {
+          "type": "string",
+          "description": "Location name."
+        },
+        "folder": {
+          "type": "string",
+          "description": "Folder on storage for artifact."
+        },
+        "cron_expression": {
+          "type": "string",
+          "description": "How often backup will be run in cron format."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "First backup wouldn't happen before this time."
+        },
+        "name": {
+          "type": "string",
+          "description": "Artifact name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "If scheduling is enabled."
+        },
+        "retries": {
+          "type": "integer",
+          "format": "int64",
+          "description": "How many times to retry a failed backup before giving up."
+        },
+        "retry_interval": {
+          "type": "string",
+          "description": "Delay between each retry. Should have a suffix in JSON: 2s, 1m, 1h."
+        },
+        "data_model": {
+          "$ref": "#/definitions/v1DataModel",
+          "description": "Backup data model (physical or logical)."
+        },
+        "mode": {
+          "$ref": "#/definitions/v1BackupMode",
+          "description": "Backup mode."
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Database vendor e.g. PostgreSQL, MongoDB, MySQL."
+        },
+        "last_run": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last run."
+        },
+        "next_run": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Next run."
+        },
+        "retention": {
+          "type": "integer",
+          "format": "int64",
+          "description": "How many artifacts keep. 0 - unlimited."
+        }
+      },
+      "description": "ScheduledBackup represents scheduled task for backup."
+    },
+    "v1StartBackupRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable location ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "If empty then name is auto-generated."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description."
+        },
+        "retry_interval": {
+          "type": "string",
+          "description": "Delay between each retry. Should have a suffix in JSON: 1s, 1m, 1h."
+        },
+        "retries": {
+          "type": "integer",
+          "format": "int64",
+          "description": "How many times to retry a failed backup before giving up."
+        },
+        "data_model": {
+          "$ref": "#/definitions/v1DataModel",
+          "description": "DataModel represents the data model used for the backup."
+        },
+        "folder": {
+          "type": "string",
+          "description": "Folder on storage for artifact."
+        }
+      }
+    },
+    "v1StartBackupResponse": {
+      "type": "object",
+      "properties": {
+        "artifact_id": {
+          "type": "string",
+          "description": "Unique identifier."
+        }
+      }
+    }
+  }
+}

--- a/api/backup/v1/backup_grpc.pb.go
+++ b/api/backup/v1/backup_grpc.pb.go
@@ -8,7 +8,6 @@ package backupv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -207,39 +206,30 @@ type UnimplementedBackupServiceServer struct{}
 func (UnimplementedBackupServiceServer) StartBackup(context.Context, *StartBackupRequest) (*StartBackupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartBackup not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ListArtifactCompatibleServices(context.Context, *ListArtifactCompatibleServicesRequest) (*ListArtifactCompatibleServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListArtifactCompatibleServices not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ScheduleBackup(context.Context, *ScheduleBackupRequest) (*ScheduleBackupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ScheduleBackup not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ListScheduledBackups(context.Context, *ListScheduledBackupsRequest) (*ListScheduledBackupsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListScheduledBackups not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ChangeScheduledBackup(context.Context, *ChangeScheduledBackupRequest) (*ChangeScheduledBackupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeScheduledBackup not implemented")
 }
-
 func (UnimplementedBackupServiceServer) RemoveScheduledBackup(context.Context, *RemoveScheduledBackupRequest) (*RemoveScheduledBackupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveScheduledBackup not implemented")
 }
-
 func (UnimplementedBackupServiceServer) GetLogs(context.Context, *GetLogsRequest) (*GetLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLogs not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ListArtifacts(context.Context, *ListArtifactsRequest) (*ListArtifactsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListArtifacts not implemented")
 }
-
 func (UnimplementedBackupServiceServer) DeleteArtifact(context.Context, *DeleteArtifactRequest) (*DeleteArtifactResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteArtifact not implemented")
 }
-
 func (UnimplementedBackupServiceServer) ListPitrTimeranges(context.Context, *ListPitrTimerangesRequest) (*ListPitrTimerangesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListPitrTimeranges not implemented")
 }

--- a/api/backup/v1/common.pb.go
+++ b/api/backup/v1/common.pb.go
@@ -7,14 +7,13 @@
 package backupv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -410,20 +409,17 @@ func file_backup_v1_common_proto_rawDescGZIP() []byte {
 	return file_backup_v1_common_proto_rawDescData
 }
 
-var (
-	file_backup_v1_common_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_backup_v1_common_proto_msgTypes  = make([]protoimpl.MessageInfo, 4)
-	file_backup_v1_common_proto_goTypes   = []any{
-		DataModel(0),                  // 0: backup.v1.DataModel
-		BackupMode(0),                 // 1: backup.v1.BackupMode
-		(*File)(nil),                  // 2: backup.v1.File
-		(*PbmMetadata)(nil),           // 3: backup.v1.PbmMetadata
-		(*Metadata)(nil),              // 4: backup.v1.Metadata
-		(*LogChunk)(nil),              // 5: backup.v1.LogChunk
-		(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
-	}
-)
-
+var file_backup_v1_common_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_backup_v1_common_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_backup_v1_common_proto_goTypes = []any{
+	(DataModel)(0),                // 0: backup.v1.DataModel
+	(BackupMode)(0),               // 1: backup.v1.BackupMode
+	(*File)(nil),                  // 2: backup.v1.File
+	(*PbmMetadata)(nil),           // 3: backup.v1.PbmMetadata
+	(*Metadata)(nil),              // 4: backup.v1.Metadata
+	(*LogChunk)(nil),              // 5: backup.v1.LogChunk
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
+}
 var file_backup_v1_common_proto_depIdxs = []int32{
 	2, // 0: backup.v1.Metadata.file_list:type_name -> backup.v1.File
 	6, // 1: backup.v1.Metadata.restore_to:type_name -> google.protobuf.Timestamp

--- a/api/backup/v1/common.pb.validate.go
+++ b/api/backup/v1/common.pb.validate.go
@@ -133,8 +133,7 @@ func (e FileValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = FileValidationError{}
@@ -235,8 +234,7 @@ func (e PbmMetadataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PbmMetadataValidationError{}
@@ -444,8 +442,7 @@ func (e MetadataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetadataValidationError{}
@@ -548,8 +545,7 @@ func (e LogChunkValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LogChunkValidationError{}

--- a/api/backup/v1/common.swagger.json
+++ b/api/backup/v1/common.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/common.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/backup/v1/errors.pb.go
+++ b/api/backup/v1/errors.pb.go
@@ -7,12 +7,11 @@
 package backupv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -161,15 +160,12 @@ func file_backup_v1_errors_proto_rawDescGZIP() []byte {
 	return file_backup_v1_errors_proto_rawDescData
 }
 
-var (
-	file_backup_v1_errors_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_backup_v1_errors_proto_msgTypes  = make([]protoimpl.MessageInfo, 1)
-	file_backup_v1_errors_proto_goTypes   = []any{
-		ErrorCode(0),  // 0: backup.v1.ErrorCode
-		(*Error)(nil), // 1: backup.v1.Error
-	}
-)
-
+var file_backup_v1_errors_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_backup_v1_errors_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_backup_v1_errors_proto_goTypes = []any{
+	(ErrorCode)(0), // 0: backup.v1.ErrorCode
+	(*Error)(nil),  // 1: backup.v1.Error
+}
 var file_backup_v1_errors_proto_depIdxs = []int32{
 	0, // 0: backup.v1.Error.code:type_name -> backup.v1.ErrorCode
 	1, // [1:1] is the sub-list for method output_type

--- a/api/backup/v1/errors.pb.validate.go
+++ b/api/backup/v1/errors.pb.validate.go
@@ -122,8 +122,7 @@ func (e ErrorValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ErrorValidationError{}

--- a/api/backup/v1/errors.swagger.json
+++ b/api/backup/v1/errors.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/errors.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/backup/v1/locations.pb.go
+++ b/api/backup/v1/locations.pb.go
@@ -7,17 +7,15 @@
 package backupv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -815,25 +813,22 @@ func file_backup_v1_locations_proto_rawDescGZIP() []byte {
 	return file_backup_v1_locations_proto_rawDescData
 }
 
-var (
-	file_backup_v1_locations_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
-	file_backup_v1_locations_proto_goTypes  = []any{
-		(*FilesystemLocationConfig)(nil),   // 0: backup.v1.FilesystemLocationConfig
-		(*S3LocationConfig)(nil),           // 1: backup.v1.S3LocationConfig
-		(*Location)(nil),                   // 2: backup.v1.Location
-		(*ListLocationsRequest)(nil),       // 3: backup.v1.ListLocationsRequest
-		(*ListLocationsResponse)(nil),      // 4: backup.v1.ListLocationsResponse
-		(*AddLocationRequest)(nil),         // 5: backup.v1.AddLocationRequest
-		(*AddLocationResponse)(nil),        // 6: backup.v1.AddLocationResponse
-		(*ChangeLocationRequest)(nil),      // 7: backup.v1.ChangeLocationRequest
-		(*ChangeLocationResponse)(nil),     // 8: backup.v1.ChangeLocationResponse
-		(*RemoveLocationRequest)(nil),      // 9: backup.v1.RemoveLocationRequest
-		(*RemoveLocationResponse)(nil),     // 10: backup.v1.RemoveLocationResponse
-		(*TestLocationConfigRequest)(nil),  // 11: backup.v1.TestLocationConfigRequest
-		(*TestLocationConfigResponse)(nil), // 12: backup.v1.TestLocationConfigResponse
-	}
-)
-
+var file_backup_v1_locations_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_backup_v1_locations_proto_goTypes = []any{
+	(*FilesystemLocationConfig)(nil),   // 0: backup.v1.FilesystemLocationConfig
+	(*S3LocationConfig)(nil),           // 1: backup.v1.S3LocationConfig
+	(*Location)(nil),                   // 2: backup.v1.Location
+	(*ListLocationsRequest)(nil),       // 3: backup.v1.ListLocationsRequest
+	(*ListLocationsResponse)(nil),      // 4: backup.v1.ListLocationsResponse
+	(*AddLocationRequest)(nil),         // 5: backup.v1.AddLocationRequest
+	(*AddLocationResponse)(nil),        // 6: backup.v1.AddLocationResponse
+	(*ChangeLocationRequest)(nil),      // 7: backup.v1.ChangeLocationRequest
+	(*ChangeLocationResponse)(nil),     // 8: backup.v1.ChangeLocationResponse
+	(*RemoveLocationRequest)(nil),      // 9: backup.v1.RemoveLocationRequest
+	(*RemoveLocationResponse)(nil),     // 10: backup.v1.RemoveLocationResponse
+	(*TestLocationConfigRequest)(nil),  // 11: backup.v1.TestLocationConfigRequest
+	(*TestLocationConfigResponse)(nil), // 12: backup.v1.TestLocationConfigResponse
+}
 var file_backup_v1_locations_proto_depIdxs = []int32{
 	0,  // 0: backup.v1.Location.filesystem_config:type_name -> backup.v1.FilesystemLocationConfig
 	1,  // 1: backup.v1.Location.s3_config:type_name -> backup.v1.S3LocationConfig

--- a/api/backup/v1/locations.pb.validate.go
+++ b/api/backup/v1/locations.pb.validate.go
@@ -135,8 +135,7 @@ func (e FilesystemLocationConfigValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = FilesystemLocationConfigValidationError{}
@@ -280,8 +279,7 @@ func (e S3LocationConfigValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = S3LocationConfigValidationError{}
@@ -473,8 +471,7 @@ func (e LocationValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LocationValidationError{}
@@ -576,8 +573,7 @@ func (e ListLocationsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListLocationsRequestValidationError{}
@@ -713,8 +709,7 @@ func (e ListLocationsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListLocationsResponseValidationError{}
@@ -887,8 +882,7 @@ func (e AddLocationRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddLocationRequestValidationError{}
@@ -992,8 +986,7 @@ func (e AddLocationResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddLocationResponseValidationError{}
@@ -1168,8 +1161,7 @@ func (e ChangeLocationRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeLocationRequestValidationError{}
@@ -1271,8 +1263,7 @@ func (e ChangeLocationResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeLocationResponseValidationError{}
@@ -1378,8 +1369,7 @@ func (e RemoveLocationRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveLocationRequestValidationError{}
@@ -1481,8 +1471,7 @@ func (e RemoveLocationResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveLocationResponseValidationError{}
@@ -1642,8 +1631,7 @@ func (e TestLocationConfigRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = TestLocationConfigRequestValidationError{}
@@ -1745,8 +1733,7 @@ func (e TestLocationConfigResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = TestLocationConfigResponseValidationError{}

--- a/api/backup/v1/locations.swagger.json
+++ b/api/backup/v1/locations.swagger.json
@@ -1,0 +1,353 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/locations.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "LocationsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/backups/locations": {
+      "get": {
+        "summary": "List Backup Locations",
+        "description": "List backup locations.",
+        "operationId": "ListLocations",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListLocationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "LocationsService"
+        ]
+      },
+      "post": {
+        "summary": "Add a Backup Location",
+        "description": "Add a backup location.",
+        "operationId": "AddLocation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddLocationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddLocationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LocationsService"
+        ]
+      }
+    },
+    "/v1/backups/locations/{location_id}": {
+      "delete": {
+        "summary": "Remove a Scheduled Backup",
+        "description": "Remove a backup location.",
+        "operationId": "RemoveLocation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveLocationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "location_id",
+            "description": "Machine-readable ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Force mode",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "LocationsService"
+        ]
+      },
+      "put": {
+        "summary": "Change a Backup Location",
+        "description": "Change a backup location.",
+        "operationId": "ChangeLocation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeLocationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "location_id",
+            "description": "Machine-readable ID.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LocationsServiceChangeLocationBody"
+            }
+          }
+        ],
+        "tags": [
+          "LocationsService"
+        ]
+      }
+    },
+    "/v1/backups/locations:testConfig": {
+      "post": {
+        "summary": "Test a Backup Location and Credentials",
+        "description": "Test a backup location and credentials.",
+        "operationId": "TestLocationConfig",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1TestLocationConfigResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1TestLocationConfigRequest"
+            }
+          }
+        ],
+        "tags": [
+          "LocationsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "LocationsServiceChangeLocationBody": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Location name"
+        },
+        "description": {
+          "type": "string"
+        },
+        "filesystem_config": {
+          "$ref": "#/definitions/v1FilesystemLocationConfig",
+          "description": "Filesystem location configuration. Exactly one config should be set."
+        },
+        "s3_config": {
+          "$ref": "#/definitions/v1S3LocationConfig",
+          "description": "S3 Bucket configuration. Exactly one config should be set."
+        }
+      }
+    },
+    "backupV1Location": {
+      "type": "object",
+      "properties": {
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable ID."
+        },
+        "name": {
+          "type": "string",
+          "title": "Location name"
+        },
+        "description": {
+          "type": "string",
+          "title": "Short description"
+        },
+        "filesystem_config": {
+          "$ref": "#/definitions/v1FilesystemLocationConfig"
+        },
+        "s3_config": {
+          "$ref": "#/definitions/v1S3LocationConfig"
+        }
+      },
+      "description": "Location represents single Backup Location."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AddLocationRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Location name"
+        },
+        "description": {
+          "type": "string"
+        },
+        "filesystem_config": {
+          "$ref": "#/definitions/v1FilesystemLocationConfig",
+          "description": "Filesystem location configuration. Exactly one config should be set."
+        },
+        "s3_config": {
+          "$ref": "#/definitions/v1S3LocationConfig",
+          "description": "S3 Bucket configuration. Exactly one config should be set."
+        }
+      }
+    },
+    "v1AddLocationResponse": {
+      "type": "object",
+      "properties": {
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable ID."
+        }
+      }
+    },
+    "v1ChangeLocationResponse": {
+      "type": "object"
+    },
+    "v1FilesystemLocationConfig": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "description": "FilesystemLocationConfig represents file system location config."
+    },
+    "v1ListLocationsResponse": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/backupV1Location"
+          }
+        }
+      }
+    },
+    "v1RemoveLocationResponse": {
+      "type": "object"
+    },
+    "v1S3LocationConfig": {
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string"
+        },
+        "access_key": {
+          "type": "string"
+        },
+        "secret_key": {
+          "type": "string"
+        },
+        "bucket_name": {
+          "type": "string"
+        }
+      },
+      "description": "S3LocationConfig represents S3 bucket configuration."
+    },
+    "v1TestLocationConfigRequest": {
+      "type": "object",
+      "properties": {
+        "filesystem_config": {
+          "$ref": "#/definitions/v1FilesystemLocationConfig",
+          "description": "Filesystem location configuration. Exactly one config should be set."
+        },
+        "s3_config": {
+          "$ref": "#/definitions/v1S3LocationConfig",
+          "description": "S3 Bucket configuration. Exactly one config should be set."
+        }
+      }
+    },
+    "v1TestLocationConfigResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/backup/v1/locations_grpc.pb.go
+++ b/api/backup/v1/locations_grpc.pb.go
@@ -8,7 +8,6 @@ package backupv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -132,19 +131,15 @@ type UnimplementedLocationsServiceServer struct{}
 func (UnimplementedLocationsServiceServer) ListLocations(context.Context, *ListLocationsRequest) (*ListLocationsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListLocations not implemented")
 }
-
 func (UnimplementedLocationsServiceServer) AddLocation(context.Context, *AddLocationRequest) (*AddLocationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddLocation not implemented")
 }
-
 func (UnimplementedLocationsServiceServer) ChangeLocation(context.Context, *ChangeLocationRequest) (*ChangeLocationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeLocation not implemented")
 }
-
 func (UnimplementedLocationsServiceServer) RemoveLocation(context.Context, *RemoveLocationRequest) (*RemoveLocationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveLocation not implemented")
 }
-
 func (UnimplementedLocationsServiceServer) TestLocationConfig(context.Context, *TestLocationConfigRequest) (*TestLocationConfigResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method TestLocationConfig not implemented")
 }

--- a/api/backup/v1/restores.pb.go
+++ b/api/backup/v1/restores.pb.go
@@ -7,16 +7,15 @@
 package backupv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -608,24 +607,21 @@ func file_backup_v1_restores_proto_rawDescGZIP() []byte {
 	return file_backup_v1_restores_proto_rawDescData
 }
 
-var (
-	file_backup_v1_restores_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_backup_v1_restores_proto_msgTypes  = make([]protoimpl.MessageInfo, 7)
-	file_backup_v1_restores_proto_goTypes   = []any{
-		RestoreStatus(0),                      // 0: backup.v1.RestoreStatus
-		(*RestoreHistoryItem)(nil),            // 1: backup.v1.RestoreHistoryItem
-		(*ListRestoresRequest)(nil),           // 2: backup.v1.ListRestoresRequest
-		(*ListRestoresResponse)(nil),          // 3: backup.v1.ListRestoresResponse
-		(*RestoreServiceGetLogsRequest)(nil),  // 4: backup.v1.RestoreServiceGetLogsRequest
-		(*RestoreServiceGetLogsResponse)(nil), // 5: backup.v1.RestoreServiceGetLogsResponse
-		(*RestoreBackupRequest)(nil),          // 6: backup.v1.RestoreBackupRequest
-		(*RestoreBackupResponse)(nil),         // 7: backup.v1.RestoreBackupResponse
-		DataModel(0),                          // 8: backup.v1.DataModel
-		(*timestamppb.Timestamp)(nil),         // 9: google.protobuf.Timestamp
-		(*LogChunk)(nil),                      // 10: backup.v1.LogChunk
-	}
-)
-
+var file_backup_v1_restores_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_backup_v1_restores_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_backup_v1_restores_proto_goTypes = []any{
+	(RestoreStatus)(0),                    // 0: backup.v1.RestoreStatus
+	(*RestoreHistoryItem)(nil),            // 1: backup.v1.RestoreHistoryItem
+	(*ListRestoresRequest)(nil),           // 2: backup.v1.ListRestoresRequest
+	(*ListRestoresResponse)(nil),          // 3: backup.v1.ListRestoresResponse
+	(*RestoreServiceGetLogsRequest)(nil),  // 4: backup.v1.RestoreServiceGetLogsRequest
+	(*RestoreServiceGetLogsResponse)(nil), // 5: backup.v1.RestoreServiceGetLogsResponse
+	(*RestoreBackupRequest)(nil),          // 6: backup.v1.RestoreBackupRequest
+	(*RestoreBackupResponse)(nil),         // 7: backup.v1.RestoreBackupResponse
+	(DataModel)(0),                        // 8: backup.v1.DataModel
+	(*timestamppb.Timestamp)(nil),         // 9: google.protobuf.Timestamp
+	(*LogChunk)(nil),                      // 10: backup.v1.LogChunk
+}
 var file_backup_v1_restores_proto_depIdxs = []int32{
 	8,  // 0: backup.v1.RestoreHistoryItem.data_model:type_name -> backup.v1.DataModel
 	0,  // 1: backup.v1.RestoreHistoryItem.status:type_name -> backup.v1.RestoreStatus

--- a/api/backup/v1/restores.pb.validate.go
+++ b/api/backup/v1/restores.pb.validate.go
@@ -231,8 +231,7 @@ func (e RestoreHistoryItemValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RestoreHistoryItemValidationError{}
@@ -334,8 +333,7 @@ func (e ListRestoresRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListRestoresRequestValidationError{}
@@ -471,8 +469,7 @@ func (e ListRestoresResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListRestoresResponseValidationError{}
@@ -590,8 +587,7 @@ func (e RestoreServiceGetLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RestoreServiceGetLogsRequestValidationError{}
@@ -730,8 +726,7 @@ func (e RestoreServiceGetLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RestoreServiceGetLogsResponseValidationError{}
@@ -884,8 +879,7 @@ func (e RestoreBackupRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RestoreBackupRequestValidationError{}
@@ -989,8 +983,7 @@ func (e RestoreBackupResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RestoreBackupResponseValidationError{}

--- a/api/backup/v1/restores.swagger.json
+++ b/api/backup/v1/restores.swagger.json
@@ -1,0 +1,303 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "backup/v1/restores.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "RestoreService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/backups/restores": {
+      "get": {
+        "summary": "List Restore History",
+        "description": "List all backup restore history items",
+        "operationId": "ListRestores",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListRestoresResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "RestoreService"
+        ]
+      }
+    },
+    "/v1/backups/restores/{restore_id}/logs": {
+      "get": {
+        "summary": "Get Logs",
+        "description": "Get logs from the underlying tools for a restore job",
+        "operationId": "GetLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RestoreServiceGetLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "restore_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "RestoreService"
+        ]
+      }
+    },
+    "/v1/backups/restores:start": {
+      "post": {
+        "summary": "Restore from a Backup",
+        "description": "Could return the Error message in the details containing specific ErrorCode indicating failure reason:\nERROR_CODE_XTRABACKUP_NOT_INSTALLED - xtrabackup is not installed on the service\nERROR_CODE_INVALID_XTRABACKUP - different versions of xtrabackup and xbcloud\nERROR_CODE_INCOMPATIBLE_XTRABACKUP - xtrabackup is not compatible with MySQL for taking a backup\nERROR_CODE_INCOMPATIBLE_TARGET_MYSQL - target MySQL version is not compatible with the artifact for performing a restore of the backup",
+        "operationId": "RestoreBackup",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RestoreBackupResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1RestoreBackupRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RestoreService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1DataModel": {
+      "type": "string",
+      "enum": [
+        "DATA_MODEL_UNSPECIFIED",
+        "DATA_MODEL_PHYSICAL",
+        "DATA_MODEL_LOGICAL"
+      ],
+      "default": "DATA_MODEL_UNSPECIFIED",
+      "description": "DataModel is a model used for performing a backup."
+    },
+    "v1ListRestoresResponse": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RestoreHistoryItem"
+          }
+        }
+      }
+    },
+    "v1LogChunk": {
+      "type": "object",
+      "properties": {
+        "chunk_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "data": {
+          "type": "string"
+        }
+      },
+      "description": "LogChunk represent one chunk of logs."
+    },
+    "v1RestoreBackupRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier where backup should be restored."
+        },
+        "artifact_id": {
+          "type": "string",
+          "description": "Artifact id to restore."
+        },
+        "pitr_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp of PITR to restore to"
+        }
+      }
+    },
+    "v1RestoreBackupResponse": {
+      "type": "object",
+      "properties": {
+        "restore_id": {
+          "type": "string",
+          "description": "Unique restore identifier."
+        }
+      }
+    },
+    "v1RestoreHistoryItem": {
+      "type": "object",
+      "properties": {
+        "restore_id": {
+          "type": "string",
+          "description": "Machine-readable restore id."
+        },
+        "artifact_id": {
+          "type": "string",
+          "description": "ID of the artifact used for restore."
+        },
+        "name": {
+          "type": "string",
+          "description": "Artifact name used for restore."
+        },
+        "vendor": {
+          "type": "string",
+          "description": "Database vendor e.g. PostgreSQL, MongoDB, MySQL."
+        },
+        "location_id": {
+          "type": "string",
+          "description": "Machine-readable location ID."
+        },
+        "location_name": {
+          "type": "string",
+          "description": "Location name."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Machine-readable service ID."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "data_model": {
+          "$ref": "#/definitions/v1DataModel",
+          "description": "Backup data model."
+        },
+        "status": {
+          "$ref": "#/definitions/v1RestoreStatus",
+          "description": "Restore status."
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Restore start time."
+        },
+        "finished_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Restore finish time."
+        },
+        "pitr_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "PITR timestamp is filled for PITR restores, empty otherwise."
+        }
+      },
+      "description": "RestoreHistoryItem represents single backup restore item."
+    },
+    "v1RestoreServiceGetLogsResponse": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1LogChunk"
+          }
+        },
+        "end": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1RestoreStatus": {
+      "type": "string",
+      "enum": [
+        "RESTORE_STATUS_UNSPECIFIED",
+        "RESTORE_STATUS_IN_PROGRESS",
+        "RESTORE_STATUS_SUCCESS",
+        "RESTORE_STATUS_ERROR"
+      ],
+      "default": "RESTORE_STATUS_UNSPECIFIED",
+      "description": "RestoreStatus shows the current status of execution of restore."
+    }
+  }
+}

--- a/api/backup/v1/restores_grpc.pb.go
+++ b/api/backup/v1/restores_grpc.pb.go
@@ -8,7 +8,6 @@ package backupv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -102,11 +101,9 @@ type UnimplementedRestoreServiceServer struct{}
 func (UnimplementedRestoreServiceServer) ListRestores(context.Context, *ListRestoresRequest) (*ListRestoresResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListRestores not implemented")
 }
-
 func (UnimplementedRestoreServiceServer) GetLogs(context.Context, *RestoreServiceGetLogsRequest) (*RestoreServiceGetLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLogs not implemented")
 }
-
 func (UnimplementedRestoreServiceServer) RestoreBackup(context.Context, *RestoreBackupRequest) (*RestoreBackupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RestoreBackup not implemented")
 }

--- a/api/common/common.pb.go
+++ b/api/common/common.pb.go
@@ -7,12 +7,11 @@
 package common
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -139,15 +138,12 @@ func file_common_common_proto_rawDescGZIP() []byte {
 	return file_common_common_proto_rawDescData
 }
 
-var (
-	file_common_common_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_common_common_proto_goTypes  = []any{
-		(*StringArray)(nil), // 0: common.StringArray
-		(*StringMap)(nil),   // 1: common.StringMap
-		nil,                 // 2: common.StringMap.ValuesEntry
-	}
-)
-
+var file_common_common_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_common_common_proto_goTypes = []any{
+	(*StringArray)(nil), // 0: common.StringArray
+	(*StringMap)(nil),   // 1: common.StringMap
+	nil,                 // 2: common.StringMap.ValuesEntry
+}
 var file_common_common_proto_depIdxs = []int32{
 	2, // 0: common.StringMap.values:type_name -> common.StringMap.ValuesEntry
 	1, // [1:1] is the sub-list for method output_type

--- a/api/common/common.pb.validate.go
+++ b/api/common/common.pb.validate.go
@@ -121,8 +121,7 @@ func (e StringArrayValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StringArrayValidationError{}
@@ -223,8 +222,7 @@ func (e StringMapValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StringMapValidationError{}

--- a/api/common/common.swagger.json
+++ b/api/common/common.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "common/common.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/common/metrics_resolutions.pb.go
+++ b/api/common/metrics_resolutions.pb.go
@@ -7,13 +7,12 @@
 package common
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -111,14 +110,11 @@ func file_common_metrics_resolutions_proto_rawDescGZIP() []byte {
 	return file_common_metrics_resolutions_proto_rawDescData
 }
 
-var (
-	file_common_metrics_resolutions_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-	file_common_metrics_resolutions_proto_goTypes  = []any{
-		(*MetricsResolutions)(nil),  // 0: common.MetricsResolutions
-		(*durationpb.Duration)(nil), // 1: google.protobuf.Duration
-	}
-)
-
+var file_common_metrics_resolutions_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_common_metrics_resolutions_proto_goTypes = []any{
+	(*MetricsResolutions)(nil),  // 0: common.MetricsResolutions
+	(*durationpb.Duration)(nil), // 1: google.protobuf.Duration
+}
 var file_common_metrics_resolutions_proto_depIdxs = []int32{
 	1, // 0: common.MetricsResolutions.hr:type_name -> google.protobuf.Duration
 	1, // 1: common.MetricsResolutions.mr:type_name -> google.protobuf.Duration

--- a/api/common/metrics_resolutions.pb.validate.go
+++ b/api/common/metrics_resolutions.pb.validate.go
@@ -211,8 +211,7 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsResolutionsValidationError{}

--- a/api/common/metrics_resolutions.swagger.json
+++ b/api/common/metrics_resolutions.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "common/metrics_resolutions.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/dump/v1beta1/dump.pb.go
+++ b/api/dump/v1beta1/dump.pb.go
@@ -7,18 +7,16 @@
 package dumpv1beta1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -876,28 +874,25 @@ func file_dump_v1beta1_dump_proto_rawDescGZIP() []byte {
 	return file_dump_v1beta1_dump_proto_rawDescData
 }
 
-var (
-	file_dump_v1beta1_dump_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_dump_v1beta1_dump_proto_msgTypes  = make([]protoimpl.MessageInfo, 13)
-	file_dump_v1beta1_dump_proto_goTypes   = []any{
-		DumpStatus(0),                 // 0: dump.v1beta1.DumpStatus
-		(*Dump)(nil),                  // 1: dump.v1beta1.Dump
-		(*StartDumpRequest)(nil),      // 2: dump.v1beta1.StartDumpRequest
-		(*StartDumpResponse)(nil),     // 3: dump.v1beta1.StartDumpResponse
-		(*ListDumpsRequest)(nil),      // 4: dump.v1beta1.ListDumpsRequest
-		(*ListDumpsResponse)(nil),     // 5: dump.v1beta1.ListDumpsResponse
-		(*DeleteDumpRequest)(nil),     // 6: dump.v1beta1.DeleteDumpRequest
-		(*DeleteDumpResponse)(nil),    // 7: dump.v1beta1.DeleteDumpResponse
-		(*GetDumpLogsRequest)(nil),    // 8: dump.v1beta1.GetDumpLogsRequest
-		(*GetDumpLogsResponse)(nil),   // 9: dump.v1beta1.GetDumpLogsResponse
-		(*LogChunk)(nil),              // 10: dump.v1beta1.LogChunk
-		(*SFTPParameters)(nil),        // 11: dump.v1beta1.SFTPParameters
-		(*UploadDumpRequest)(nil),     // 12: dump.v1beta1.UploadDumpRequest
-		(*UploadDumpResponse)(nil),    // 13: dump.v1beta1.UploadDumpResponse
-		(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
-	}
-)
-
+var file_dump_v1beta1_dump_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_dump_v1beta1_dump_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_dump_v1beta1_dump_proto_goTypes = []any{
+	(DumpStatus)(0),               // 0: dump.v1beta1.DumpStatus
+	(*Dump)(nil),                  // 1: dump.v1beta1.Dump
+	(*StartDumpRequest)(nil),      // 2: dump.v1beta1.StartDumpRequest
+	(*StartDumpResponse)(nil),     // 3: dump.v1beta1.StartDumpResponse
+	(*ListDumpsRequest)(nil),      // 4: dump.v1beta1.ListDumpsRequest
+	(*ListDumpsResponse)(nil),     // 5: dump.v1beta1.ListDumpsResponse
+	(*DeleteDumpRequest)(nil),     // 6: dump.v1beta1.DeleteDumpRequest
+	(*DeleteDumpResponse)(nil),    // 7: dump.v1beta1.DeleteDumpResponse
+	(*GetDumpLogsRequest)(nil),    // 8: dump.v1beta1.GetDumpLogsRequest
+	(*GetDumpLogsResponse)(nil),   // 9: dump.v1beta1.GetDumpLogsResponse
+	(*LogChunk)(nil),              // 10: dump.v1beta1.LogChunk
+	(*SFTPParameters)(nil),        // 11: dump.v1beta1.SFTPParameters
+	(*UploadDumpRequest)(nil),     // 12: dump.v1beta1.UploadDumpRequest
+	(*UploadDumpResponse)(nil),    // 13: dump.v1beta1.UploadDumpResponse
+	(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
+}
 var file_dump_v1beta1_dump_proto_depIdxs = []int32{
 	0,  // 0: dump.v1beta1.Dump.status:type_name -> dump.v1beta1.DumpStatus
 	14, // 1: dump.v1beta1.Dump.start_time:type_name -> google.protobuf.Timestamp

--- a/api/dump/v1beta1/dump.pb.validate.go
+++ b/api/dump/v1beta1/dump.pb.validate.go
@@ -213,8 +213,7 @@ func (e DumpValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DumpValidationError{}
@@ -380,8 +379,7 @@ func (e StartDumpRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartDumpRequestValidationError{}
@@ -485,8 +483,7 @@ func (e StartDumpResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartDumpResponseValidationError{}
@@ -586,8 +583,7 @@ func (e ListDumpsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListDumpsRequestValidationError{}
@@ -723,8 +719,7 @@ func (e ListDumpsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListDumpsResponseValidationError{}
@@ -858,8 +853,7 @@ func (e DeleteDumpRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteDumpRequestValidationError{}
@@ -961,8 +955,7 @@ func (e DeleteDumpResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DeleteDumpResponseValidationError{}
@@ -1079,8 +1072,7 @@ func (e GetDumpLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetDumpLogsRequestValidationError{}
@@ -1218,8 +1210,7 @@ func (e GetDumpLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetDumpLogsResponseValidationError{}
@@ -1322,8 +1313,7 @@ func (e LogChunkValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LogChunkValidationError{}
@@ -1458,8 +1448,7 @@ func (e SFTPParametersValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SFTPParametersValidationError{}
@@ -1633,8 +1622,7 @@ func (e UploadDumpRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UploadDumpRequestValidationError{}
@@ -1736,8 +1724,7 @@ func (e UploadDumpResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UploadDumpResponseValidationError{}

--- a/api/dump/v1beta1/dump.swagger.json
+++ b/api/dump/v1beta1/dump.swagger.json
@@ -1,0 +1,395 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "dump/v1beta1/dump.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "DumpService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/dumps": {
+      "get": {
+        "summary": "List All Dumps",
+        "description": "List all dumps",
+        "operationId": "ListDumps",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1ListDumpsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "DumpService"
+        ]
+      }
+    },
+    "/v1/dumps/{dump_id}/logs": {
+      "get": {
+        "summary": "Get Dump Logs",
+        "description": "Get logs of a selected dump.",
+        "operationId": "GetDumpLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1GetDumpLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "dump_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "DumpService"
+        ]
+      }
+    },
+    "/v1/dumps:batchDelete": {
+      "post": {
+        "summary": "Delete Dumps",
+        "description": "Delete selected dumps.",
+        "operationId": "DeleteDump",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1DeleteDumpResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1DeleteDumpRequest"
+            }
+          }
+        ],
+        "tags": [
+          "DumpService"
+        ]
+      }
+    },
+    "/v1/dumps:start": {
+      "post": {
+        "summary": "Start a New Dump",
+        "description": "Start a new dump.",
+        "operationId": "StartDump",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1StartDumpResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1StartDumpRequest"
+            }
+          }
+        ],
+        "tags": [
+          "DumpService"
+        ]
+      }
+    },
+    "/v1/dumps:upload": {
+      "post": {
+        "summary": "Upload Dumps",
+        "description": "Upload selected dumps to a remote server.",
+        "operationId": "UploadDump",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1UploadDumpResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1beta1UploadDumpRequest"
+            }
+          }
+        ],
+        "tags": [
+          "DumpService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1beta1DeleteDumpRequest": {
+      "type": "object",
+      "properties": {
+        "dump_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "v1beta1DeleteDumpResponse": {
+      "type": "object"
+    },
+    "v1beta1Dump": {
+      "type": "object",
+      "properties": {
+        "dump_id": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/definitions/v1beta1DumpStatus"
+        },
+        "service_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "encrypted": {
+          "type": "boolean",
+          "description": "This field is set to true if the dump was created with encryption enabled, and false otherwise."
+        }
+      }
+    },
+    "v1beta1DumpStatus": {
+      "type": "string",
+      "enum": [
+        "DUMP_STATUS_UNSPECIFIED",
+        "DUMP_STATUS_IN_PROGRESS",
+        "DUMP_STATUS_SUCCESS",
+        "DUMP_STATUS_ERROR"
+      ],
+      "default": "DUMP_STATUS_UNSPECIFIED"
+    },
+    "v1beta1GetDumpLogsResponse": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1beta1LogChunk"
+          }
+        },
+        "end": {
+          "type": "boolean"
+        }
+      }
+    },
+    "v1beta1ListDumpsResponse": {
+      "type": "object",
+      "properties": {
+        "dumps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1beta1Dump"
+          }
+        }
+      }
+    },
+    "v1beta1LogChunk": {
+      "type": "object",
+      "properties": {
+        "chunk_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "data": {
+          "type": "string"
+        }
+      },
+      "description": "LogChunk represent one chunk of logs."
+    },
+    "v1beta1SFTPParameters": {
+      "type": "object",
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "directory": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1StartDumpRequest": {
+      "type": "object",
+      "properties": {
+        "service_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "export_qan": {
+          "type": "boolean"
+        },
+        "ignore_load": {
+          "type": "boolean"
+        },
+        "enable_encryption": {
+          "type": "boolean",
+          "description": "If true, the dump will be encrypted. Note that enabling encryption may increase the time required to create the dump."
+        },
+        "encryption_password": {
+          "type": "string",
+          "description": "The password used for encryption. It must be at least 8 characters long. This field is required if enable_encryption is true."
+        }
+      }
+    },
+    "v1beta1StartDumpResponse": {
+      "type": "object",
+      "properties": {
+        "dump_id": {
+          "type": "string"
+        }
+      }
+    },
+    "v1beta1UploadDumpRequest": {
+      "type": "object",
+      "properties": {
+        "dump_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sftp_parameters": {
+          "$ref": "#/definitions/v1beta1SFTPParameters",
+          "description": "SFTP upload parameters."
+        }
+      }
+    },
+    "v1beta1UploadDumpResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/dump/v1beta1/dump_grpc.pb.go
+++ b/api/dump/v1beta1/dump_grpc.pb.go
@@ -8,7 +8,6 @@ package dumpv1beta1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -128,19 +127,15 @@ type UnimplementedDumpServiceServer struct{}
 func (UnimplementedDumpServiceServer) StartDump(context.Context, *StartDumpRequest) (*StartDumpResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartDump not implemented")
 }
-
 func (UnimplementedDumpServiceServer) ListDumps(context.Context, *ListDumpsRequest) (*ListDumpsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListDumps not implemented")
 }
-
 func (UnimplementedDumpServiceServer) DeleteDump(context.Context, *DeleteDumpRequest) (*DeleteDumpResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteDump not implemented")
 }
-
 func (UnimplementedDumpServiceServer) GetDumpLogs(context.Context, *GetDumpLogsRequest) (*GetDumpLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDumpLogs not implemented")
 }
-
 func (UnimplementedDumpServiceServer) UploadDump(context.Context, *UploadDumpRequest) (*UploadDumpResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UploadDump not implemented")
 }

--- a/api/extensions/v1/redact.pb.go
+++ b/api/extensions/v1/redact.pb.go
@@ -7,13 +7,12 @@
 package extensionsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -128,14 +127,11 @@ func file_extensions_v1_redact_proto_rawDescGZIP() []byte {
 	return file_extensions_v1_redact_proto_rawDescData
 }
 
-var (
-	file_extensions_v1_redact_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_extensions_v1_redact_proto_goTypes   = []any{
-		RedactType(0),                     // 0: extensions.v1.RedactType
-		(*descriptorpb.FieldOptions)(nil), // 1: google.protobuf.FieldOptions
-	}
-)
-
+var file_extensions_v1_redact_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_extensions_v1_redact_proto_goTypes = []any{
+	(RedactType)(0),                   // 0: extensions.v1.RedactType
+	(*descriptorpb.FieldOptions)(nil), // 1: google.protobuf.FieldOptions
+}
 var file_extensions_v1_redact_proto_depIdxs = []int32{
 	1, // 0: extensions.v1.sensitive:extendee -> google.protobuf.FieldOptions
 	0, // 1: extensions.v1.sensitive:type_name -> extensions.v1.RedactType

--- a/api/extensions/v1/redact.swagger.json
+++ b/api/extensions/v1/redact.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "extensions/v1/redact.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ha/v1beta1/ha.pb.go
+++ b/api/ha/v1beta1/ha.pb.go
@@ -7,14 +7,13 @@
 package hav1beta1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -339,19 +338,16 @@ func file_ha_v1beta1_ha_proto_rawDescGZIP() []byte {
 	return file_ha_v1beta1_ha_proto_rawDescData
 }
 
-var (
-	file_ha_v1beta1_ha_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_ha_v1beta1_ha_proto_msgTypes  = make([]protoimpl.MessageInfo, 5)
-	file_ha_v1beta1_ha_proto_goTypes   = []any{
-		NodeRole(0),               // 0: ha.v1beta1.NodeRole
-		(*ListNodesRequest)(nil),  // 1: ha.v1beta1.ListNodesRequest
-		(*HANode)(nil),            // 2: ha.v1beta1.HANode
-		(*ListNodesResponse)(nil), // 3: ha.v1beta1.ListNodesResponse
-		(*StatusRequest)(nil),     // 4: ha.v1beta1.StatusRequest
-		(*StatusResponse)(nil),    // 5: ha.v1beta1.StatusResponse
-	}
-)
-
+var file_ha_v1beta1_ha_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_ha_v1beta1_ha_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_ha_v1beta1_ha_proto_goTypes = []any{
+	(NodeRole)(0),             // 0: ha.v1beta1.NodeRole
+	(*ListNodesRequest)(nil),  // 1: ha.v1beta1.ListNodesRequest
+	(*HANode)(nil),            // 2: ha.v1beta1.HANode
+	(*ListNodesResponse)(nil), // 3: ha.v1beta1.ListNodesResponse
+	(*StatusRequest)(nil),     // 4: ha.v1beta1.StatusRequest
+	(*StatusResponse)(nil),    // 5: ha.v1beta1.StatusResponse
+}
 var file_ha_v1beta1_ha_proto_depIdxs = []int32{
 	0, // 0: ha.v1beta1.HANode.role:type_name -> ha.v1beta1.NodeRole
 	2, // 1: ha.v1beta1.ListNodesResponse.nodes:type_name -> ha.v1beta1.HANode

--- a/api/ha/v1beta1/ha.pb.validate.go
+++ b/api/ha/v1beta1/ha.pb.validate.go
@@ -122,8 +122,7 @@ func (e ListNodesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesRequestValidationError{}
@@ -227,8 +226,7 @@ func (e HANodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HANodeValidationError{}
@@ -364,8 +362,7 @@ func (e ListNodesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesResponseValidationError{}
@@ -465,8 +462,7 @@ func (e StatusRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StatusRequestValidationError{}
@@ -568,8 +564,7 @@ func (e StatusResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StatusResponseValidationError{}

--- a/api/ha/v1beta1/ha.swagger.json
+++ b/api/ha/v1beta1/ha.swagger.json
@@ -1,0 +1,148 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ha/v1beta1/ha.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "HAService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/ha/nodes": {
+      "get": {
+        "summary": "List HA Nodes",
+        "description": "Returns a list of all nodes in the High Availability cluster with their current status and roles.",
+        "operationId": "ListNodes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1ListNodesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "HAService"
+        ]
+      }
+    },
+    "/v1/ha/status": {
+      "get": {
+        "summary": "HA Status",
+        "description": "Returns whether High Availability mode is enabled or disabled.",
+        "operationId": "Status",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1beta1StatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "HAService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "v1beta1HANode": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Human-readable name of the node."
+        },
+        "role": {
+          "$ref": "#/definitions/v1beta1NodeRole",
+          "description": "Role of the node in the cluster."
+        },
+        "status": {
+          "type": "string",
+          "description": "Current status of the node from MemberList."
+        }
+      },
+      "description": "HANode represents a single node in the HA cluster."
+    },
+    "v1beta1ListNodesResponse": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1beta1HANode"
+          },
+          "description": "List of nodes in the HA cluster."
+        }
+      }
+    },
+    "v1beta1NodeRole": {
+      "type": "string",
+      "enum": [
+        "NODE_ROLE_UNSPECIFIED",
+        "NODE_ROLE_LEADER",
+        "NODE_ROLE_FOLLOWER"
+      ],
+      "default": "NODE_ROLE_UNSPECIFIED",
+      "description": "NodeRole represents the role of a node in the HA cluster."
+    },
+    "v1beta1StatusResponse": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Status of HA mode: \"Enabled\" or \"Disabled\"."
+        }
+      }
+    }
+  }
+}

--- a/api/ha/v1beta1/ha_grpc.pb.go
+++ b/api/ha/v1beta1/ha_grpc.pb.go
@@ -8,7 +8,6 @@ package hav1beta1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -87,7 +86,6 @@ type UnimplementedHAServiceServer struct{}
 func (UnimplementedHAServiceServer) Status(context.Context, *StatusRequest) (*StatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Status not implemented")
 }
-
 func (UnimplementedHAServiceServer) ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNodes not implemented")
 }

--- a/api/inventory/v1/agent_status.pb.go
+++ b/api/inventory/v1/agent_status.pb.go
@@ -7,12 +7,11 @@
 package inventoryv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -122,13 +121,10 @@ func file_inventory_v1_agent_status_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_agent_status_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_agent_status_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_agent_status_proto_goTypes   = []any{
-		AgentStatus(0), // 0: inventory.v1.AgentStatus
-	}
-)
-
+var file_inventory_v1_agent_status_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_agent_status_proto_goTypes = []any{
+	(AgentStatus)(0), // 0: inventory.v1.AgentStatus
+}
 var file_inventory_v1_agent_status_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/inventory/v1/agent_status.swagger.json
+++ b/api/inventory/v1/agent_status.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/agent_status.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/inventory/v1/agents.go
+++ b/api/inventory/v1/agents.go
@@ -44,3 +44,4 @@ func (*ExternalExporter) sealedAgent()                {}
 func (*AzureDatabaseExporter) sealedAgent()           {}
 func (*ValkeyExporter) sealedAgent()                  {}
 func (*RTAMongoDBAgent) sealedAgent()                 {}
+func (*RTAPostgreSQLAgent) sealedAgent()              {}

--- a/api/inventory/v1/agents.pb.go
+++ b/api/inventory/v1/agents.pb.go
@@ -7,19 +7,17 @@
 package inventoryv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	common "github.com/percona/pmm/api/common"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	common "github.com/percona/pmm/api/common"
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -53,6 +51,7 @@ const (
 	AgentType_AGENT_TYPE_AZURE_DATABASE_EXPORTER            AgentType = 15
 	AgentType_AGENT_TYPE_NOMAD_AGENT                        AgentType = 16
 	AgentType_AGENT_TYPE_RTA_MONGODB_AGENT                  AgentType = 19
+	AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT               AgentType = 20
 )
 
 // Enum value maps for AgentType.
@@ -78,6 +77,7 @@ var (
 		15: "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
 		16: "AGENT_TYPE_NOMAD_AGENT",
 		19: "AGENT_TYPE_RTA_MONGODB_AGENT",
+		20: "AGENT_TYPE_RTA_POSTGRESQL_AGENT",
 	}
 	AgentType_value = map[string]int32{
 		"AGENT_TYPE_UNSPECIFIED":                        0,
@@ -100,6 +100,7 @@ var (
 		"AGENT_TYPE_AZURE_DATABASE_EXPORTER":            15,
 		"AGENT_TYPE_NOMAD_AGENT":                        16,
 		"AGENT_TYPE_RTA_MONGODB_AGENT":                  19,
+		"AGENT_TYPE_RTA_POSTGRESQL_AGENT":               20,
 	}
 )
 
@@ -2335,6 +2336,142 @@ func (x *RTAOptions) GetCollectInterval() *durationpb.Duration {
 	return nil
 }
 
+// RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server.
+type RTAPostgreSQLAgent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique agent identifier.
+	AgentId string `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	// The pmm-agent identifier which runs this instance.
+	PmmAgentId string `protobuf:"bytes,2,opt,name=pmm_agent_id,json=pmmAgentId,proto3" json:"pmm_agent_id,omitempty"`
+	// Desired Agent status: enabled (false) or disabled (true).
+	Disabled bool `protobuf:"varint,3,opt,name=disabled,proto3" json:"disabled,omitempty"`
+	// Service identifier.
+	ServiceId string `protobuf:"bytes,4,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
+	// Use TLS for database connections.
+	Tls bool `protobuf:"varint,6,opt,name=tls,proto3" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify bool `protobuf:"varint,7,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3" json:"tls_skip_verify,omitempty"`
+	// Custom user-assigned labels.
+	CustomLabels map[string]string `protobuf:"bytes,8,rep,name=custom_labels,json=customLabels,proto3" json:"custom_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Real-Time Analytics options.
+	RtaOptions *RTAOptions `protobuf:"bytes,9,opt,name=rta_options,json=rtaOptions,proto3" json:"rta_options,omitempty"`
+	// Actual Agent status.
+	Status AgentStatus `protobuf:"varint,10,opt,name=status,proto3,enum=inventory.v1.AgentStatus" json:"status,omitempty"`
+	// Log level for agent.
+	LogLevel      LogLevel `protobuf:"varint,11,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel" json:"log_level,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RTAPostgreSQLAgent) Reset() {
+	*x = RTAPostgreSQLAgent{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RTAPostgreSQLAgent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RTAPostgreSQLAgent) ProtoMessage() {}
+
+func (x *RTAPostgreSQLAgent) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RTAPostgreSQLAgent.ProtoReflect.Descriptor instead.
+func (*RTAPostgreSQLAgent) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RTAPostgreSQLAgent) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetPmmAgentId() string {
+	if x != nil {
+		return x.PmmAgentId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetDisabled() bool {
+	if x != nil {
+		return x.Disabled
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetTls() bool {
+	if x != nil {
+		return x.Tls
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetTlsSkipVerify() bool {
+	if x != nil {
+		return x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetCustomLabels() map[string]string {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *RTAPostgreSQLAgent) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
+func (x *RTAPostgreSQLAgent) GetStatus() AgentStatus {
+	if x != nil {
+		return x.Status
+	}
+	return AgentStatus_AGENT_STATUS_UNSPECIFIED
+}
+
+func (x *RTAPostgreSQLAgent) GetLogLevel() LogLevel {
+	if x != nil {
+		return x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
 // RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server.
 type RTAMongoDBAgent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2366,7 +2503,7 @@ type RTAMongoDBAgent struct {
 
 func (x *RTAMongoDBAgent) Reset() {
 	*x = RTAMongoDBAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	mi := &file_inventory_v1_agents_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2378,7 +2515,7 @@ func (x *RTAMongoDBAgent) String() string {
 func (*RTAMongoDBAgent) ProtoMessage() {}
 
 func (x *RTAMongoDBAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	mi := &file_inventory_v1_agents_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2391,7 +2528,7 @@ func (x *RTAMongoDBAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RTAMongoDBAgent.ProtoReflect.Descriptor instead.
 func (*RTAMongoDBAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{14}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RTAMongoDBAgent) GetAgentId() string {
@@ -2506,7 +2643,7 @@ type QANPostgreSQLPgStatementsAgent struct {
 
 func (x *QANPostgreSQLPgStatementsAgent) Reset() {
 	*x = QANPostgreSQLPgStatementsAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[15]
+	mi := &file_inventory_v1_agents_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2518,7 +2655,7 @@ func (x *QANPostgreSQLPgStatementsAgent) String() string {
 func (*QANPostgreSQLPgStatementsAgent) ProtoMessage() {}
 
 func (x *QANPostgreSQLPgStatementsAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[15]
+	mi := &file_inventory_v1_agents_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2531,7 +2668,7 @@ func (x *QANPostgreSQLPgStatementsAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QANPostgreSQLPgStatementsAgent.ProtoReflect.Descriptor instead.
 func (*QANPostgreSQLPgStatementsAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{15}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *QANPostgreSQLPgStatementsAgent) GetAgentId() string {
@@ -2662,7 +2799,7 @@ type QANPostgreSQLPgStatMonitorAgent struct {
 
 func (x *QANPostgreSQLPgStatMonitorAgent) Reset() {
 	*x = QANPostgreSQLPgStatMonitorAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[16]
+	mi := &file_inventory_v1_agents_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2674,7 +2811,7 @@ func (x *QANPostgreSQLPgStatMonitorAgent) String() string {
 func (*QANPostgreSQLPgStatMonitorAgent) ProtoMessage() {}
 
 func (x *QANPostgreSQLPgStatMonitorAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[16]
+	mi := &file_inventory_v1_agents_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2687,7 +2824,7 @@ func (x *QANPostgreSQLPgStatMonitorAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QANPostgreSQLPgStatMonitorAgent.ProtoReflect.Descriptor instead.
 func (*QANPostgreSQLPgStatMonitorAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{16}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *QANPostgreSQLPgStatMonitorAgent) GetAgentId() string {
@@ -2827,7 +2964,7 @@ type RDSExporter struct {
 
 func (x *RDSExporter) Reset() {
 	*x = RDSExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[17]
+	mi := &file_inventory_v1_agents_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2839,7 +2976,7 @@ func (x *RDSExporter) String() string {
 func (*RDSExporter) ProtoMessage() {}
 
 func (x *RDSExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[17]
+	mi := &file_inventory_v1_agents_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2852,7 +2989,7 @@ func (x *RDSExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RDSExporter.ProtoReflect.Descriptor instead.
 func (*RDSExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{17}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RDSExporter) GetAgentId() string {
@@ -2997,7 +3134,7 @@ type ExternalExporter struct {
 
 func (x *ExternalExporter) Reset() {
 	*x = ExternalExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[18]
+	mi := &file_inventory_v1_agents_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3009,7 +3146,7 @@ func (x *ExternalExporter) String() string {
 func (*ExternalExporter) ProtoMessage() {}
 
 func (x *ExternalExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[18]
+	mi := &file_inventory_v1_agents_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3022,7 +3159,7 @@ func (x *ExternalExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalExporter.ProtoReflect.Descriptor instead.
 func (*ExternalExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{18}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExternalExporter) GetAgentId() string {
@@ -3158,7 +3295,7 @@ type AzureDatabaseExporter struct {
 
 func (x *AzureDatabaseExporter) Reset() {
 	*x = AzureDatabaseExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[19]
+	mi := &file_inventory_v1_agents_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3170,7 +3307,7 @@ func (x *AzureDatabaseExporter) String() string {
 func (*AzureDatabaseExporter) ProtoMessage() {}
 
 func (x *AzureDatabaseExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[19]
+	mi := &file_inventory_v1_agents_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3183,7 +3320,7 @@ func (x *AzureDatabaseExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureDatabaseExporter.ProtoReflect.Descriptor instead.
 func (*AzureDatabaseExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{19}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AzureDatabaseExporter) GetAgentId() string {
@@ -3294,7 +3431,7 @@ type ChangeCommonAgentParams struct {
 
 func (x *ChangeCommonAgentParams) Reset() {
 	*x = ChangeCommonAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[20]
+	mi := &file_inventory_v1_agents_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3306,7 +3443,7 @@ func (x *ChangeCommonAgentParams) String() string {
 func (*ChangeCommonAgentParams) ProtoMessage() {}
 
 func (x *ChangeCommonAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[20]
+	mi := &file_inventory_v1_agents_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3319,7 +3456,7 @@ func (x *ChangeCommonAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeCommonAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeCommonAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{20}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ChangeCommonAgentParams) GetEnable() bool {
@@ -3369,7 +3506,7 @@ type ListAgentsRequest struct {
 
 func (x *ListAgentsRequest) Reset() {
 	*x = ListAgentsRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[21]
+	mi := &file_inventory_v1_agents_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3381,7 +3518,7 @@ func (x *ListAgentsRequest) String() string {
 func (*ListAgentsRequest) ProtoMessage() {}
 
 func (x *ListAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[21]
+	mi := &file_inventory_v1_agents_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3394,7 +3531,7 @@ func (x *ListAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAgentsRequest.ProtoReflect.Descriptor instead.
 func (*ListAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{21}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListAgentsRequest) GetPmmAgentId() string {
@@ -3446,13 +3583,14 @@ type ListAgentsResponse struct {
 	NomadAgent                      []*NomadAgent                      `protobuf:"bytes,16,rep,name=nomad_agent,json=nomadAgent,proto3" json:"nomad_agent,omitempty"`
 	ValkeyExporter                  []*ValkeyExporter                  `protobuf:"bytes,17,rep,name=valkey_exporter,json=valkeyExporter,proto3" json:"valkey_exporter,omitempty"`
 	RtaMongodbAgent                 []*RTAMongoDBAgent                 `protobuf:"bytes,19,rep,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3" json:"rta_mongodb_agent,omitempty"`
+	RtaPostgresqlAgent              []*RTAPostgreSQLAgent              `protobuf:"bytes,20,rep,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
 	unknownFields                   protoimpl.UnknownFields
 	sizeCache                       protoimpl.SizeCache
 }
 
 func (x *ListAgentsResponse) Reset() {
 	*x = ListAgentsResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[22]
+	mi := &file_inventory_v1_agents_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3464,7 +3602,7 @@ func (x *ListAgentsResponse) String() string {
 func (*ListAgentsResponse) ProtoMessage() {}
 
 func (x *ListAgentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[22]
+	mi := &file_inventory_v1_agents_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3477,7 +3615,7 @@ func (x *ListAgentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAgentsResponse.ProtoReflect.Descriptor instead.
 func (*ListAgentsResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{22}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListAgentsResponse) GetPmmAgent() []*PMMAgent {
@@ -3613,6 +3751,13 @@ func (x *ListAgentsResponse) GetRtaMongodbAgent() []*RTAMongoDBAgent {
 	return nil
 }
 
+func (x *ListAgentsResponse) GetRtaPostgresqlAgent() []*RTAPostgreSQLAgent {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return nil
+}
+
 type GetAgentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique randomly generated instance identifier.
@@ -3623,7 +3768,7 @@ type GetAgentRequest struct {
 
 func (x *GetAgentRequest) Reset() {
 	*x = GetAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[23]
+	mi := &file_inventory_v1_agents_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3635,7 +3780,7 @@ func (x *GetAgentRequest) String() string {
 func (*GetAgentRequest) ProtoMessage() {}
 
 func (x *GetAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[23]
+	mi := &file_inventory_v1_agents_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3648,7 +3793,7 @@ func (x *GetAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentRequest.ProtoReflect.Descriptor instead.
 func (*GetAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{23}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetAgentRequest) GetAgentId() string {
@@ -3681,6 +3826,7 @@ type GetAgentResponse struct {
 	//	*GetAgentResponse_NomadAgent
 	//	*GetAgentResponse_ValkeyExporter
 	//	*GetAgentResponse_RtaMongodbAgent
+	//	*GetAgentResponse_RtaPostgresqlAgent
 	Agent         isGetAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3688,7 +3834,7 @@ type GetAgentResponse struct {
 
 func (x *GetAgentResponse) Reset() {
 	*x = GetAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[24]
+	mi := &file_inventory_v1_agents_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3700,7 +3846,7 @@ func (x *GetAgentResponse) String() string {
 func (*GetAgentResponse) ProtoMessage() {}
 
 func (x *GetAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[24]
+	mi := &file_inventory_v1_agents_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3713,7 +3859,7 @@ func (x *GetAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentResponse.ProtoReflect.Descriptor instead.
 func (*GetAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{24}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetAgentResponse) GetAgent() isGetAgentResponse_Agent {
@@ -3894,6 +4040,15 @@ func (x *GetAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *GetAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*GetAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isGetAgentResponse_Agent interface {
 	isGetAgentResponse_Agent()
 }
@@ -3974,6 +4129,10 @@ type GetAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,19,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type GetAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,20,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*GetAgentResponse_PmmAgent) isGetAgentResponse_Agent() {}
 
 func (*GetAgentResponse_Vmagent) isGetAgentResponse_Agent() {}
@@ -4012,6 +4171,8 @@ func (*GetAgentResponse_ValkeyExporter) isGetAgentResponse_Agent() {}
 
 func (*GetAgentResponse_RtaMongodbAgent) isGetAgentResponse_Agent() {}
 
+func (*GetAgentResponse_RtaPostgresqlAgent) isGetAgentResponse_Agent() {}
+
 type GetAgentLogsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique randomly generated instance identifier.
@@ -4024,7 +4185,7 @@ type GetAgentLogsRequest struct {
 
 func (x *GetAgentLogsRequest) Reset() {
 	*x = GetAgentLogsRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[25]
+	mi := &file_inventory_v1_agents_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4036,7 +4197,7 @@ func (x *GetAgentLogsRequest) String() string {
 func (*GetAgentLogsRequest) ProtoMessage() {}
 
 func (x *GetAgentLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[25]
+	mi := &file_inventory_v1_agents_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4049,7 +4210,7 @@ func (x *GetAgentLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetAgentLogsRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{25}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetAgentLogsRequest) GetAgentId() string {
@@ -4076,7 +4237,7 @@ type GetAgentLogsResponse struct {
 
 func (x *GetAgentLogsResponse) Reset() {
 	*x = GetAgentLogsResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[26]
+	mi := &file_inventory_v1_agents_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4088,7 +4249,7 @@ func (x *GetAgentLogsResponse) String() string {
 func (*GetAgentLogsResponse) ProtoMessage() {}
 
 func (x *GetAgentLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[26]
+	mi := &file_inventory_v1_agents_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4101,7 +4262,7 @@ func (x *GetAgentLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetAgentLogsResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{26}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetAgentLogsResponse) GetLogs() []string {
@@ -4139,6 +4300,7 @@ type AddAgentRequest struct {
 	//	*AddAgentRequest_QanPostgresqlPgstatmonitorAgent
 	//	*AddAgentRequest_ValkeyExporter
 	//	*AddAgentRequest_RtaMongodbAgent
+	//	*AddAgentRequest_RtaPostgresqlAgent
 	Agent         isAddAgentRequest_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4146,7 +4308,7 @@ type AddAgentRequest struct {
 
 func (x *AddAgentRequest) Reset() {
 	*x = AddAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[27]
+	mi := &file_inventory_v1_agents_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4158,7 +4320,7 @@ func (x *AddAgentRequest) String() string {
 func (*AddAgentRequest) ProtoMessage() {}
 
 func (x *AddAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[27]
+	mi := &file_inventory_v1_agents_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4171,7 +4333,7 @@ func (x *AddAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAgentRequest.ProtoReflect.Descriptor instead.
 func (*AddAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{27}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AddAgentRequest) GetAgent() isAddAgentRequest_Agent {
@@ -4334,6 +4496,15 @@ func (x *AddAgentRequest) GetRtaMongodbAgent() *AddRTAMongoDBAgentParams {
 	return nil
 }
 
+func (x *AddAgentRequest) GetRtaPostgresqlAgent() *AddRTAPostgreSQLAgentParams {
+	if x != nil {
+		if x, ok := x.Agent.(*AddAgentRequest_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isAddAgentRequest_Agent interface {
 	isAddAgentRequest_Agent()
 }
@@ -4406,6 +4577,10 @@ type AddAgentRequest_RtaMongodbAgent struct {
 	RtaMongodbAgent *AddRTAMongoDBAgentParams `protobuf:"bytes,17,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type AddAgentRequest_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *AddRTAPostgreSQLAgentParams `protobuf:"bytes,18,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*AddAgentRequest_PmmAgent) isAddAgentRequest_Agent() {}
 
 func (*AddAgentRequest_NodeExporter) isAddAgentRequest_Agent() {}
@@ -4440,6 +4615,8 @@ func (*AddAgentRequest_ValkeyExporter) isAddAgentRequest_Agent() {}
 
 func (*AddAgentRequest_RtaMongodbAgent) isAddAgentRequest_Agent() {}
 
+func (*AddAgentRequest_RtaPostgresqlAgent) isAddAgentRequest_Agent() {}
+
 type AddAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Agent:
@@ -4461,6 +4638,7 @@ type AddAgentResponse struct {
 	//	*AddAgentResponse_QanPostgresqlPgstatmonitorAgent
 	//	*AddAgentResponse_ValkeyExporter
 	//	*AddAgentResponse_RtaMongodbAgent
+	//	*AddAgentResponse_RtaPostgresqlAgent
 	Agent         isAddAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4468,7 +4646,7 @@ type AddAgentResponse struct {
 
 func (x *AddAgentResponse) Reset() {
 	*x = AddAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[28]
+	mi := &file_inventory_v1_agents_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4658,7 @@ func (x *AddAgentResponse) String() string {
 func (*AddAgentResponse) ProtoMessage() {}
 
 func (x *AddAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[28]
+	mi := &file_inventory_v1_agents_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4671,7 @@ func (x *AddAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAgentResponse.ProtoReflect.Descriptor instead.
 func (*AddAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{28}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AddAgentResponse) GetAgent() isAddAgentResponse_Agent {
@@ -4656,6 +4834,15 @@ func (x *AddAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *AddAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*AddAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isAddAgentResponse_Agent interface {
 	isAddAgentResponse_Agent()
 }
@@ -4728,6 +4915,10 @@ type AddAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,17,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type AddAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,18,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*AddAgentResponse_PmmAgent) isAddAgentResponse_Agent() {}
 
 func (*AddAgentResponse_NodeExporter) isAddAgentResponse_Agent() {}
@@ -4762,6 +4953,8 @@ func (*AddAgentResponse_ValkeyExporter) isAddAgentResponse_Agent() {}
 
 func (*AddAgentResponse_RtaMongodbAgent) isAddAgentResponse_Agent() {}
 
+func (*AddAgentResponse_RtaPostgresqlAgent) isAddAgentResponse_Agent() {}
+
 type ChangeAgentRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	AgentId string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
@@ -4784,6 +4977,7 @@ type ChangeAgentRequest struct {
 	//	*ChangeAgentRequest_NomadAgent
 	//	*ChangeAgentRequest_ValkeyExporter
 	//	*ChangeAgentRequest_RtaMongodbAgent
+	//	*ChangeAgentRequest_RtaPostgresqlAgent
 	Agent         isChangeAgentRequest_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4791,7 +4985,7 @@ type ChangeAgentRequest struct {
 
 func (x *ChangeAgentRequest) Reset() {
 	*x = ChangeAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[29]
+	mi := &file_inventory_v1_agents_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4803,7 +4997,7 @@ func (x *ChangeAgentRequest) String() string {
 func (*ChangeAgentRequest) ProtoMessage() {}
 
 func (x *ChangeAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[29]
+	mi := &file_inventory_v1_agents_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4816,7 +5010,7 @@ func (x *ChangeAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeAgentRequest.ProtoReflect.Descriptor instead.
 func (*ChangeAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{29}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ChangeAgentRequest) GetAgentId() string {
@@ -4986,6 +5180,15 @@ func (x *ChangeAgentRequest) GetRtaMongodbAgent() *ChangeRTAMongoDBAgentParams {
 	return nil
 }
 
+func (x *ChangeAgentRequest) GetRtaPostgresqlAgent() *ChangeRTAPostgreSQLAgentParams {
+	if x != nil {
+		if x, ok := x.Agent.(*ChangeAgentRequest_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isChangeAgentRequest_Agent interface {
 	isChangeAgentRequest_Agent()
 }
@@ -5058,6 +5261,10 @@ type ChangeAgentRequest_RtaMongodbAgent struct {
 	RtaMongodbAgent *ChangeRTAMongoDBAgentParams `protobuf:"bytes,18,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type ChangeAgentRequest_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *ChangeRTAPostgreSQLAgentParams `protobuf:"bytes,19,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*ChangeAgentRequest_NodeExporter) isChangeAgentRequest_Agent() {}
 
 func (*ChangeAgentRequest_MysqldExporter) isChangeAgentRequest_Agent() {}
@@ -5092,6 +5299,8 @@ func (*ChangeAgentRequest_ValkeyExporter) isChangeAgentRequest_Agent() {}
 
 func (*ChangeAgentRequest_RtaMongodbAgent) isChangeAgentRequest_Agent() {}
 
+func (*ChangeAgentRequest_RtaPostgresqlAgent) isChangeAgentRequest_Agent() {}
+
 type ChangeAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Agent:
@@ -5113,6 +5322,7 @@ type ChangeAgentResponse struct {
 	//	*ChangeAgentResponse_NomadAgent
 	//	*ChangeAgentResponse_ValkeyExporter
 	//	*ChangeAgentResponse_RtaMongodbAgent
+	//	*ChangeAgentResponse_RtaPostgresqlAgent
 	Agent         isChangeAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5120,7 +5330,7 @@ type ChangeAgentResponse struct {
 
 func (x *ChangeAgentResponse) Reset() {
 	*x = ChangeAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[30]
+	mi := &file_inventory_v1_agents_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5132,7 +5342,7 @@ func (x *ChangeAgentResponse) String() string {
 func (*ChangeAgentResponse) ProtoMessage() {}
 
 func (x *ChangeAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[30]
+	mi := &file_inventory_v1_agents_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5145,7 +5355,7 @@ func (x *ChangeAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeAgentResponse.ProtoReflect.Descriptor instead.
 func (*ChangeAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{30}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ChangeAgentResponse) GetAgent() isChangeAgentResponse_Agent {
@@ -5308,6 +5518,15 @@ func (x *ChangeAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *ChangeAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*ChangeAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isChangeAgentResponse_Agent interface {
 	isChangeAgentResponse_Agent()
 }
@@ -5380,6 +5599,10 @@ type ChangeAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,18,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type ChangeAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,19,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*ChangeAgentResponse_NodeExporter) isChangeAgentResponse_Agent() {}
 
 func (*ChangeAgentResponse_MysqldExporter) isChangeAgentResponse_Agent() {}
@@ -5414,6 +5637,8 @@ func (*ChangeAgentResponse_ValkeyExporter) isChangeAgentResponse_Agent() {}
 
 func (*ChangeAgentResponse_RtaMongodbAgent) isChangeAgentResponse_Agent() {}
 
+func (*ChangeAgentResponse_RtaPostgresqlAgent) isChangeAgentResponse_Agent() {}
+
 type AddPMMAgentParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Node identifier where this instance runs.
@@ -5426,7 +5651,7 @@ type AddPMMAgentParams struct {
 
 func (x *AddPMMAgentParams) Reset() {
 	*x = AddPMMAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[31]
+	mi := &file_inventory_v1_agents_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5438,7 +5663,7 @@ func (x *AddPMMAgentParams) String() string {
 func (*AddPMMAgentParams) ProtoMessage() {}
 
 func (x *AddPMMAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[31]
+	mi := &file_inventory_v1_agents_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5451,7 +5676,7 @@ func (x *AddPMMAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPMMAgentParams.ProtoReflect.Descriptor instead.
 func (*AddPMMAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{31}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *AddPMMAgentParams) GetRunsOnNodeId() string {
@@ -5488,7 +5713,7 @@ type AddNodeExporterParams struct {
 
 func (x *AddNodeExporterParams) Reset() {
 	*x = AddNodeExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[32]
+	mi := &file_inventory_v1_agents_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5500,7 +5725,7 @@ func (x *AddNodeExporterParams) String() string {
 func (*AddNodeExporterParams) ProtoMessage() {}
 
 func (x *AddNodeExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[32]
+	mi := &file_inventory_v1_agents_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5513,7 +5738,7 @@ func (x *AddNodeExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddNodeExporterParams.ProtoReflect.Descriptor instead.
 func (*AddNodeExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{32}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *AddNodeExporterParams) GetPmmAgentId() string {
@@ -5580,7 +5805,7 @@ type ChangeNodeExporterParams struct {
 
 func (x *ChangeNodeExporterParams) Reset() {
 	*x = ChangeNodeExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[33]
+	mi := &file_inventory_v1_agents_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5592,7 +5817,7 @@ func (x *ChangeNodeExporterParams) String() string {
 func (*ChangeNodeExporterParams) ProtoMessage() {}
 
 func (x *ChangeNodeExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[33]
+	mi := &file_inventory_v1_agents_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5605,7 +5830,7 @@ func (x *ChangeNodeExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeNodeExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeNodeExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{33}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ChangeNodeExporterParams) GetEnable() bool {
@@ -5705,7 +5930,7 @@ type AddMySQLdExporterParams struct {
 
 func (x *AddMySQLdExporterParams) Reset() {
 	*x = AddMySQLdExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[34]
+	mi := &file_inventory_v1_agents_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5717,7 +5942,7 @@ func (x *AddMySQLdExporterParams) String() string {
 func (*AddMySQLdExporterParams) ProtoMessage() {}
 
 func (x *AddMySQLdExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[34]
+	mi := &file_inventory_v1_agents_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5730,7 +5955,7 @@ func (x *AddMySQLdExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMySQLdExporterParams.ProtoReflect.Descriptor instead.
 func (*AddMySQLdExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{34}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *AddMySQLdExporterParams) GetPmmAgentId() string {
@@ -5910,7 +6135,7 @@ type ChangeMySQLdExporterParams struct {
 
 func (x *ChangeMySQLdExporterParams) Reset() {
 	*x = ChangeMySQLdExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[35]
+	mi := &file_inventory_v1_agents_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5922,7 +6147,7 @@ func (x *ChangeMySQLdExporterParams) String() string {
 func (*ChangeMySQLdExporterParams) ProtoMessage() {}
 
 func (x *ChangeMySQLdExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[35]
+	mi := &file_inventory_v1_agents_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5935,7 +6160,7 @@ func (x *ChangeMySQLdExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeMySQLdExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeMySQLdExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{35}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ChangeMySQLdExporterParams) GetEnable() bool {
@@ -6122,7 +6347,7 @@ type AddMongoDBExporterParams struct {
 
 func (x *AddMongoDBExporterParams) Reset() {
 	*x = AddMongoDBExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[36]
+	mi := &file_inventory_v1_agents_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6134,7 +6359,7 @@ func (x *AddMongoDBExporterParams) String() string {
 func (*AddMongoDBExporterParams) ProtoMessage() {}
 
 func (x *AddMongoDBExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[36]
+	mi := &file_inventory_v1_agents_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6147,7 +6372,7 @@ func (x *AddMongoDBExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMongoDBExporterParams.ProtoReflect.Descriptor instead.
 func (*AddMongoDBExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{36}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AddMongoDBExporterParams) GetPmmAgentId() string {
@@ -6363,7 +6588,7 @@ type ChangeMongoDBExporterParams struct {
 
 func (x *ChangeMongoDBExporterParams) Reset() {
 	*x = ChangeMongoDBExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[37]
+	mi := &file_inventory_v1_agents_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6375,7 +6600,7 @@ func (x *ChangeMongoDBExporterParams) String() string {
 func (*ChangeMongoDBExporterParams) ProtoMessage() {}
 
 func (x *ChangeMongoDBExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[37]
+	mi := &file_inventory_v1_agents_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6388,7 +6613,7 @@ func (x *ChangeMongoDBExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeMongoDBExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeMongoDBExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{37}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ChangeMongoDBExporterParams) GetEnable() bool {
@@ -6591,7 +6816,7 @@ type AddPostgresExporterParams struct {
 
 func (x *AddPostgresExporterParams) Reset() {
 	*x = AddPostgresExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[38]
+	mi := &file_inventory_v1_agents_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6603,7 +6828,7 @@ func (x *AddPostgresExporterParams) String() string {
 func (*AddPostgresExporterParams) ProtoMessage() {}
 
 func (x *AddPostgresExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[38]
+	mi := &file_inventory_v1_agents_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6616,7 +6841,7 @@ func (x *AddPostgresExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPostgresExporterParams.ProtoReflect.Descriptor instead.
 func (*AddPostgresExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{38}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *AddPostgresExporterParams) GetPmmAgentId() string {
@@ -6798,7 +7023,7 @@ type ChangePostgresExporterParams struct {
 
 func (x *ChangePostgresExporterParams) Reset() {
 	*x = ChangePostgresExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[39]
+	mi := &file_inventory_v1_agents_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6810,7 +7035,7 @@ func (x *ChangePostgresExporterParams) String() string {
 func (*ChangePostgresExporterParams) ProtoMessage() {}
 
 func (x *ChangePostgresExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[39]
+	mi := &file_inventory_v1_agents_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6823,7 +7048,7 @@ func (x *ChangePostgresExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangePostgresExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangePostgresExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{39}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ChangePostgresExporterParams) GetEnable() bool {
@@ -6995,7 +7220,7 @@ type AddProxySQLExporterParams struct {
 
 func (x *AddProxySQLExporterParams) Reset() {
 	*x = AddProxySQLExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[40]
+	mi := &file_inventory_v1_agents_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7007,7 +7232,7 @@ func (x *AddProxySQLExporterParams) String() string {
 func (*AddProxySQLExporterParams) ProtoMessage() {}
 
 func (x *AddProxySQLExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[40]
+	mi := &file_inventory_v1_agents_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7020,7 +7245,7 @@ func (x *AddProxySQLExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddProxySQLExporterParams.ProtoReflect.Descriptor instead.
 func (*AddProxySQLExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{40}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AddProxySQLExporterParams) GetPmmAgentId() string {
@@ -7155,7 +7380,7 @@ type ChangeProxySQLExporterParams struct {
 
 func (x *ChangeProxySQLExporterParams) Reset() {
 	*x = ChangeProxySQLExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[41]
+	mi := &file_inventory_v1_agents_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7167,7 +7392,7 @@ func (x *ChangeProxySQLExporterParams) String() string {
 func (*ChangeProxySQLExporterParams) ProtoMessage() {}
 
 func (x *ChangeProxySQLExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[41]
+	mi := &file_inventory_v1_agents_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7180,7 +7405,7 @@ func (x *ChangeProxySQLExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeProxySQLExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeProxySQLExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{41}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ChangeProxySQLExporterParams) GetEnable() bool {
@@ -7314,7 +7539,7 @@ type AddQANMySQLPerfSchemaAgentParams struct {
 
 func (x *AddQANMySQLPerfSchemaAgentParams) Reset() {
 	*x = AddQANMySQLPerfSchemaAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[42]
+	mi := &file_inventory_v1_agents_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7326,7 +7551,7 @@ func (x *AddQANMySQLPerfSchemaAgentParams) String() string {
 func (*AddQANMySQLPerfSchemaAgentParams) ProtoMessage() {}
 
 func (x *AddQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[42]
+	mi := &file_inventory_v1_agents_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7339,7 +7564,7 @@ func (x *AddQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMySQLPerfSchemaAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMySQLPerfSchemaAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{42}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *AddQANMySQLPerfSchemaAgentParams) GetPmmAgentId() string {
@@ -7494,7 +7719,7 @@ type ChangeQANMySQLPerfSchemaAgentParams struct {
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) Reset() {
 	*x = ChangeQANMySQLPerfSchemaAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[43]
+	mi := &file_inventory_v1_agents_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7506,7 +7731,7 @@ func (x *ChangeQANMySQLPerfSchemaAgentParams) String() string {
 func (*ChangeQANMySQLPerfSchemaAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[43]
+	mi := &file_inventory_v1_agents_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7519,7 +7744,7 @@ func (x *ChangeQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMySQLPerfSchemaAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMySQLPerfSchemaAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{43}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) GetEnable() bool {
@@ -7677,7 +7902,7 @@ type AddQANMySQLSlowlogAgentParams struct {
 
 func (x *AddQANMySQLSlowlogAgentParams) Reset() {
 	*x = AddQANMySQLSlowlogAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[44]
+	mi := &file_inventory_v1_agents_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7689,7 +7914,7 @@ func (x *AddQANMySQLSlowlogAgentParams) String() string {
 func (*AddQANMySQLSlowlogAgentParams) ProtoMessage() {}
 
 func (x *AddQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[44]
+	mi := &file_inventory_v1_agents_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7702,7 +7927,7 @@ func (x *AddQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMySQLSlowlogAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMySQLSlowlogAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{44}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AddQANMySQLSlowlogAgentParams) GetPmmAgentId() string {
@@ -7866,7 +8091,7 @@ type ChangeQANMySQLSlowlogAgentParams struct {
 
 func (x *ChangeQANMySQLSlowlogAgentParams) Reset() {
 	*x = ChangeQANMySQLSlowlogAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[45]
+	mi := &file_inventory_v1_agents_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7878,7 +8103,7 @@ func (x *ChangeQANMySQLSlowlogAgentParams) String() string {
 func (*ChangeQANMySQLSlowlogAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[45]
+	mi := &file_inventory_v1_agents_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7891,7 +8116,7 @@ func (x *ChangeQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeQANMySQLSlowlogAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMySQLSlowlogAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{45}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ChangeQANMySQLSlowlogAgentParams) GetEnable() bool {
@@ -8053,7 +8278,7 @@ type AddQANMongoDBProfilerAgentParams struct {
 
 func (x *AddQANMongoDBProfilerAgentParams) Reset() {
 	*x = AddQANMongoDBProfilerAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[46]
+	mi := &file_inventory_v1_agents_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8065,7 +8290,7 @@ func (x *AddQANMongoDBProfilerAgentParams) String() string {
 func (*AddQANMongoDBProfilerAgentParams) ProtoMessage() {}
 
 func (x *AddQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[46]
+	mi := &file_inventory_v1_agents_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8078,7 +8303,7 @@ func (x *AddQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMongoDBProfilerAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMongoDBProfilerAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{46}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AddQANMongoDBProfilerAgentParams) GetPmmAgentId() string {
@@ -8224,7 +8449,7 @@ type ChangeQANMongoDBProfilerAgentParams struct {
 
 func (x *ChangeQANMongoDBProfilerAgentParams) Reset() {
 	*x = ChangeQANMongoDBProfilerAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[47]
+	mi := &file_inventory_v1_agents_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8236,7 +8461,7 @@ func (x *ChangeQANMongoDBProfilerAgentParams) String() string {
 func (*ChangeQANMongoDBProfilerAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[47]
+	mi := &file_inventory_v1_agents_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8249,7 +8474,7 @@ func (x *ChangeQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMongoDBProfilerAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMongoDBProfilerAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{47}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ChangeQANMongoDBProfilerAgentParams) GetEnable() bool {
@@ -8397,7 +8622,7 @@ type AddQANMongoDBMongologAgentParams struct {
 
 func (x *AddQANMongoDBMongologAgentParams) Reset() {
 	*x = AddQANMongoDBMongologAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[48]
+	mi := &file_inventory_v1_agents_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8409,7 +8634,7 @@ func (x *AddQANMongoDBMongologAgentParams) String() string {
 func (*AddQANMongoDBMongologAgentParams) ProtoMessage() {}
 
 func (x *AddQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[48]
+	mi := &file_inventory_v1_agents_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8422,7 +8647,7 @@ func (x *AddQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMongoDBMongologAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMongoDBMongologAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{48}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AddQANMongoDBMongologAgentParams) GetPmmAgentId() string {
@@ -8568,7 +8793,7 @@ type ChangeQANMongoDBMongologAgentParams struct {
 
 func (x *ChangeQANMongoDBMongologAgentParams) Reset() {
 	*x = ChangeQANMongoDBMongologAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[49]
+	mi := &file_inventory_v1_agents_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8580,7 +8805,7 @@ func (x *ChangeQANMongoDBMongologAgentParams) String() string {
 func (*ChangeQANMongoDBMongologAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[49]
+	mi := &file_inventory_v1_agents_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8593,7 +8818,7 @@ func (x *ChangeQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMongoDBMongologAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMongoDBMongologAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{49}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ChangeQANMongoDBMongologAgentParams) GetEnable() bool {
@@ -8737,7 +8962,7 @@ type AddQANPostgreSQLPgStatementsAgentParams struct {
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) Reset() {
 	*x = AddQANPostgreSQLPgStatementsAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[50]
+	mi := &file_inventory_v1_agents_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8749,7 +8974,7 @@ func (x *AddQANPostgreSQLPgStatementsAgentParams) String() string {
 func (*AddQANPostgreSQLPgStatementsAgentParams) ProtoMessage() {}
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[50]
+	mi := &file_inventory_v1_agents_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8762,7 +8987,7 @@ func (x *AddQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use AddQANPostgreSQLPgStatementsAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANPostgreSQLPgStatementsAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{50}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) GetPmmAgentId() string {
@@ -8899,7 +9124,7 @@ type ChangeQANPostgreSQLPgStatementsAgentParams struct {
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) Reset() {
 	*x = ChangeQANPostgreSQLPgStatementsAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[51]
+	mi := &file_inventory_v1_agents_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8911,7 +9136,7 @@ func (x *ChangeQANPostgreSQLPgStatementsAgentParams) String() string {
 func (*ChangeQANPostgreSQLPgStatementsAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[51]
+	mi := &file_inventory_v1_agents_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8924,7 +9149,7 @@ func (x *ChangeQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect
 
 // Deprecated: Use ChangeQANPostgreSQLPgStatementsAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANPostgreSQLPgStatementsAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{51}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) GetEnable() bool {
@@ -9063,7 +9288,7 @@ type AddQANPostgreSQLPgStatMonitorAgentParams struct {
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) Reset() {
 	*x = AddQANPostgreSQLPgStatMonitorAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[52]
+	mi := &file_inventory_v1_agents_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9075,7 +9300,7 @@ func (x *AddQANPostgreSQLPgStatMonitorAgentParams) String() string {
 func (*AddQANPostgreSQLPgStatMonitorAgentParams) ProtoMessage() {}
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[52]
+	mi := &file_inventory_v1_agents_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9088,7 +9313,7 @@ func (x *AddQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.M
 
 // Deprecated: Use AddQANPostgreSQLPgStatMonitorAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANPostgreSQLPgStatMonitorAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{52}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) GetPmmAgentId() string {
@@ -9234,7 +9459,7 @@ type ChangeQANPostgreSQLPgStatMonitorAgentParams struct {
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) Reset() {
 	*x = ChangeQANPostgreSQLPgStatMonitorAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[53]
+	mi := &file_inventory_v1_agents_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9246,7 +9471,7 @@ func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) String() string {
 func (*ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[53]
+	mi := &file_inventory_v1_agents_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9259,7 +9484,7 @@ func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflec
 
 // Deprecated: Use ChangeQANPostgreSQLPgStatMonitorAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANPostgreSQLPgStatMonitorAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{53}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) GetEnable() bool {
@@ -9395,7 +9620,7 @@ type AddRDSExporterParams struct {
 
 func (x *AddRDSExporterParams) Reset() {
 	*x = AddRDSExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[54]
+	mi := &file_inventory_v1_agents_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9407,7 +9632,7 @@ func (x *AddRDSExporterParams) String() string {
 func (*AddRDSExporterParams) ProtoMessage() {}
 
 func (x *AddRDSExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[54]
+	mi := &file_inventory_v1_agents_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9420,7 +9645,7 @@ func (x *AddRDSExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRDSExporterParams.ProtoReflect.Descriptor instead.
 func (*AddRDSExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{54}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AddRDSExporterParams) GetPmmAgentId() string {
@@ -9519,7 +9744,7 @@ type ChangeRDSExporterParams struct {
 
 func (x *ChangeRDSExporterParams) Reset() {
 	*x = ChangeRDSExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[55]
+	mi := &file_inventory_v1_agents_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9531,7 +9756,7 @@ func (x *ChangeRDSExporterParams) String() string {
 func (*ChangeRDSExporterParams) ProtoMessage() {}
 
 func (x *ChangeRDSExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[55]
+	mi := &file_inventory_v1_agents_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9544,7 +9769,7 @@ func (x *ChangeRDSExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRDSExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeRDSExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{55}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ChangeRDSExporterParams) GetEnable() bool {
@@ -9638,7 +9863,7 @@ type AddExternalExporterParams struct {
 
 func (x *AddExternalExporterParams) Reset() {
 	*x = AddExternalExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[56]
+	mi := &file_inventory_v1_agents_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9650,7 +9875,7 @@ func (x *AddExternalExporterParams) String() string {
 func (*AddExternalExporterParams) ProtoMessage() {}
 
 func (x *AddExternalExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[56]
+	mi := &file_inventory_v1_agents_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9663,7 +9888,7 @@ func (x *AddExternalExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddExternalExporterParams.ProtoReflect.Descriptor instead.
 func (*AddExternalExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{56}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *AddExternalExporterParams) GetRunsOnNodeId() string {
@@ -9760,7 +9985,7 @@ type ChangeExternalExporterParams struct {
 
 func (x *ChangeExternalExporterParams) Reset() {
 	*x = ChangeExternalExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[57]
+	mi := &file_inventory_v1_agents_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9772,7 +9997,7 @@ func (x *ChangeExternalExporterParams) String() string {
 func (*ChangeExternalExporterParams) ProtoMessage() {}
 
 func (x *ChangeExternalExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[57]
+	mi := &file_inventory_v1_agents_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9785,7 +10010,7 @@ func (x *ChangeExternalExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeExternalExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeExternalExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{57}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ChangeExternalExporterParams) GetEnable() bool {
@@ -9876,7 +10101,7 @@ type AddAzureDatabaseExporterParams struct {
 
 func (x *AddAzureDatabaseExporterParams) Reset() {
 	*x = AddAzureDatabaseExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[58]
+	mi := &file_inventory_v1_agents_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9888,7 +10113,7 @@ func (x *AddAzureDatabaseExporterParams) String() string {
 func (*AddAzureDatabaseExporterParams) ProtoMessage() {}
 
 func (x *AddAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[58]
+	mi := &file_inventory_v1_agents_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9901,7 +10126,7 @@ func (x *AddAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAzureDatabaseExporterParams.ProtoReflect.Descriptor instead.
 func (*AddAzureDatabaseExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{58}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *AddAzureDatabaseExporterParams) GetPmmAgentId() string {
@@ -10016,7 +10241,7 @@ type ChangeAzureDatabaseExporterParams struct {
 
 func (x *ChangeAzureDatabaseExporterParams) Reset() {
 	*x = ChangeAzureDatabaseExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[59]
+	mi := &file_inventory_v1_agents_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10028,7 +10253,7 @@ func (x *ChangeAzureDatabaseExporterParams) String() string {
 func (*ChangeAzureDatabaseExporterParams) ProtoMessage() {}
 
 func (x *ChangeAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[59]
+	mi := &file_inventory_v1_agents_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10041,7 +10266,7 @@ func (x *ChangeAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ChangeAzureDatabaseExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeAzureDatabaseExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{59}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ChangeAzureDatabaseExporterParams) GetEnable() bool {
@@ -10124,7 +10349,7 @@ type ChangeNomadAgentParams struct {
 
 func (x *ChangeNomadAgentParams) Reset() {
 	*x = ChangeNomadAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[60]
+	mi := &file_inventory_v1_agents_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10136,7 +10361,7 @@ func (x *ChangeNomadAgentParams) String() string {
 func (*ChangeNomadAgentParams) ProtoMessage() {}
 
 func (x *ChangeNomadAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[60]
+	mi := &file_inventory_v1_agents_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10149,7 +10374,7 @@ func (x *ChangeNomadAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeNomadAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeNomadAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{60}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ChangeNomadAgentParams) GetEnable() bool {
@@ -10201,7 +10426,7 @@ type AddValkeyExporterParams struct {
 
 func (x *AddValkeyExporterParams) Reset() {
 	*x = AddValkeyExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[61]
+	mi := &file_inventory_v1_agents_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10213,7 +10438,7 @@ func (x *AddValkeyExporterParams) String() string {
 func (*AddValkeyExporterParams) ProtoMessage() {}
 
 func (x *AddValkeyExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[61]
+	mi := &file_inventory_v1_agents_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10226,7 +10451,7 @@ func (x *AddValkeyExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddValkeyExporterParams.ProtoReflect.Descriptor instead.
 func (*AddValkeyExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{61}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *AddValkeyExporterParams) GetPmmAgentId() string {
@@ -10388,7 +10613,7 @@ type ChangeValkeyExporterParams struct {
 
 func (x *ChangeValkeyExporterParams) Reset() {
 	*x = ChangeValkeyExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[62]
+	mi := &file_inventory_v1_agents_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10400,7 +10625,7 @@ func (x *ChangeValkeyExporterParams) String() string {
 func (*ChangeValkeyExporterParams) ProtoMessage() {}
 
 func (x *ChangeValkeyExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[62]
+	mi := &file_inventory_v1_agents_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10413,7 +10638,7 @@ func (x *ChangeValkeyExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeValkeyExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeValkeyExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{62}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ChangeValkeyExporterParams) GetEnable() bool {
@@ -10567,7 +10792,7 @@ type AddRTAMongoDBAgentParams struct {
 
 func (x *AddRTAMongoDBAgentParams) Reset() {
 	*x = AddRTAMongoDBAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[63]
+	mi := &file_inventory_v1_agents_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10579,7 +10804,7 @@ func (x *AddRTAMongoDBAgentParams) String() string {
 func (*AddRTAMongoDBAgentParams) ProtoMessage() {}
 
 func (x *AddRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[63]
+	mi := &file_inventory_v1_agents_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10592,7 +10817,7 @@ func (x *AddRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRTAMongoDBAgentParams.ProtoReflect.Descriptor instead.
 func (*AddRTAMongoDBAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{63}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *AddRTAMongoDBAgentParams) GetPmmAgentId() string {
@@ -10725,7 +10950,7 @@ type ChangeRTAMongoDBAgentParams struct {
 
 func (x *ChangeRTAMongoDBAgentParams) Reset() {
 	*x = ChangeRTAMongoDBAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[64]
+	mi := &file_inventory_v1_agents_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10737,7 +10962,7 @@ func (x *ChangeRTAMongoDBAgentParams) String() string {
 func (*ChangeRTAMongoDBAgentParams) ProtoMessage() {}
 
 func (x *ChangeRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[64]
+	mi := &file_inventory_v1_agents_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10750,7 +10975,7 @@ func (x *ChangeRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRTAMongoDBAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeRTAMongoDBAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{64}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ChangeRTAMongoDBAgentParams) GetEnable() bool {
@@ -10837,6 +11062,294 @@ func (x *ChangeRTAMongoDBAgentParams) GetRtaOptions() *RTAOptions {
 	return nil
 }
 
+type AddRTAPostgreSQLAgentParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The pmm-agent identifier which runs this instance.
+	PmmAgentId string `protobuf:"bytes,1,opt,name=pmm_agent_id,json=pmmAgentId,proto3" json:"pmm_agent_id,omitempty"`
+	// Service identifier.
+	ServiceId string `protobuf:"bytes,2,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
+	// PostgreSQL password for getting session data.
+	Password string `protobuf:"bytes,4,opt,name=password,proto3" json:"password,omitempty"`
+	// Custom user-assigned labels.
+	CustomLabels map[string]string `protobuf:"bytes,5,rep,name=custom_labels,json=customLabels,proto3" json:"custom_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Log level for agent.
+	LogLevel LogLevel `protobuf:"varint,6,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel" json:"log_level,omitempty"`
+	// Use TLS for database connections.
+	Tls bool `protobuf:"varint,7,opt,name=tls,proto3" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify bool `protobuf:"varint,8,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3" json:"tls_skip_verify,omitempty"`
+	// TLS CA certificate.
+	TlsCa string `protobuf:"bytes,9,opt,name=tls_ca,json=tlsCa,proto3" json:"tls_ca,omitempty"`
+	// TLS certificate.
+	TlsCert string `protobuf:"bytes,10,opt,name=tls_cert,json=tlsCert,proto3" json:"tls_cert,omitempty"`
+	// TLS certificate key.
+	TlsKey string `protobuf:"bytes,11,opt,name=tls_key,json=tlsKey,proto3" json:"tls_key,omitempty"`
+	// Skip connection check.
+	SkipConnectionCheck bool `protobuf:"varint,12,opt,name=skip_connection_check,json=skipConnectionCheck,proto3" json:"skip_connection_check,omitempty"`
+	// Real-Time Analytics options.
+	RtaOptions    *RTAOptions `protobuf:"bytes,13,opt,name=rta_options,json=rtaOptions,proto3" json:"rta_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddRTAPostgreSQLAgentParams) Reset() {
+	*x = AddRTAPostgreSQLAgentParams{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddRTAPostgreSQLAgentParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddRTAPostgreSQLAgentParams) ProtoMessage() {}
+
+func (x *AddRTAPostgreSQLAgentParams) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddRTAPostgreSQLAgentParams.ProtoReflect.Descriptor instead.
+func (*AddRTAPostgreSQLAgentParams) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetPmmAgentId() string {
+	if x != nil {
+		return x.PmmAgentId
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetPassword() string {
+	if x != nil {
+		return x.Password
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetCustomLabels() map[string]string {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetLogLevel() LogLevel {
+	if x != nil {
+		return x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTls() bool {
+	if x != nil {
+		return x.Tls
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsSkipVerify() bool {
+	if x != nil {
+		return x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsCa() string {
+	if x != nil {
+		return x.TlsCa
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsCert() string {
+	if x != nil {
+		return x.TlsCert
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsKey() string {
+	if x != nil {
+		return x.TlsKey
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetSkipConnectionCheck() bool {
+	if x != nil {
+		return x.SkipConnectionCheck
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
+type ChangeRTAPostgreSQLAgentParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Enable this Agent. Agents are enabled by default when they get added.
+	Enable *bool `protobuf:"varint,1,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
+	// Replace all custom user-assigned labels.
+	CustomLabels *common.StringMap `protobuf:"bytes,2,opt,name=custom_labels,json=customLabels,proto3,oneof" json:"custom_labels,omitempty"`
+	// Log level for agent.
+	LogLevel *LogLevel `protobuf:"varint,3,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel,oneof" json:"log_level,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username *string `protobuf:"bytes,4,opt,name=username,proto3,oneof" json:"username,omitempty"`
+	// PostgreSQL password for getting session data.
+	Password *string `protobuf:"bytes,5,opt,name=password,proto3,oneof" json:"password,omitempty"`
+	// Use TLS for database connections.
+	Tls *bool `protobuf:"varint,6,opt,name=tls,proto3,oneof" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify *bool `protobuf:"varint,7,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3,oneof" json:"tls_skip_verify,omitempty"`
+	// TLS CA certificate.
+	TlsCa *string `protobuf:"bytes,8,opt,name=tls_ca,json=tlsCa,proto3,oneof" json:"tls_ca,omitempty"`
+	// TLS certificate.
+	TlsCert *string `protobuf:"bytes,9,opt,name=tls_cert,json=tlsCert,proto3,oneof" json:"tls_cert,omitempty"`
+	// TLS certificate key.
+	TlsKey *string `protobuf:"bytes,10,opt,name=tls_key,json=tlsKey,proto3,oneof" json:"tls_key,omitempty"`
+	// Real-Time Analytics options.
+	RtaOptions    *RTAOptions `protobuf:"bytes,11,opt,name=rta_options,json=rtaOptions,proto3,oneof" json:"rta_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) Reset() {
+	*x = ChangeRTAPostgreSQLAgentParams{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChangeRTAPostgreSQLAgentParams) ProtoMessage() {}
+
+func (x *ChangeRTAPostgreSQLAgentParams) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChangeRTAPostgreSQLAgentParams.ProtoReflect.Descriptor instead.
+func (*ChangeRTAPostgreSQLAgentParams) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetEnable() bool {
+	if x != nil && x.Enable != nil {
+		return *x.Enable
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetCustomLabels() *common.StringMap {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetLogLevel() LogLevel {
+	if x != nil && x.LogLevel != nil {
+		return *x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetUsername() string {
+	if x != nil && x.Username != nil {
+		return *x.Username
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetPassword() string {
+	if x != nil && x.Password != nil {
+		return *x.Password
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTls() bool {
+	if x != nil && x.Tls != nil {
+		return *x.Tls
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsSkipVerify() bool {
+	if x != nil && x.TlsSkipVerify != nil {
+		return *x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsCa() string {
+	if x != nil && x.TlsCa != nil {
+		return *x.TlsCa
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsCert() string {
+	if x != nil && x.TlsCert != nil {
+		return *x.TlsCert
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsKey() string {
+	if x != nil && x.TlsKey != nil {
+		return *x.TlsKey
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
 type RemoveAgentRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	AgentId string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
@@ -10848,7 +11361,7 @@ type RemoveAgentRequest struct {
 
 func (x *RemoveAgentRequest) Reset() {
 	*x = RemoveAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[65]
+	mi := &file_inventory_v1_agents_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10860,7 +11373,7 @@ func (x *RemoveAgentRequest) String() string {
 func (*RemoveAgentRequest) ProtoMessage() {}
 
 func (x *RemoveAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[65]
+	mi := &file_inventory_v1_agents_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10873,7 +11386,7 @@ func (x *RemoveAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAgentRequest.ProtoReflect.Descriptor instead.
 func (*RemoveAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{65}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RemoveAgentRequest) GetAgentId() string {
@@ -10898,7 +11411,7 @@ type RemoveAgentResponse struct {
 
 func (x *RemoveAgentResponse) Reset() {
 	*x = RemoveAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	mi := &file_inventory_v1_agents_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10910,7 +11423,7 @@ func (x *RemoveAgentResponse) String() string {
 func (*RemoveAgentResponse) ProtoMessage() {}
 
 func (x *RemoveAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	mi := &file_inventory_v1_agents_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10923,7 +11436,7 @@ func (x *RemoveAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAgentResponse.ProtoReflect.Descriptor instead.
 func (*RemoveAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{66}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{69}
 }
 
 var File_inventory_v1_agents_proto protoreflect.FileDescriptor
@@ -11219,7 +11732,26 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\n" +
 	"RTAOptions\x12P\n" +
 	"\x10collect_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationB\n" +
-	"\xfaB\a\xaa\x01\x042\x02\b\x01R\x0fcollectInterval\"\x9f\x04\n" +
+	"\xfaB\a\xaa\x01\x042\x02\b\x01R\x0fcollectInterval\"\xa5\x04\n" +
+	"\x12RTAPostgreSQLAgent\x12\x19\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12 \n" +
+	"\fpmm_agent_id\x18\x02 \x01(\tR\n" +
+	"pmmAgentId\x12\x1a\n" +
+	"\bdisabled\x18\x03 \x01(\bR\bdisabled\x12\x1d\n" +
+	"\n" +
+	"service_id\x18\x04 \x01(\tR\tserviceId\x12 \n" +
+	"\busername\x18\x05 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12\x10\n" +
+	"\x03tls\x18\x06 \x01(\bR\x03tls\x12&\n" +
+	"\x0ftls_skip_verify\x18\a \x01(\bR\rtlsSkipVerify\x12W\n" +
+	"\rcustom_labels\x18\b \x03(\v22.inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntryR\fcustomLabels\x129\n" +
+	"\vrta_options\x18\t \x01(\v2\x18.inventory.v1.RTAOptionsR\n" +
+	"rtaOptions\x121\n" +
+	"\x06status\x18\n" +
+	" \x01(\x0e2\x19.inventory.v1.AgentStatusR\x06status\x123\n" +
+	"\tlog_level\x18\v \x01(\x0e2\x16.inventory.v1.LogLevelR\blogLevel\x1a?\n" +
+	"\x11CustomLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9f\x04\n" +
 	"\x0fRTAMongoDBAgent\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12 \n" +
 	"\fpmm_agent_id\x18\x02 \x01(\tR\n" +
@@ -11358,7 +11890,7 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\n" +
 	"service_id\x18\x03 \x01(\tR\tserviceId\x126\n" +
 	"\n" +
-	"agent_type\x18\x04 \x01(\x0e2\x17.inventory.v1.AgentTypeR\tagentType\"\x98\f\n" +
+	"agent_type\x18\x04 \x01(\x0e2\x17.inventory.v1.AgentTypeR\tagentType\"\xec\f\n" +
 	"\x12ListAgentsResponse\x123\n" +
 	"\tpmm_agent\x18\x01 \x03(\v2\x16.inventory.v1.PMMAgentR\bpmmAgent\x120\n" +
 	"\bvm_agent\x18\x02 \x03(\v2\x15.inventory.v1.VMAgentR\avmAgent\x12?\n" +
@@ -11380,9 +11912,10 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x10 \x03(\v2\x18.inventory.v1.NomadAgentR\n" +
 	"nomadAgent\x12E\n" +
 	"\x0fvalkey_exporter\x18\x11 \x03(\v2\x1c.inventory.v1.ValkeyExporterR\x0evalkeyExporter\x12I\n" +
-	"\x11rta_mongodb_agent\x18\x13 \x03(\v2\x1d.inventory.v1.RTAMongoDBAgentR\x0frtaMongodbAgent\"5\n" +
+	"\x11rta_mongodb_agent\x18\x13 \x03(\v2\x1d.inventory.v1.RTAMongoDBAgentR\x0frtaMongodbAgent\x12R\n" +
+	"\x14rta_postgresql_agent\x18\x14 \x03(\v2 .inventory.v1.RTAPostgreSQLAgentR\x12rtaPostgresqlAgent\"5\n" +
 	"\x0fGetAgentRequest\x12\"\n" +
-	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\"\xc4\f\n" +
+	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\"\x9a\r\n" +
 	"\x10GetAgentResponse\x125\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x16.inventory.v1.PMMAgentH\x00R\bpmmAgent\x121\n" +
 	"\avmagent\x18\x02 \x01(\v2\x15.inventory.v1.VMAgentH\x00R\avmagent\x12A\n" +
@@ -11404,14 +11937,15 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x10 \x01(\v2\x18.inventory.v1.NomadAgentH\x00R\n" +
 	"nomadAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x11 \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x13 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
+	"\x11rta_mongodb_agent\x18\x13 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x14 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
 	"\x05agent\"O\n" +
 	"\x13GetAgentLogsRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\rR\x05limit\"j\n" +
 	"\x14GetAgentLogsResponse\x12\x12\n" +
 	"\x04logs\x18\x01 \x03(\tR\x04logs\x12>\n" +
-	"\x1cagent_config_log_lines_count\x18\x02 \x01(\rR\x18agentConfigLogLinesCount\"\xee\f\n" +
+	"\x1cagent_config_log_lines_count\x18\x02 \x01(\rR\x18agentConfigLogLinesCount\"\xcd\r\n" +
 	"\x0fAddAgentRequest\x12>\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x1f.inventory.v1.AddPMMAgentParamsH\x00R\bpmmAgent\x12J\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2#.inventory.v1.AddNodeExporterParamsH\x00R\fnodeExporter\x12P\n" +
@@ -11430,8 +11964,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"!qan_postgresql_pgstatements_agent\x18\r \x01(\v25.inventory.v1.AddQANPostgreSQLPgStatementsAgentParamsH\x00R\x1eqanPostgresqlPgstatementsAgent\x12\x85\x01\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x0e \x01(\v26.inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParamsH\x00R\x1fqanPostgresqlPgstatmonitorAgent\x12P\n" +
 	"\x0fvalkey_exporter\x18\x0f \x01(\v2%.inventory.v1.AddValkeyExporterParamsH\x00R\x0evalkeyExporter\x12T\n" +
-	"\x11rta_mongodb_agent\x18\x11 \x01(\v2&.inventory.v1.AddRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xd4\v\n" +
+	"\x11rta_mongodb_agent\x18\x11 \x01(\v2&.inventory.v1.AddRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgent\x12]\n" +
+	"\x14rta_postgresql_agent\x18\x12 \x01(\v2).inventory.v1.AddRTAPostgreSQLAgentParamsH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xaa\f\n" +
 	"\x10AddAgentResponse\x125\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x16.inventory.v1.PMMAgentH\x00R\bpmmAgent\x12A\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2\x1a.inventory.v1.NodeExporterH\x00R\fnodeExporter\x12G\n" +
@@ -11450,8 +11985,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"!qan_postgresql_pgstatements_agent\x18\r \x01(\v2,.inventory.v1.QANPostgreSQLPgStatementsAgentH\x00R\x1eqanPostgresqlPgstatementsAgent\x12|\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x0e \x01(\v2-.inventory.v1.QANPostgreSQLPgStatMonitorAgentH\x00R\x1fqanPostgresqlPgstatmonitorAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x0f \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x11 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xce\r\n" +
+	"\x11rta_mongodb_agent\x18\x11 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x12 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xb0\x0e\n" +
 	"\x12ChangeAgentRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aagentId\x12M\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2&.inventory.v1.ChangeNodeExporterParamsH\x00R\fnodeExporter\x12S\n" +
@@ -11472,8 +12008,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x0f \x01(\v2$.inventory.v1.ChangeNomadAgentParamsH\x00R\n" +
 	"nomadAgent\x12S\n" +
 	"\x0fvalkey_exporter\x18\x10 \x01(\v2(.inventory.v1.ChangeValkeyExporterParamsH\x00R\x0evalkeyExporter\x12W\n" +
-	"\x11rta_mongodb_agent\x18\x12 \x01(\v2).inventory.v1.ChangeRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xdd\v\n" +
+	"\x11rta_mongodb_agent\x18\x12 \x01(\v2).inventory.v1.ChangeRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgent\x12`\n" +
+	"\x14rta_postgresql_agent\x18\x13 \x01(\v2,.inventory.v1.ChangeRTAPostgreSQLAgentParamsH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xb3\f\n" +
 	"\x13ChangeAgentResponse\x12A\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2\x1a.inventory.v1.NodeExporterH\x00R\fnodeExporter\x12G\n" +
 	"\x0fmysqld_exporter\x18\x03 \x01(\v2\x1c.inventory.v1.MySQLdExporterH\x00R\x0emysqldExporter\x12J\n" +
@@ -11493,7 +12030,8 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x0f \x01(\v2\x18.inventory.v1.NomadAgentH\x00R\n" +
 	"nomadAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x10 \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x12 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
+	"\x11rta_mongodb_agent\x18\x12 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x13 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
 	"\x05agent\"\xdc\x01\n" +
 	"\x11AddPMMAgentParams\x12.\n" +
 	"\x0fruns_on_node_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\frunsOnNodeId\x12V\n" +
@@ -12345,11 +12883,60 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\"_tls_certificate_key_file_passwordB\t\n" +
 	"\a_tls_caB\x1b\n" +
 	"\x19_authentication_mechanismB\x0e\n" +
+	"\f_rta_options\"\x8c\x05\n" +
+	"\x1bAddRTAPostgreSQLAgentParams\x12)\n" +
+	"\fpmm_agent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\n" +
+	"pmmAgentId\x12&\n" +
+	"\n" +
+	"service_id\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\tserviceId\x12 \n" +
+	"\busername\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12 \n" +
+	"\bpassword\x18\x04 \x01(\tB\x04\x88\xb5\x18\x01R\bpassword\x12`\n" +
+	"\rcustom_labels\x18\x05 \x03(\v2;.inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntryR\fcustomLabels\x123\n" +
+	"\tlog_level\x18\x06 \x01(\x0e2\x16.inventory.v1.LogLevelR\blogLevel\x12\x10\n" +
+	"\x03tls\x18\a \x01(\bR\x03tls\x12&\n" +
+	"\x0ftls_skip_verify\x18\b \x01(\bR\rtlsSkipVerify\x12\x15\n" +
+	"\x06tls_ca\x18\t \x01(\tR\x05tlsCa\x12\x1f\n" +
+	"\btls_cert\x18\n" +
+	" \x01(\tB\x04\x88\xb5\x18\x01R\atlsCert\x12\x1d\n" +
+	"\atls_key\x18\v \x01(\tB\x04\x88\xb5\x18\x01R\x06tlsKey\x122\n" +
+	"\x15skip_connection_check\x18\f \x01(\bR\x13skipConnectionCheck\x129\n" +
+	"\vrta_options\x18\r \x01(\v2\x18.inventory.v1.RTAOptionsR\n" +
+	"rtaOptions\x1a?\n" +
+	"\x11CustomLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x05\n" +
+	"\x1eChangeRTAPostgreSQLAgentParams\x12\x1b\n" +
+	"\x06enable\x18\x01 \x01(\bH\x00R\x06enable\x88\x01\x01\x12;\n" +
+	"\rcustom_labels\x18\x02 \x01(\v2\x11.common.StringMapH\x01R\fcustomLabels\x88\x01\x01\x128\n" +
+	"\tlog_level\x18\x03 \x01(\x0e2\x16.inventory.v1.LogLevelH\x02R\blogLevel\x88\x01\x01\x12%\n" +
+	"\busername\x18\x04 \x01(\tB\x04\x88\xb5\x18\x01H\x03R\busername\x88\x01\x01\x12%\n" +
+	"\bpassword\x18\x05 \x01(\tB\x04\x88\xb5\x18\x01H\x04R\bpassword\x88\x01\x01\x12\x15\n" +
+	"\x03tls\x18\x06 \x01(\bH\x05R\x03tls\x88\x01\x01\x12+\n" +
+	"\x0ftls_skip_verify\x18\a \x01(\bH\x06R\rtlsSkipVerify\x88\x01\x01\x12\x1a\n" +
+	"\x06tls_ca\x18\b \x01(\tH\aR\x05tlsCa\x88\x01\x01\x12$\n" +
+	"\btls_cert\x18\t \x01(\tB\x04\x88\xb5\x18\x01H\bR\atlsCert\x88\x01\x01\x12\"\n" +
+	"\atls_key\x18\n" +
+	" \x01(\tB\x04\x88\xb5\x18\x01H\tR\x06tlsKey\x88\x01\x01\x12>\n" +
+	"\vrta_options\x18\v \x01(\v2\x18.inventory.v1.RTAOptionsH\n" +
+	"R\n" +
+	"rtaOptions\x88\x01\x01B\t\n" +
+	"\a_enableB\x10\n" +
+	"\x0e_custom_labelsB\f\n" +
+	"\n" +
+	"_log_levelB\v\n" +
+	"\t_usernameB\v\n" +
+	"\t_passwordB\x06\n" +
+	"\x04_tlsB\x12\n" +
+	"\x10_tls_skip_verifyB\t\n" +
+	"\a_tls_caB\v\n" +
+	"\t_tls_certB\n" +
+	"\n" +
+	"\b_tls_keyB\x0e\n" +
 	"\f_rta_options\"N\n" +
 	"\x12RemoveAgentRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aagentId\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\"\x15\n" +
-	"\x13RemoveAgentResponse*\xd0\x05\n" +
+	"\x13RemoveAgentResponse*\xf5\x05\n" +
 	"\tAgentType\x12\x1a\n" +
 	"\x16AGENT_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14AGENT_TYPE_PMM_AGENT\x10\x01\x12\x17\n" +
@@ -12371,7 +12958,8 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\x17AGENT_TYPE_RDS_EXPORTER\x10\v\x12&\n" +
 	"\"AGENT_TYPE_AZURE_DATABASE_EXPORTER\x10\x0f\x12\x1a\n" +
 	"\x16AGENT_TYPE_NOMAD_AGENT\x10\x10\x12 \n" +
-	"\x1cAGENT_TYPE_RTA_MONGODB_AGENT\x10\x132\x83\t\n" +
+	"\x1cAGENT_TYPE_RTA_MONGODB_AGENT\x10\x13\x12#\n" +
+	"\x1fAGENT_TYPE_RTA_POSTGRESQL_AGENT\x10\x142\x83\t\n" +
 	"\rAgentsService\x12\x9c\x01\n" +
 	"\n" +
 	"ListAgents\x12\x1f.inventory.v1.ListAgentsRequest\x1a .inventory.v1.ListAgentsResponse\"K\x92A,\x12\vList Agents\x1a\x1dReturns a list of all Agents.\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/inventory/agents\x12\x9f\x01\n" +
@@ -12394,414 +12982,432 @@ func file_inventory_v1_agents_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_agents_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_agents_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_agents_proto_msgTypes  = make([]protoimpl.MessageInfo, 107)
-	file_inventory_v1_agents_proto_goTypes   = []any{
-		AgentType(0),                                        // 0: inventory.v1.AgentType
-		(*PMMAgent)(nil),                                    // 1: inventory.v1.PMMAgent
-		(*VMAgent)(nil),                                     // 2: inventory.v1.VMAgent
-		(*NomadAgent)(nil),                                  // 3: inventory.v1.NomadAgent
-		(*NodeExporter)(nil),                                // 4: inventory.v1.NodeExporter
-		(*MySQLdExporter)(nil),                              // 5: inventory.v1.MySQLdExporter
-		(*MongoDBExporter)(nil),                             // 6: inventory.v1.MongoDBExporter
-		(*PostgresExporter)(nil),                            // 7: inventory.v1.PostgresExporter
-		(*ProxySQLExporter)(nil),                            // 8: inventory.v1.ProxySQLExporter
-		(*ValkeyExporter)(nil),                              // 9: inventory.v1.ValkeyExporter
-		(*QANMySQLPerfSchemaAgent)(nil),                     // 10: inventory.v1.QANMySQLPerfSchemaAgent
-		(*QANMySQLSlowlogAgent)(nil),                        // 11: inventory.v1.QANMySQLSlowlogAgent
-		(*QANMongoDBProfilerAgent)(nil),                     // 12: inventory.v1.QANMongoDBProfilerAgent
-		(*QANMongoDBMongologAgent)(nil),                     // 13: inventory.v1.QANMongoDBMongologAgent
-		(*RTAOptions)(nil),                                  // 14: inventory.v1.RTAOptions
-		(*RTAMongoDBAgent)(nil),                             // 15: inventory.v1.RTAMongoDBAgent
-		(*QANPostgreSQLPgStatementsAgent)(nil),              // 16: inventory.v1.QANPostgreSQLPgStatementsAgent
-		(*QANPostgreSQLPgStatMonitorAgent)(nil),             // 17: inventory.v1.QANPostgreSQLPgStatMonitorAgent
-		(*RDSExporter)(nil),                                 // 18: inventory.v1.RDSExporter
-		(*ExternalExporter)(nil),                            // 19: inventory.v1.ExternalExporter
-		(*AzureDatabaseExporter)(nil),                       // 20: inventory.v1.AzureDatabaseExporter
-		(*ChangeCommonAgentParams)(nil),                     // 21: inventory.v1.ChangeCommonAgentParams
-		(*ListAgentsRequest)(nil),                           // 22: inventory.v1.ListAgentsRequest
-		(*ListAgentsResponse)(nil),                          // 23: inventory.v1.ListAgentsResponse
-		(*GetAgentRequest)(nil),                             // 24: inventory.v1.GetAgentRequest
-		(*GetAgentResponse)(nil),                            // 25: inventory.v1.GetAgentResponse
-		(*GetAgentLogsRequest)(nil),                         // 26: inventory.v1.GetAgentLogsRequest
-		(*GetAgentLogsResponse)(nil),                        // 27: inventory.v1.GetAgentLogsResponse
-		(*AddAgentRequest)(nil),                             // 28: inventory.v1.AddAgentRequest
-		(*AddAgentResponse)(nil),                            // 29: inventory.v1.AddAgentResponse
-		(*ChangeAgentRequest)(nil),                          // 30: inventory.v1.ChangeAgentRequest
-		(*ChangeAgentResponse)(nil),                         // 31: inventory.v1.ChangeAgentResponse
-		(*AddPMMAgentParams)(nil),                           // 32: inventory.v1.AddPMMAgentParams
-		(*AddNodeExporterParams)(nil),                       // 33: inventory.v1.AddNodeExporterParams
-		(*ChangeNodeExporterParams)(nil),                    // 34: inventory.v1.ChangeNodeExporterParams
-		(*AddMySQLdExporterParams)(nil),                     // 35: inventory.v1.AddMySQLdExporterParams
-		(*ChangeMySQLdExporterParams)(nil),                  // 36: inventory.v1.ChangeMySQLdExporterParams
-		(*AddMongoDBExporterParams)(nil),                    // 37: inventory.v1.AddMongoDBExporterParams
-		(*ChangeMongoDBExporterParams)(nil),                 // 38: inventory.v1.ChangeMongoDBExporterParams
-		(*AddPostgresExporterParams)(nil),                   // 39: inventory.v1.AddPostgresExporterParams
-		(*ChangePostgresExporterParams)(nil),                // 40: inventory.v1.ChangePostgresExporterParams
-		(*AddProxySQLExporterParams)(nil),                   // 41: inventory.v1.AddProxySQLExporterParams
-		(*ChangeProxySQLExporterParams)(nil),                // 42: inventory.v1.ChangeProxySQLExporterParams
-		(*AddQANMySQLPerfSchemaAgentParams)(nil),            // 43: inventory.v1.AddQANMySQLPerfSchemaAgentParams
-		(*ChangeQANMySQLPerfSchemaAgentParams)(nil),         // 44: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
-		(*AddQANMySQLSlowlogAgentParams)(nil),               // 45: inventory.v1.AddQANMySQLSlowlogAgentParams
-		(*ChangeQANMySQLSlowlogAgentParams)(nil),            // 46: inventory.v1.ChangeQANMySQLSlowlogAgentParams
-		(*AddQANMongoDBProfilerAgentParams)(nil),            // 47: inventory.v1.AddQANMongoDBProfilerAgentParams
-		(*ChangeQANMongoDBProfilerAgentParams)(nil),         // 48: inventory.v1.ChangeQANMongoDBProfilerAgentParams
-		(*AddQANMongoDBMongologAgentParams)(nil),            // 49: inventory.v1.AddQANMongoDBMongologAgentParams
-		(*ChangeQANMongoDBMongologAgentParams)(nil),         // 50: inventory.v1.ChangeQANMongoDBMongologAgentParams
-		(*AddQANPostgreSQLPgStatementsAgentParams)(nil),     // 51: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
-		(*ChangeQANPostgreSQLPgStatementsAgentParams)(nil),  // 52: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
-		(*AddQANPostgreSQLPgStatMonitorAgentParams)(nil),    // 53: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
-		(*ChangeQANPostgreSQLPgStatMonitorAgentParams)(nil), // 54: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
-		(*AddRDSExporterParams)(nil),                        // 55: inventory.v1.AddRDSExporterParams
-		(*ChangeRDSExporterParams)(nil),                     // 56: inventory.v1.ChangeRDSExporterParams
-		(*AddExternalExporterParams)(nil),                   // 57: inventory.v1.AddExternalExporterParams
-		(*ChangeExternalExporterParams)(nil),                // 58: inventory.v1.ChangeExternalExporterParams
-		(*AddAzureDatabaseExporterParams)(nil),              // 59: inventory.v1.AddAzureDatabaseExporterParams
-		(*ChangeAzureDatabaseExporterParams)(nil),           // 60: inventory.v1.ChangeAzureDatabaseExporterParams
-		(*ChangeNomadAgentParams)(nil),                      // 61: inventory.v1.ChangeNomadAgentParams
-		(*AddValkeyExporterParams)(nil),                     // 62: inventory.v1.AddValkeyExporterParams
-		(*ChangeValkeyExporterParams)(nil),                  // 63: inventory.v1.ChangeValkeyExporterParams
-		(*AddRTAMongoDBAgentParams)(nil),                    // 64: inventory.v1.AddRTAMongoDBAgentParams
-		(*ChangeRTAMongoDBAgentParams)(nil),                 // 65: inventory.v1.ChangeRTAMongoDBAgentParams
-		(*RemoveAgentRequest)(nil),                          // 66: inventory.v1.RemoveAgentRequest
-		(*RemoveAgentResponse)(nil),                         // 67: inventory.v1.RemoveAgentResponse
-		nil,                                                 // 68: inventory.v1.PMMAgent.CustomLabelsEntry
-		nil,                                                 // 69: inventory.v1.NodeExporter.CustomLabelsEntry
-		nil,                                                 // 70: inventory.v1.MySQLdExporter.CustomLabelsEntry
-		nil,                                                 // 71: inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
-		nil,                                                 // 72: inventory.v1.MongoDBExporter.CustomLabelsEntry
-		nil,                                                 // 73: inventory.v1.PostgresExporter.CustomLabelsEntry
-		nil,                                                 // 74: inventory.v1.ProxySQLExporter.CustomLabelsEntry
-		nil,                                                 // 75: inventory.v1.ValkeyExporter.CustomLabelsEntry
-		nil,                                                 // 76: inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
-		nil,                                                 // 77: inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
-		nil,                                                 // 78: inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
-		nil,                                                 // 79: inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
-		nil,                                                 // 80: inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
-		nil,                                                 // 81: inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
-		nil,                                                 // 82: inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
-		nil,                                                 // 83: inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
-		nil,                                                 // 84: inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
-		nil,                                                 // 85: inventory.v1.RDSExporter.CustomLabelsEntry
-		nil,                                                 // 86: inventory.v1.ExternalExporter.CustomLabelsEntry
-		nil,                                                 // 87: inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
-		nil,                                                 // 88: inventory.v1.AddPMMAgentParams.CustomLabelsEntry
-		nil,                                                 // 89: inventory.v1.AddNodeExporterParams.CustomLabelsEntry
-		nil,                                                 // 90: inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
-		nil,                                                 // 91: inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
-		nil,                                                 // 92: inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
-		nil,                                                 // 93: inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
-		nil,                                                 // 94: inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
-		nil,                                                 // 95: inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
-		nil,                                                 // 96: inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
-		nil,                                                 // 97: inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
-		nil,                                                 // 98: inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
-		nil,                                                 // 99: inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
-		nil,                                                 // 100: inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
-		nil,                                                 // 101: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
-		nil,                                                 // 102: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
-		nil,                                                 // 103: inventory.v1.AddRDSExporterParams.CustomLabelsEntry
-		nil,                                                 // 104: inventory.v1.AddExternalExporterParams.CustomLabelsEntry
-		nil,                                                 // 105: inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
-		nil,                                                 // 106: inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
-		nil,                                                 // 107: inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
-		AgentStatus(0),                                      // 108: inventory.v1.AgentStatus
-		LogLevel(0),                                         // 109: inventory.v1.LogLevel
-		(*common.MetricsResolutions)(nil),                   // 110: common.MetricsResolutions
-		(*durationpb.Duration)(nil),                         // 111: google.protobuf.Duration
-		(*common.StringMap)(nil),                            // 112: common.StringMap
-	}
-)
-
+var file_inventory_v1_agents_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_agents_proto_msgTypes = make([]protoimpl.MessageInfo, 112)
+var file_inventory_v1_agents_proto_goTypes = []any{
+	(AgentType)(0),                                      // 0: inventory.v1.AgentType
+	(*PMMAgent)(nil),                                    // 1: inventory.v1.PMMAgent
+	(*VMAgent)(nil),                                     // 2: inventory.v1.VMAgent
+	(*NomadAgent)(nil),                                  // 3: inventory.v1.NomadAgent
+	(*NodeExporter)(nil),                                // 4: inventory.v1.NodeExporter
+	(*MySQLdExporter)(nil),                              // 5: inventory.v1.MySQLdExporter
+	(*MongoDBExporter)(nil),                             // 6: inventory.v1.MongoDBExporter
+	(*PostgresExporter)(nil),                            // 7: inventory.v1.PostgresExporter
+	(*ProxySQLExporter)(nil),                            // 8: inventory.v1.ProxySQLExporter
+	(*ValkeyExporter)(nil),                              // 9: inventory.v1.ValkeyExporter
+	(*QANMySQLPerfSchemaAgent)(nil),                     // 10: inventory.v1.QANMySQLPerfSchemaAgent
+	(*QANMySQLSlowlogAgent)(nil),                        // 11: inventory.v1.QANMySQLSlowlogAgent
+	(*QANMongoDBProfilerAgent)(nil),                     // 12: inventory.v1.QANMongoDBProfilerAgent
+	(*QANMongoDBMongologAgent)(nil),                     // 13: inventory.v1.QANMongoDBMongologAgent
+	(*RTAOptions)(nil),                                  // 14: inventory.v1.RTAOptions
+	(*RTAPostgreSQLAgent)(nil),                          // 15: inventory.v1.RTAPostgreSQLAgent
+	(*RTAMongoDBAgent)(nil),                             // 16: inventory.v1.RTAMongoDBAgent
+	(*QANPostgreSQLPgStatementsAgent)(nil),              // 17: inventory.v1.QANPostgreSQLPgStatementsAgent
+	(*QANPostgreSQLPgStatMonitorAgent)(nil),             // 18: inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	(*RDSExporter)(nil),                                 // 19: inventory.v1.RDSExporter
+	(*ExternalExporter)(nil),                            // 20: inventory.v1.ExternalExporter
+	(*AzureDatabaseExporter)(nil),                       // 21: inventory.v1.AzureDatabaseExporter
+	(*ChangeCommonAgentParams)(nil),                     // 22: inventory.v1.ChangeCommonAgentParams
+	(*ListAgentsRequest)(nil),                           // 23: inventory.v1.ListAgentsRequest
+	(*ListAgentsResponse)(nil),                          // 24: inventory.v1.ListAgentsResponse
+	(*GetAgentRequest)(nil),                             // 25: inventory.v1.GetAgentRequest
+	(*GetAgentResponse)(nil),                            // 26: inventory.v1.GetAgentResponse
+	(*GetAgentLogsRequest)(nil),                         // 27: inventory.v1.GetAgentLogsRequest
+	(*GetAgentLogsResponse)(nil),                        // 28: inventory.v1.GetAgentLogsResponse
+	(*AddAgentRequest)(nil),                             // 29: inventory.v1.AddAgentRequest
+	(*AddAgentResponse)(nil),                            // 30: inventory.v1.AddAgentResponse
+	(*ChangeAgentRequest)(nil),                          // 31: inventory.v1.ChangeAgentRequest
+	(*ChangeAgentResponse)(nil),                         // 32: inventory.v1.ChangeAgentResponse
+	(*AddPMMAgentParams)(nil),                           // 33: inventory.v1.AddPMMAgentParams
+	(*AddNodeExporterParams)(nil),                       // 34: inventory.v1.AddNodeExporterParams
+	(*ChangeNodeExporterParams)(nil),                    // 35: inventory.v1.ChangeNodeExporterParams
+	(*AddMySQLdExporterParams)(nil),                     // 36: inventory.v1.AddMySQLdExporterParams
+	(*ChangeMySQLdExporterParams)(nil),                  // 37: inventory.v1.ChangeMySQLdExporterParams
+	(*AddMongoDBExporterParams)(nil),                    // 38: inventory.v1.AddMongoDBExporterParams
+	(*ChangeMongoDBExporterParams)(nil),                 // 39: inventory.v1.ChangeMongoDBExporterParams
+	(*AddPostgresExporterParams)(nil),                   // 40: inventory.v1.AddPostgresExporterParams
+	(*ChangePostgresExporterParams)(nil),                // 41: inventory.v1.ChangePostgresExporterParams
+	(*AddProxySQLExporterParams)(nil),                   // 42: inventory.v1.AddProxySQLExporterParams
+	(*ChangeProxySQLExporterParams)(nil),                // 43: inventory.v1.ChangeProxySQLExporterParams
+	(*AddQANMySQLPerfSchemaAgentParams)(nil),            // 44: inventory.v1.AddQANMySQLPerfSchemaAgentParams
+	(*ChangeQANMySQLPerfSchemaAgentParams)(nil),         // 45: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
+	(*AddQANMySQLSlowlogAgentParams)(nil),               // 46: inventory.v1.AddQANMySQLSlowlogAgentParams
+	(*ChangeQANMySQLSlowlogAgentParams)(nil),            // 47: inventory.v1.ChangeQANMySQLSlowlogAgentParams
+	(*AddQANMongoDBProfilerAgentParams)(nil),            // 48: inventory.v1.AddQANMongoDBProfilerAgentParams
+	(*ChangeQANMongoDBProfilerAgentParams)(nil),         // 49: inventory.v1.ChangeQANMongoDBProfilerAgentParams
+	(*AddQANMongoDBMongologAgentParams)(nil),            // 50: inventory.v1.AddQANMongoDBMongologAgentParams
+	(*ChangeQANMongoDBMongologAgentParams)(nil),         // 51: inventory.v1.ChangeQANMongoDBMongologAgentParams
+	(*AddQANPostgreSQLPgStatementsAgentParams)(nil),     // 52: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
+	(*ChangeQANPostgreSQLPgStatementsAgentParams)(nil),  // 53: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
+	(*AddQANPostgreSQLPgStatMonitorAgentParams)(nil),    // 54: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
+	(*ChangeQANPostgreSQLPgStatMonitorAgentParams)(nil), // 55: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
+	(*AddRDSExporterParams)(nil),                        // 56: inventory.v1.AddRDSExporterParams
+	(*ChangeRDSExporterParams)(nil),                     // 57: inventory.v1.ChangeRDSExporterParams
+	(*AddExternalExporterParams)(nil),                   // 58: inventory.v1.AddExternalExporterParams
+	(*ChangeExternalExporterParams)(nil),                // 59: inventory.v1.ChangeExternalExporterParams
+	(*AddAzureDatabaseExporterParams)(nil),              // 60: inventory.v1.AddAzureDatabaseExporterParams
+	(*ChangeAzureDatabaseExporterParams)(nil),           // 61: inventory.v1.ChangeAzureDatabaseExporterParams
+	(*ChangeNomadAgentParams)(nil),                      // 62: inventory.v1.ChangeNomadAgentParams
+	(*AddValkeyExporterParams)(nil),                     // 63: inventory.v1.AddValkeyExporterParams
+	(*ChangeValkeyExporterParams)(nil),                  // 64: inventory.v1.ChangeValkeyExporterParams
+	(*AddRTAMongoDBAgentParams)(nil),                    // 65: inventory.v1.AddRTAMongoDBAgentParams
+	(*ChangeRTAMongoDBAgentParams)(nil),                 // 66: inventory.v1.ChangeRTAMongoDBAgentParams
+	(*AddRTAPostgreSQLAgentParams)(nil),                 // 67: inventory.v1.AddRTAPostgreSQLAgentParams
+	(*ChangeRTAPostgreSQLAgentParams)(nil),              // 68: inventory.v1.ChangeRTAPostgreSQLAgentParams
+	(*RemoveAgentRequest)(nil),                          // 69: inventory.v1.RemoveAgentRequest
+	(*RemoveAgentResponse)(nil),                         // 70: inventory.v1.RemoveAgentResponse
+	nil,                                                 // 71: inventory.v1.PMMAgent.CustomLabelsEntry
+	nil,                                                 // 72: inventory.v1.NodeExporter.CustomLabelsEntry
+	nil,                                                 // 73: inventory.v1.MySQLdExporter.CustomLabelsEntry
+	nil,                                                 // 74: inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
+	nil,                                                 // 75: inventory.v1.MongoDBExporter.CustomLabelsEntry
+	nil,                                                 // 76: inventory.v1.PostgresExporter.CustomLabelsEntry
+	nil,                                                 // 77: inventory.v1.ProxySQLExporter.CustomLabelsEntry
+	nil,                                                 // 78: inventory.v1.ValkeyExporter.CustomLabelsEntry
+	nil,                                                 // 79: inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
+	nil,                                                 // 80: inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
+	nil,                                                 // 81: inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
+	nil,                                                 // 82: inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
+	nil,                                                 // 83: inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
+	nil,                                                 // 84: inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
+	nil,                                                 // 85: inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntry
+	nil,                                                 // 86: inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
+	nil,                                                 // 87: inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
+	nil,                                                 // 88: inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
+	nil,                                                 // 89: inventory.v1.RDSExporter.CustomLabelsEntry
+	nil,                                                 // 90: inventory.v1.ExternalExporter.CustomLabelsEntry
+	nil,                                                 // 91: inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
+	nil,                                                 // 92: inventory.v1.AddPMMAgentParams.CustomLabelsEntry
+	nil,                                                 // 93: inventory.v1.AddNodeExporterParams.CustomLabelsEntry
+	nil,                                                 // 94: inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
+	nil,                                                 // 95: inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
+	nil,                                                 // 96: inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
+	nil,                                                 // 97: inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
+	nil,                                                 // 98: inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
+	nil,                                                 // 99: inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
+	nil,                                                 // 100: inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
+	nil,                                                 // 101: inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
+	nil,                                                 // 102: inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
+	nil,                                                 // 103: inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
+	nil,                                                 // 104: inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
+	nil,                                                 // 105: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
+	nil,                                                 // 106: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
+	nil,                                                 // 107: inventory.v1.AddRDSExporterParams.CustomLabelsEntry
+	nil,                                                 // 108: inventory.v1.AddExternalExporterParams.CustomLabelsEntry
+	nil,                                                 // 109: inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
+	nil,                                                 // 110: inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
+	nil,                                                 // 111: inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
+	nil,                                                 // 112: inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntry
+	(AgentStatus)(0),                                    // 113: inventory.v1.AgentStatus
+	(LogLevel)(0),                                       // 114: inventory.v1.LogLevel
+	(*common.MetricsResolutions)(nil),                   // 115: common.MetricsResolutions
+	(*durationpb.Duration)(nil),                         // 116: google.protobuf.Duration
+	(*common.StringMap)(nil),                            // 117: common.StringMap
+}
 var file_inventory_v1_agents_proto_depIdxs = []int32{
-	68,  // 0: inventory.v1.PMMAgent.custom_labels:type_name -> inventory.v1.PMMAgent.CustomLabelsEntry
-	108, // 1: inventory.v1.VMAgent.status:type_name -> inventory.v1.AgentStatus
-	108, // 2: inventory.v1.NomadAgent.status:type_name -> inventory.v1.AgentStatus
-	69,  // 3: inventory.v1.NodeExporter.custom_labels:type_name -> inventory.v1.NodeExporter.CustomLabelsEntry
-	108, // 4: inventory.v1.NodeExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 5: inventory.v1.NodeExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 6: inventory.v1.NodeExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	70,  // 7: inventory.v1.MySQLdExporter.custom_labels:type_name -> inventory.v1.MySQLdExporter.CustomLabelsEntry
-	108, // 8: inventory.v1.MySQLdExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 9: inventory.v1.MySQLdExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 10: inventory.v1.MySQLdExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	71,  // 11: inventory.v1.MySQLdExporter.extra_dsn_params:type_name -> inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
-	111, // 12: inventory.v1.MySQLdExporter.connection_timeout:type_name -> google.protobuf.Duration
-	72,  // 13: inventory.v1.MongoDBExporter.custom_labels:type_name -> inventory.v1.MongoDBExporter.CustomLabelsEntry
-	108, // 14: inventory.v1.MongoDBExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 15: inventory.v1.MongoDBExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 16: inventory.v1.MongoDBExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 17: inventory.v1.MongoDBExporter.connection_timeout:type_name -> google.protobuf.Duration
-	73,  // 18: inventory.v1.PostgresExporter.custom_labels:type_name -> inventory.v1.PostgresExporter.CustomLabelsEntry
-	108, // 19: inventory.v1.PostgresExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 20: inventory.v1.PostgresExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 21: inventory.v1.PostgresExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 22: inventory.v1.PostgresExporter.connection_timeout:type_name -> google.protobuf.Duration
-	74,  // 23: inventory.v1.ProxySQLExporter.custom_labels:type_name -> inventory.v1.ProxySQLExporter.CustomLabelsEntry
-	108, // 24: inventory.v1.ProxySQLExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 25: inventory.v1.ProxySQLExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 26: inventory.v1.ProxySQLExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 27: inventory.v1.ProxySQLExporter.connection_timeout:type_name -> google.protobuf.Duration
-	75,  // 28: inventory.v1.ValkeyExporter.custom_labels:type_name -> inventory.v1.ValkeyExporter.CustomLabelsEntry
-	108, // 29: inventory.v1.ValkeyExporter.status:type_name -> inventory.v1.AgentStatus
-	110, // 30: inventory.v1.ValkeyExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 31: inventory.v1.ValkeyExporter.connection_timeout:type_name -> google.protobuf.Duration
-	76,  // 32: inventory.v1.QANMySQLPerfSchemaAgent.custom_labels:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
-	108, // 33: inventory.v1.QANMySQLPerfSchemaAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 34: inventory.v1.QANMySQLPerfSchemaAgent.log_level:type_name -> inventory.v1.LogLevel
-	77,  // 35: inventory.v1.QANMySQLPerfSchemaAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
-	78,  // 36: inventory.v1.QANMySQLSlowlogAgent.custom_labels:type_name -> inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
-	108, // 37: inventory.v1.QANMySQLSlowlogAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 38: inventory.v1.QANMySQLSlowlogAgent.log_level:type_name -> inventory.v1.LogLevel
-	79,  // 39: inventory.v1.QANMySQLSlowlogAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
-	80,  // 40: inventory.v1.QANMongoDBProfilerAgent.custom_labels:type_name -> inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
-	108, // 41: inventory.v1.QANMongoDBProfilerAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 42: inventory.v1.QANMongoDBProfilerAgent.log_level:type_name -> inventory.v1.LogLevel
-	81,  // 43: inventory.v1.QANMongoDBMongologAgent.custom_labels:type_name -> inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
-	108, // 44: inventory.v1.QANMongoDBMongologAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 45: inventory.v1.QANMongoDBMongologAgent.log_level:type_name -> inventory.v1.LogLevel
-	111, // 46: inventory.v1.RTAOptions.collect_interval:type_name -> google.protobuf.Duration
-	82,  // 47: inventory.v1.RTAMongoDBAgent.custom_labels:type_name -> inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
-	14,  // 48: inventory.v1.RTAMongoDBAgent.rta_options:type_name -> inventory.v1.RTAOptions
-	108, // 49: inventory.v1.RTAMongoDBAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 50: inventory.v1.RTAMongoDBAgent.log_level:type_name -> inventory.v1.LogLevel
-	83,  // 51: inventory.v1.QANPostgreSQLPgStatementsAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
-	108, // 52: inventory.v1.QANPostgreSQLPgStatementsAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 53: inventory.v1.QANPostgreSQLPgStatementsAgent.log_level:type_name -> inventory.v1.LogLevel
-	84,  // 54: inventory.v1.QANPostgreSQLPgStatMonitorAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
-	108, // 55: inventory.v1.QANPostgreSQLPgStatMonitorAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 56: inventory.v1.QANPostgreSQLPgStatMonitorAgent.log_level:type_name -> inventory.v1.LogLevel
-	85,  // 57: inventory.v1.RDSExporter.custom_labels:type_name -> inventory.v1.RDSExporter.CustomLabelsEntry
-	108, // 58: inventory.v1.RDSExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 59: inventory.v1.RDSExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 60: inventory.v1.RDSExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	86,  // 61: inventory.v1.ExternalExporter.custom_labels:type_name -> inventory.v1.ExternalExporter.CustomLabelsEntry
-	110, // 62: inventory.v1.ExternalExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	108, // 63: inventory.v1.ExternalExporter.status:type_name -> inventory.v1.AgentStatus
-	87,  // 64: inventory.v1.AzureDatabaseExporter.custom_labels:type_name -> inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
-	108, // 65: inventory.v1.AzureDatabaseExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 66: inventory.v1.AzureDatabaseExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 67: inventory.v1.AzureDatabaseExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	112, // 68: inventory.v1.ChangeCommonAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 69: inventory.v1.ChangeCommonAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	0,   // 70: inventory.v1.ListAgentsRequest.agent_type:type_name -> inventory.v1.AgentType
-	1,   // 71: inventory.v1.ListAgentsResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	2,   // 72: inventory.v1.ListAgentsResponse.vm_agent:type_name -> inventory.v1.VMAgent
-	4,   // 73: inventory.v1.ListAgentsResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 74: inventory.v1.ListAgentsResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 75: inventory.v1.ListAgentsResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 76: inventory.v1.ListAgentsResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 77: inventory.v1.ListAgentsResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	10,  // 78: inventory.v1.ListAgentsResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 79: inventory.v1.ListAgentsResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 80: inventory.v1.ListAgentsResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 81: inventory.v1.ListAgentsResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 82: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 83: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	19,  // 84: inventory.v1.ListAgentsResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 85: inventory.v1.ListAgentsResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 86: inventory.v1.ListAgentsResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	3,   // 87: inventory.v1.ListAgentsResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 88: inventory.v1.ListAgentsResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 89: inventory.v1.ListAgentsResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	1,   // 90: inventory.v1.GetAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	2,   // 91: inventory.v1.GetAgentResponse.vmagent:type_name -> inventory.v1.VMAgent
-	4,   // 92: inventory.v1.GetAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 93: inventory.v1.GetAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 94: inventory.v1.GetAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 95: inventory.v1.GetAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 96: inventory.v1.GetAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	10,  // 97: inventory.v1.GetAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 98: inventory.v1.GetAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 99: inventory.v1.GetAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 100: inventory.v1.GetAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 101: inventory.v1.GetAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 102: inventory.v1.GetAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	19,  // 103: inventory.v1.GetAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 104: inventory.v1.GetAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 105: inventory.v1.GetAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	3,   // 106: inventory.v1.GetAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 107: inventory.v1.GetAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 108: inventory.v1.GetAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	32,  // 109: inventory.v1.AddAgentRequest.pmm_agent:type_name -> inventory.v1.AddPMMAgentParams
-	33,  // 110: inventory.v1.AddAgentRequest.node_exporter:type_name -> inventory.v1.AddNodeExporterParams
-	35,  // 111: inventory.v1.AddAgentRequest.mysqld_exporter:type_name -> inventory.v1.AddMySQLdExporterParams
-	37,  // 112: inventory.v1.AddAgentRequest.mongodb_exporter:type_name -> inventory.v1.AddMongoDBExporterParams
-	39,  // 113: inventory.v1.AddAgentRequest.postgres_exporter:type_name -> inventory.v1.AddPostgresExporterParams
-	41,  // 114: inventory.v1.AddAgentRequest.proxysql_exporter:type_name -> inventory.v1.AddProxySQLExporterParams
-	57,  // 115: inventory.v1.AddAgentRequest.external_exporter:type_name -> inventory.v1.AddExternalExporterParams
-	55,  // 116: inventory.v1.AddAgentRequest.rds_exporter:type_name -> inventory.v1.AddRDSExporterParams
-	59,  // 117: inventory.v1.AddAgentRequest.azure_database_exporter:type_name -> inventory.v1.AddAzureDatabaseExporterParams
-	43,  // 118: inventory.v1.AddAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams
-	45,  // 119: inventory.v1.AddAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams
-	47,  // 120: inventory.v1.AddAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams
-	49,  // 121: inventory.v1.AddAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams
-	51,  // 122: inventory.v1.AddAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
-	53,  // 123: inventory.v1.AddAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
-	62,  // 124: inventory.v1.AddAgentRequest.valkey_exporter:type_name -> inventory.v1.AddValkeyExporterParams
-	64,  // 125: inventory.v1.AddAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.AddRTAMongoDBAgentParams
-	1,   // 126: inventory.v1.AddAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	4,   // 127: inventory.v1.AddAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 128: inventory.v1.AddAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 129: inventory.v1.AddAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 130: inventory.v1.AddAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 131: inventory.v1.AddAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	19,  // 132: inventory.v1.AddAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 133: inventory.v1.AddAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 134: inventory.v1.AddAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	10,  // 135: inventory.v1.AddAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 136: inventory.v1.AddAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 137: inventory.v1.AddAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 138: inventory.v1.AddAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 139: inventory.v1.AddAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 140: inventory.v1.AddAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	9,   // 141: inventory.v1.AddAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 142: inventory.v1.AddAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	34,  // 143: inventory.v1.ChangeAgentRequest.node_exporter:type_name -> inventory.v1.ChangeNodeExporterParams
-	36,  // 144: inventory.v1.ChangeAgentRequest.mysqld_exporter:type_name -> inventory.v1.ChangeMySQLdExporterParams
-	38,  // 145: inventory.v1.ChangeAgentRequest.mongodb_exporter:type_name -> inventory.v1.ChangeMongoDBExporterParams
-	40,  // 146: inventory.v1.ChangeAgentRequest.postgres_exporter:type_name -> inventory.v1.ChangePostgresExporterParams
-	42,  // 147: inventory.v1.ChangeAgentRequest.proxysql_exporter:type_name -> inventory.v1.ChangeProxySQLExporterParams
-	58,  // 148: inventory.v1.ChangeAgentRequest.external_exporter:type_name -> inventory.v1.ChangeExternalExporterParams
-	56,  // 149: inventory.v1.ChangeAgentRequest.rds_exporter:type_name -> inventory.v1.ChangeRDSExporterParams
-	60,  // 150: inventory.v1.ChangeAgentRequest.azure_database_exporter:type_name -> inventory.v1.ChangeAzureDatabaseExporterParams
-	44,  // 151: inventory.v1.ChangeAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
-	46,  // 152: inventory.v1.ChangeAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.ChangeQANMySQLSlowlogAgentParams
-	48,  // 153: inventory.v1.ChangeAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.ChangeQANMongoDBProfilerAgentParams
-	50,  // 154: inventory.v1.ChangeAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.ChangeQANMongoDBMongologAgentParams
-	52,  // 155: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
-	54,  // 156: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
-	61,  // 157: inventory.v1.ChangeAgentRequest.nomad_agent:type_name -> inventory.v1.ChangeNomadAgentParams
-	63,  // 158: inventory.v1.ChangeAgentRequest.valkey_exporter:type_name -> inventory.v1.ChangeValkeyExporterParams
-	65,  // 159: inventory.v1.ChangeAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.ChangeRTAMongoDBAgentParams
-	4,   // 160: inventory.v1.ChangeAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 161: inventory.v1.ChangeAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 162: inventory.v1.ChangeAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 163: inventory.v1.ChangeAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 164: inventory.v1.ChangeAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	19,  // 165: inventory.v1.ChangeAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 166: inventory.v1.ChangeAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 167: inventory.v1.ChangeAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	10,  // 168: inventory.v1.ChangeAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 169: inventory.v1.ChangeAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 170: inventory.v1.ChangeAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 171: inventory.v1.ChangeAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 172: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 173: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	3,   // 174: inventory.v1.ChangeAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 175: inventory.v1.ChangeAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 176: inventory.v1.ChangeAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	88,  // 177: inventory.v1.AddPMMAgentParams.custom_labels:type_name -> inventory.v1.AddPMMAgentParams.CustomLabelsEntry
-	89,  // 178: inventory.v1.AddNodeExporterParams.custom_labels:type_name -> inventory.v1.AddNodeExporterParams.CustomLabelsEntry
-	109, // 179: inventory.v1.AddNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 180: inventory.v1.ChangeNodeExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 181: inventory.v1.ChangeNodeExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 182: inventory.v1.ChangeNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	90,  // 183: inventory.v1.AddMySQLdExporterParams.custom_labels:type_name -> inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
-	109, // 184: inventory.v1.AddMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	91,  // 185: inventory.v1.AddMySQLdExporterParams.extra_dsn_params:type_name -> inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
-	111, // 186: inventory.v1.AddMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 187: inventory.v1.ChangeMySQLdExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 188: inventory.v1.ChangeMySQLdExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 189: inventory.v1.ChangeMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 190: inventory.v1.ChangeMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	92,  // 191: inventory.v1.AddMongoDBExporterParams.custom_labels:type_name -> inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
-	109, // 192: inventory.v1.AddMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 193: inventory.v1.AddMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 194: inventory.v1.ChangeMongoDBExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 195: inventory.v1.ChangeMongoDBExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 196: inventory.v1.ChangeMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 197: inventory.v1.ChangeMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	93,  // 198: inventory.v1.AddPostgresExporterParams.custom_labels:type_name -> inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
-	109, // 199: inventory.v1.AddPostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 200: inventory.v1.AddPostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 201: inventory.v1.ChangePostgresExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 202: inventory.v1.ChangePostgresExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 203: inventory.v1.ChangePostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 204: inventory.v1.ChangePostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	94,  // 205: inventory.v1.AddProxySQLExporterParams.custom_labels:type_name -> inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
-	109, // 206: inventory.v1.AddProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 207: inventory.v1.AddProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 208: inventory.v1.ChangeProxySQLExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 209: inventory.v1.ChangeProxySQLExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 210: inventory.v1.ChangeProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 211: inventory.v1.ChangeProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	95,  // 212: inventory.v1.AddQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
-	109, // 213: inventory.v1.AddQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	96,  // 214: inventory.v1.AddQANMySQLPerfSchemaAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
-	112, // 215: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 216: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 217: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	97,  // 218: inventory.v1.AddQANMySQLSlowlogAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
-	109, // 219: inventory.v1.AddQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	98,  // 220: inventory.v1.AddQANMySQLSlowlogAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
-	112, // 221: inventory.v1.ChangeQANMySQLSlowlogAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 222: inventory.v1.ChangeQANMySQLSlowlogAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 223: inventory.v1.ChangeQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	99,  // 224: inventory.v1.AddQANMongoDBProfilerAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
-	109, // 225: inventory.v1.AddQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 226: inventory.v1.ChangeQANMongoDBProfilerAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 227: inventory.v1.ChangeQANMongoDBProfilerAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 228: inventory.v1.ChangeQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	100, // 229: inventory.v1.AddQANMongoDBMongologAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
-	109, // 230: inventory.v1.AddQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 231: inventory.v1.ChangeQANMongoDBMongologAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 232: inventory.v1.ChangeQANMongoDBMongologAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 233: inventory.v1.ChangeQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	101, // 234: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
-	109, // 235: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 236: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 237: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 238: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	102, // 239: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
-	109, // 240: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 241: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 242: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 243: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	103, // 244: inventory.v1.AddRDSExporterParams.custom_labels:type_name -> inventory.v1.AddRDSExporterParams.CustomLabelsEntry
-	109, // 245: inventory.v1.AddRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 246: inventory.v1.ChangeRDSExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 247: inventory.v1.ChangeRDSExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 248: inventory.v1.ChangeRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	104, // 249: inventory.v1.AddExternalExporterParams.custom_labels:type_name -> inventory.v1.AddExternalExporterParams.CustomLabelsEntry
-	112, // 250: inventory.v1.ChangeExternalExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 251: inventory.v1.ChangeExternalExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	105, // 252: inventory.v1.AddAzureDatabaseExporterParams.custom_labels:type_name -> inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
-	109, // 253: inventory.v1.AddAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 254: inventory.v1.ChangeAzureDatabaseExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 255: inventory.v1.ChangeAzureDatabaseExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 256: inventory.v1.ChangeAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	106, // 257: inventory.v1.AddValkeyExporterParams.custom_labels:type_name -> inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
-	109, // 258: inventory.v1.AddValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 259: inventory.v1.AddValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 260: inventory.v1.ChangeValkeyExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 261: inventory.v1.ChangeValkeyExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 262: inventory.v1.ChangeValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 263: inventory.v1.ChangeValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	107, // 264: inventory.v1.AddRTAMongoDBAgentParams.custom_labels:type_name -> inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
-	109, // 265: inventory.v1.AddRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	14,  // 266: inventory.v1.AddRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
-	112, // 267: inventory.v1.ChangeRTAMongoDBAgentParams.custom_labels:type_name -> common.StringMap
-	109, // 268: inventory.v1.ChangeRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	14,  // 269: inventory.v1.ChangeRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
-	22,  // 270: inventory.v1.AgentsService.ListAgents:input_type -> inventory.v1.ListAgentsRequest
-	24,  // 271: inventory.v1.AgentsService.GetAgent:input_type -> inventory.v1.GetAgentRequest
-	26,  // 272: inventory.v1.AgentsService.GetAgentLogs:input_type -> inventory.v1.GetAgentLogsRequest
-	28,  // 273: inventory.v1.AgentsService.AddAgent:input_type -> inventory.v1.AddAgentRequest
-	30,  // 274: inventory.v1.AgentsService.ChangeAgent:input_type -> inventory.v1.ChangeAgentRequest
-	66,  // 275: inventory.v1.AgentsService.RemoveAgent:input_type -> inventory.v1.RemoveAgentRequest
-	23,  // 276: inventory.v1.AgentsService.ListAgents:output_type -> inventory.v1.ListAgentsResponse
-	25,  // 277: inventory.v1.AgentsService.GetAgent:output_type -> inventory.v1.GetAgentResponse
-	27,  // 278: inventory.v1.AgentsService.GetAgentLogs:output_type -> inventory.v1.GetAgentLogsResponse
-	29,  // 279: inventory.v1.AgentsService.AddAgent:output_type -> inventory.v1.AddAgentResponse
-	31,  // 280: inventory.v1.AgentsService.ChangeAgent:output_type -> inventory.v1.ChangeAgentResponse
-	67,  // 281: inventory.v1.AgentsService.RemoveAgent:output_type -> inventory.v1.RemoveAgentResponse
-	276, // [276:282] is the sub-list for method output_type
-	270, // [270:276] is the sub-list for method input_type
-	270, // [270:270] is the sub-list for extension type_name
-	270, // [270:270] is the sub-list for extension extendee
-	0,   // [0:270] is the sub-list for field type_name
+	71,  // 0: inventory.v1.PMMAgent.custom_labels:type_name -> inventory.v1.PMMAgent.CustomLabelsEntry
+	113, // 1: inventory.v1.VMAgent.status:type_name -> inventory.v1.AgentStatus
+	113, // 2: inventory.v1.NomadAgent.status:type_name -> inventory.v1.AgentStatus
+	72,  // 3: inventory.v1.NodeExporter.custom_labels:type_name -> inventory.v1.NodeExporter.CustomLabelsEntry
+	113, // 4: inventory.v1.NodeExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 5: inventory.v1.NodeExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 6: inventory.v1.NodeExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	73,  // 7: inventory.v1.MySQLdExporter.custom_labels:type_name -> inventory.v1.MySQLdExporter.CustomLabelsEntry
+	113, // 8: inventory.v1.MySQLdExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 9: inventory.v1.MySQLdExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 10: inventory.v1.MySQLdExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	74,  // 11: inventory.v1.MySQLdExporter.extra_dsn_params:type_name -> inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
+	116, // 12: inventory.v1.MySQLdExporter.connection_timeout:type_name -> google.protobuf.Duration
+	75,  // 13: inventory.v1.MongoDBExporter.custom_labels:type_name -> inventory.v1.MongoDBExporter.CustomLabelsEntry
+	113, // 14: inventory.v1.MongoDBExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 15: inventory.v1.MongoDBExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 16: inventory.v1.MongoDBExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 17: inventory.v1.MongoDBExporter.connection_timeout:type_name -> google.protobuf.Duration
+	76,  // 18: inventory.v1.PostgresExporter.custom_labels:type_name -> inventory.v1.PostgresExporter.CustomLabelsEntry
+	113, // 19: inventory.v1.PostgresExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 20: inventory.v1.PostgresExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 21: inventory.v1.PostgresExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 22: inventory.v1.PostgresExporter.connection_timeout:type_name -> google.protobuf.Duration
+	77,  // 23: inventory.v1.ProxySQLExporter.custom_labels:type_name -> inventory.v1.ProxySQLExporter.CustomLabelsEntry
+	113, // 24: inventory.v1.ProxySQLExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 25: inventory.v1.ProxySQLExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 26: inventory.v1.ProxySQLExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 27: inventory.v1.ProxySQLExporter.connection_timeout:type_name -> google.protobuf.Duration
+	78,  // 28: inventory.v1.ValkeyExporter.custom_labels:type_name -> inventory.v1.ValkeyExporter.CustomLabelsEntry
+	113, // 29: inventory.v1.ValkeyExporter.status:type_name -> inventory.v1.AgentStatus
+	115, // 30: inventory.v1.ValkeyExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 31: inventory.v1.ValkeyExporter.connection_timeout:type_name -> google.protobuf.Duration
+	79,  // 32: inventory.v1.QANMySQLPerfSchemaAgent.custom_labels:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
+	113, // 33: inventory.v1.QANMySQLPerfSchemaAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 34: inventory.v1.QANMySQLPerfSchemaAgent.log_level:type_name -> inventory.v1.LogLevel
+	80,  // 35: inventory.v1.QANMySQLPerfSchemaAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
+	81,  // 36: inventory.v1.QANMySQLSlowlogAgent.custom_labels:type_name -> inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
+	113, // 37: inventory.v1.QANMySQLSlowlogAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 38: inventory.v1.QANMySQLSlowlogAgent.log_level:type_name -> inventory.v1.LogLevel
+	82,  // 39: inventory.v1.QANMySQLSlowlogAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
+	83,  // 40: inventory.v1.QANMongoDBProfilerAgent.custom_labels:type_name -> inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
+	113, // 41: inventory.v1.QANMongoDBProfilerAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 42: inventory.v1.QANMongoDBProfilerAgent.log_level:type_name -> inventory.v1.LogLevel
+	84,  // 43: inventory.v1.QANMongoDBMongologAgent.custom_labels:type_name -> inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
+	113, // 44: inventory.v1.QANMongoDBMongologAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 45: inventory.v1.QANMongoDBMongologAgent.log_level:type_name -> inventory.v1.LogLevel
+	116, // 46: inventory.v1.RTAOptions.collect_interval:type_name -> google.protobuf.Duration
+	85,  // 47: inventory.v1.RTAPostgreSQLAgent.custom_labels:type_name -> inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntry
+	14,  // 48: inventory.v1.RTAPostgreSQLAgent.rta_options:type_name -> inventory.v1.RTAOptions
+	113, // 49: inventory.v1.RTAPostgreSQLAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 50: inventory.v1.RTAPostgreSQLAgent.log_level:type_name -> inventory.v1.LogLevel
+	86,  // 51: inventory.v1.RTAMongoDBAgent.custom_labels:type_name -> inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
+	14,  // 52: inventory.v1.RTAMongoDBAgent.rta_options:type_name -> inventory.v1.RTAOptions
+	113, // 53: inventory.v1.RTAMongoDBAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 54: inventory.v1.RTAMongoDBAgent.log_level:type_name -> inventory.v1.LogLevel
+	87,  // 55: inventory.v1.QANPostgreSQLPgStatementsAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
+	113, // 56: inventory.v1.QANPostgreSQLPgStatementsAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 57: inventory.v1.QANPostgreSQLPgStatementsAgent.log_level:type_name -> inventory.v1.LogLevel
+	88,  // 58: inventory.v1.QANPostgreSQLPgStatMonitorAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
+	113, // 59: inventory.v1.QANPostgreSQLPgStatMonitorAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 60: inventory.v1.QANPostgreSQLPgStatMonitorAgent.log_level:type_name -> inventory.v1.LogLevel
+	89,  // 61: inventory.v1.RDSExporter.custom_labels:type_name -> inventory.v1.RDSExporter.CustomLabelsEntry
+	113, // 62: inventory.v1.RDSExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 63: inventory.v1.RDSExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 64: inventory.v1.RDSExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	90,  // 65: inventory.v1.ExternalExporter.custom_labels:type_name -> inventory.v1.ExternalExporter.CustomLabelsEntry
+	115, // 66: inventory.v1.ExternalExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	113, // 67: inventory.v1.ExternalExporter.status:type_name -> inventory.v1.AgentStatus
+	91,  // 68: inventory.v1.AzureDatabaseExporter.custom_labels:type_name -> inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
+	113, // 69: inventory.v1.AzureDatabaseExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 70: inventory.v1.AzureDatabaseExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 71: inventory.v1.AzureDatabaseExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	117, // 72: inventory.v1.ChangeCommonAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 73: inventory.v1.ChangeCommonAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	0,   // 74: inventory.v1.ListAgentsRequest.agent_type:type_name -> inventory.v1.AgentType
+	1,   // 75: inventory.v1.ListAgentsResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	2,   // 76: inventory.v1.ListAgentsResponse.vm_agent:type_name -> inventory.v1.VMAgent
+	4,   // 77: inventory.v1.ListAgentsResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 78: inventory.v1.ListAgentsResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 79: inventory.v1.ListAgentsResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 80: inventory.v1.ListAgentsResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 81: inventory.v1.ListAgentsResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	10,  // 82: inventory.v1.ListAgentsResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 83: inventory.v1.ListAgentsResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 84: inventory.v1.ListAgentsResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 85: inventory.v1.ListAgentsResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 86: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 87: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	20,  // 88: inventory.v1.ListAgentsResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 89: inventory.v1.ListAgentsResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 90: inventory.v1.ListAgentsResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	3,   // 91: inventory.v1.ListAgentsResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 92: inventory.v1.ListAgentsResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 93: inventory.v1.ListAgentsResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 94: inventory.v1.ListAgentsResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	1,   // 95: inventory.v1.GetAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	2,   // 96: inventory.v1.GetAgentResponse.vmagent:type_name -> inventory.v1.VMAgent
+	4,   // 97: inventory.v1.GetAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 98: inventory.v1.GetAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 99: inventory.v1.GetAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 100: inventory.v1.GetAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 101: inventory.v1.GetAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	10,  // 102: inventory.v1.GetAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 103: inventory.v1.GetAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 104: inventory.v1.GetAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 105: inventory.v1.GetAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 106: inventory.v1.GetAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 107: inventory.v1.GetAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	20,  // 108: inventory.v1.GetAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 109: inventory.v1.GetAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 110: inventory.v1.GetAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	3,   // 111: inventory.v1.GetAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 112: inventory.v1.GetAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 113: inventory.v1.GetAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 114: inventory.v1.GetAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	33,  // 115: inventory.v1.AddAgentRequest.pmm_agent:type_name -> inventory.v1.AddPMMAgentParams
+	34,  // 116: inventory.v1.AddAgentRequest.node_exporter:type_name -> inventory.v1.AddNodeExporterParams
+	36,  // 117: inventory.v1.AddAgentRequest.mysqld_exporter:type_name -> inventory.v1.AddMySQLdExporterParams
+	38,  // 118: inventory.v1.AddAgentRequest.mongodb_exporter:type_name -> inventory.v1.AddMongoDBExporterParams
+	40,  // 119: inventory.v1.AddAgentRequest.postgres_exporter:type_name -> inventory.v1.AddPostgresExporterParams
+	42,  // 120: inventory.v1.AddAgentRequest.proxysql_exporter:type_name -> inventory.v1.AddProxySQLExporterParams
+	58,  // 121: inventory.v1.AddAgentRequest.external_exporter:type_name -> inventory.v1.AddExternalExporterParams
+	56,  // 122: inventory.v1.AddAgentRequest.rds_exporter:type_name -> inventory.v1.AddRDSExporterParams
+	60,  // 123: inventory.v1.AddAgentRequest.azure_database_exporter:type_name -> inventory.v1.AddAzureDatabaseExporterParams
+	44,  // 124: inventory.v1.AddAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams
+	46,  // 125: inventory.v1.AddAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams
+	48,  // 126: inventory.v1.AddAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams
+	50,  // 127: inventory.v1.AddAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams
+	52,  // 128: inventory.v1.AddAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
+	54,  // 129: inventory.v1.AddAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
+	63,  // 130: inventory.v1.AddAgentRequest.valkey_exporter:type_name -> inventory.v1.AddValkeyExporterParams
+	65,  // 131: inventory.v1.AddAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.AddRTAMongoDBAgentParams
+	67,  // 132: inventory.v1.AddAgentRequest.rta_postgresql_agent:type_name -> inventory.v1.AddRTAPostgreSQLAgentParams
+	1,   // 133: inventory.v1.AddAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	4,   // 134: inventory.v1.AddAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 135: inventory.v1.AddAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 136: inventory.v1.AddAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 137: inventory.v1.AddAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 138: inventory.v1.AddAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	20,  // 139: inventory.v1.AddAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 140: inventory.v1.AddAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 141: inventory.v1.AddAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	10,  // 142: inventory.v1.AddAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 143: inventory.v1.AddAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 144: inventory.v1.AddAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 145: inventory.v1.AddAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 146: inventory.v1.AddAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 147: inventory.v1.AddAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	9,   // 148: inventory.v1.AddAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 149: inventory.v1.AddAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 150: inventory.v1.AddAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	35,  // 151: inventory.v1.ChangeAgentRequest.node_exporter:type_name -> inventory.v1.ChangeNodeExporterParams
+	37,  // 152: inventory.v1.ChangeAgentRequest.mysqld_exporter:type_name -> inventory.v1.ChangeMySQLdExporterParams
+	39,  // 153: inventory.v1.ChangeAgentRequest.mongodb_exporter:type_name -> inventory.v1.ChangeMongoDBExporterParams
+	41,  // 154: inventory.v1.ChangeAgentRequest.postgres_exporter:type_name -> inventory.v1.ChangePostgresExporterParams
+	43,  // 155: inventory.v1.ChangeAgentRequest.proxysql_exporter:type_name -> inventory.v1.ChangeProxySQLExporterParams
+	59,  // 156: inventory.v1.ChangeAgentRequest.external_exporter:type_name -> inventory.v1.ChangeExternalExporterParams
+	57,  // 157: inventory.v1.ChangeAgentRequest.rds_exporter:type_name -> inventory.v1.ChangeRDSExporterParams
+	61,  // 158: inventory.v1.ChangeAgentRequest.azure_database_exporter:type_name -> inventory.v1.ChangeAzureDatabaseExporterParams
+	45,  // 159: inventory.v1.ChangeAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
+	47,  // 160: inventory.v1.ChangeAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.ChangeQANMySQLSlowlogAgentParams
+	49,  // 161: inventory.v1.ChangeAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.ChangeQANMongoDBProfilerAgentParams
+	51,  // 162: inventory.v1.ChangeAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.ChangeQANMongoDBMongologAgentParams
+	53,  // 163: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
+	55,  // 164: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
+	62,  // 165: inventory.v1.ChangeAgentRequest.nomad_agent:type_name -> inventory.v1.ChangeNomadAgentParams
+	64,  // 166: inventory.v1.ChangeAgentRequest.valkey_exporter:type_name -> inventory.v1.ChangeValkeyExporterParams
+	66,  // 167: inventory.v1.ChangeAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.ChangeRTAMongoDBAgentParams
+	68,  // 168: inventory.v1.ChangeAgentRequest.rta_postgresql_agent:type_name -> inventory.v1.ChangeRTAPostgreSQLAgentParams
+	4,   // 169: inventory.v1.ChangeAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 170: inventory.v1.ChangeAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 171: inventory.v1.ChangeAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 172: inventory.v1.ChangeAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 173: inventory.v1.ChangeAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	20,  // 174: inventory.v1.ChangeAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 175: inventory.v1.ChangeAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 176: inventory.v1.ChangeAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	10,  // 177: inventory.v1.ChangeAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 178: inventory.v1.ChangeAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 179: inventory.v1.ChangeAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 180: inventory.v1.ChangeAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 181: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 182: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	3,   // 183: inventory.v1.ChangeAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 184: inventory.v1.ChangeAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 185: inventory.v1.ChangeAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 186: inventory.v1.ChangeAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	92,  // 187: inventory.v1.AddPMMAgentParams.custom_labels:type_name -> inventory.v1.AddPMMAgentParams.CustomLabelsEntry
+	93,  // 188: inventory.v1.AddNodeExporterParams.custom_labels:type_name -> inventory.v1.AddNodeExporterParams.CustomLabelsEntry
+	114, // 189: inventory.v1.AddNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 190: inventory.v1.ChangeNodeExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 191: inventory.v1.ChangeNodeExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 192: inventory.v1.ChangeNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	94,  // 193: inventory.v1.AddMySQLdExporterParams.custom_labels:type_name -> inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
+	114, // 194: inventory.v1.AddMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	95,  // 195: inventory.v1.AddMySQLdExporterParams.extra_dsn_params:type_name -> inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
+	116, // 196: inventory.v1.AddMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 197: inventory.v1.ChangeMySQLdExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 198: inventory.v1.ChangeMySQLdExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 199: inventory.v1.ChangeMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 200: inventory.v1.ChangeMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	96,  // 201: inventory.v1.AddMongoDBExporterParams.custom_labels:type_name -> inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
+	114, // 202: inventory.v1.AddMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 203: inventory.v1.AddMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 204: inventory.v1.ChangeMongoDBExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 205: inventory.v1.ChangeMongoDBExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 206: inventory.v1.ChangeMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 207: inventory.v1.ChangeMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	97,  // 208: inventory.v1.AddPostgresExporterParams.custom_labels:type_name -> inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
+	114, // 209: inventory.v1.AddPostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 210: inventory.v1.AddPostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 211: inventory.v1.ChangePostgresExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 212: inventory.v1.ChangePostgresExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 213: inventory.v1.ChangePostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 214: inventory.v1.ChangePostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	98,  // 215: inventory.v1.AddProxySQLExporterParams.custom_labels:type_name -> inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
+	114, // 216: inventory.v1.AddProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 217: inventory.v1.AddProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 218: inventory.v1.ChangeProxySQLExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 219: inventory.v1.ChangeProxySQLExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 220: inventory.v1.ChangeProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 221: inventory.v1.ChangeProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	99,  // 222: inventory.v1.AddQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
+	114, // 223: inventory.v1.AddQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	100, // 224: inventory.v1.AddQANMySQLPerfSchemaAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
+	117, // 225: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 226: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 227: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	101, // 228: inventory.v1.AddQANMySQLSlowlogAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
+	114, // 229: inventory.v1.AddQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	102, // 230: inventory.v1.AddQANMySQLSlowlogAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
+	117, // 231: inventory.v1.ChangeQANMySQLSlowlogAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 232: inventory.v1.ChangeQANMySQLSlowlogAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 233: inventory.v1.ChangeQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	103, // 234: inventory.v1.AddQANMongoDBProfilerAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
+	114, // 235: inventory.v1.AddQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 236: inventory.v1.ChangeQANMongoDBProfilerAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 237: inventory.v1.ChangeQANMongoDBProfilerAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 238: inventory.v1.ChangeQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	104, // 239: inventory.v1.AddQANMongoDBMongologAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
+	114, // 240: inventory.v1.AddQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 241: inventory.v1.ChangeQANMongoDBMongologAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 242: inventory.v1.ChangeQANMongoDBMongologAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 243: inventory.v1.ChangeQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	105, // 244: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
+	114, // 245: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 246: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 247: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 248: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	106, // 249: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
+	114, // 250: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 251: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 252: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 253: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	107, // 254: inventory.v1.AddRDSExporterParams.custom_labels:type_name -> inventory.v1.AddRDSExporterParams.CustomLabelsEntry
+	114, // 255: inventory.v1.AddRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 256: inventory.v1.ChangeRDSExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 257: inventory.v1.ChangeRDSExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 258: inventory.v1.ChangeRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	108, // 259: inventory.v1.AddExternalExporterParams.custom_labels:type_name -> inventory.v1.AddExternalExporterParams.CustomLabelsEntry
+	117, // 260: inventory.v1.ChangeExternalExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 261: inventory.v1.ChangeExternalExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	109, // 262: inventory.v1.AddAzureDatabaseExporterParams.custom_labels:type_name -> inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
+	114, // 263: inventory.v1.AddAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 264: inventory.v1.ChangeAzureDatabaseExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 265: inventory.v1.ChangeAzureDatabaseExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 266: inventory.v1.ChangeAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	110, // 267: inventory.v1.AddValkeyExporterParams.custom_labels:type_name -> inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
+	114, // 268: inventory.v1.AddValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 269: inventory.v1.AddValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 270: inventory.v1.ChangeValkeyExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 271: inventory.v1.ChangeValkeyExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 272: inventory.v1.ChangeValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 273: inventory.v1.ChangeValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	111, // 274: inventory.v1.AddRTAMongoDBAgentParams.custom_labels:type_name -> inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
+	114, // 275: inventory.v1.AddRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 276: inventory.v1.AddRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	117, // 277: inventory.v1.ChangeRTAMongoDBAgentParams.custom_labels:type_name -> common.StringMap
+	114, // 278: inventory.v1.ChangeRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 279: inventory.v1.ChangeRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	112, // 280: inventory.v1.AddRTAPostgreSQLAgentParams.custom_labels:type_name -> inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntry
+	114, // 281: inventory.v1.AddRTAPostgreSQLAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 282: inventory.v1.AddRTAPostgreSQLAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	117, // 283: inventory.v1.ChangeRTAPostgreSQLAgentParams.custom_labels:type_name -> common.StringMap
+	114, // 284: inventory.v1.ChangeRTAPostgreSQLAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 285: inventory.v1.ChangeRTAPostgreSQLAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	23,  // 286: inventory.v1.AgentsService.ListAgents:input_type -> inventory.v1.ListAgentsRequest
+	25,  // 287: inventory.v1.AgentsService.GetAgent:input_type -> inventory.v1.GetAgentRequest
+	27,  // 288: inventory.v1.AgentsService.GetAgentLogs:input_type -> inventory.v1.GetAgentLogsRequest
+	29,  // 289: inventory.v1.AgentsService.AddAgent:input_type -> inventory.v1.AddAgentRequest
+	31,  // 290: inventory.v1.AgentsService.ChangeAgent:input_type -> inventory.v1.ChangeAgentRequest
+	69,  // 291: inventory.v1.AgentsService.RemoveAgent:input_type -> inventory.v1.RemoveAgentRequest
+	24,  // 292: inventory.v1.AgentsService.ListAgents:output_type -> inventory.v1.ListAgentsResponse
+	26,  // 293: inventory.v1.AgentsService.GetAgent:output_type -> inventory.v1.GetAgentResponse
+	28,  // 294: inventory.v1.AgentsService.GetAgentLogs:output_type -> inventory.v1.GetAgentLogsResponse
+	30,  // 295: inventory.v1.AgentsService.AddAgent:output_type -> inventory.v1.AddAgentResponse
+	32,  // 296: inventory.v1.AgentsService.ChangeAgent:output_type -> inventory.v1.ChangeAgentResponse
+	70,  // 297: inventory.v1.AgentsService.RemoveAgent:output_type -> inventory.v1.RemoveAgentResponse
+	292, // [292:298] is the sub-list for method output_type
+	286, // [286:292] is the sub-list for method input_type
+	286, // [286:286] is the sub-list for extension type_name
+	286, // [286:286] is the sub-list for extension extendee
+	0,   // [0:286] is the sub-list for field type_name
 }
 
 func init() { file_inventory_v1_agents_proto_init() }
@@ -12811,8 +13417,8 @@ func file_inventory_v1_agents_proto_init() {
 	}
 	file_inventory_v1_agent_status_proto_init()
 	file_inventory_v1_log_level_proto_init()
-	file_inventory_v1_agents_proto_msgTypes[20].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[24].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[21].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[25].OneofWrappers = []any{
 		(*GetAgentResponse_PmmAgent)(nil),
 		(*GetAgentResponse_Vmagent)(nil),
 		(*GetAgentResponse_NodeExporter)(nil),
@@ -12832,8 +13438,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*GetAgentResponse_NomadAgent)(nil),
 		(*GetAgentResponse_ValkeyExporter)(nil),
 		(*GetAgentResponse_RtaMongodbAgent)(nil),
+		(*GetAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[27].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[28].OneofWrappers = []any{
 		(*AddAgentRequest_PmmAgent)(nil),
 		(*AddAgentRequest_NodeExporter)(nil),
 		(*AddAgentRequest_MysqldExporter)(nil),
@@ -12851,8 +13458,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*AddAgentRequest_QanPostgresqlPgstatmonitorAgent)(nil),
 		(*AddAgentRequest_ValkeyExporter)(nil),
 		(*AddAgentRequest_RtaMongodbAgent)(nil),
+		(*AddAgentRequest_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[28].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[29].OneofWrappers = []any{
 		(*AddAgentResponse_PmmAgent)(nil),
 		(*AddAgentResponse_NodeExporter)(nil),
 		(*AddAgentResponse_MysqldExporter)(nil),
@@ -12870,8 +13478,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*AddAgentResponse_QanPostgresqlPgstatmonitorAgent)(nil),
 		(*AddAgentResponse_ValkeyExporter)(nil),
 		(*AddAgentResponse_RtaMongodbAgent)(nil),
+		(*AddAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[29].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[30].OneofWrappers = []any{
 		(*ChangeAgentRequest_NodeExporter)(nil),
 		(*ChangeAgentRequest_MysqldExporter)(nil),
 		(*ChangeAgentRequest_MongodbExporter)(nil),
@@ -12889,8 +13498,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*ChangeAgentRequest_NomadAgent)(nil),
 		(*ChangeAgentRequest_ValkeyExporter)(nil),
 		(*ChangeAgentRequest_RtaMongodbAgent)(nil),
+		(*ChangeAgentRequest_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[30].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[31].OneofWrappers = []any{
 		(*ChangeAgentResponse_NodeExporter)(nil),
 		(*ChangeAgentResponse_MysqldExporter)(nil),
 		(*ChangeAgentResponse_MongodbExporter)(nil),
@@ -12908,31 +13518,33 @@ func file_inventory_v1_agents_proto_init() {
 		(*ChangeAgentResponse_NomadAgent)(nil),
 		(*ChangeAgentResponse_ValkeyExporter)(nil),
 		(*ChangeAgentResponse_RtaMongodbAgent)(nil),
+		(*ChangeAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[33].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[35].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[37].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[39].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[41].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[43].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[45].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[47].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[49].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[51].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[53].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[55].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[57].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[59].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[34].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[36].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[38].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[40].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[42].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[44].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[46].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[48].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[50].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[52].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[54].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[56].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[58].OneofWrappers = []any{}
 	file_inventory_v1_agents_proto_msgTypes[60].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[62].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[64].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[61].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[63].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[65].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[67].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_inventory_v1_agents_proto_rawDesc), len(file_inventory_v1_agents_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   107,
+			NumMessages:   112,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/inventory/v1/agents.pb.validate.go
+++ b/api/inventory/v1/agents.pb.validate.go
@@ -134,8 +134,7 @@ func (e PMMAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PMMAgentValidationError{}
@@ -243,8 +242,7 @@ func (e VMAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VMAgentValidationError{}
@@ -355,8 +353,7 @@ func (e NomadAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = NomadAgentValidationError{}
@@ -504,8 +501,7 @@ func (e NodeExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = NodeExporterValidationError{}
@@ -705,8 +701,7 @@ func (e MySQLdExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MySQLdExporterValidationError{}
@@ -896,8 +891,7 @@ func (e MongoDBExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MongoDBExporterValidationError{}
@@ -1087,8 +1081,7 @@ func (e PostgresExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PostgresExporterValidationError{}
@@ -1274,8 +1267,7 @@ func (e ProxySQLExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ProxySQLExporterValidationError{}
@@ -1459,8 +1451,7 @@ func (e ValkeyExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ValkeyExporterValidationError{}
@@ -1598,8 +1589,7 @@ func (e QANMySQLPerfSchemaAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMySQLPerfSchemaAgentValidationError{}
@@ -1739,8 +1729,7 @@ func (e QANMySQLSlowlogAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMySQLSlowlogAgentValidationError{}
@@ -1866,8 +1855,7 @@ func (e QANMongoDBProfilerAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMongoDBProfilerAgentValidationError{}
@@ -1993,8 +1981,7 @@ func (e QANMongoDBMongologAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMongoDBMongologAgentValidationError{}
@@ -2123,8 +2110,7 @@ func (e RTAOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RTAOptionsValidationError{}
@@ -2136,6 +2122,157 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = RTAOptionsValidationError{}
+
+// Validate checks the field values on RTAPostgreSQLAgent with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *RTAPostgreSQLAgent) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on RTAPostgreSQLAgent with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// RTAPostgreSQLAgentMultiError, or nil if none found.
+func (m *RTAPostgreSQLAgent) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *RTAPostgreSQLAgent) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for AgentId
+
+	// no validation rules for PmmAgentId
+
+	// no validation rules for Disabled
+
+	// no validation rules for ServiceId
+
+	// no validation rules for Username
+
+	// no validation rules for Tls
+
+	// no validation rules for TlsSkipVerify
+
+	// no validation rules for CustomLabels
+
+	if all {
+		switch v := interface{}(m.GetRtaOptions()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RTAPostgreSQLAgentValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RTAPostgreSQLAgentValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RTAPostgreSQLAgentValidationError{
+				field:  "RtaOptions",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for Status
+
+	// no validation rules for LogLevel
+
+	if len(errors) > 0 {
+		return RTAPostgreSQLAgentMultiError(errors)
+	}
+
+	return nil
+}
+
+// RTAPostgreSQLAgentMultiError is an error wrapping multiple validation errors
+// returned by RTAPostgreSQLAgent.ValidateAll() if the designated constraints
+// aren't met.
+type RTAPostgreSQLAgentMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m RTAPostgreSQLAgentMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m RTAPostgreSQLAgentMultiError) AllErrors() []error { return m }
+
+// RTAPostgreSQLAgentValidationError is the validation error returned by
+// RTAPostgreSQLAgent.Validate if the designated constraints aren't met.
+type RTAPostgreSQLAgentValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e RTAPostgreSQLAgentValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e RTAPostgreSQLAgentValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e RTAPostgreSQLAgentValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e RTAPostgreSQLAgentValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e RTAPostgreSQLAgentValidationError) ErrorName() string {
+	return "RTAPostgreSQLAgentValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e RTAPostgreSQLAgentValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sRTAPostgreSQLAgent.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = RTAPostgreSQLAgentValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = RTAPostgreSQLAgentValidationError{}
 
 // Validate checks the field values on RTAMongoDBAgent with the rules defined
 // in the proto definition for this message. If any rules are violated, the
@@ -2273,8 +2410,7 @@ func (e RTAMongoDBAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RTAMongoDBAgentValidationError{}
@@ -2403,8 +2539,7 @@ func (e QANPostgreSQLPgStatementsAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANPostgreSQLPgStatementsAgentValidationError{}
@@ -2535,8 +2670,7 @@ func (e QANPostgreSQLPgStatMonitorAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANPostgreSQLPgStatMonitorAgentValidationError{}
@@ -2692,8 +2826,7 @@ func (e RDSExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RDSExporterValidationError{}
@@ -2848,8 +2981,7 @@ func (e ExternalExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExternalExporterValidationError{}
@@ -3004,8 +3136,7 @@ func (e AzureDatabaseExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AzureDatabaseExporterValidationError{}
@@ -3074,6 +3205,7 @@ func (m *ChangeCommonAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -3102,6 +3234,7 @@ func (m *ChangeCommonAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -3175,8 +3308,7 @@ func (e ChangeCommonAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeCommonAgentParamsValidationError{}
@@ -3286,8 +3418,7 @@ func (e ListAgentsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsRequestValidationError{}
@@ -3968,6 +4099,40 @@ func (m *ListAgentsResponse) validate(all bool) error {
 
 	}
 
+	for idx, item := range m.GetRtaPostgresqlAgent() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListAgentsResponseValidationError{
+						field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListAgentsResponseValidationError{
+						field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListAgentsResponseValidationError{
+					field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return ListAgentsResponseMultiError(errors)
 	}
@@ -4035,8 +4200,7 @@ func (e ListAgentsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsResponseValidationError{}
@@ -4147,8 +4311,7 @@ func (e GetAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentRequestValidationError{}
@@ -4963,6 +5126,47 @@ func (m *GetAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *GetAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := GetAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, GetAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, GetAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return GetAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -5032,8 +5236,7 @@ func (e GetAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentResponseValidationError{}
@@ -5148,8 +5351,7 @@ func (e GetAgentLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentLogsRequestValidationError{}
@@ -5253,8 +5455,7 @@ func (e GetAgentLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentLogsResponseValidationError{}
@@ -5987,6 +6188,47 @@ func (m *AddAgentRequest) validate(all bool) error {
 			}
 		}
 
+	case *AddAgentRequest_RtaPostgresqlAgent:
+		if v == nil {
+			err := AddAgentRequestValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, AddAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, AddAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return AddAgentRequestValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -6056,8 +6298,7 @@ func (e AddAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAgentRequestValidationError{}
@@ -6790,6 +7031,47 @@ func (m *AddAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *AddAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := AddAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, AddAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, AddAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return AddAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -6859,8 +7141,7 @@ func (e AddAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAgentResponseValidationError{}
@@ -7604,6 +7885,47 @@ func (m *ChangeAgentRequest) validate(all bool) error {
 			}
 		}
 
+	case *ChangeAgentRequest_RtaPostgresqlAgent:
+		if v == nil {
+			err := ChangeAgentRequestValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeAgentRequestValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -7675,8 +7997,7 @@ func (e ChangeAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAgentRequestValidationError{}
@@ -8409,6 +8730,47 @@ func (m *ChangeAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *ChangeAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := ChangeAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -8480,8 +8842,7 @@ func (e ChangeAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAgentResponseValidationError{}
@@ -8596,8 +8957,7 @@ func (e AddPMMAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPMMAgentParamsValidationError{}
@@ -8718,8 +9078,7 @@ func (e AddNodeExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddNodeExporterParamsValidationError{}
@@ -8788,6 +9147,7 @@ func (m *ChangeNodeExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -8816,6 +9176,7 @@ func (m *ChangeNodeExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -8897,8 +9258,7 @@ func (e ChangeNodeExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeNodeExporterParamsValidationError{}
@@ -9091,8 +9451,7 @@ func (e AddMySQLdExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMySQLdExporterParamsValidationError{}
@@ -9191,6 +9550,7 @@ func (m *ChangeMySQLdExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -9219,6 +9579,7 @@ func (m *ChangeMySQLdExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -9340,8 +9701,7 @@ func (e ChangeMySQLdExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeMySQLdExporterParamsValidationError{}
@@ -9529,8 +9889,7 @@ func (e AddMongoDBExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMongoDBExporterParamsValidationError{}
@@ -9629,6 +9988,7 @@ func (m *ChangeMongoDBExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -9657,6 +10017,7 @@ func (m *ChangeMongoDBExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -9791,8 +10152,7 @@ func (e ChangeMongoDBExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeMongoDBExporterParamsValidationError{}
@@ -9985,8 +10345,7 @@ func (e AddPostgresExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPostgresExporterParamsValidationError{}
@@ -10085,6 +10444,7 @@ func (m *ChangePostgresExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10113,6 +10473,7 @@ func (m *ChangePostgresExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -10239,8 +10600,7 @@ func (e ChangePostgresExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangePostgresExporterParamsValidationError{}
@@ -10423,8 +10783,7 @@ func (e AddProxySQLExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddProxySQLExporterParamsValidationError{}
@@ -10523,6 +10882,7 @@ func (m *ChangeProxySQLExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10551,6 +10911,7 @@ func (m *ChangeProxySQLExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -10653,8 +11014,7 @@ func (e ChangeProxySQLExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeProxySQLExporterParamsValidationError{}
@@ -10818,8 +11178,7 @@ func (e AddQANMySQLPerfSchemaAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMySQLPerfSchemaAgentParamsValidationError{}
@@ -10889,6 +11248,7 @@ func (m *ChangeQANMySQLPerfSchemaAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10917,6 +11277,7 @@ func (m *ChangeQANMySQLPerfSchemaAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11040,8 +11401,7 @@ func (e ChangeQANMySQLPerfSchemaAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMySQLPerfSchemaAgentParamsValidationError{}
@@ -11205,8 +11565,7 @@ func (e AddQANMySQLSlowlogAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMySQLSlowlogAgentParamsValidationError{}
@@ -11276,6 +11635,7 @@ func (m *ChangeQANMySQLSlowlogAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -11304,6 +11664,7 @@ func (m *ChangeQANMySQLSlowlogAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11431,8 +11792,7 @@ func (e ChangeQANMySQLSlowlogAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMySQLSlowlogAgentParamsValidationError{}
@@ -11585,8 +11945,7 @@ func (e AddQANMongoDBProfilerAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMongoDBProfilerAgentParamsValidationError{}
@@ -11656,6 +12015,7 @@ func (m *ChangeQANMongoDBProfilerAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -11684,6 +12044,7 @@ func (m *ChangeQANMongoDBProfilerAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11803,8 +12164,7 @@ func (e ChangeQANMongoDBProfilerAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMongoDBProfilerAgentParamsValidationError{}
@@ -11957,8 +12317,7 @@ func (e AddQANMongoDBMongologAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMongoDBMongologAgentParamsValidationError{}
@@ -12028,6 +12387,7 @@ func (m *ChangeQANMongoDBMongologAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12056,6 +12416,7 @@ func (m *ChangeQANMongoDBMongologAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12175,8 +12536,7 @@ func (e ChangeQANMongoDBMongologAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMongoDBMongologAgentParamsValidationError{}
@@ -12337,8 +12697,7 @@ func (e AddQANPostgreSQLPgStatementsAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANPostgreSQLPgStatementsAgentParamsValidationError{}
@@ -12409,6 +12768,7 @@ func (m *ChangeQANPostgreSQLPgStatementsAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12437,6 +12797,7 @@ func (m *ChangeQANPostgreSQLPgStatementsAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12552,8 +12913,7 @@ func (e ChangeQANPostgreSQLPgStatementsAgentParamsValidationError) Error() strin
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANPostgreSQLPgStatementsAgentParamsValidationError{}
@@ -12716,8 +13076,7 @@ func (e AddQANPostgreSQLPgStatMonitorAgentParamsValidationError) Error() string 
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANPostgreSQLPgStatMonitorAgentParamsValidationError{}
@@ -12788,6 +13147,7 @@ func (m *ChangeQANPostgreSQLPgStatMonitorAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12816,6 +13176,7 @@ func (m *ChangeQANPostgreSQLPgStatMonitorAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12935,8 +13296,7 @@ func (e ChangeQANPostgreSQLPgStatMonitorAgentParamsValidationError) Error() stri
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANPostgreSQLPgStatMonitorAgentParamsValidationError{}
@@ -13076,8 +13436,7 @@ func (e AddRDSExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRDSExporterParamsValidationError{}
@@ -13146,6 +13505,7 @@ func (m *ChangeRDSExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13174,6 +13534,7 @@ func (m *ChangeRDSExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13267,8 +13628,7 @@ func (e ChangeRDSExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeRDSExporterParamsValidationError{}
@@ -13408,8 +13768,7 @@ func (e AddExternalExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddExternalExporterParamsValidationError{}
@@ -13478,6 +13837,7 @@ func (m *ChangeExternalExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13506,6 +13866,7 @@ func (m *ChangeExternalExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13596,8 +13957,7 @@ func (e ChangeExternalExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeExternalExporterParamsValidationError{}
@@ -13751,8 +14111,7 @@ func (e AddAzureDatabaseExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAzureDatabaseExporterParamsValidationError{}
@@ -13822,6 +14181,7 @@ func (m *ChangeAzureDatabaseExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13850,6 +14210,7 @@ func (m *ChangeAzureDatabaseExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13949,8 +14310,7 @@ func (e ChangeAzureDatabaseExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAzureDatabaseExporterParamsValidationError{}
@@ -14056,8 +14416,7 @@ func (e ChangeNomadAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeNomadAgentParamsValidationError{}
@@ -14255,8 +14614,7 @@ func (e AddValkeyExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddValkeyExporterParamsValidationError{}
@@ -14355,6 +14713,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14383,6 +14742,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -14390,6 +14750,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 	}
 
 	if m.Username != nil {
+
 		if utf8.RuneCountInString(m.GetUsername()) < 1 {
 			err := ChangeValkeyExporterParamsValidationError{
 				field:  "Username",
@@ -14400,6 +14761,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.Password != nil {
@@ -14505,8 +14867,7 @@ func (e ChangeValkeyExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeValkeyExporterParamsValidationError{}
@@ -14681,8 +15042,7 @@ func (e AddRTAMongoDBAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRTAMongoDBAgentParamsValidationError{}
@@ -14722,6 +15082,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14750,6 +15111,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.LogLevel != nil {
@@ -14789,6 +15151,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 	}
 
 	if m.RtaOptions != nil {
+
 		if all {
 			switch v := interface{}(m.GetRtaOptions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14817,6 +15180,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if len(errors) > 0 {
@@ -14887,8 +15251,7 @@ func (e ChangeRTAMongoDBAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeRTAMongoDBAgentParamsValidationError{}
@@ -14900,6 +15263,385 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = ChangeRTAMongoDBAgentParamsValidationError{}
+
+// Validate checks the field values on AddRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *AddRTAPostgreSQLAgentParams) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on AddRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// AddRTAPostgreSQLAgentParamsMultiError, or nil if none found.
+func (m *AddRTAPostgreSQLAgentParams) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *AddRTAPostgreSQLAgentParams) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if utf8.RuneCountInString(m.GetPmmAgentId()) < 1 {
+		err := AddRTAPostgreSQLAgentParamsValidationError{
+			field:  "PmmAgentId",
+			reason: "value length must be at least 1 runes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if utf8.RuneCountInString(m.GetServiceId()) < 1 {
+		err := AddRTAPostgreSQLAgentParamsValidationError{
+			field:  "ServiceId",
+			reason: "value length must be at least 1 runes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	// no validation rules for Username
+
+	// no validation rules for Password
+
+	// no validation rules for CustomLabels
+
+	// no validation rules for LogLevel
+
+	// no validation rules for Tls
+
+	// no validation rules for TlsSkipVerify
+
+	// no validation rules for TlsCa
+
+	// no validation rules for TlsCert
+
+	// no validation rules for TlsKey
+
+	// no validation rules for SkipConnectionCheck
+
+	if all {
+		switch v := interface{}(m.GetRtaOptions()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, AddRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, AddRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return AddRTAPostgreSQLAgentParamsValidationError{
+				field:  "RtaOptions",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return AddRTAPostgreSQLAgentParamsMultiError(errors)
+	}
+
+	return nil
+}
+
+// AddRTAPostgreSQLAgentParamsMultiError is an error wrapping multiple
+// validation errors returned by AddRTAPostgreSQLAgentParams.ValidateAll() if
+// the designated constraints aren't met.
+type AddRTAPostgreSQLAgentParamsMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m AddRTAPostgreSQLAgentParamsMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m AddRTAPostgreSQLAgentParamsMultiError) AllErrors() []error { return m }
+
+// AddRTAPostgreSQLAgentParamsValidationError is the validation error returned
+// by AddRTAPostgreSQLAgentParams.Validate if the designated constraints
+// aren't met.
+type AddRTAPostgreSQLAgentParamsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e AddRTAPostgreSQLAgentParamsValidationError) ErrorName() string {
+	return "AddRTAPostgreSQLAgentParamsValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e AddRTAPostgreSQLAgentParamsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sAddRTAPostgreSQLAgentParams.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = AddRTAPostgreSQLAgentParamsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = AddRTAPostgreSQLAgentParamsValidationError{}
+
+// Validate checks the field values on ChangeRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ChangeRTAPostgreSQLAgentParams) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ChangeRTAPostgreSQLAgentParams with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// ChangeRTAPostgreSQLAgentParamsMultiError, or nil if none found.
+func (m *ChangeRTAPostgreSQLAgentParams) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ChangeRTAPostgreSQLAgentParams) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.Enable != nil {
+		// no validation rules for Enable
+	}
+
+	if m.CustomLabels != nil {
+
+		if all {
+			switch v := interface{}(m.GetCustomLabels()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "CustomLabels",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "CustomLabels",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetCustomLabels()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeRTAPostgreSQLAgentParamsValidationError{
+					field:  "CustomLabels",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if m.LogLevel != nil {
+		// no validation rules for LogLevel
+	}
+
+	if m.Username != nil {
+		// no validation rules for Username
+	}
+
+	if m.Password != nil {
+		// no validation rules for Password
+	}
+
+	if m.Tls != nil {
+		// no validation rules for Tls
+	}
+
+	if m.TlsSkipVerify != nil {
+		// no validation rules for TlsSkipVerify
+	}
+
+	if m.TlsCa != nil {
+		// no validation rules for TlsCa
+	}
+
+	if m.TlsCert != nil {
+		// no validation rules for TlsCert
+	}
+
+	if m.TlsKey != nil {
+		// no validation rules for TlsKey
+	}
+
+	if m.RtaOptions != nil {
+
+		if all {
+			switch v := interface{}(m.GetRtaOptions()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "RtaOptions",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "RtaOptions",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return ChangeRTAPostgreSQLAgentParamsMultiError(errors)
+	}
+
+	return nil
+}
+
+// ChangeRTAPostgreSQLAgentParamsMultiError is an error wrapping multiple
+// validation errors returned by ChangeRTAPostgreSQLAgentParams.ValidateAll()
+// if the designated constraints aren't met.
+type ChangeRTAPostgreSQLAgentParamsMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ChangeRTAPostgreSQLAgentParamsMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ChangeRTAPostgreSQLAgentParamsMultiError) AllErrors() []error { return m }
+
+// ChangeRTAPostgreSQLAgentParamsValidationError is the validation error
+// returned by ChangeRTAPostgreSQLAgentParams.Validate if the designated
+// constraints aren't met.
+type ChangeRTAPostgreSQLAgentParamsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) ErrorName() string {
+	return "ChangeRTAPostgreSQLAgentParamsValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sChangeRTAPostgreSQLAgentParams.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ChangeRTAPostgreSQLAgentParamsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ChangeRTAPostgreSQLAgentParamsValidationError{}
 
 // Validate checks the field values on RemoveAgentRequest with the rules
 // defined in the proto definition for this message. If any rules are
@@ -15003,8 +15745,7 @@ func (e RemoveAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveAgentRequestValidationError{}
@@ -15106,8 +15847,7 @@ func (e RemoveAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveAgentResponseValidationError{}

--- a/api/inventory/v1/agents.proto
+++ b/api/inventory/v1/agents.proto
@@ -34,6 +34,7 @@ enum AgentType {
   AGENT_TYPE_AZURE_DATABASE_EXPORTER = 15;
   AGENT_TYPE_NOMAD_AGENT = 16;
   AGENT_TYPE_RTA_MONGODB_AGENT = 19;
+  AGENT_TYPE_RTA_POSTGRESQL_AGENT = 20;
 }
 
 // PMMAgent runs on Generic or Container Node.
@@ -548,6 +549,32 @@ message RTAOptions {
   }];
 }
 
+// RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server.
+message RTAPostgreSQLAgent {
+  // Unique agent identifier.
+  string agent_id = 1;
+  // The pmm-agent identifier which runs this instance.
+  string pmm_agent_id = 2;
+  // Desired Agent status: enabled (false) or disabled (true).
+  bool disabled = 3;
+  // Service identifier.
+  string service_id = 4;
+  // PostgreSQL username for getting session data.
+  string username = 5 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Use TLS for database connections.
+  bool tls = 6;
+  // Skip TLS certificate and hostname validation.
+  bool tls_skip_verify = 7;
+  // Custom user-assigned labels.
+  map<string, string> custom_labels = 8;
+  // Real-Time Analytics options.
+  RTAOptions rta_options = 9;
+  // Actual Agent status.
+  AgentStatus status = 10;
+  // Log level for agent.
+  LogLevel log_level = 11;
+}
+
 // RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server.
 message RTAMongoDBAgent {
   // Unique agent identifier.
@@ -805,6 +832,7 @@ message ListAgentsResponse {
   repeated NomadAgent nomad_agent = 16;
   repeated ValkeyExporter valkey_exporter = 17;
   repeated RTAMongoDBAgent rta_mongodb_agent = 19;
+  repeated RTAPostgreSQLAgent rta_postgresql_agent = 20;
 }
 
 // Get
@@ -835,6 +863,7 @@ message GetAgentResponse {
     NomadAgent nomad_agent = 16;
     ValkeyExporter valkey_exporter = 17;
     RTAMongoDBAgent rta_mongodb_agent = 19;
+    RTAPostgreSQLAgent rta_postgresql_agent = 20;
   }
 }
 
@@ -875,6 +904,7 @@ message AddAgentRequest {
     AddQANPostgreSQLPgStatMonitorAgentParams qan_postgresql_pgstatmonitor_agent = 14;
     AddValkeyExporterParams valkey_exporter = 15;
     AddRTAMongoDBAgentParams rta_mongodb_agent = 17;
+    AddRTAPostgreSQLAgentParams rta_postgresql_agent = 18;
   }
 }
 
@@ -897,6 +927,7 @@ message AddAgentResponse {
     QANPostgreSQLPgStatMonitorAgent qan_postgresql_pgstatmonitor_agent = 14;
     ValkeyExporter valkey_exporter = 15;
     RTAMongoDBAgent rta_mongodb_agent = 17;
+    RTAPostgreSQLAgent rta_postgresql_agent = 18;
   }
 }
 
@@ -923,6 +954,7 @@ message ChangeAgentRequest {
     ChangeNomadAgentParams nomad_agent = 15;
     ChangeValkeyExporterParams valkey_exporter = 16;
     ChangeRTAMongoDBAgentParams rta_mongodb_agent = 18;
+    ChangeRTAPostgreSQLAgentParams rta_postgresql_agent = 19;
   }
 }
 
@@ -947,6 +979,7 @@ message ChangeAgentResponse {
     NomadAgent nomad_agent = 15;
     ValkeyExporter valkey_exporter = 16;
     RTAMongoDBAgent rta_mongodb_agent = 18;
+    RTAPostgreSQLAgent rta_postgresql_agent = 19;
   }
 }
 
@@ -2079,6 +2112,62 @@ message ChangeRTAMongoDBAgentParams {
   optional string authentication_mechanism = 11;
   // Real-Time Analytics options.
   optional RTAOptions rta_options = 12;
+}
+
+// Add/Change RTAPostgreSQLAgent
+
+message AddRTAPostgreSQLAgentParams {
+  // The pmm-agent identifier which runs this instance.
+  string pmm_agent_id = 1 [(validate.rules).string.min_len = 1];
+  // Service identifier.
+  string service_id = 2 [(validate.rules).string.min_len = 1];
+  // PostgreSQL username for getting session data.
+  string username = 3 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // PostgreSQL password for getting session data.
+  string password = 4 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Custom user-assigned labels.
+  map<string, string> custom_labels = 5;
+  // Log level for agent.
+  LogLevel log_level = 6;
+  // Use TLS for database connections.
+  bool tls = 7;
+  // Skip TLS certificate and hostname validation.
+  bool tls_skip_verify = 8;
+  // TLS CA certificate.
+  string tls_ca = 9;
+  // TLS certificate.
+  string tls_cert = 10 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // TLS certificate key.
+  string tls_key = 11 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Skip connection check.
+  bool skip_connection_check = 12;
+  // Real-Time Analytics options.
+  RTAOptions rta_options = 13;
+}
+
+message ChangeRTAPostgreSQLAgentParams {
+  // Enable this Agent. Agents are enabled by default when they get added.
+  optional bool enable = 1;
+  // Replace all custom user-assigned labels.
+  optional common.StringMap custom_labels = 2;
+  // Log level for agent.
+  optional LogLevel log_level = 3;
+  // PostgreSQL username for getting session data.
+  optional string username = 4 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // PostgreSQL password for getting session data.
+  optional string password = 5 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Use TLS for database connections.
+  optional bool tls = 6;
+  // Skip TLS certificate and hostname validation.
+  optional bool tls_skip_verify = 7;
+  // TLS CA certificate.
+  optional string tls_ca = 8;
+  // TLS certificate.
+  optional string tls_cert = 9 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // TLS certificate key.
+  optional string tls_key = 10 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Real-Time Analytics options.
+  optional RTAOptions rta_options = 11;
 }
 
 // Remove

--- a/api/inventory/v1/agents.swagger.json
+++ b/api/inventory/v1/agents.swagger.json
@@ -1,0 +1,4687 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/agents.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AgentsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/inventory/agents": {
+      "get": {
+        "summary": "List Agents",
+        "description": "Returns a list of all Agents.",
+        "operationId": "ListAgents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAgentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmm_agent_id",
+            "description": "Return only Agents started by this pmm-agent.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "node_id",
+            "description": "Return only Agents that provide insights for that Node.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "service_id",
+            "description": "Return only Agents that provide insights for that Service.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "agent_type",
+            "description": "Return only agents of a particular type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AGENT_TYPE_UNSPECIFIED",
+              "AGENT_TYPE_PMM_AGENT",
+              "AGENT_TYPE_VM_AGENT",
+              "AGENT_TYPE_NODE_EXPORTER",
+              "AGENT_TYPE_MYSQLD_EXPORTER",
+              "AGENT_TYPE_MONGODB_EXPORTER",
+              "AGENT_TYPE_POSTGRES_EXPORTER",
+              "AGENT_TYPE_PROXYSQL_EXPORTER",
+              "AGENT_TYPE_VALKEY_EXPORTER",
+              "AGENT_TYPE_QAN_MYSQL_PERFSCHEMA_AGENT",
+              "AGENT_TYPE_QAN_MYSQL_SLOWLOG_AGENT",
+              "AGENT_TYPE_QAN_MONGODB_PROFILER_AGENT",
+              "AGENT_TYPE_QAN_MONGODB_MONGOLOG_AGENT",
+              "AGENT_TYPE_QAN_POSTGRESQL_PGSTATEMENTS_AGENT",
+              "AGENT_TYPE_QAN_POSTGRESQL_PGSTATMONITOR_AGENT",
+              "AGENT_TYPE_EXTERNAL_EXPORTER",
+              "AGENT_TYPE_RDS_EXPORTER",
+              "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
+              "AGENT_TYPE_NOMAD_AGENT",
+              "AGENT_TYPE_RTA_MONGODB_AGENT",
+              "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
+            ],
+            "default": "AGENT_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "post": {
+        "summary": "Add an Agent to Inventory",
+        "description": "Adds an Agent to Inventory. Only one agent at a time can be passed.",
+        "operationId": "AddAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddAgentRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    },
+    "/v1/inventory/agents/{agent_id}": {
+      "get": {
+        "summary": "Get Agent",
+        "description": "Returns a single Agent by ID.",
+        "operationId": "GetAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "delete": {
+        "summary": "Remove an Agent from Inventory",
+        "description": "Removes an Agent from Inventory.",
+        "operationId": "RemoveAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Remove agent with all dependencies.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "put": {
+        "summary": "Update an Agent in Inventory",
+        "description": "Updates an Agent in Inventory. Only one agent at a time can be passed.",
+        "operationId": "ChangeAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentsServiceChangeAgentBody"
+            }
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    },
+    "/v1/inventory/agents/{agent_id}/logs": {
+      "get": {
+        "summary": "Get Agent logs",
+        "description": "Returns Agent logs by ID.",
+        "operationId": "GetAgentLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAgentLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "description": "Limit the number of log lines to this value. Pass 0 for no limit.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "AgentsServiceChangeAgentBody": {
+      "type": "object",
+      "properties": {
+        "node_exporter": {
+          "$ref": "#/definitions/v1ChangeNodeExporterParams"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1ChangeMySQLdExporterParams"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1ChangeMongoDBExporterParams"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1ChangePostgresExporterParams"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ChangeProxySQLExporterParams"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ChangeExternalExporterParams"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1ChangeRDSExporterParams"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1ChangeAzureDatabaseExporterParams"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1ChangeQANMySQLPerfSchemaAgentParams"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1ChangeQANMySQLSlowlogAgentParams"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1ChangeQANMongoDBProfilerAgentParams"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1ChangeQANMongoDBMongologAgentParams"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1ChangeQANPostgreSQLPgStatementsAgentParams"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1ChangeQANPostgreSQLPgStatMonitorAgentParams"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1ChangeNomadAgentParams"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ChangeValkeyExporterParams"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1ChangeRTAMongoDBAgentParams"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1ChangeRTAPostgreSQLAgentParams"
+        }
+      }
+    },
+    "commonMetricsResolutions": {
+      "type": "object",
+      "properties": {
+        "hr": {
+          "type": "string",
+          "description": "High resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "mr": {
+          "type": "string",
+          "description": "Medium resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "lr": {
+          "type": "string",
+          "description": "Low resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        }
+      },
+      "description": "MetricsResolutions represents Prometheus exporters metrics resolutions."
+    },
+    "commonStringMap": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "A wrapper for map[string]string. This type allows to distinguish between an empty map and a null value."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AddAgentRequest": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1AddPMMAgentParams"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1AddNodeExporterParams"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1AddMySQLdExporterParams"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1AddMongoDBExporterParams"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1AddPostgresExporterParams"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1AddProxySQLExporterParams"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1AddExternalExporterParams"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1AddRDSExporterParams"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AddAzureDatabaseExporterParams"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1AddQANMySQLPerfSchemaAgentParams"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1AddQANMySQLSlowlogAgentParams"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1AddQANMongoDBProfilerAgentParams"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1AddQANMongoDBMongologAgentParams"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1AddQANPostgreSQLPgStatementsAgentParams"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1AddQANPostgreSQLPgStatMonitorAgentParams"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1AddValkeyExporterParams"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1AddRTAMongoDBAgentParams"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1AddRTAPostgreSQLAgentParams"
+        }
+      }
+    },
+    "v1AddAgentResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1PMMAgent"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1AddAzureDatabaseExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "azure_client_id": {
+          "type": "string",
+          "title": "Azure client ID"
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "title": "Azure client secret"
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "title": "Azure tanant ID"
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "title": "Azure subscription ID"
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "description": "Azure resource group."
+        },
+        "azure_database_resource_type": {
+          "type": "string",
+          "title": "Azure resource type (mysql, maria, postgres)"
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddExternalExporterParams": {
+      "type": "object",
+      "properties": {
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "The node identifier where this instance is run."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "HTTP basic auth password for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints(default: http)."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI(default: /metrics)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        }
+      }
+    },
+    "v1AddMongoDBExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of colletions to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names to pass to the exporter.\nValues will be resolved from pmm-agent's environment when starting the exporter."
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "Enable all collectors."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddMySQLdExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddNodeExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Expose the node_exporter process on all public interfaces"
+        }
+      }
+    },
+    "v1AddPMMAgentParams": {
+      "type": "object",
+      "properties": {
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddPostgresExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddProxySQLExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "ProxySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddQANMongoDBMongologAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      }
+    },
+    "v1AddQANMongoDBProfilerAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      }
+    },
+    "v1AddQANMySQLPerfSchemaAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      }
+    },
+    "v1AddQANMySQLSlowlogAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting slowlog data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for getting slowlog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Rotate slowlog file at this size if \u003e 0.\nUse zero or negative value to disable rotation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      }
+    },
+    "v1AddQANPostgreSQLPgStatMonitorAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddQANPostgreSQLPgStatementsAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting pg stat statements data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddRDSExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "description": "AWS Secret Key."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_basic_metrics": {
+          "type": "boolean",
+          "description": "Disable basic metrics."
+        },
+        "disable_enhanced_metrics": {
+          "type": "boolean",
+          "description": "Disable enhanced metrics."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddRTAMongoDBAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting queries data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting queries data."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "MongoDB specific options.\nUse TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1AddRTAPostgreSQLAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting session data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting session data."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS certificate key."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1AddValkeyExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "Valkey password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AgentStatus": {
+      "type": "string",
+      "enum": [
+        "AGENT_STATUS_UNSPECIFIED",
+        "AGENT_STATUS_STARTING",
+        "AGENT_STATUS_INITIALIZATION_ERROR",
+        "AGENT_STATUS_RUNNING",
+        "AGENT_STATUS_WAITING",
+        "AGENT_STATUS_STOPPING",
+        "AGENT_STATUS_DONE",
+        "AGENT_STATUS_UNKNOWN"
+      ],
+      "default": "AGENT_STATUS_UNSPECIFIED",
+      "description": "AgentStatus represents actual Agent status.\n\n - AGENT_STATUS_STARTING: Agent is starting.\n - AGENT_STATUS_INITIALIZATION_ERROR: Agent encountered error when starting.\n - AGENT_STATUS_RUNNING: Agent is running.\n - AGENT_STATUS_WAITING: Agent encountered error and will be restarted automatically soon.\n - AGENT_STATUS_STOPPING: Agent is stopping.\n - AGENT_STATUS_DONE: Agent has been stopped or disabled.\n - AGENT_STATUS_UNKNOWN: Agent is not connected, we don't know anything about it's state."
+    },
+    "v1AgentType": {
+      "type": "string",
+      "enum": [
+        "AGENT_TYPE_UNSPECIFIED",
+        "AGENT_TYPE_PMM_AGENT",
+        "AGENT_TYPE_VM_AGENT",
+        "AGENT_TYPE_NODE_EXPORTER",
+        "AGENT_TYPE_MYSQLD_EXPORTER",
+        "AGENT_TYPE_MONGODB_EXPORTER",
+        "AGENT_TYPE_POSTGRES_EXPORTER",
+        "AGENT_TYPE_PROXYSQL_EXPORTER",
+        "AGENT_TYPE_VALKEY_EXPORTER",
+        "AGENT_TYPE_QAN_MYSQL_PERFSCHEMA_AGENT",
+        "AGENT_TYPE_QAN_MYSQL_SLOWLOG_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_PROFILER_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_MONGOLOG_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATEMENTS_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATMONITOR_AGENT",
+        "AGENT_TYPE_EXTERNAL_EXPORTER",
+        "AGENT_TYPE_RDS_EXPORTER",
+        "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
+        "AGENT_TYPE_NOMAD_AGENT",
+        "AGENT_TYPE_RTA_MONGODB_AGENT",
+        "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
+      ],
+      "default": "AGENT_TYPE_UNSPECIFIED",
+      "description": "AgentType describes supported Agent types."
+    },
+    "v1AzureDatabaseExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "azure_database_subscription_id": {
+          "type": "string",
+          "description": "Azure database subscription ID."
+        },
+        "azure_database_resource_type": {
+          "type": "string",
+          "title": "Azure database resource type (mysql, maria, postgres)"
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status (the same for several configurations)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics (the same for several configurations)."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if the exporter operates in push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "AzureDatabaseExporter runs on Generic or Container Node and exposes RemoteAzure Node metrics."
+    },
+    "v1ChangeAgentResponse": {
+      "type": "object",
+      "properties": {
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1NomadAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1ChangeAzureDatabaseExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "azure_client_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure client ID"
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure client secret"
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure tenant ID"
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure subscription ID"
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Azure resource group."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeExternalExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "Listen port for scraping metrics."
+        }
+      }
+    },
+    "v1ChangeMongoDBExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of collections to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server is less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable all collectors."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeMySQLdExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeNodeExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Expose the node_exporter process on all public interfaces."
+        }
+      }
+    },
+    "v1ChangeNomadAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        }
+      }
+    },
+    "v1ChangePostgresExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeProxySQLExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "ProxySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeQANMongoDBMongologAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting mongolog data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting mongolog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMongoDBProfilerAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMySQLPerfSchemaAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for getting performance data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMySQLSlowlogAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for getting slowlog data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for getting slowlog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "Rotate slowlog file at this size if \u003e 0."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANPostgreSQLPgStatMonitorAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANPostgreSQLPgStatementsAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting pg stat statements data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeRDSExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "AWS Access Key."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "AWS Secret Key."
+        },
+        "disable_basic_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable basic metrics."
+        },
+        "disable_enhanced_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable enhanced metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeRTAMongoDBAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "x-nullable": true,
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1ChangeRTAPostgreSQLAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting session data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting session data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS certificate key."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "x-nullable": true,
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1ChangeValkeyExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Valkey username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Valkey password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ExternalExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "If disabled, metrics from this exporter will not be collected."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        }
+      },
+      "description": "ExternalExporter runs on any Node type, including Remote Node."
+    },
+    "v1GetAgentLogsResponse": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "agent_config_log_lines_count": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "v1GetAgentResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1PMMAgent"
+        },
+        "vmagent": {
+          "$ref": "#/definitions/v1VMAgent"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1NomadAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1ListAgentsResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PMMAgent"
+          }
+        },
+        "vm_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VMAgent"
+          }
+        },
+        "node_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NodeExporter"
+          }
+        },
+        "mysqld_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MySQLdExporter"
+          }
+        },
+        "mongodb_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBExporter"
+          }
+        },
+        "postgres_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PostgresExporter"
+          }
+        },
+        "proxysql_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ProxySQLExporter"
+          }
+        },
+        "qan_mysql_perfschema_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+          }
+        },
+        "qan_mysql_slowlog_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+          }
+        },
+        "qan_mongodb_profiler_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+          }
+        },
+        "qan_mongodb_mongolog_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+          }
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+          }
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+          }
+        },
+        "external_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ExternalExporter"
+          }
+        },
+        "rds_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RDSExporter"
+          }
+        },
+        "azure_database_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AzureDatabaseExporter"
+          }
+        },
+        "nomad_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NomadAgent"
+          }
+        },
+        "valkey_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ValkeyExporter"
+          }
+        },
+        "rta_mongodb_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RTAMongoDBAgent"
+          }
+        },
+        "rta_postgresql_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+          }
+        }
+      }
+    },
+    "v1LogLevel": {
+      "type": "string",
+      "enum": [
+        "LOG_LEVEL_UNSPECIFIED",
+        "LOG_LEVEL_FATAL",
+        "LOG_LEVEL_ERROR",
+        "LOG_LEVEL_WARN",
+        "LOG_LEVEL_INFO",
+        "LOG_LEVEL_DEBUG"
+      ],
+      "default": "LOG_LEVEL_UNSPECIFIED",
+      "description": "- LOG_LEVEL_UNSPECIFIED: Auto",
+      "title": "Log level for exporters"
+    },
+    "v1MongoDBExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of colletions to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "Enable all collectors."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names passed to the exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MongoDBExporter runs on Generic or Container Node and exposes MongoDB Service metrics."
+    },
+    "v1MySQLdExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors are disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "table_count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual table count at the moment of adding."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "tablestats_group_disabled": {
+          "type": "boolean",
+          "description": "True if tablestats group collectors are currently disabled."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MySQLdExporter runs on Generic or Container Node and exposes MySQL Service metrics."
+    },
+    "v1NodeExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "NodeExporter runs on Generic or Container Node and exposes its metrics."
+    },
+    "v1NomadAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        }
+      }
+    },
+    "v1PMMAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "connected": {
+          "type": "boolean",
+          "description": "True if Agent is running and connected to pmm-managed."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        }
+      },
+      "description": "PMMAgent runs on Generic or Container Node."
+    },
+    "v1PostgresExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "PostgresExporter runs on Generic or Container Node and exposes PostgreSQL Service metrics."
+    },
+    "v1ProxySQLExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ProxySQLExporter runs on Generic or Container Node and exposes ProxySQL Service metrics."
+    },
+    "v1QANMongoDBMongologAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBMongologAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMongoDBProfilerAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBProfilerAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLPerfSchemaAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLPerfSchemaAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLSlowlogAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Limit query length in QAN (default: server-defined; -1: no limit)"
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Slowlog file is rotated at this size if \u003e 0."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "title": "mod tidy"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLSlowlogAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatMonitorAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatMonitorAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatementsAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatementsAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1RDSExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status (the same for several configurations)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics (the same for several configurations)."
+        },
+        "basic_metrics_disabled": {
+          "type": "boolean",
+          "description": "Basic metrics are disabled."
+        },
+        "enhanced_metrics_disabled": {
+          "type": "boolean",
+          "description": "Enhanced metrics are disabled."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "RDSExporter runs on Generic or Container Node and exposes RemoteRDS Node metrics."
+    },
+    "v1RTAMongoDBAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RTAOptions": {
+      "type": "object",
+      "properties": {
+        "collect_interval": {
+          "type": "string",
+          "description": "Query collect interval (default 2s is set by server)."
+        }
+      },
+      "description": "RTAOptions holds Real-Time Query Analytics agent options."
+    },
+    "v1RTAPostgreSQLAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting session data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      },
+      "description": "RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RemoveAgentResponse": {
+      "type": "object"
+    },
+    "v1VMAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        }
+      },
+      "description": "VMAgent runs on Generic or Container Node alongside pmm-agent.\nIt scrapes other exporter Agents that are configured with push_metrics_enabled\nand uses Prometheus remote write protocol to push metrics to PMM Server."
+    },
+    "v1ValkeyExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ValkeyExporter runs on Generic or Container Node and exposes Valkey Service metrics."
+    }
+  }
+}

--- a/api/inventory/v1/agents_grpc.pb.go
+++ b/api/inventory/v1/agents_grpc.pb.go
@@ -8,7 +8,6 @@ package inventoryv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -147,23 +146,18 @@ type UnimplementedAgentsServiceServer struct{}
 func (UnimplementedAgentsServiceServer) ListAgents(context.Context, *ListAgentsRequest) (*ListAgentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAgents not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) GetAgent(context.Context, *GetAgentRequest) (*GetAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) GetAgentLogs(context.Context, *GetAgentLogsRequest) (*GetAgentLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAgentLogs not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) AddAgent(context.Context, *AddAgentRequest) (*AddAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) ChangeAgent(context.Context, *ChangeAgentRequest) (*ChangeAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) RemoveAgent(context.Context, *RemoveAgentRequest) (*RemoveAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveAgent not implemented")
 }

--- a/api/inventory/v1/log_level.pb.go
+++ b/api/inventory/v1/log_level.pb.go
@@ -7,12 +7,11 @@
 package inventoryv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -108,13 +107,10 @@ func file_inventory_v1_log_level_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_log_level_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_log_level_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_log_level_proto_goTypes   = []any{
-		LogLevel(0), // 0: inventory.v1.LogLevel
-	}
-)
-
+var file_inventory_v1_log_level_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_log_level_proto_goTypes = []any{
+	(LogLevel)(0), // 0: inventory.v1.LogLevel
+}
 var file_inventory_v1_log_level_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/inventory/v1/log_level.swagger.json
+++ b/api/inventory/v1/log_level.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/log_level.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/inventory/v1/nodes.pb.go
+++ b/api/inventory/v1/nodes.pb.go
@@ -7,15 +7,14 @@
 package inventoryv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -2008,42 +2007,39 @@ func file_inventory_v1_nodes_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_nodes_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_nodes_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_nodes_proto_msgTypes  = make([]protoimpl.MessageInfo, 28)
-	file_inventory_v1_nodes_proto_goTypes   = []any{
-		NodeType(0),                      // 0: inventory.v1.NodeType
-		(*GenericNode)(nil),              // 1: inventory.v1.GenericNode
-		(*ContainerNode)(nil),            // 2: inventory.v1.ContainerNode
-		(*RemoteNode)(nil),               // 3: inventory.v1.RemoteNode
-		(*RemoteRDSNode)(nil),            // 4: inventory.v1.RemoteRDSNode
-		(*RemoteAzureDatabaseNode)(nil),  // 5: inventory.v1.RemoteAzureDatabaseNode
-		(*ListNodesRequest)(nil),         // 6: inventory.v1.ListNodesRequest
-		(*ListNodesResponse)(nil),        // 7: inventory.v1.ListNodesResponse
-		(*GetNodeRequest)(nil),           // 8: inventory.v1.GetNodeRequest
-		(*GetNodeResponse)(nil),          // 9: inventory.v1.GetNodeResponse
-		(*AddNodeRequest)(nil),           // 10: inventory.v1.AddNodeRequest
-		(*AddNodeResponse)(nil),          // 11: inventory.v1.AddNodeResponse
-		(*AddGenericNodeParams)(nil),     // 12: inventory.v1.AddGenericNodeParams
-		(*AddContainerNodeParams)(nil),   // 13: inventory.v1.AddContainerNodeParams
-		(*AddRemoteNodeParams)(nil),      // 14: inventory.v1.AddRemoteNodeParams
-		(*AddRemoteRDSNodeParams)(nil),   // 15: inventory.v1.AddRemoteRDSNodeParams
-		(*AddRemoteAzureNodeParams)(nil), // 16: inventory.v1.AddRemoteAzureNodeParams
-		(*RemoveNodeRequest)(nil),        // 17: inventory.v1.RemoveNodeRequest
-		(*RemoveNodeResponse)(nil),       // 18: inventory.v1.RemoveNodeResponse
-		nil,                              // 19: inventory.v1.GenericNode.CustomLabelsEntry
-		nil,                              // 20: inventory.v1.ContainerNode.CustomLabelsEntry
-		nil,                              // 21: inventory.v1.RemoteNode.CustomLabelsEntry
-		nil,                              // 22: inventory.v1.RemoteRDSNode.CustomLabelsEntry
-		nil,                              // 23: inventory.v1.RemoteAzureDatabaseNode.CustomLabelsEntry
-		nil,                              // 24: inventory.v1.AddGenericNodeParams.CustomLabelsEntry
-		nil,                              // 25: inventory.v1.AddContainerNodeParams.CustomLabelsEntry
-		nil,                              // 26: inventory.v1.AddRemoteNodeParams.CustomLabelsEntry
-		nil,                              // 27: inventory.v1.AddRemoteRDSNodeParams.CustomLabelsEntry
-		nil,                              // 28: inventory.v1.AddRemoteAzureNodeParams.CustomLabelsEntry
-	}
-)
-
+var file_inventory_v1_nodes_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_nodes_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_inventory_v1_nodes_proto_goTypes = []any{
+	(NodeType)(0),                    // 0: inventory.v1.NodeType
+	(*GenericNode)(nil),              // 1: inventory.v1.GenericNode
+	(*ContainerNode)(nil),            // 2: inventory.v1.ContainerNode
+	(*RemoteNode)(nil),               // 3: inventory.v1.RemoteNode
+	(*RemoteRDSNode)(nil),            // 4: inventory.v1.RemoteRDSNode
+	(*RemoteAzureDatabaseNode)(nil),  // 5: inventory.v1.RemoteAzureDatabaseNode
+	(*ListNodesRequest)(nil),         // 6: inventory.v1.ListNodesRequest
+	(*ListNodesResponse)(nil),        // 7: inventory.v1.ListNodesResponse
+	(*GetNodeRequest)(nil),           // 8: inventory.v1.GetNodeRequest
+	(*GetNodeResponse)(nil),          // 9: inventory.v1.GetNodeResponse
+	(*AddNodeRequest)(nil),           // 10: inventory.v1.AddNodeRequest
+	(*AddNodeResponse)(nil),          // 11: inventory.v1.AddNodeResponse
+	(*AddGenericNodeParams)(nil),     // 12: inventory.v1.AddGenericNodeParams
+	(*AddContainerNodeParams)(nil),   // 13: inventory.v1.AddContainerNodeParams
+	(*AddRemoteNodeParams)(nil),      // 14: inventory.v1.AddRemoteNodeParams
+	(*AddRemoteRDSNodeParams)(nil),   // 15: inventory.v1.AddRemoteRDSNodeParams
+	(*AddRemoteAzureNodeParams)(nil), // 16: inventory.v1.AddRemoteAzureNodeParams
+	(*RemoveNodeRequest)(nil),        // 17: inventory.v1.RemoveNodeRequest
+	(*RemoveNodeResponse)(nil),       // 18: inventory.v1.RemoveNodeResponse
+	nil,                              // 19: inventory.v1.GenericNode.CustomLabelsEntry
+	nil,                              // 20: inventory.v1.ContainerNode.CustomLabelsEntry
+	nil,                              // 21: inventory.v1.RemoteNode.CustomLabelsEntry
+	nil,                              // 22: inventory.v1.RemoteRDSNode.CustomLabelsEntry
+	nil,                              // 23: inventory.v1.RemoteAzureDatabaseNode.CustomLabelsEntry
+	nil,                              // 24: inventory.v1.AddGenericNodeParams.CustomLabelsEntry
+	nil,                              // 25: inventory.v1.AddContainerNodeParams.CustomLabelsEntry
+	nil,                              // 26: inventory.v1.AddRemoteNodeParams.CustomLabelsEntry
+	nil,                              // 27: inventory.v1.AddRemoteRDSNodeParams.CustomLabelsEntry
+	nil,                              // 28: inventory.v1.AddRemoteAzureNodeParams.CustomLabelsEntry
+}
 var file_inventory_v1_nodes_proto_depIdxs = []int32{
 	19, // 0: inventory.v1.GenericNode.custom_labels:type_name -> inventory.v1.GenericNode.CustomLabelsEntry
 	20, // 1: inventory.v1.ContainerNode.custom_labels:type_name -> inventory.v1.ContainerNode.CustomLabelsEntry

--- a/api/inventory/v1/nodes.pb.validate.go
+++ b/api/inventory/v1/nodes.pb.validate.go
@@ -141,8 +141,7 @@ func (e GenericNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GenericNodeValidationError{}
@@ -264,8 +263,7 @@ func (e ContainerNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ContainerNodeValidationError{}
@@ -378,8 +376,7 @@ func (e RemoteNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoteNodeValidationError{}
@@ -495,8 +492,7 @@ func (e RemoteRDSNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoteRDSNodeValidationError{}
@@ -612,8 +608,7 @@ func (e RemoteAzureDatabaseNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoteAzureDatabaseNodeValidationError{}
@@ -715,8 +710,7 @@ func (e ListNodesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesRequestValidationError{}
@@ -988,8 +982,7 @@ func (e ListNodesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesResponseValidationError{}
@@ -1100,8 +1093,7 @@ func (e GetNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetNodeRequestValidationError{}
@@ -1411,8 +1403,7 @@ func (e GetNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetNodeResponseValidationError{}
@@ -1722,8 +1713,7 @@ func (e AddNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddNodeRequestValidationError{}
@@ -2033,8 +2023,7 @@ func (e AddNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddNodeResponseValidationError{}
@@ -2170,8 +2159,7 @@ func (e AddGenericNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddGenericNodeParamsValidationError{}
@@ -2309,8 +2297,7 @@ func (e AddContainerNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddContainerNodeParamsValidationError{}
@@ -2442,8 +2429,7 @@ func (e AddRemoteNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRemoteNodeParamsValidationError{}
@@ -2584,8 +2570,7 @@ func (e AddRemoteRDSNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRemoteRDSNodeParamsValidationError{}
@@ -2726,8 +2711,7 @@ func (e AddRemoteAzureNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRemoteAzureNodeParamsValidationError{}
@@ -2842,8 +2826,7 @@ func (e RemoveNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveNodeRequestValidationError{}
@@ -2945,8 +2928,7 @@ func (e RemoveNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveNodeResponseValidationError{}

--- a/api/inventory/v1/nodes.swagger.json
+++ b/api/inventory/v1/nodes.swagger.json
@@ -1,0 +1,708 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/nodes.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "NodesService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/inventory/nodes": {
+      "get": {
+        "summary": "List Nodes",
+        "description": "Returns a list of all Nodes.",
+        "operationId": "ListNodes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListNodesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_type",
+            "description": "Return only Nodes with matching Node type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "NODE_TYPE_UNSPECIFIED",
+              "NODE_TYPE_GENERIC_NODE",
+              "NODE_TYPE_CONTAINER_NODE",
+              "NODE_TYPE_REMOTE_NODE",
+              "NODE_TYPE_REMOTE_RDS_NODE",
+              "NODE_TYPE_REMOTE_AZURE_DATABASE_NODE"
+            ],
+            "default": "NODE_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "NodesService"
+        ]
+      },
+      "post": {
+        "summary": "Add a Node",
+        "description": "Adds a Node.",
+        "operationId": "AddNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddNodeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "NodesService"
+        ]
+      }
+    },
+    "/v1/inventory/nodes/{node_id}": {
+      "get": {
+        "summary": "Get a Node",
+        "description": "Returns a single Node by ID.",
+        "operationId": "GetNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "NodesService"
+        ]
+      },
+      "delete": {
+        "summary": "Remove a Node",
+        "description": "Removes a Node.",
+        "operationId": "RemoveNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Remove node with all dependencies.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "NodesService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AddContainerNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id of the Generic Node where this Container Node runs."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "Container identifier. If specified, must be a unique Docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddGenericNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddNodeRequest": {
+      "type": "object",
+      "properties": {
+        "generic": {
+          "$ref": "#/definitions/v1AddGenericNodeParams"
+        },
+        "container": {
+          "$ref": "#/definitions/v1AddContainerNodeParams"
+        },
+        "remote": {
+          "$ref": "#/definitions/v1AddRemoteNodeParams"
+        },
+        "remote_rds": {
+          "$ref": "#/definitions/v1AddRemoteRDSNodeParams"
+        },
+        "remote_azure": {
+          "$ref": "#/definitions/v1AddRemoteAzureNodeParams"
+        }
+      }
+    },
+    "v1AddNodeResponse": {
+      "type": "object",
+      "properties": {
+        "generic": {
+          "$ref": "#/definitions/v1GenericNode"
+        },
+        "container": {
+          "$ref": "#/definitions/v1ContainerNode"
+        },
+        "remote": {
+          "$ref": "#/definitions/v1RemoteNode"
+        },
+        "remote_rds": {
+          "$ref": "#/definitions/v1RemoteRDSNode"
+        },
+        "remote_azure_database": {
+          "$ref": "#/definitions/v1RemoteAzureDatabaseNode"
+        }
+      }
+    },
+    "v1AddRemoteAzureNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "DB instance identifier."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddRemoteNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddRemoteRDSNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "DB instance identifier."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1ContainerNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id of the Generic Node where this Container Node runs."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "Container identifier. If specified, must be a unique Docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "is_pmm_server_node": {
+          "type": "boolean",
+          "description": "True if this node is a PMM Server node (HA mode)."
+        }
+      },
+      "description": "ContainerNode represents a Docker container."
+    },
+    "v1GenericNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "is_pmm_server_node": {
+          "type": "boolean",
+          "description": "True if this node is a PMM Server node (HA mode)."
+        }
+      },
+      "description": "GenericNode represents a bare metal server or virtual machine."
+    },
+    "v1GetNodeResponse": {
+      "type": "object",
+      "properties": {
+        "generic": {
+          "$ref": "#/definitions/v1GenericNode"
+        },
+        "container": {
+          "$ref": "#/definitions/v1ContainerNode"
+        },
+        "remote": {
+          "$ref": "#/definitions/v1RemoteNode"
+        },
+        "remote_rds": {
+          "$ref": "#/definitions/v1RemoteRDSNode"
+        },
+        "remote_azure_database": {
+          "$ref": "#/definitions/v1RemoteAzureDatabaseNode"
+        }
+      }
+    },
+    "v1ListNodesResponse": {
+      "type": "object",
+      "properties": {
+        "generic": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1GenericNode"
+          }
+        },
+        "container": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ContainerNode"
+          }
+        },
+        "remote": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RemoteNode"
+          }
+        },
+        "remote_rds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RemoteRDSNode"
+          }
+        },
+        "remote_azure_database": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RemoteAzureDatabaseNode"
+          }
+        }
+      }
+    },
+    "v1NodeType": {
+      "type": "string",
+      "enum": [
+        "NODE_TYPE_UNSPECIFIED",
+        "NODE_TYPE_GENERIC_NODE",
+        "NODE_TYPE_CONTAINER_NODE",
+        "NODE_TYPE_REMOTE_NODE",
+        "NODE_TYPE_REMOTE_RDS_NODE",
+        "NODE_TYPE_REMOTE_AZURE_DATABASE_NODE"
+      ],
+      "default": "NODE_TYPE_UNSPECIFIED",
+      "description": "NodeType describes supported Node types."
+    },
+    "v1RemoteAzureDatabaseNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "DB instance identifier."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      },
+      "description": "RemoteAzureDatabaseNode represents remote AzureDatabase Node. Agents can't run on Remote AzureDatabase Nodes."
+    },
+    "v1RemoteNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      },
+      "description": "RemoteNode represents generic remote Node. It's a node where we don't run pmm-agents. Only external exporters can run on Remote Nodes."
+    },
+    "v1RemoteRDSNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "DB instance identifier."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "AWS instance ID."
+        }
+      },
+      "description": "RemoteRDSNode represents remote RDS Node. Agents can't run on Remote RDS Nodes."
+    },
+    "v1RemoveNodeResponse": {
+      "type": "object"
+    }
+  }
+}

--- a/api/inventory/v1/nodes_grpc.pb.go
+++ b/api/inventory/v1/nodes_grpc.pb.go
@@ -8,7 +8,6 @@ package inventoryv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -117,15 +116,12 @@ type UnimplementedNodesServiceServer struct{}
 func (UnimplementedNodesServiceServer) ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNodes not implemented")
 }
-
 func (UnimplementedNodesServiceServer) GetNode(context.Context, *GetNodeRequest) (*GetNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNode not implemented")
 }
-
 func (UnimplementedNodesServiceServer) AddNode(context.Context, *AddNodeRequest) (*AddNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddNode not implemented")
 }
-
 func (UnimplementedNodesServiceServer) RemoveNode(context.Context, *RemoveNodeRequest) (*RemoveNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveNode not implemented")
 }

--- a/api/inventory/v1/services.pb.go
+++ b/api/inventory/v1/services.pb.go
@@ -7,17 +7,15 @@
 package inventoryv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	common "github.com/percona/pmm/api/common"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	common "github.com/percona/pmm/api/common"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -3284,57 +3282,54 @@ func file_inventory_v1_services_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_services_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_services_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_services_proto_msgTypes  = make([]protoimpl.MessageInfo, 42)
-	file_inventory_v1_services_proto_goTypes   = []any{
-		ServiceType(0),                         // 0: inventory.v1.ServiceType
-		(*MySQLService)(nil),                   // 1: inventory.v1.MySQLService
-		(*MongoDBService)(nil),                 // 2: inventory.v1.MongoDBService
-		(*PostgreSQLService)(nil),              // 3: inventory.v1.PostgreSQLService
-		(*ValkeyService)(nil),                  // 4: inventory.v1.ValkeyService
-		(*ProxySQLService)(nil),                // 5: inventory.v1.ProxySQLService
-		(*HAProxyService)(nil),                 // 6: inventory.v1.HAProxyService
-		(*ExternalService)(nil),                // 7: inventory.v1.ExternalService
-		(*ListServicesRequest)(nil),            // 8: inventory.v1.ListServicesRequest
-		(*ListServicesResponse)(nil),           // 9: inventory.v1.ListServicesResponse
-		(*ListActiveServiceTypesRequest)(nil),  // 10: inventory.v1.ListActiveServiceTypesRequest
-		(*ListActiveServiceTypesResponse)(nil), // 11: inventory.v1.ListActiveServiceTypesResponse
-		(*GetServiceRequest)(nil),              // 12: inventory.v1.GetServiceRequest
-		(*GetServiceResponse)(nil),             // 13: inventory.v1.GetServiceResponse
-		(*AddServiceRequest)(nil),              // 14: inventory.v1.AddServiceRequest
-		(*AddServiceResponse)(nil),             // 15: inventory.v1.AddServiceResponse
-		(*AddMySQLServiceParams)(nil),          // 16: inventory.v1.AddMySQLServiceParams
-		(*AddMongoDBServiceParams)(nil),        // 17: inventory.v1.AddMongoDBServiceParams
-		(*AddPostgreSQLServiceParams)(nil),     // 18: inventory.v1.AddPostgreSQLServiceParams
-		(*AddValkeyServiceParams)(nil),         // 19: inventory.v1.AddValkeyServiceParams
-		(*AddProxySQLServiceParams)(nil),       // 20: inventory.v1.AddProxySQLServiceParams
-		(*AddHAProxyServiceParams)(nil),        // 21: inventory.v1.AddHAProxyServiceParams
-		(*AddExternalServiceParams)(nil),       // 22: inventory.v1.AddExternalServiceParams
-		(*RemoveServiceRequest)(nil),           // 23: inventory.v1.RemoveServiceRequest
-		(*RemoveServiceResponse)(nil),          // 24: inventory.v1.RemoveServiceResponse
-		(*ChangeServiceRequest)(nil),           // 25: inventory.v1.ChangeServiceRequest
-		(*ChangeServiceResponse)(nil),          // 26: inventory.v1.ChangeServiceResponse
-		nil,                                    // 27: inventory.v1.MySQLService.CustomLabelsEntry
-		nil,                                    // 28: inventory.v1.MySQLService.ExtraDsnParamsEntry
-		nil,                                    // 29: inventory.v1.MongoDBService.CustomLabelsEntry
-		nil,                                    // 30: inventory.v1.PostgreSQLService.CustomLabelsEntry
-		nil,                                    // 31: inventory.v1.ValkeyService.CustomLabelsEntry
-		nil,                                    // 32: inventory.v1.ProxySQLService.CustomLabelsEntry
-		nil,                                    // 33: inventory.v1.HAProxyService.CustomLabelsEntry
-		nil,                                    // 34: inventory.v1.ExternalService.CustomLabelsEntry
-		nil,                                    // 35: inventory.v1.AddMySQLServiceParams.CustomLabelsEntry
-		nil,                                    // 36: inventory.v1.AddMySQLServiceParams.ExtraDsnParamsEntry
-		nil,                                    // 37: inventory.v1.AddMongoDBServiceParams.CustomLabelsEntry
-		nil,                                    // 38: inventory.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
-		nil,                                    // 39: inventory.v1.AddValkeyServiceParams.CustomLabelsEntry
-		nil,                                    // 40: inventory.v1.AddProxySQLServiceParams.CustomLabelsEntry
-		nil,                                    // 41: inventory.v1.AddHAProxyServiceParams.CustomLabelsEntry
-		nil,                                    // 42: inventory.v1.AddExternalServiceParams.CustomLabelsEntry
-		(*common.StringMap)(nil),               // 43: common.StringMap
-	}
-)
-
+var file_inventory_v1_services_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_services_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
+var file_inventory_v1_services_proto_goTypes = []any{
+	(ServiceType)(0),                       // 0: inventory.v1.ServiceType
+	(*MySQLService)(nil),                   // 1: inventory.v1.MySQLService
+	(*MongoDBService)(nil),                 // 2: inventory.v1.MongoDBService
+	(*PostgreSQLService)(nil),              // 3: inventory.v1.PostgreSQLService
+	(*ValkeyService)(nil),                  // 4: inventory.v1.ValkeyService
+	(*ProxySQLService)(nil),                // 5: inventory.v1.ProxySQLService
+	(*HAProxyService)(nil),                 // 6: inventory.v1.HAProxyService
+	(*ExternalService)(nil),                // 7: inventory.v1.ExternalService
+	(*ListServicesRequest)(nil),            // 8: inventory.v1.ListServicesRequest
+	(*ListServicesResponse)(nil),           // 9: inventory.v1.ListServicesResponse
+	(*ListActiveServiceTypesRequest)(nil),  // 10: inventory.v1.ListActiveServiceTypesRequest
+	(*ListActiveServiceTypesResponse)(nil), // 11: inventory.v1.ListActiveServiceTypesResponse
+	(*GetServiceRequest)(nil),              // 12: inventory.v1.GetServiceRequest
+	(*GetServiceResponse)(nil),             // 13: inventory.v1.GetServiceResponse
+	(*AddServiceRequest)(nil),              // 14: inventory.v1.AddServiceRequest
+	(*AddServiceResponse)(nil),             // 15: inventory.v1.AddServiceResponse
+	(*AddMySQLServiceParams)(nil),          // 16: inventory.v1.AddMySQLServiceParams
+	(*AddMongoDBServiceParams)(nil),        // 17: inventory.v1.AddMongoDBServiceParams
+	(*AddPostgreSQLServiceParams)(nil),     // 18: inventory.v1.AddPostgreSQLServiceParams
+	(*AddValkeyServiceParams)(nil),         // 19: inventory.v1.AddValkeyServiceParams
+	(*AddProxySQLServiceParams)(nil),       // 20: inventory.v1.AddProxySQLServiceParams
+	(*AddHAProxyServiceParams)(nil),        // 21: inventory.v1.AddHAProxyServiceParams
+	(*AddExternalServiceParams)(nil),       // 22: inventory.v1.AddExternalServiceParams
+	(*RemoveServiceRequest)(nil),           // 23: inventory.v1.RemoveServiceRequest
+	(*RemoveServiceResponse)(nil),          // 24: inventory.v1.RemoveServiceResponse
+	(*ChangeServiceRequest)(nil),           // 25: inventory.v1.ChangeServiceRequest
+	(*ChangeServiceResponse)(nil),          // 26: inventory.v1.ChangeServiceResponse
+	nil,                                    // 27: inventory.v1.MySQLService.CustomLabelsEntry
+	nil,                                    // 28: inventory.v1.MySQLService.ExtraDsnParamsEntry
+	nil,                                    // 29: inventory.v1.MongoDBService.CustomLabelsEntry
+	nil,                                    // 30: inventory.v1.PostgreSQLService.CustomLabelsEntry
+	nil,                                    // 31: inventory.v1.ValkeyService.CustomLabelsEntry
+	nil,                                    // 32: inventory.v1.ProxySQLService.CustomLabelsEntry
+	nil,                                    // 33: inventory.v1.HAProxyService.CustomLabelsEntry
+	nil,                                    // 34: inventory.v1.ExternalService.CustomLabelsEntry
+	nil,                                    // 35: inventory.v1.AddMySQLServiceParams.CustomLabelsEntry
+	nil,                                    // 36: inventory.v1.AddMySQLServiceParams.ExtraDsnParamsEntry
+	nil,                                    // 37: inventory.v1.AddMongoDBServiceParams.CustomLabelsEntry
+	nil,                                    // 38: inventory.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
+	nil,                                    // 39: inventory.v1.AddValkeyServiceParams.CustomLabelsEntry
+	nil,                                    // 40: inventory.v1.AddProxySQLServiceParams.CustomLabelsEntry
+	nil,                                    // 41: inventory.v1.AddHAProxyServiceParams.CustomLabelsEntry
+	nil,                                    // 42: inventory.v1.AddExternalServiceParams.CustomLabelsEntry
+	(*common.StringMap)(nil),               // 43: common.StringMap
+}
 var file_inventory_v1_services_proto_depIdxs = []int32{
 	27, // 0: inventory.v1.MySQLService.custom_labels:type_name -> inventory.v1.MySQLService.CustomLabelsEntry
 	28, // 1: inventory.v1.MySQLService.extra_dsn_params:type_name -> inventory.v1.MySQLService.ExtraDsnParamsEntry

--- a/api/inventory/v1/services.pb.validate.go
+++ b/api/inventory/v1/services.pb.validate.go
@@ -145,8 +145,7 @@ func (e MySQLServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MySQLServiceValidationError{}
@@ -268,8 +267,7 @@ func (e MongoDBServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MongoDBServiceValidationError{}
@@ -397,8 +395,7 @@ func (e PostgreSQLServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PostgreSQLServiceValidationError{}
@@ -520,8 +517,7 @@ func (e ValkeyServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ValkeyServiceValidationError{}
@@ -643,8 +639,7 @@ func (e ProxySQLServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ProxySQLServiceValidationError{}
@@ -758,8 +753,7 @@ func (e HAProxyServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HAProxyServiceValidationError{}
@@ -879,8 +873,7 @@ func (e ExternalServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExternalServiceValidationError{}
@@ -988,8 +981,7 @@ func (e ListServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesRequestValidationError{}
@@ -1329,8 +1321,7 @@ func (e ListServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesResponseValidationError{}
@@ -1433,8 +1424,7 @@ func (e ListActiveServiceTypesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListActiveServiceTypesRequestValidationError{}
@@ -1537,8 +1527,7 @@ func (e ListActiveServiceTypesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListActiveServiceTypesResponseValidationError{}
@@ -1651,8 +1640,7 @@ func (e GetServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetServiceRequestValidationError{}
@@ -2046,8 +2034,7 @@ func (e GetServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetServiceResponseValidationError{}
@@ -2441,8 +2428,7 @@ func (e AddServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddServiceRequestValidationError{}
@@ -2836,8 +2822,7 @@ func (e AddServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddServiceResponseValidationError{}
@@ -2977,8 +2962,7 @@ func (e AddMySQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMySQLServiceParamsValidationError{}
@@ -3116,8 +3100,7 @@ func (e AddMongoDBServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMongoDBServiceParamsValidationError{}
@@ -3257,8 +3240,7 @@ func (e AddPostgreSQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPostgreSQLServiceParamsValidationError{}
@@ -3396,8 +3378,7 @@ func (e AddValkeyServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddValkeyServiceParamsValidationError{}
@@ -3535,8 +3516,7 @@ func (e AddProxySQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddProxySQLServiceParamsValidationError{}
@@ -3668,8 +3648,7 @@ func (e AddHAProxyServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddHAProxyServiceParamsValidationError{}
@@ -3803,8 +3782,7 @@ func (e AddExternalServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddExternalServiceParamsValidationError{}
@@ -3919,8 +3897,7 @@ func (e RemoveServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveServiceRequestValidationError{}
@@ -4022,8 +3999,7 @@ func (e RemoveServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveServiceResponseValidationError{}
@@ -4086,6 +4062,7 @@ func (m *ChangeServiceRequest) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -4114,6 +4091,7 @@ func (m *ChangeServiceRequest) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if len(errors) > 0 {
@@ -4183,8 +4161,7 @@ func (e ChangeServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeServiceRequestValidationError{}
@@ -4578,8 +4555,7 @@ func (e ChangeServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeServiceResponseValidationError{}

--- a/api/inventory/v1/services.swagger.json
+++ b/api/inventory/v1/services.swagger.json
@@ -1,0 +1,1189 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/services.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "ServicesService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/inventory/services": {
+      "get": {
+        "summary": "List Services",
+        "description": "Returns a list of Services filtered by type.",
+        "operationId": "ListServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Return only Services running on that Node.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "service_type",
+            "description": "Return only services filtered by service type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SERVICE_TYPE_UNSPECIFIED",
+              "SERVICE_TYPE_MYSQL_SERVICE",
+              "SERVICE_TYPE_MONGODB_SERVICE",
+              "SERVICE_TYPE_POSTGRESQL_SERVICE",
+              "SERVICE_TYPE_VALKEY_SERVICE",
+              "SERVICE_TYPE_PROXYSQL_SERVICE",
+              "SERVICE_TYPE_HAPROXY_SERVICE",
+              "SERVICE_TYPE_EXTERNAL_SERVICE"
+            ],
+            "default": "SERVICE_TYPE_UNSPECIFIED"
+          },
+          {
+            "name": "external_group",
+            "description": "Return only services in this external group.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      },
+      "post": {
+        "summary": "Add a Service",
+        "description": "Adds a Service.",
+        "operationId": "AddService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddServiceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      }
+    },
+    "/v1/inventory/services/{service_id}": {
+      "get": {
+        "summary": "Get a Service",
+        "description": "Returns a single Service by ID.",
+        "operationId": "GetService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      },
+      "delete": {
+        "summary": "Remove Service",
+        "description": "Removes Service.",
+        "operationId": "RemoveService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_id",
+            "description": "Unique randomly generated instance identifier. Required.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Remove service with all dependencies.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      },
+      "put": {
+        "summary": "Change service",
+        "description": "Changes service configuration. If a new cluster label is specified, it removes all backup/restore tasks scheduled for the related services. Fails if there are running backup/restore tasks.",
+        "operationId": "ChangeService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServicesServiceChangeServiceBody"
+            }
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      }
+    },
+    "/v1/inventory/services:getTypes": {
+      "post": {
+        "summary": "List Active Service Types",
+        "description": "Returns a list of active Service types.",
+        "operationId": "ListActiveServiceTypes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListActiveServiceTypesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ListActiveServiceTypesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ServicesService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ServicesServiceChangeServiceBody": {
+      "type": "object",
+      "properties": {
+        "environment": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "cluster": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "replication_set": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "external_group": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        }
+      }
+    },
+    "commonStringMap": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "A wrapper for map[string]string. This type allows to distinguish between an empty map and a null value."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AddExternalServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "group": {
+          "type": "string",
+          "description": "Group name of external service."
+        }
+      }
+    },
+    "v1AddHAProxyServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddMongoDBServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddMySQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra parameters to be added to the DSN."
+        }
+      }
+    },
+    "v1AddPostgreSQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        }
+      }
+    },
+    "v1AddProxySQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddServiceRequest": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1AddMySQLServiceParams"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1AddMongoDBServiceParams"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1AddPostgreSQLServiceParams"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1AddProxySQLServiceParams"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1AddHAProxyServiceParams"
+        },
+        "external": {
+          "$ref": "#/definitions/v1AddExternalServiceParams"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1AddValkeyServiceParams"
+        }
+      }
+    },
+    "v1AddServiceResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1MySQLService"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1MongoDBService"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1PostgreSQLService"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1ProxySQLService"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1HAProxyService"
+        },
+        "external": {
+          "$ref": "#/definitions/v1ExternalService"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1ValkeyService"
+        }
+      }
+    },
+    "v1AddValkeyServiceParams": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1ChangeServiceResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1MySQLService"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1MongoDBService"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1PostgreSQLService"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1ProxySQLService"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1HAProxyService"
+        },
+        "external": {
+          "$ref": "#/definitions/v1ExternalService"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1ValkeyService"
+        }
+      }
+    },
+    "v1ExternalService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this service instance runs."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "group": {
+          "type": "string",
+          "description": "Group name of external service."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP)."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port."
+        }
+      },
+      "description": "ExternalService represents a generic External service instance."
+    },
+    "v1GetServiceResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1MySQLService"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1MongoDBService"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1PostgreSQLService"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1ProxySQLService"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1HAProxyService"
+        },
+        "external": {
+          "$ref": "#/definitions/v1ExternalService"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1ValkeyService"
+        }
+      }
+    },
+    "v1HAProxyService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this service instance runs."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      },
+      "description": "HAProxyService represents a generic HAProxy service instance."
+    },
+    "v1ListActiveServiceTypesRequest": {
+      "type": "object"
+    },
+    "v1ListActiveServiceTypesResponse": {
+      "type": "object",
+      "properties": {
+        "service_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1ServiceType"
+          }
+        }
+      }
+    },
+    "v1ListServicesResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MySQLService"
+          }
+        },
+        "mongodb": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBService"
+          }
+        },
+        "postgresql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PostgreSQLService"
+          }
+        },
+        "proxysql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ProxySQLService"
+          }
+        },
+        "haproxy": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HAProxyService"
+          }
+        },
+        "external": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ExternalService"
+          }
+        },
+        "valkey": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ValkeyService"
+          }
+        }
+      }
+    },
+    "v1MongoDBService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MongoDB version."
+        }
+      },
+      "description": "MongoDBService represents a generic MongoDB instance."
+    },
+    "v1MySQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MySQL version."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra parameters to be added to the DSN."
+        }
+      },
+      "description": "MySQLService represents a generic MySQL instance."
+    },
+    "v1PostgreSQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "PostgreSQL version."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        }
+      },
+      "description": "PostgreSQLService represents a generic PostgreSQL instance."
+    },
+    "v1ProxySQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "ProxySQL version."
+        }
+      },
+      "description": "ProxySQLService represents a generic ProxySQL instance."
+    },
+    "v1RemoveServiceResponse": {
+      "type": "object"
+    },
+    "v1ServiceType": {
+      "type": "string",
+      "enum": [
+        "SERVICE_TYPE_UNSPECIFIED",
+        "SERVICE_TYPE_MYSQL_SERVICE",
+        "SERVICE_TYPE_MONGODB_SERVICE",
+        "SERVICE_TYPE_POSTGRESQL_SERVICE",
+        "SERVICE_TYPE_VALKEY_SERVICE",
+        "SERVICE_TYPE_PROXYSQL_SERVICE",
+        "SERVICE_TYPE_HAPROXY_SERVICE",
+        "SERVICE_TYPE_EXTERNAL_SERVICE"
+      ],
+      "default": "SERVICE_TYPE_UNSPECIFIED",
+      "description": "ServiceType describes supported Service types."
+    },
+    "v1ValkeyService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "Valkey version."
+        }
+      },
+      "description": "ValkeyService represents a generic Valkey instance."
+    }
+  }
+}

--- a/api/inventory/v1/services_grpc.pb.go
+++ b/api/inventory/v1/services_grpc.pb.go
@@ -8,7 +8,6 @@ package inventoryv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -147,23 +146,18 @@ type UnimplementedServicesServiceServer struct{}
 func (UnimplementedServicesServiceServer) ListServices(context.Context, *ListServicesRequest) (*ListServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListServices not implemented")
 }
-
 func (UnimplementedServicesServiceServer) ListActiveServiceTypes(context.Context, *ListActiveServiceTypesRequest) (*ListActiveServiceTypesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListActiveServiceTypes not implemented")
 }
-
 func (UnimplementedServicesServiceServer) GetService(context.Context, *GetServiceRequest) (*GetServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetService not implemented")
 }
-
 func (UnimplementedServicesServiceServer) AddService(context.Context, *AddServiceRequest) (*AddServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddService not implemented")
 }
-
 func (UnimplementedServicesServiceServer) RemoveService(context.Context, *RemoveServiceRequest) (*RemoveServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveService not implemented")
 }
-
 func (UnimplementedServicesServiceServer) ChangeService(context.Context, *ChangeServiceRequest) (*ChangeServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeService not implemented")
 }

--- a/api/inventory/v1/types/agent_types.go
+++ b/api/inventory/v1/types/agent_types.go
@@ -37,6 +37,7 @@ const (
 	AgentTypeExternalExporter                = "AGENT_TYPE_EXTERNAL_EXPORTER"
 	AgentTypeAzureDatabaseExporter           = "AGENT_TYPE_AZURE_DATABASE_EXPORTER"
 	AgentTypeRTAMongoDBAgent                 = "AGENT_TYPE_RTA_MONGODB_AGENT"
+	AgentTypeRTAPostgreSQLAgent              = "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
 )
 
 var agentTypeNames = map[string]string{
@@ -60,6 +61,7 @@ var agentTypeNames = map[string]string{
 	AgentTypeExternalExporter:                "external-exporter",
 	AgentTypeAzureDatabaseExporter:           "azure_database_exporter",
 	AgentTypeRTAMongoDBAgent:                 "rta_mongodb_agent",
+	AgentTypeRTAPostgreSQLAgent:              "rta_postgresql_agent",
 }
 
 // AgentTypeName returns human friendly agent type to be used in reports.

--- a/api/management/v1/agent.pb.go
+++ b/api/management/v1/agent.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1217,31 +1215,28 @@ func file_management_v1_agent_proto_rawDescGZIP() []byte {
 	return file_management_v1_agent_proto_rawDescData
 }
 
-var (
-	file_management_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_agent_proto_msgTypes  = make([]protoimpl.MessageInfo, 13)
-	file_management_v1_agent_proto_goTypes   = []any{
-		UpdateSeverity(0),                        // 0: management.v1.UpdateSeverity
-		(*UniversalAgent)(nil),                   // 1: management.v1.UniversalAgent
-		(*ListAgentsRequest)(nil),                // 2: management.v1.ListAgentsRequest
-		(*ListAgentsResponse)(nil),               // 3: management.v1.ListAgentsResponse
-		(*AgentVersions)(nil),                    // 4: management.v1.AgentVersions
-		(*ListAgentVersionsRequest)(nil),         // 5: management.v1.ListAgentVersionsRequest
-		(*ListAgentVersionsResponse)(nil),        // 6: management.v1.ListAgentVersionsResponse
-		(*UniversalAgent_MySQLOptions)(nil),      // 7: management.v1.UniversalAgent.MySQLOptions
-		(*UniversalAgent_AzureOptions)(nil),      // 8: management.v1.UniversalAgent.AzureOptions
-		(*UniversalAgent_MongoDBOptions)(nil),    // 9: management.v1.UniversalAgent.MongoDBOptions
-		(*UniversalAgent_PostgreSQLOptions)(nil), // 10: management.v1.UniversalAgent.PostgreSQLOptions
-		(*UniversalAgent_ValkeyOptions)(nil),     // 11: management.v1.UniversalAgent.ValkeyOptions
-		nil,                                      // 12: management.v1.UniversalAgent.CustomLabelsEntry
-		nil,                                      // 13: management.v1.UniversalAgent.MySQLOptions.ExtraDsnParamsEntry
-		(*timestamppb.Timestamp)(nil),            // 14: google.protobuf.Timestamp
-		v1.LogLevel(0),                           // 15: inventory.v1.LogLevel
-		(*v1.RTAOptions)(nil),                    // 16: inventory.v1.RTAOptions
-		(*durationpb.Duration)(nil),              // 17: google.protobuf.Duration
-	}
-)
-
+var file_management_v1_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_management_v1_agent_proto_goTypes = []any{
+	(UpdateSeverity)(0),                      // 0: management.v1.UpdateSeverity
+	(*UniversalAgent)(nil),                   // 1: management.v1.UniversalAgent
+	(*ListAgentsRequest)(nil),                // 2: management.v1.ListAgentsRequest
+	(*ListAgentsResponse)(nil),               // 3: management.v1.ListAgentsResponse
+	(*AgentVersions)(nil),                    // 4: management.v1.AgentVersions
+	(*ListAgentVersionsRequest)(nil),         // 5: management.v1.ListAgentVersionsRequest
+	(*ListAgentVersionsResponse)(nil),        // 6: management.v1.ListAgentVersionsResponse
+	(*UniversalAgent_MySQLOptions)(nil),      // 7: management.v1.UniversalAgent.MySQLOptions
+	(*UniversalAgent_AzureOptions)(nil),      // 8: management.v1.UniversalAgent.AzureOptions
+	(*UniversalAgent_MongoDBOptions)(nil),    // 9: management.v1.UniversalAgent.MongoDBOptions
+	(*UniversalAgent_PostgreSQLOptions)(nil), // 10: management.v1.UniversalAgent.PostgreSQLOptions
+	(*UniversalAgent_ValkeyOptions)(nil),     // 11: management.v1.UniversalAgent.ValkeyOptions
+	nil,                                      // 12: management.v1.UniversalAgent.CustomLabelsEntry
+	nil,                                      // 13: management.v1.UniversalAgent.MySQLOptions.ExtraDsnParamsEntry
+	(*timestamppb.Timestamp)(nil),            // 14: google.protobuf.Timestamp
+	(v1.LogLevel)(0),                         // 15: inventory.v1.LogLevel
+	(*v1.RTAOptions)(nil),                    // 16: inventory.v1.RTAOptions
+	(*durationpb.Duration)(nil),              // 17: google.protobuf.Duration
+}
 var file_management_v1_agent_proto_depIdxs = []int32{
 	8,  // 0: management.v1.UniversalAgent.azure_options:type_name -> management.v1.UniversalAgent.AzureOptions
 	14, // 1: management.v1.UniversalAgent.created_at:type_name -> google.protobuf.Timestamp

--- a/api/management/v1/agent.pb.validate.go
+++ b/api/management/v1/agent.pb.validate.go
@@ -453,8 +453,7 @@ func (e UniversalAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgentValidationError{}
@@ -560,8 +559,7 @@ func (e ListAgentsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsRequestValidationError{}
@@ -697,8 +695,7 @@ func (e ListAgentsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsResponseValidationError{}
@@ -806,8 +803,7 @@ func (e AgentVersionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AgentVersionsValidationError{}
@@ -909,8 +905,7 @@ func (e ListAgentVersionsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentVersionsRequestValidationError{}
@@ -1046,8 +1041,7 @@ func (e ListAgentVersionsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentVersionsResponseValidationError{}
@@ -1154,8 +1148,7 @@ func (e UniversalAgent_MySQLOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgent_MySQLOptionsValidationError{}
@@ -1268,8 +1261,7 @@ func (e UniversalAgent_AzureOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgent_AzureOptionsValidationError{}
@@ -1384,8 +1376,7 @@ func (e UniversalAgent_MongoDBOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgent_MongoDBOptionsValidationError{}
@@ -1496,8 +1487,7 @@ func (e UniversalAgent_PostgreSQLOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgent_PostgreSQLOptionsValidationError{}
@@ -1600,8 +1590,7 @@ func (e UniversalAgent_ValkeyOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalAgent_ValkeyOptionsValidationError{}

--- a/api/management/v1/agent.swagger.json
+++ b/api/management/v1/agent.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/agent.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/annotation.pb.go
+++ b/api/management/v1/annotation.pb.go
@@ -7,13 +7,12 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -157,14 +156,11 @@ func file_management_v1_annotation_proto_rawDescGZIP() []byte {
 	return file_management_v1_annotation_proto_rawDescData
 }
 
-var (
-	file_management_v1_annotation_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-	file_management_v1_annotation_proto_goTypes  = []any{
-		(*AddAnnotationRequest)(nil),  // 0: management.v1.AddAnnotationRequest
-		(*AddAnnotationResponse)(nil), // 1: management.v1.AddAnnotationResponse
-	}
-)
-
+var file_management_v1_annotation_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_management_v1_annotation_proto_goTypes = []any{
+	(*AddAnnotationRequest)(nil),  // 0: management.v1.AddAnnotationRequest
+	(*AddAnnotationResponse)(nil), // 1: management.v1.AddAnnotationResponse
+}
 var file_management_v1_annotation_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/management/v1/annotation.pb.validate.go
+++ b/api/management/v1/annotation.pb.validate.go
@@ -137,8 +137,7 @@ func (e AddAnnotationRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAnnotationRequestValidationError{}
@@ -240,8 +239,7 @@ func (e AddAnnotationResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAnnotationResponseValidationError{}

--- a/api/management/v1/annotation.swagger.json
+++ b/api/management/v1/annotation.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/annotation.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/azure.pb.go
+++ b/api/management/v1/azure.pb.go
@@ -7,16 +7,14 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -712,21 +710,18 @@ func file_management_v1_azure_proto_rawDescGZIP() []byte {
 	return file_management_v1_azure_proto_rawDescData
 }
 
-var (
-	file_management_v1_azure_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_azure_proto_msgTypes  = make([]protoimpl.MessageInfo, 6)
-	file_management_v1_azure_proto_goTypes   = []any{
-		DiscoverAzureDatabaseType(0),          // 0: management.v1.DiscoverAzureDatabaseType
-		(*DiscoverAzureDatabaseRequest)(nil),  // 1: management.v1.DiscoverAzureDatabaseRequest
-		(*DiscoverAzureDatabaseInstance)(nil), // 2: management.v1.DiscoverAzureDatabaseInstance
-		(*DiscoverAzureDatabaseResponse)(nil), // 3: management.v1.DiscoverAzureDatabaseResponse
-		(*AddAzureDatabaseRequest)(nil),       // 4: management.v1.AddAzureDatabaseRequest
-		(*AddAzureDatabaseResponse)(nil),      // 5: management.v1.AddAzureDatabaseResponse
-		nil,                                   // 6: management.v1.AddAzureDatabaseRequest.CustomLabelsEntry
-		(*durationpb.Duration)(nil),           // 7: google.protobuf.Duration
-	}
-)
-
+var file_management_v1_azure_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_azure_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_management_v1_azure_proto_goTypes = []any{
+	(DiscoverAzureDatabaseType)(0),        // 0: management.v1.DiscoverAzureDatabaseType
+	(*DiscoverAzureDatabaseRequest)(nil),  // 1: management.v1.DiscoverAzureDatabaseRequest
+	(*DiscoverAzureDatabaseInstance)(nil), // 2: management.v1.DiscoverAzureDatabaseInstance
+	(*DiscoverAzureDatabaseResponse)(nil), // 3: management.v1.DiscoverAzureDatabaseResponse
+	(*AddAzureDatabaseRequest)(nil),       // 4: management.v1.AddAzureDatabaseRequest
+	(*AddAzureDatabaseResponse)(nil),      // 5: management.v1.AddAzureDatabaseResponse
+	nil,                                   // 6: management.v1.AddAzureDatabaseRequest.CustomLabelsEntry
+	(*durationpb.Duration)(nil),           // 7: google.protobuf.Duration
+}
 var file_management_v1_azure_proto_depIdxs = []int32{
 	0, // 0: management.v1.DiscoverAzureDatabaseInstance.type:type_name -> management.v1.DiscoverAzureDatabaseType
 	2, // 1: management.v1.DiscoverAzureDatabaseResponse.azure_database_instance:type_name -> management.v1.DiscoverAzureDatabaseInstance

--- a/api/management/v1/azure.pb.validate.go
+++ b/api/management/v1/azure.pb.validate.go
@@ -169,8 +169,7 @@ func (e DiscoverAzureDatabaseRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverAzureDatabaseRequestValidationError{}
@@ -293,8 +292,7 @@ func (e DiscoverAzureDatabaseInstanceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverAzureDatabaseInstanceValidationError{}
@@ -431,8 +429,7 @@ func (e DiscoverAzureDatabaseResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverAzureDatabaseResponseValidationError{}
@@ -704,8 +701,7 @@ func (e AddAzureDatabaseRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAzureDatabaseRequestValidationError{}
@@ -807,8 +803,7 @@ func (e AddAzureDatabaseResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAzureDatabaseResponseValidationError{}

--- a/api/management/v1/azure.swagger.json
+++ b/api/management/v1/azure.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/azure.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/external.pb.go
+++ b/api/management/v1/external.pb.go
@@ -7,16 +7,14 @@
 package managementv1
 
 import (
+	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
 )
 
 const (
@@ -343,19 +341,16 @@ func file_management_v1_external_proto_rawDescGZIP() []byte {
 	return file_management_v1_external_proto_rawDescData
 }
 
-var (
-	file_management_v1_external_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_external_proto_goTypes  = []any{
-		(*AddExternalServiceParams)(nil), // 0: management.v1.AddExternalServiceParams
-		(*ExternalServiceResult)(nil),    // 1: management.v1.ExternalServiceResult
-		nil,                              // 2: management.v1.AddExternalServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),            // 3: management.v1.AddNodeParams
-		MetricsMode(0),                   // 4: management.v1.MetricsMode
-		(*v1.ExternalService)(nil),       // 5: inventory.v1.ExternalService
-		(*v1.ExternalExporter)(nil),      // 6: inventory.v1.ExternalExporter
-	}
-)
-
+var file_management_v1_external_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_external_proto_goTypes = []any{
+	(*AddExternalServiceParams)(nil), // 0: management.v1.AddExternalServiceParams
+	(*ExternalServiceResult)(nil),    // 1: management.v1.ExternalServiceResult
+	nil,                              // 2: management.v1.AddExternalServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),            // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                 // 4: management.v1.MetricsMode
+	(*v1.ExternalService)(nil),       // 5: inventory.v1.ExternalService
+	(*v1.ExternalExporter)(nil),      // 6: inventory.v1.ExternalExporter
+}
 var file_management_v1_external_proto_depIdxs = []int32{
 	3, // 0: management.v1.AddExternalServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2, // 1: management.v1.AddExternalServiceParams.custom_labels:type_name -> management.v1.AddExternalServiceParams.CustomLabelsEntry

--- a/api/management/v1/external.pb.validate.go
+++ b/api/management/v1/external.pb.validate.go
@@ -207,8 +207,7 @@ func (e AddExternalServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddExternalServiceParamsValidationError{}
@@ -368,8 +367,7 @@ func (e ExternalServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExternalServiceResultValidationError{}

--- a/api/management/v1/external.swagger.json
+++ b/api/management/v1/external.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/external.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/haproxy.pb.go
+++ b/api/management/v1/haproxy.pb.go
@@ -7,16 +7,14 @@
 package managementv1
 
 import (
+	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	_ "github.com/envoyproxy/protoc-gen-validate/validate"
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
 )
 
 const (
@@ -321,19 +319,16 @@ func file_management_v1_haproxy_proto_rawDescGZIP() []byte {
 	return file_management_v1_haproxy_proto_rawDescData
 }
 
-var (
-	file_management_v1_haproxy_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_haproxy_proto_goTypes  = []any{
-		(*AddHAProxyServiceParams)(nil), // 0: management.v1.AddHAProxyServiceParams
-		(*HAProxyServiceResult)(nil),    // 1: management.v1.HAProxyServiceResult
-		nil,                             // 2: management.v1.AddHAProxyServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),           // 3: management.v1.AddNodeParams
-		MetricsMode(0),                  // 4: management.v1.MetricsMode
-		(*v1.HAProxyService)(nil),       // 5: inventory.v1.HAProxyService
-		(*v1.ExternalExporter)(nil),     // 6: inventory.v1.ExternalExporter
-	}
-)
-
+var file_management_v1_haproxy_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_haproxy_proto_goTypes = []any{
+	(*AddHAProxyServiceParams)(nil), // 0: management.v1.AddHAProxyServiceParams
+	(*HAProxyServiceResult)(nil),    // 1: management.v1.HAProxyServiceResult
+	nil,                             // 2: management.v1.AddHAProxyServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),           // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                // 4: management.v1.MetricsMode
+	(*v1.HAProxyService)(nil),       // 5: inventory.v1.HAProxyService
+	(*v1.ExternalExporter)(nil),     // 6: inventory.v1.ExternalExporter
+}
 var file_management_v1_haproxy_proto_depIdxs = []int32{
 	3, // 0: management.v1.AddHAProxyServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2, // 1: management.v1.AddHAProxyServiceParams.custom_labels:type_name -> management.v1.AddHAProxyServiceParams.CustomLabelsEntry

--- a/api/management/v1/haproxy.pb.validate.go
+++ b/api/management/v1/haproxy.pb.validate.go
@@ -203,8 +203,7 @@ func (e AddHAProxyServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddHAProxyServiceParamsValidationError{}
@@ -364,8 +363,7 @@ func (e HAProxyServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HAProxyServiceResultValidationError{}

--- a/api/management/v1/haproxy.swagger.json
+++ b/api/management/v1/haproxy.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/haproxy.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/metrics.pb.go
+++ b/api/management/v1/metrics.pb.go
@@ -7,12 +7,11 @@
 package managementv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -97,13 +96,10 @@ func file_management_v1_metrics_proto_rawDescGZIP() []byte {
 	return file_management_v1_metrics_proto_rawDescData
 }
 
-var (
-	file_management_v1_metrics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_metrics_proto_goTypes   = []any{
-		MetricsMode(0), // 0: management.v1.MetricsMode
-	}
-)
-
+var file_management_v1_metrics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_metrics_proto_goTypes = []any{
+	(MetricsMode)(0), // 0: management.v1.MetricsMode
+}
 var file_management_v1_metrics_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/management/v1/metrics.swagger.json
+++ b/api/management/v1/metrics.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/metrics.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/mongodb.pb.go
+++ b/api/management/v1/mongodb.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -542,24 +540,21 @@ func file_management_v1_mongodb_proto_rawDescGZIP() []byte {
 	return file_management_v1_mongodb_proto_rawDescData
 }
 
-var (
-	file_management_v1_mongodb_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_mongodb_proto_goTypes  = []any{
-		(*AddMongoDBServiceParams)(nil),    // 0: management.v1.AddMongoDBServiceParams
-		(*MongoDBServiceResult)(nil),       // 1: management.v1.MongoDBServiceResult
-		nil,                                // 2: management.v1.AddMongoDBServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),              // 3: management.v1.AddNodeParams
-		MetricsMode(0),                     // 4: management.v1.MetricsMode
-		v1.LogLevel(0),                     // 5: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),        // 6: google.protobuf.Duration
-		(*v1.MongoDBService)(nil),          // 7: inventory.v1.MongoDBService
-		(*v1.MongoDBExporter)(nil),         // 8: inventory.v1.MongoDBExporter
-		(*v1.QANMongoDBProfilerAgent)(nil), // 9: inventory.v1.QANMongoDBProfilerAgent
-		(*v1.QANMongoDBMongologAgent)(nil), // 10: inventory.v1.QANMongoDBMongologAgent
-		(*v1.RTAMongoDBAgent)(nil),         // 11: inventory.v1.RTAMongoDBAgent
-	}
-)
-
+var file_management_v1_mongodb_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_mongodb_proto_goTypes = []any{
+	(*AddMongoDBServiceParams)(nil),    // 0: management.v1.AddMongoDBServiceParams
+	(*MongoDBServiceResult)(nil),       // 1: management.v1.MongoDBServiceResult
+	nil,                                // 2: management.v1.AddMongoDBServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),              // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                   // 4: management.v1.MetricsMode
+	(v1.LogLevel)(0),                   // 5: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),        // 6: google.protobuf.Duration
+	(*v1.MongoDBService)(nil),          // 7: inventory.v1.MongoDBService
+	(*v1.MongoDBExporter)(nil),         // 8: inventory.v1.MongoDBExporter
+	(*v1.QANMongoDBProfilerAgent)(nil), // 9: inventory.v1.QANMongoDBProfilerAgent
+	(*v1.QANMongoDBMongologAgent)(nil), // 10: inventory.v1.QANMongoDBMongologAgent
+	(*v1.RTAMongoDBAgent)(nil),         // 11: inventory.v1.RTAMongoDBAgent
+}
 var file_management_v1_mongodb_proto_depIdxs = []int32{
 	3,  // 0: management.v1.AddMongoDBServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2,  // 1: management.v1.AddMongoDBServiceParams.custom_labels:type_name -> management.v1.AddMongoDBServiceParams.CustomLabelsEntry

--- a/api/management/v1/mongodb.pb.validate.go
+++ b/api/management/v1/mongodb.pb.validate.go
@@ -267,8 +267,7 @@ func (e AddMongoDBServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMongoDBServiceParamsValidationError{}
@@ -515,8 +514,7 @@ func (e MongoDBServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MongoDBServiceResultValidationError{}

--- a/api/management/v1/mongodb.swagger.json
+++ b/api/management/v1/mongodb.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/mongodb.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/mysql.pb.go
+++ b/api/management/v1/mysql.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -528,24 +526,21 @@ func file_management_v1_mysql_proto_rawDescGZIP() []byte {
 	return file_management_v1_mysql_proto_rawDescData
 }
 
-var (
-	file_management_v1_mysql_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-	file_management_v1_mysql_proto_goTypes  = []any{
-		(*AddMySQLServiceParams)(nil),      // 0: management.v1.AddMySQLServiceParams
-		(*MySQLServiceResult)(nil),         // 1: management.v1.MySQLServiceResult
-		nil,                                // 2: management.v1.AddMySQLServiceParams.CustomLabelsEntry
-		nil,                                // 3: management.v1.AddMySQLServiceParams.ExtraDsnParamsEntry
-		(*AddNodeParams)(nil),              // 4: management.v1.AddNodeParams
-		MetricsMode(0),                     // 5: management.v1.MetricsMode
-		v1.LogLevel(0),                     // 6: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),        // 7: google.protobuf.Duration
-		(*v1.MySQLService)(nil),            // 8: inventory.v1.MySQLService
-		(*v1.MySQLdExporter)(nil),          // 9: inventory.v1.MySQLdExporter
-		(*v1.QANMySQLPerfSchemaAgent)(nil), // 10: inventory.v1.QANMySQLPerfSchemaAgent
-		(*v1.QANMySQLSlowlogAgent)(nil),    // 11: inventory.v1.QANMySQLSlowlogAgent
-	}
-)
-
+var file_management_v1_mysql_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_management_v1_mysql_proto_goTypes = []any{
+	(*AddMySQLServiceParams)(nil),      // 0: management.v1.AddMySQLServiceParams
+	(*MySQLServiceResult)(nil),         // 1: management.v1.MySQLServiceResult
+	nil,                                // 2: management.v1.AddMySQLServiceParams.CustomLabelsEntry
+	nil,                                // 3: management.v1.AddMySQLServiceParams.ExtraDsnParamsEntry
+	(*AddNodeParams)(nil),              // 4: management.v1.AddNodeParams
+	(MetricsMode)(0),                   // 5: management.v1.MetricsMode
+	(v1.LogLevel)(0),                   // 6: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),        // 7: google.protobuf.Duration
+	(*v1.MySQLService)(nil),            // 8: inventory.v1.MySQLService
+	(*v1.MySQLdExporter)(nil),          // 9: inventory.v1.MySQLdExporter
+	(*v1.QANMySQLPerfSchemaAgent)(nil), // 10: inventory.v1.QANMySQLPerfSchemaAgent
+	(*v1.QANMySQLSlowlogAgent)(nil),    // 11: inventory.v1.QANMySQLSlowlogAgent
+}
 var file_management_v1_mysql_proto_depIdxs = []int32{
 	4,  // 0: management.v1.AddMySQLServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2,  // 1: management.v1.AddMySQLServiceParams.custom_labels:type_name -> management.v1.AddMySQLServiceParams.CustomLabelsEntry

--- a/api/management/v1/mysql.pb.validate.go
+++ b/api/management/v1/mysql.pb.validate.go
@@ -276,8 +276,7 @@ func (e AddMySQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMySQLServiceParamsValidationError{}
@@ -497,8 +496,7 @@ func (e MySQLServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MySQLServiceResultValidationError{}

--- a/api/management/v1/mysql.swagger.json
+++ b/api/management/v1/mysql.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/mysql.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/node.pb.go
+++ b/api/management/v1/node.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1227,35 +1225,32 @@ func file_management_v1_node_proto_rawDescGZIP() []byte {
 	return file_management_v1_node_proto_rawDescData
 }
 
-var (
-	file_management_v1_node_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_node_proto_msgTypes  = make([]protoimpl.MessageInfo, 15)
-	file_management_v1_node_proto_goTypes   = []any{
-		UniversalNode_Status(0),        // 0: management.v1.UniversalNode.Status
-		(*AddNodeParams)(nil),          // 1: management.v1.AddNodeParams
-		(*RegisterNodeRequest)(nil),    // 2: management.v1.RegisterNodeRequest
-		(*RegisterNodeResponse)(nil),   // 3: management.v1.RegisterNodeResponse
-		(*UnregisterNodeRequest)(nil),  // 4: management.v1.UnregisterNodeRequest
-		(*UnregisterNodeResponse)(nil), // 5: management.v1.UnregisterNodeResponse
-		(*UniversalNode)(nil),          // 6: management.v1.UniversalNode
-		(*ListNodesRequest)(nil),       // 7: management.v1.ListNodesRequest
-		(*ListNodesResponse)(nil),      // 8: management.v1.ListNodesResponse
-		(*GetNodeRequest)(nil),         // 9: management.v1.GetNodeRequest
-		(*GetNodeResponse)(nil),        // 10: management.v1.GetNodeResponse
-		nil,                            // 11: management.v1.AddNodeParams.CustomLabelsEntry
-		nil,                            // 12: management.v1.RegisterNodeRequest.CustomLabelsEntry
-		(*UniversalNode_Service)(nil),  // 13: management.v1.UniversalNode.Service
-		(*UniversalNode_Agent)(nil),    // 14: management.v1.UniversalNode.Agent
-		nil,                            // 15: management.v1.UniversalNode.CustomLabelsEntry
-		v1.NodeType(0),                 // 16: inventory.v1.NodeType
-		MetricsMode(0),                 // 17: management.v1.MetricsMode
-		(*v1.GenericNode)(nil),         // 18: inventory.v1.GenericNode
-		(*v1.ContainerNode)(nil),       // 19: inventory.v1.ContainerNode
-		(*v1.PMMAgent)(nil),            // 20: inventory.v1.PMMAgent
-		(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
-	}
-)
-
+var file_management_v1_node_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_node_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_management_v1_node_proto_goTypes = []any{
+	(UniversalNode_Status)(0),      // 0: management.v1.UniversalNode.Status
+	(*AddNodeParams)(nil),          // 1: management.v1.AddNodeParams
+	(*RegisterNodeRequest)(nil),    // 2: management.v1.RegisterNodeRequest
+	(*RegisterNodeResponse)(nil),   // 3: management.v1.RegisterNodeResponse
+	(*UnregisterNodeRequest)(nil),  // 4: management.v1.UnregisterNodeRequest
+	(*UnregisterNodeResponse)(nil), // 5: management.v1.UnregisterNodeResponse
+	(*UniversalNode)(nil),          // 6: management.v1.UniversalNode
+	(*ListNodesRequest)(nil),       // 7: management.v1.ListNodesRequest
+	(*ListNodesResponse)(nil),      // 8: management.v1.ListNodesResponse
+	(*GetNodeRequest)(nil),         // 9: management.v1.GetNodeRequest
+	(*GetNodeResponse)(nil),        // 10: management.v1.GetNodeResponse
+	nil,                            // 11: management.v1.AddNodeParams.CustomLabelsEntry
+	nil,                            // 12: management.v1.RegisterNodeRequest.CustomLabelsEntry
+	(*UniversalNode_Service)(nil),  // 13: management.v1.UniversalNode.Service
+	(*UniversalNode_Agent)(nil),    // 14: management.v1.UniversalNode.Agent
+	nil,                            // 15: management.v1.UniversalNode.CustomLabelsEntry
+	(v1.NodeType)(0),               // 16: inventory.v1.NodeType
+	(MetricsMode)(0),               // 17: management.v1.MetricsMode
+	(*v1.GenericNode)(nil),         // 18: inventory.v1.GenericNode
+	(*v1.ContainerNode)(nil),       // 19: inventory.v1.ContainerNode
+	(*v1.PMMAgent)(nil),            // 20: inventory.v1.PMMAgent
+	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
+}
 var file_management_v1_node_proto_depIdxs = []int32{
 	16, // 0: management.v1.AddNodeParams.node_type:type_name -> inventory.v1.NodeType
 	11, // 1: management.v1.AddNodeParams.custom_labels:type_name -> management.v1.AddNodeParams.CustomLabelsEntry

--- a/api/management/v1/node.pb.validate.go
+++ b/api/management/v1/node.pb.validate.go
@@ -155,8 +155,7 @@ func (e AddNodeParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddNodeParamsValidationError{}
@@ -299,8 +298,7 @@ func (e RegisterNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RegisterNodeRequestValidationError{}
@@ -493,8 +491,7 @@ func (e RegisterNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RegisterNodeResponseValidationError{}
@@ -609,8 +606,7 @@ func (e UnregisterNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UnregisterNodeRequestValidationError{}
@@ -714,8 +710,7 @@ func (e UnregisterNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UnregisterNodeResponseValidationError{}
@@ -971,8 +966,7 @@ func (e UniversalNodeValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalNodeValidationError{}
@@ -1074,8 +1068,7 @@ func (e ListNodesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesRequestValidationError{}
@@ -1211,8 +1204,7 @@ func (e ListNodesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListNodesResponseValidationError{}
@@ -1323,8 +1315,7 @@ func (e GetNodeRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetNodeRequestValidationError{}
@@ -1453,8 +1444,7 @@ func (e GetNodeResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetNodeResponseValidationError{}
@@ -1562,8 +1552,7 @@ func (e UniversalNode_ServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalNode_ServiceValidationError{}
@@ -1673,8 +1662,7 @@ func (e UniversalNode_AgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalNode_AgentValidationError{}

--- a/api/management/v1/node.swagger.json
+++ b/api/management/v1/node.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/node.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/postgresql.pb.go
+++ b/api/management/v1/postgresql.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -105,8 +103,10 @@ type AddPostgreSQLServiceParams struct {
 	MaxExporterConnections int32 `protobuf:"varint,33,opt,name=max_exporter_connections,json=maxExporterConnections,proto3" json:"max_exporter_connections,omitempty"`
 	// Connection timeout for exporter (if set).
 	ConnectionTimeout *durationpb.Duration `protobuf:"bytes,34,opt,name=connection_timeout,json=connectionTimeout,proto3" json:"connection_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// If true, adds rta-postgresql-agent for provided service.
+	RtaPostgresqlAgent bool `protobuf:"varint,35,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *AddPostgreSQLServiceParams) Reset() {
@@ -377,6 +377,13 @@ func (x *AddPostgreSQLServiceParams) GetConnectionTimeout() *durationpb.Duration
 	return nil
 }
 
+func (x *AddPostgreSQLServiceParams) GetRtaPostgresqlAgent() bool {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return false
+}
+
 type PostgreSQLServiceResult struct {
 	state                           protoimpl.MessageState              `protogen:"open.v1"`
 	Service                         *v1.PostgreSQLService               `protobuf:"bytes,1,opt,name=service,proto3" json:"service,omitempty"`
@@ -384,9 +391,10 @@ type PostgreSQLServiceResult struct {
 	QanPostgresqlPgstatementsAgent  *v1.QANPostgreSQLPgStatementsAgent  `protobuf:"bytes,3,opt,name=qan_postgresql_pgstatements_agent,json=qanPostgresqlPgstatementsAgent,proto3" json:"qan_postgresql_pgstatements_agent,omitempty"`
 	QanPostgresqlPgstatmonitorAgent *v1.QANPostgreSQLPgStatMonitorAgent `protobuf:"bytes,4,opt,name=qan_postgresql_pgstatmonitor_agent,json=qanPostgresqlPgstatmonitorAgent,proto3" json:"qan_postgresql_pgstatmonitor_agent,omitempty"`
 	// Warning message.
-	Warning       string `protobuf:"bytes,5,opt,name=warning,proto3" json:"warning,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Warning            string                 `protobuf:"bytes,5,opt,name=warning,proto3" json:"warning,omitempty"`
+	RtaPostgresqlAgent *v1.RTAPostgreSQLAgent `protobuf:"bytes,6,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *PostgreSQLServiceResult) Reset() {
@@ -454,11 +462,18 @@ func (x *PostgreSQLServiceResult) GetWarning() string {
 	return ""
 }
 
+func (x *PostgreSQLServiceResult) GetRtaPostgresqlAgent() *v1.RTAPostgreSQLAgent {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return nil
+}
+
 var File_management_v1_postgresql_proto protoreflect.FileDescriptor
 
 const file_management_v1_postgresql_proto_rawDesc = "" +
 	"\n" +
-	"\x1emanagement/v1/postgresql.proto\x12\rmanagement.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19inventory/v1/agents.proto\x1a\x1cinventory/v1/log_level.proto\x1a\x1binventory/v1/services.proto\x1a\x1bmanagement/v1/metrics.proto\x1a\x18management/v1/node.proto\x1a\x17validate/validate.proto\"\xc7\f\n" +
+	"\x1emanagement/v1/postgresql.proto\x12\rmanagement.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19inventory/v1/agents.proto\x1a\x1cinventory/v1/log_level.proto\x1a\x1binventory/v1/services.proto\x1a\x1bmanagement/v1/metrics.proto\x1a\x18management/v1/node.proto\x1a\x17validate/validate.proto\"\xf9\f\n" +
 	"\x1aAddPostgreSQLServiceParams\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x127\n" +
@@ -495,16 +510,18 @@ const file_management_v1_postgresql_proto_rawDesc = "" +
 	"\x14auto_discovery_limit\x18\x1f \x01(\x05R\x12autoDiscoveryLimit\x12'\n" +
 	"\x0fexpose_exporter\x18  \x01(\bR\x0eexposeExporter\x128\n" +
 	"\x18max_exporter_connections\x18! \x01(\x05R\x16maxExporterConnections\x12R\n" +
-	"\x12connection_timeout\x18\" \x01(\v2\x19.google.protobuf.DurationB\b\xfaB\x05\xaa\x01\x022\x00R\x11connectionTimeout\x1a?\n" +
+	"\x12connection_timeout\x18\" \x01(\v2\x19.google.protobuf.DurationB\b\xfaB\x05\xaa\x01\x022\x00R\x11connectionTimeout\x120\n" +
+	"\x14rta_postgresql_agent\x18# \x01(\bR\x12rtaPostgresqlAgent\x1a?\n" +
 	"\x11CustomLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb0\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x84\x04\n" +
 	"\x17PostgreSQLServiceResult\x129\n" +
 	"\aservice\x18\x01 \x01(\v2\x1f.inventory.v1.PostgreSQLServiceR\aservice\x12K\n" +
 	"\x11postgres_exporter\x18\x02 \x01(\v2\x1e.inventory.v1.PostgresExporterR\x10postgresExporter\x12w\n" +
 	"!qan_postgresql_pgstatements_agent\x18\x03 \x01(\v2,.inventory.v1.QANPostgreSQLPgStatementsAgentR\x1eqanPostgresqlPgstatementsAgent\x12z\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x04 \x01(\v2-.inventory.v1.QANPostgreSQLPgStatMonitorAgentR\x1fqanPostgresqlPgstatmonitorAgent\x12\x18\n" +
-	"\awarning\x18\x05 \x01(\tR\awarningB\xb0\x01\n" +
+	"\awarning\x18\x05 \x01(\tR\awarning\x12R\n" +
+	"\x14rta_postgresql_agent\x18\x06 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentR\x12rtaPostgresqlAgentB\xb0\x01\n" +
 	"\x11com.management.v1B\x0fPostgresqlProtoP\x01Z5github.com/percona/pmm/api/management/v1;managementv1\xa2\x02\x03MXX\xaa\x02\rManagement.V1\xca\x02\rManagement\\V1\xe2\x02\x19Management\\V1\\GPBMetadata\xea\x02\x0eManagement::V1b\x06proto3"
 
 var (
@@ -519,23 +536,21 @@ func file_management_v1_postgresql_proto_rawDescGZIP() []byte {
 	return file_management_v1_postgresql_proto_rawDescData
 }
 
-var (
-	file_management_v1_postgresql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_postgresql_proto_goTypes  = []any{
-		(*AddPostgreSQLServiceParams)(nil),         // 0: management.v1.AddPostgreSQLServiceParams
-		(*PostgreSQLServiceResult)(nil),            // 1: management.v1.PostgreSQLServiceResult
-		nil,                                        // 2: management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),                      // 3: management.v1.AddNodeParams
-		MetricsMode(0),                             // 4: management.v1.MetricsMode
-		v1.LogLevel(0),                             // 5: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),                // 6: google.protobuf.Duration
-		(*v1.PostgreSQLService)(nil),               // 7: inventory.v1.PostgreSQLService
-		(*v1.PostgresExporter)(nil),                // 8: inventory.v1.PostgresExporter
-		(*v1.QANPostgreSQLPgStatementsAgent)(nil),  // 9: inventory.v1.QANPostgreSQLPgStatementsAgent
-		(*v1.QANPostgreSQLPgStatMonitorAgent)(nil), // 10: inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	}
-)
-
+var file_management_v1_postgresql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_postgresql_proto_goTypes = []any{
+	(*AddPostgreSQLServiceParams)(nil),         // 0: management.v1.AddPostgreSQLServiceParams
+	(*PostgreSQLServiceResult)(nil),            // 1: management.v1.PostgreSQLServiceResult
+	nil,                                        // 2: management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),                      // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                           // 4: management.v1.MetricsMode
+	(v1.LogLevel)(0),                           // 5: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),                // 6: google.protobuf.Duration
+	(*v1.PostgreSQLService)(nil),               // 7: inventory.v1.PostgreSQLService
+	(*v1.PostgresExporter)(nil),                // 8: inventory.v1.PostgresExporter
+	(*v1.QANPostgreSQLPgStatementsAgent)(nil),  // 9: inventory.v1.QANPostgreSQLPgStatementsAgent
+	(*v1.QANPostgreSQLPgStatMonitorAgent)(nil), // 10: inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	(*v1.RTAPostgreSQLAgent)(nil),              // 11: inventory.v1.RTAPostgreSQLAgent
+}
 var file_management_v1_postgresql_proto_depIdxs = []int32{
 	3,  // 0: management.v1.AddPostgreSQLServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2,  // 1: management.v1.AddPostgreSQLServiceParams.custom_labels:type_name -> management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
@@ -546,11 +561,12 @@ var file_management_v1_postgresql_proto_depIdxs = []int32{
 	8,  // 6: management.v1.PostgreSQLServiceResult.postgres_exporter:type_name -> inventory.v1.PostgresExporter
 	9,  // 7: management.v1.PostgreSQLServiceResult.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
 	10, // 8: management.v1.PostgreSQLServiceResult.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	11, // 9: management.v1.PostgreSQLServiceResult.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_management_v1_postgresql_proto_init() }

--- a/api/management/v1/postgresql.pb.validate.go
+++ b/api/management/v1/postgresql.pb.validate.go
@@ -209,6 +209,8 @@ func (m *AddPostgreSQLServiceParams) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for RtaPostgresqlAgent
+
 	if len(errors) > 0 {
 		return AddPostgreSQLServiceParamsMultiError(errors)
 	}
@@ -276,8 +278,7 @@ func (e AddPostgreSQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPostgreSQLServiceParamsValidationError{}
@@ -430,6 +431,35 @@ func (m *PostgreSQLServiceResult) validate(all bool) error {
 
 	// no validation rules for Warning
 
+	if all {
+		switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PostgreSQLServiceResultValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PostgreSQLServiceResultValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PostgreSQLServiceResultValidationError{
+				field:  "RtaPostgresqlAgent",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return PostgreSQLServiceResultMultiError(errors)
 	}
@@ -497,8 +527,7 @@ func (e PostgreSQLServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PostgreSQLServiceResultValidationError{}

--- a/api/management/v1/postgresql.proto
+++ b/api/management/v1/postgresql.proto
@@ -95,6 +95,8 @@ message AddPostgreSQLServiceParams {
   google.protobuf.Duration connection_timeout = 34 [(validate.rules).duration = {
     gte: {seconds: 0}
   }];
+  // If true, adds rta-postgresql-agent for provided service.
+  bool rta_postgresql_agent = 35;
 }
 
 message PostgreSQLServiceResult {
@@ -104,4 +106,5 @@ message PostgreSQLServiceResult {
   inventory.v1.QANPostgreSQLPgStatMonitorAgent qan_postgresql_pgstatmonitor_agent = 4;
   // Warning message.
   string warning = 5;
+  inventory.v1.RTAPostgreSQLAgent rta_postgresql_agent = 6;
 }

--- a/api/management/v1/postgresql.swagger.json
+++ b/api/management/v1/postgresql.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/postgresql.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/proxysql.pb.go
+++ b/api/management/v1/proxysql.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -381,21 +379,18 @@ func file_management_v1_proxysql_proto_rawDescGZIP() []byte {
 	return file_management_v1_proxysql_proto_rawDescData
 }
 
-var (
-	file_management_v1_proxysql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_proxysql_proto_goTypes  = []any{
-		(*AddProxySQLServiceParams)(nil), // 0: management.v1.AddProxySQLServiceParams
-		(*ProxySQLServiceResult)(nil),    // 1: management.v1.ProxySQLServiceResult
-		nil,                              // 2: management.v1.AddProxySQLServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),            // 3: management.v1.AddNodeParams
-		MetricsMode(0),                   // 4: management.v1.MetricsMode
-		v1.LogLevel(0),                   // 5: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),      // 6: google.protobuf.Duration
-		(*v1.ProxySQLService)(nil),       // 7: inventory.v1.ProxySQLService
-		(*v1.ProxySQLExporter)(nil),      // 8: inventory.v1.ProxySQLExporter
-	}
-)
-
+var file_management_v1_proxysql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_proxysql_proto_goTypes = []any{
+	(*AddProxySQLServiceParams)(nil), // 0: management.v1.AddProxySQLServiceParams
+	(*ProxySQLServiceResult)(nil),    // 1: management.v1.ProxySQLServiceResult
+	nil,                              // 2: management.v1.AddProxySQLServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),            // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                 // 4: management.v1.MetricsMode
+	(v1.LogLevel)(0),                 // 5: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),      // 6: google.protobuf.Duration
+	(*v1.ProxySQLService)(nil),       // 7: inventory.v1.ProxySQLService
+	(*v1.ProxySQLExporter)(nil),      // 8: inventory.v1.ProxySQLExporter
+}
 var file_management_v1_proxysql_proto_depIdxs = []int32{
 	3, // 0: management.v1.AddProxySQLServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2, // 1: management.v1.AddProxySQLServiceParams.custom_labels:type_name -> management.v1.AddProxySQLServiceParams.CustomLabelsEntry

--- a/api/management/v1/proxysql.pb.validate.go
+++ b/api/management/v1/proxysql.pb.validate.go
@@ -254,8 +254,7 @@ func (e AddProxySQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddProxySQLServiceParamsValidationError{}
@@ -415,8 +414,7 @@ func (e ProxySQLServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ProxySQLServiceResultValidationError{}

--- a/api/management/v1/proxysql.swagger.json
+++ b/api/management/v1/proxysql.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/proxysql.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/rds.pb.go
+++ b/api/management/v1/rds.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -831,30 +829,27 @@ func file_management_v1_rds_proto_rawDescGZIP() []byte {
 	return file_management_v1_rds_proto_rawDescData
 }
 
-var (
-	file_management_v1_rds_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_rds_proto_msgTypes  = make([]protoimpl.MessageInfo, 6)
-	file_management_v1_rds_proto_goTypes   = []any{
-		DiscoverRDSEngine(0),                      // 0: management.v1.DiscoverRDSEngine
-		(*DiscoverRDSInstance)(nil),               // 1: management.v1.DiscoverRDSInstance
-		(*DiscoverRDSRequest)(nil),                // 2: management.v1.DiscoverRDSRequest
-		(*DiscoverRDSResponse)(nil),               // 3: management.v1.DiscoverRDSResponse
-		(*AddRDSServiceParams)(nil),               // 4: management.v1.AddRDSServiceParams
-		(*RDSServiceResult)(nil),                  // 5: management.v1.RDSServiceResult
-		nil,                                       // 6: management.v1.AddRDSServiceParams.CustomLabelsEntry
-		MetricsMode(0),                            // 7: management.v1.MetricsMode
-		(*durationpb.Duration)(nil),               // 8: google.protobuf.Duration
-		(*v1.RemoteRDSNode)(nil),                  // 9: inventory.v1.RemoteRDSNode
-		(*v1.RDSExporter)(nil),                    // 10: inventory.v1.RDSExporter
-		(*v1.MySQLService)(nil),                   // 11: inventory.v1.MySQLService
-		(*v1.MySQLdExporter)(nil),                 // 12: inventory.v1.MySQLdExporter
-		(*v1.QANMySQLPerfSchemaAgent)(nil),        // 13: inventory.v1.QANMySQLPerfSchemaAgent
-		(*v1.PostgreSQLService)(nil),              // 14: inventory.v1.PostgreSQLService
-		(*v1.PostgresExporter)(nil),               // 15: inventory.v1.PostgresExporter
-		(*v1.QANPostgreSQLPgStatementsAgent)(nil), // 16: inventory.v1.QANPostgreSQLPgStatementsAgent
-	}
-)
-
+var file_management_v1_rds_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_rds_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_management_v1_rds_proto_goTypes = []any{
+	(DiscoverRDSEngine)(0),                    // 0: management.v1.DiscoverRDSEngine
+	(*DiscoverRDSInstance)(nil),               // 1: management.v1.DiscoverRDSInstance
+	(*DiscoverRDSRequest)(nil),                // 2: management.v1.DiscoverRDSRequest
+	(*DiscoverRDSResponse)(nil),               // 3: management.v1.DiscoverRDSResponse
+	(*AddRDSServiceParams)(nil),               // 4: management.v1.AddRDSServiceParams
+	(*RDSServiceResult)(nil),                  // 5: management.v1.RDSServiceResult
+	nil,                                       // 6: management.v1.AddRDSServiceParams.CustomLabelsEntry
+	(MetricsMode)(0),                          // 7: management.v1.MetricsMode
+	(*durationpb.Duration)(nil),               // 8: google.protobuf.Duration
+	(*v1.RemoteRDSNode)(nil),                  // 9: inventory.v1.RemoteRDSNode
+	(*v1.RDSExporter)(nil),                    // 10: inventory.v1.RDSExporter
+	(*v1.MySQLService)(nil),                   // 11: inventory.v1.MySQLService
+	(*v1.MySQLdExporter)(nil),                 // 12: inventory.v1.MySQLdExporter
+	(*v1.QANMySQLPerfSchemaAgent)(nil),        // 13: inventory.v1.QANMySQLPerfSchemaAgent
+	(*v1.PostgreSQLService)(nil),              // 14: inventory.v1.PostgreSQLService
+	(*v1.PostgresExporter)(nil),               // 15: inventory.v1.PostgresExporter
+	(*v1.QANPostgreSQLPgStatementsAgent)(nil), // 16: inventory.v1.QANPostgreSQLPgStatementsAgent
+}
 var file_management_v1_rds_proto_depIdxs = []int32{
 	0,  // 0: management.v1.DiscoverRDSInstance.engine:type_name -> management.v1.DiscoverRDSEngine
 	1,  // 1: management.v1.DiscoverRDSResponse.rds_instances:type_name -> management.v1.DiscoverRDSInstance

--- a/api/management/v1/rds.pb.validate.go
+++ b/api/management/v1/rds.pb.validate.go
@@ -140,8 +140,7 @@ func (e DiscoverRDSInstanceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverRDSInstanceValidationError{}
@@ -247,8 +246,7 @@ func (e DiscoverRDSRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverRDSRequestValidationError{}
@@ -384,8 +382,7 @@ func (e DiscoverRDSResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DiscoverRDSResponseValidationError{}
@@ -630,8 +627,7 @@ func (e AddRDSServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRDSServiceParamsValidationError{}
@@ -963,8 +959,7 @@ func (e RDSServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RDSServiceResultValidationError{}

--- a/api/management/v1/rds.swagger.json
+++ b/api/management/v1/rds.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/rds.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/service.pb.go
+++ b/api/management/v1/service.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -951,61 +949,58 @@ func file_management_v1_service_proto_rawDescGZIP() []byte {
 	return file_management_v1_service_proto_rawDescData
 }
 
-var (
-	file_management_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_service_proto_msgTypes  = make([]protoimpl.MessageInfo, 8)
-	file_management_v1_service_proto_goTypes   = []any{
-		UniversalService_Status(0),            // 0: management.v1.UniversalService.Status
-		(*AddServiceRequest)(nil),             // 1: management.v1.AddServiceRequest
-		(*AddServiceResponse)(nil),            // 2: management.v1.AddServiceResponse
-		(*RemoveServiceRequest)(nil),          // 3: management.v1.RemoveServiceRequest
-		(*RemoveServiceResponse)(nil),         // 4: management.v1.RemoveServiceResponse
-		(*UniversalService)(nil),              // 5: management.v1.UniversalService
-		(*ListServicesRequest)(nil),           // 6: management.v1.ListServicesRequest
-		(*ListServicesResponse)(nil),          // 7: management.v1.ListServicesResponse
-		nil,                                   // 8: management.v1.UniversalService.CustomLabelsEntry
-		(*AddMySQLServiceParams)(nil),         // 9: management.v1.AddMySQLServiceParams
-		(*AddMongoDBServiceParams)(nil),       // 10: management.v1.AddMongoDBServiceParams
-		(*AddPostgreSQLServiceParams)(nil),    // 11: management.v1.AddPostgreSQLServiceParams
-		(*AddProxySQLServiceParams)(nil),      // 12: management.v1.AddProxySQLServiceParams
-		(*AddHAProxyServiceParams)(nil),       // 13: management.v1.AddHAProxyServiceParams
-		(*AddExternalServiceParams)(nil),      // 14: management.v1.AddExternalServiceParams
-		(*AddRDSServiceParams)(nil),           // 15: management.v1.AddRDSServiceParams
-		(*AddValkeyServiceParams)(nil),        // 16: management.v1.AddValkeyServiceParams
-		(*MySQLServiceResult)(nil),            // 17: management.v1.MySQLServiceResult
-		(*MongoDBServiceResult)(nil),          // 18: management.v1.MongoDBServiceResult
-		(*PostgreSQLServiceResult)(nil),       // 19: management.v1.PostgreSQLServiceResult
-		(*ProxySQLServiceResult)(nil),         // 20: management.v1.ProxySQLServiceResult
-		(*HAProxyServiceResult)(nil),          // 21: management.v1.HAProxyServiceResult
-		(*ExternalServiceResult)(nil),         // 22: management.v1.ExternalServiceResult
-		(*RDSServiceResult)(nil),              // 23: management.v1.RDSServiceResult
-		(*ValkeyServiceResult)(nil),           // 24: management.v1.ValkeyServiceResult
-		v1.ServiceType(0),                     // 25: inventory.v1.ServiceType
-		(*timestamppb.Timestamp)(nil),         // 26: google.protobuf.Timestamp
-		(*UniversalAgent)(nil),                // 27: management.v1.UniversalAgent
-		(*AddAnnotationRequest)(nil),          // 28: management.v1.AddAnnotationRequest
-		(*ListAgentsRequest)(nil),             // 29: management.v1.ListAgentsRequest
-		(*ListAgentVersionsRequest)(nil),      // 30: management.v1.ListAgentVersionsRequest
-		(*RegisterNodeRequest)(nil),           // 31: management.v1.RegisterNodeRequest
-		(*UnregisterNodeRequest)(nil),         // 32: management.v1.UnregisterNodeRequest
-		(*ListNodesRequest)(nil),              // 33: management.v1.ListNodesRequest
-		(*GetNodeRequest)(nil),                // 34: management.v1.GetNodeRequest
-		(*DiscoverRDSRequest)(nil),            // 35: management.v1.DiscoverRDSRequest
-		(*DiscoverAzureDatabaseRequest)(nil),  // 36: management.v1.DiscoverAzureDatabaseRequest
-		(*AddAzureDatabaseRequest)(nil),       // 37: management.v1.AddAzureDatabaseRequest
-		(*AddAnnotationResponse)(nil),         // 38: management.v1.AddAnnotationResponse
-		(*ListAgentsResponse)(nil),            // 39: management.v1.ListAgentsResponse
-		(*ListAgentVersionsResponse)(nil),     // 40: management.v1.ListAgentVersionsResponse
-		(*RegisterNodeResponse)(nil),          // 41: management.v1.RegisterNodeResponse
-		(*UnregisterNodeResponse)(nil),        // 42: management.v1.UnregisterNodeResponse
-		(*ListNodesResponse)(nil),             // 43: management.v1.ListNodesResponse
-		(*GetNodeResponse)(nil),               // 44: management.v1.GetNodeResponse
-		(*DiscoverRDSResponse)(nil),           // 45: management.v1.DiscoverRDSResponse
-		(*DiscoverAzureDatabaseResponse)(nil), // 46: management.v1.DiscoverAzureDatabaseResponse
-		(*AddAzureDatabaseResponse)(nil),      // 47: management.v1.AddAzureDatabaseResponse
-	}
-)
-
+var file_management_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_management_v1_service_proto_goTypes = []any{
+	(UniversalService_Status)(0),          // 0: management.v1.UniversalService.Status
+	(*AddServiceRequest)(nil),             // 1: management.v1.AddServiceRequest
+	(*AddServiceResponse)(nil),            // 2: management.v1.AddServiceResponse
+	(*RemoveServiceRequest)(nil),          // 3: management.v1.RemoveServiceRequest
+	(*RemoveServiceResponse)(nil),         // 4: management.v1.RemoveServiceResponse
+	(*UniversalService)(nil),              // 5: management.v1.UniversalService
+	(*ListServicesRequest)(nil),           // 6: management.v1.ListServicesRequest
+	(*ListServicesResponse)(nil),          // 7: management.v1.ListServicesResponse
+	nil,                                   // 8: management.v1.UniversalService.CustomLabelsEntry
+	(*AddMySQLServiceParams)(nil),         // 9: management.v1.AddMySQLServiceParams
+	(*AddMongoDBServiceParams)(nil),       // 10: management.v1.AddMongoDBServiceParams
+	(*AddPostgreSQLServiceParams)(nil),    // 11: management.v1.AddPostgreSQLServiceParams
+	(*AddProxySQLServiceParams)(nil),      // 12: management.v1.AddProxySQLServiceParams
+	(*AddHAProxyServiceParams)(nil),       // 13: management.v1.AddHAProxyServiceParams
+	(*AddExternalServiceParams)(nil),      // 14: management.v1.AddExternalServiceParams
+	(*AddRDSServiceParams)(nil),           // 15: management.v1.AddRDSServiceParams
+	(*AddValkeyServiceParams)(nil),        // 16: management.v1.AddValkeyServiceParams
+	(*MySQLServiceResult)(nil),            // 17: management.v1.MySQLServiceResult
+	(*MongoDBServiceResult)(nil),          // 18: management.v1.MongoDBServiceResult
+	(*PostgreSQLServiceResult)(nil),       // 19: management.v1.PostgreSQLServiceResult
+	(*ProxySQLServiceResult)(nil),         // 20: management.v1.ProxySQLServiceResult
+	(*HAProxyServiceResult)(nil),          // 21: management.v1.HAProxyServiceResult
+	(*ExternalServiceResult)(nil),         // 22: management.v1.ExternalServiceResult
+	(*RDSServiceResult)(nil),              // 23: management.v1.RDSServiceResult
+	(*ValkeyServiceResult)(nil),           // 24: management.v1.ValkeyServiceResult
+	(v1.ServiceType)(0),                   // 25: inventory.v1.ServiceType
+	(*timestamppb.Timestamp)(nil),         // 26: google.protobuf.Timestamp
+	(*UniversalAgent)(nil),                // 27: management.v1.UniversalAgent
+	(*AddAnnotationRequest)(nil),          // 28: management.v1.AddAnnotationRequest
+	(*ListAgentsRequest)(nil),             // 29: management.v1.ListAgentsRequest
+	(*ListAgentVersionsRequest)(nil),      // 30: management.v1.ListAgentVersionsRequest
+	(*RegisterNodeRequest)(nil),           // 31: management.v1.RegisterNodeRequest
+	(*UnregisterNodeRequest)(nil),         // 32: management.v1.UnregisterNodeRequest
+	(*ListNodesRequest)(nil),              // 33: management.v1.ListNodesRequest
+	(*GetNodeRequest)(nil),                // 34: management.v1.GetNodeRequest
+	(*DiscoverRDSRequest)(nil),            // 35: management.v1.DiscoverRDSRequest
+	(*DiscoverAzureDatabaseRequest)(nil),  // 36: management.v1.DiscoverAzureDatabaseRequest
+	(*AddAzureDatabaseRequest)(nil),       // 37: management.v1.AddAzureDatabaseRequest
+	(*AddAnnotationResponse)(nil),         // 38: management.v1.AddAnnotationResponse
+	(*ListAgentsResponse)(nil),            // 39: management.v1.ListAgentsResponse
+	(*ListAgentVersionsResponse)(nil),     // 40: management.v1.ListAgentVersionsResponse
+	(*RegisterNodeResponse)(nil),          // 41: management.v1.RegisterNodeResponse
+	(*UnregisterNodeResponse)(nil),        // 42: management.v1.UnregisterNodeResponse
+	(*ListNodesResponse)(nil),             // 43: management.v1.ListNodesResponse
+	(*GetNodeResponse)(nil),               // 44: management.v1.GetNodeResponse
+	(*DiscoverRDSResponse)(nil),           // 45: management.v1.DiscoverRDSResponse
+	(*DiscoverAzureDatabaseResponse)(nil), // 46: management.v1.DiscoverAzureDatabaseResponse
+	(*AddAzureDatabaseResponse)(nil),      // 47: management.v1.AddAzureDatabaseResponse
+}
 var file_management_v1_service_proto_depIdxs = []int32{
 	9,  // 0: management.v1.AddServiceRequest.mysql:type_name -> management.v1.AddMySQLServiceParams
 	10, // 1: management.v1.AddServiceRequest.mongodb:type_name -> management.v1.AddMongoDBServiceParams

--- a/api/management/v1/service.pb.validate.go
+++ b/api/management/v1/service.pb.validate.go
@@ -461,8 +461,7 @@ func (e AddServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddServiceRequestValidationError{}
@@ -897,8 +896,7 @@ func (e AddServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddServiceResponseValidationError{}
@@ -1004,8 +1002,7 @@ func (e RemoveServiceRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveServiceRequestValidationError{}
@@ -1107,8 +1104,7 @@ func (e RemoveServiceResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveServiceResponseValidationError{}
@@ -1332,8 +1328,7 @@ func (e UniversalServiceValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UniversalServiceValidationError{}
@@ -1441,8 +1436,7 @@ func (e ListServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesRequestValidationError{}
@@ -1578,8 +1572,7 @@ func (e ListServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesResponseValidationError{}

--- a/api/management/v1/service.swagger.json
+++ b/api/management/v1/service.swagger.json
@@ -1,0 +1,4607 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/service.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "ManagementService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/management/agents": {
+      "get": {
+        "summary": "List Agents",
+        "description": "Lists Agents with filter.",
+        "operationId": "ListAgents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAgentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_id",
+            "description": "Return only Agents that relate to a specific ServiceID.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "node_id",
+            "description": "Return only Agents that relate to a specific NodeID.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/agents/versions": {
+      "get": {
+        "summary": "List Agent Versions",
+        "description": "Lists Agent versions and their update severity.",
+        "operationId": "ListAgentVersions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAgentVersionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/annotations": {
+      "post": {
+        "summary": "Add an Annotation",
+        "description": "Adds an annotation.",
+        "operationId": "AddAnnotation",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddAnnotationResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "AddAnnotationRequest is a params to add new annotation.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddAnnotationRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/nodes": {
+      "get": {
+        "summary": "List Nodes",
+        "description": "Lists Nodes with filter.",
+        "operationId": "ListNodes",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListNodesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_type",
+            "description": "Node type to be filtered out.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "NODE_TYPE_UNSPECIFIED",
+              "NODE_TYPE_GENERIC_NODE",
+              "NODE_TYPE_CONTAINER_NODE",
+              "NODE_TYPE_REMOTE_NODE",
+              "NODE_TYPE_REMOTE_RDS_NODE",
+              "NODE_TYPE_REMOTE_AZURE_DATABASE_NODE"
+            ],
+            "default": "NODE_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      },
+      "post": {
+        "summary": "Register a Node",
+        "description": "Registers a new Node and a pmm-agent.",
+        "operationId": "RegisterNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RegisterNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1RegisterNodeRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/nodes/{node_id}": {
+      "get": {
+        "summary": "Get Node",
+        "description": "Gets a single Node by ID.",
+        "operationId": "GetNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Unique Node identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      },
+      "delete": {
+        "summary": "Unregister a Node",
+        "description": "Unregisters a Node and pmm-agent",
+        "operationId": "UnregisterNode",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UnregisterNodeResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Node_id to be unregistered.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Force delete node, related service account, even if it has more service tokens attached.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/services": {
+      "get": {
+        "summary": "List Services",
+        "description": "Returns a filtered list of Services.",
+        "operationId": "ListServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "node_id",
+            "description": "Return only Services running on that Node.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "service_type",
+            "description": "Return only services filtered by service type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SERVICE_TYPE_UNSPECIFIED",
+              "SERVICE_TYPE_MYSQL_SERVICE",
+              "SERVICE_TYPE_MONGODB_SERVICE",
+              "SERVICE_TYPE_POSTGRESQL_SERVICE",
+              "SERVICE_TYPE_VALKEY_SERVICE",
+              "SERVICE_TYPE_PROXYSQL_SERVICE",
+              "SERVICE_TYPE_HAPROXY_SERVICE",
+              "SERVICE_TYPE_EXTERNAL_SERVICE"
+            ],
+            "default": "SERVICE_TYPE_UNSPECIFIED"
+          },
+          {
+            "name": "external_group",
+            "description": "Return only services in this external group.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      },
+      "post": {
+        "summary": "Add a Service",
+        "description": "Adds a service and starts several agents.",
+        "operationId": "AddService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddServiceRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/services/azure": {
+      "post": {
+        "summary": "Add Azure Database",
+        "description": "Adds an Azure Database instance.",
+        "operationId": "AddAzureDatabase",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddAzureDatabaseResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddAzureDatabaseRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/services/{service_id}": {
+      "delete": {
+        "summary": "Remove a Service",
+        "description": "Removes a Service along with its Agents.",
+        "operationId": "RemoveService",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveServiceResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_id",
+            "description": "Either a Service ID or a Service Name.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "service_type",
+            "description": "Service type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SERVICE_TYPE_UNSPECIFIED",
+              "SERVICE_TYPE_MYSQL_SERVICE",
+              "SERVICE_TYPE_MONGODB_SERVICE",
+              "SERVICE_TYPE_POSTGRESQL_SERVICE",
+              "SERVICE_TYPE_VALKEY_SERVICE",
+              "SERVICE_TYPE_PROXYSQL_SERVICE",
+              "SERVICE_TYPE_HAPROXY_SERVICE",
+              "SERVICE_TYPE_EXTERNAL_SERVICE"
+            ],
+            "default": "SERVICE_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/services:discoverAzure": {
+      "post": {
+        "summary": "Discover Azure Database",
+        "description": "Discovers Azure Database for MySQL, MariaDB and PostgreSQL Server instances.",
+        "operationId": "DiscoverAzureDatabase",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DiscoverAzureDatabaseResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "DiscoverAzureDatabaseRequest discover azure databases request.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DiscoverAzureDatabaseRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    },
+    "/v1/management/services:discoverRDS": {
+      "post": {
+        "summary": "Discover RDS",
+        "description": "Discovers RDS instances.",
+        "operationId": "DiscoverRDS",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1DiscoverRDSResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/googleRpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1DiscoverRDSRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ManagementService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "UniversalAgentAzureOptions": {
+      "type": "object",
+      "properties": {
+        "client_id": {
+          "type": "string",
+          "description": "Azure client ID."
+        },
+        "is_client_secret_set": {
+          "type": "boolean",
+          "description": "True if Azure client secret is set."
+        },
+        "resource_group": {
+          "type": "string",
+          "description": "Azure resource group."
+        },
+        "subscription_id": {
+          "type": "string",
+          "description": "Azure subscription ID."
+        },
+        "tenant_id": {
+          "type": "string",
+          "description": "Azure tenant ID."
+        }
+      }
+    },
+    "UniversalAgentMongoDBOptions": {
+      "type": "object",
+      "properties": {
+        "is_tls_certificate_key_set": {
+          "type": "boolean",
+          "description": "True if TLS certificate is set."
+        },
+        "is_tls_certificate_key_file_password_set": {
+          "type": "boolean",
+          "description": "True if TLS certificate file password is set."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "MongoDB auth mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "MongoDB auth database."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "MongoDB stats collections."
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "MongoDB collections limit."
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "True if all collectors are enabled."
+        }
+      }
+    },
+    "UniversalAgentMySQLOptions": {
+      "type": "object",
+      "properties": {
+        "is_tls_key_set": {
+          "type": "boolean",
+          "description": "True if TLS key is set."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      }
+    },
+    "UniversalAgentPostgreSQLOptions": {
+      "type": "object",
+      "properties": {
+        "is_ssl_key_set": {
+          "type": "boolean",
+          "description": "True if TLS key is set."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections from exporter to PostgreSQL instance."
+        }
+      }
+    },
+    "UniversalAgentValkeyOptions": {
+      "type": "object"
+    },
+    "UniversalNodeAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique Agent identifier."
+        },
+        "agent_type": {
+          "type": "string",
+          "description": "Agent type."
+        },
+        "status": {
+          "type": "string",
+          "description": "Actual Agent status."
+        },
+        "is_connected": {
+          "type": "boolean",
+          "description": "True if Agent is running and connected to pmm-managed."
+        }
+      }
+    },
+    "UniversalNodeService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique Service identifier."
+        },
+        "service_type": {
+          "type": "string",
+          "description": "Service type."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        }
+      },
+      "description": "Service represents a service running on a node."
+    },
+    "commonMetricsResolutions": {
+      "type": "object",
+      "properties": {
+        "hr": {
+          "type": "string",
+          "description": "High resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "mr": {
+          "type": "string",
+          "description": "Medium resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "lr": {
+          "type": "string",
+          "description": "Low resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        }
+      },
+      "description": "MetricsResolutions represents Prometheus exporters metrics resolutions."
+    },
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "v1AddAnnotationRequest": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "An annotation description. Required."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags are used to filter annotations."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Used for annotating a node."
+        },
+        "service_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Used for annotating services."
+        }
+      },
+      "description": "AddAnnotationRequest is a params to add new annotation."
+    },
+    "v1AddAnnotationResponse": {
+      "type": "object"
+    },
+    "v1AddAzureDatabaseRequest": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Azure database location."
+        },
+        "az": {
+          "type": "string",
+          "description": "Azure database availability zone."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "Azure database instance ID."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Represents a purchasable Stock Keeping Unit (SKU) under a product.\nhttps://docs.microsoft.com/en-us/partner-center/develop/product-resources#sku."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address used to connect to it."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name. Defaults to Azure Database instance ID."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Defaults to Azure Database instance ID."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "username": {
+          "type": "string",
+          "description": "Username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for scraping metrics."
+        },
+        "azure_client_id": {
+          "type": "string",
+          "description": "Azure client ID."
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "description": "Azure client secret."
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "description": "Azure tanant ID."
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "description": "Azure subscription ID."
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "description": "Azure resource group."
+        },
+        "azure_database_exporter": {
+          "type": "boolean",
+          "description": "If true, adds azure_database_exporter."
+        },
+        "qan": {
+          "type": "boolean",
+          "description": "If true, adds qan-mysql-perfschema-agent or qan-postgresql-pgstatements-agent."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Node and Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables.\nIf zero, server's default value is used.\nUse negative value to disable them."
+        },
+        "type": {
+          "$ref": "#/definitions/v1DiscoverAzureDatabaseType",
+          "title": "Azure database resource type (mysql, maria, postgres)"
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddAzureDatabaseResponse": {
+      "type": "object"
+    },
+    "v1AddExternalServiceParams": {
+      "type": "object",
+      "properties": {
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier on which an external exporter is been running.\nruns_on_node_id should always be passed with node_id.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service and node is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nadd_node should always be passed with address.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Exporter access address (DNS name or IP).\naddress should always be passed with add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "HTTP basic auth password for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which an external service is been running.\nnode_id should always be passed with runs_on_node_id."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "group": {
+          "type": "string",
+          "description": "Group name of external service."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically.\nNode with registered pmm_agent_id must present at pmm-server\nin case of push metrics_mode."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        }
+      }
+    },
+    "v1AddHAProxyServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which an external exporter is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service and node is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nadd_node always should be passed with address.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Exporter access address (DNS name or IP).\naddress always should be passed with add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "HTTP basic auth password for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically.\nNode with registered pmm_agent_id must present at pmm-server\nin case of push metrics_mode."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        }
+      }
+    },
+    "v1AddMongoDBServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Service access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Service Access socket.\nAddress (and port) or socket is required."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The \"pmm-agent\" identifier which should run agents. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for exporter and QAN agent access."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for exporter and QAN agent access."
+        },
+        "qan_mongodb_profiler": {
+          "type": "boolean",
+          "description": "If true, adds qan-mongodb-profiler-agent for provided service."
+        },
+        "qan_mongodb_mongolog": {
+          "type": "boolean",
+          "description": "If true, adds qan-mongodb-mongolog-agent for provided service."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collections to get stats from. Can use * ."
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "title": "Enable all collectors"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "title": "Exporter log level"
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names to pass to the exporter.\nValues will be resolved from pmm-agent's environment when starting the exporter."
+        },
+        "rta_mongodb_agent": {
+          "type": "boolean",
+          "description": "If true, adds Real-Time Analytics agent for the provided service."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddMySQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Service access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Service Access socket.\nAddress (and port) or socket is required."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The \"pmm-agent\" identifier which should run agents. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for scraping metrics."
+        },
+        "qan_mysql_perfschema": {
+          "type": "boolean",
+          "description": "If true, adds qan-mysql-perfschema-agent for provided service."
+        },
+        "qan_mysql_slowlog": {
+          "type": "boolean",
+          "description": "If true, adds qan-mysql-slowlog-agent for provided service."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "If qan-mysql-slowlog-agent is added, slowlog file is rotated at this size if \u003e 0.\nIf zero, server's default value is used.\nUse negative value to disable rotation."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables.\nIf zero, server's default value is used.\nUse negative value to disable them."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "title": "Exporter log level"
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "extra DSN parameters to be used for connecting to MySQL."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddNodeParams": {
+      "type": "object",
+      "properties": {
+        "node_type": {
+          "$ref": "#/definitions/v1NodeType",
+          "description": "Node type to be registered."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "Container identifier. If specified, must be a unique Docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Node."
+        }
+      },
+      "description": "AddNodeParams holds node params and is used to add new node to inventory while adding new service."
+    },
+    "v1AddPostgreSQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Service access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service Access port.\nPort is required when the address present."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Service Access socket.\nAddress (and port) or socket is required."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The \"pmm-agent\" identifier which should run agents. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for scraping metrics."
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "type": "boolean",
+          "description": "If true, adds qan-postgresql-pgstatements-agent for provided service."
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "type": "boolean",
+          "description": "If true, adds qan-postgresql-pgstatmonitor-agent for provided service."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "title": "Exporter log level"
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit for auto discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        },
+        "rta_postgresql_agent": {
+          "type": "boolean",
+          "description": "If true, adds rta-postgresql-agent for provided service."
+        }
+      }
+    },
+    "v1AddProxySQLServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service is been running.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nExactly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Required."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Service access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Service Access socket.\nAddress (and port) or socket is required."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The \"pmm-agent\" identifier which should run agents. Required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "ProxySQL password for scraping metrics."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "title": "Exporter log level"
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddRDSServiceParams": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "AWS region."
+        },
+        "az": {
+          "type": "string",
+          "description": "AWS availability zone."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "AWS instance ID."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "AWS instance class."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address used to connect to it."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port."
+        },
+        "engine": {
+          "$ref": "#/definitions/v1DiscoverRDSEngine",
+          "description": "Instance engine."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "PMM Agent ID."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name. Defaults to AWS instance ID."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name. Defaults to AWS instance ID."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "username": {
+          "type": "string",
+          "description": "Username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for scraping metrics."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access key."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "description": "AWS Secret key."
+        },
+        "rds_exporter": {
+          "type": "boolean",
+          "description": "If true, adds rds_exporter."
+        },
+        "qan_mysql_perfschema": {
+          "type": "boolean",
+          "description": "If true, adds qan-mysql-perfschema-agent."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Node and Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables.\nIf zero, server's default value is used.\nUse negative value to disable them."
+        },
+        "disable_basic_metrics": {
+          "type": "boolean",
+          "description": "Disable basic metrics."
+        },
+        "disable_enhanced_metrics": {
+          "type": "boolean",
+          "description": "Disable enhanced metrics."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for this exporter.\nPush metrics mode is not allowed."
+        },
+        "qan_postgresql_pgstatements": {
+          "type": "boolean",
+          "title": "If true, add qan-pgstatements"
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "database": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_postgresql_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of exporter connections to PostgreSQL instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddServiceRequest": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1AddMySQLServiceParams"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1AddMongoDBServiceParams"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1AddPostgreSQLServiceParams"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1AddProxySQLServiceParams"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1AddHAProxyServiceParams"
+        },
+        "external": {
+          "$ref": "#/definitions/v1AddExternalServiceParams"
+        },
+        "rds": {
+          "$ref": "#/definitions/v1AddRDSServiceParams"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1AddValkeyServiceParams"
+        }
+      }
+    },
+    "v1AddServiceResponse": {
+      "type": "object",
+      "properties": {
+        "mysql": {
+          "$ref": "#/definitions/v1MySQLServiceResult"
+        },
+        "mongodb": {
+          "$ref": "#/definitions/v1MongoDBServiceResult"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1PostgreSQLServiceResult"
+        },
+        "proxysql": {
+          "$ref": "#/definitions/v1ProxySQLServiceResult"
+        },
+        "haproxy": {
+          "$ref": "#/definitions/v1HAProxyServiceResult"
+        },
+        "external": {
+          "$ref": "#/definitions/v1ExternalServiceResult"
+        },
+        "rds": {
+          "$ref": "#/definitions/v1RDSServiceResult"
+        },
+        "valkey": {
+          "$ref": "#/definitions/v1ValkeyServiceResult"
+        }
+      }
+    },
+    "v1AddValkeyServiceParams": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier on which the service is running.\nOnly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name on which a service is running.\nOnly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "add_node": {
+          "$ref": "#/definitions/v1AddNodeParams",
+          "description": "Create a new Node with those parameters.\nOnly one of these parameters should be present: node_id, node_name, add_node."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "User-defined name, it is required and should be unique across all services."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node and Service access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Service access port.\nPort is required when the address is present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Service access socket.\nAddress (and port) or socket is required."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The \"pmm-agent\" identifier which should run agents. Required."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "Valkey password for scraping metrics."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for connection."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS verification."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for the Valkey exporter.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "title": "Exporter log level"
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AgentStatus": {
+      "type": "string",
+      "enum": [
+        "AGENT_STATUS_UNSPECIFIED",
+        "AGENT_STATUS_STARTING",
+        "AGENT_STATUS_INITIALIZATION_ERROR",
+        "AGENT_STATUS_RUNNING",
+        "AGENT_STATUS_WAITING",
+        "AGENT_STATUS_STOPPING",
+        "AGENT_STATUS_DONE",
+        "AGENT_STATUS_UNKNOWN"
+      ],
+      "default": "AGENT_STATUS_UNSPECIFIED",
+      "description": "AgentStatus represents actual Agent status.\n\n - AGENT_STATUS_STARTING: Agent is starting.\n - AGENT_STATUS_INITIALIZATION_ERROR: Agent encountered error when starting.\n - AGENT_STATUS_RUNNING: Agent is running.\n - AGENT_STATUS_WAITING: Agent encountered error and will be restarted automatically soon.\n - AGENT_STATUS_STOPPING: Agent is stopping.\n - AGENT_STATUS_DONE: Agent has been stopped or disabled.\n - AGENT_STATUS_UNKNOWN: Agent is not connected, we don't know anything about it's state."
+    },
+    "v1AgentVersions": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Agent ID."
+        },
+        "version": {
+          "type": "string",
+          "description": "Agent version."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name where the agent runs."
+        },
+        "severity": {
+          "$ref": "#/definitions/v1UpdateSeverity",
+          "description": "Update severity."
+        }
+      }
+    },
+    "v1ContainerNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id of the Generic Node where this Container Node runs."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "Container identifier. If specified, must be a unique Docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "is_pmm_server_node": {
+          "type": "boolean",
+          "description": "True if this node is a PMM Server node (HA mode)."
+        }
+      },
+      "description": "ContainerNode represents a Docker container."
+    },
+    "v1DiscoverAzureDatabaseInstance": {
+      "type": "object",
+      "properties": {
+        "instance_id": {
+          "type": "string",
+          "description": "Azure database instance ID."
+        },
+        "region": {
+          "type": "string",
+          "description": "Azure database location."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Azure database server name."
+        },
+        "username": {
+          "type": "string",
+          "description": "Database username."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address used to connect to it."
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "description": "Azure Resource group."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment tag."
+        },
+        "type": {
+          "$ref": "#/definitions/v1DiscoverAzureDatabaseType",
+          "description": "Database type."
+        },
+        "az": {
+          "type": "string",
+          "description": "Azure database availability zone."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Represents a purchasable Stock Keeping Unit (SKU) under a product.\nhttps://docs.microsoft.com/en-us/partner-center/develop/product-resources#sku."
+        }
+      },
+      "description": "DiscoverAzureDatabaseInstance models an unique Azure Database instance for the list of instances returned by Discovery."
+    },
+    "v1DiscoverAzureDatabaseRequest": {
+      "type": "object",
+      "properties": {
+        "azure_client_id": {
+          "type": "string",
+          "description": "Azure client ID."
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "description": "Azure client secret."
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "description": "Azure tanant ID."
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "description": "Azure subscription ID."
+        }
+      },
+      "description": "DiscoverAzureDatabaseRequest discover azure databases request."
+    },
+    "v1DiscoverAzureDatabaseResponse": {
+      "type": "object",
+      "properties": {
+        "azure_database_instance": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1DiscoverAzureDatabaseInstance"
+          }
+        }
+      },
+      "description": "DiscoverAzureDatabaseResponse discover azure databases response."
+    },
+    "v1DiscoverAzureDatabaseType": {
+      "type": "string",
+      "enum": [
+        "DISCOVER_AZURE_DATABASE_TYPE_UNSPECIFIED",
+        "DISCOVER_AZURE_DATABASE_TYPE_MYSQL",
+        "DISCOVER_AZURE_DATABASE_TYPE_POSTGRESQL"
+      ],
+      "default": "DISCOVER_AZURE_DATABASE_TYPE_UNSPECIFIED",
+      "description": "DiscoverAzureDatabaseType describes supported Azure Database instance engines.\n\n - DISCOVER_AZURE_DATABASE_TYPE_MYSQL: MySQL type: microsoft.dbformysql or MariaDB type: microsoft.dbformariadb\n - DISCOVER_AZURE_DATABASE_TYPE_POSTGRESQL: PostgreSQL type: microsoft.dbformysql"
+    },
+    "v1DiscoverRDSEngine": {
+      "type": "string",
+      "enum": [
+        "DISCOVER_RDS_ENGINE_UNSPECIFIED",
+        "DISCOVER_RDS_ENGINE_MYSQL",
+        "DISCOVER_RDS_ENGINE_POSTGRESQL"
+      ],
+      "default": "DISCOVER_RDS_ENGINE_UNSPECIFIED",
+      "description": "DiscoverRDSEngine describes supported RDS instance engines."
+    },
+    "v1DiscoverRDSInstance": {
+      "type": "object",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "AWS region."
+        },
+        "az": {
+          "type": "string",
+          "description": "AWS availability zone."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "AWS instance ID."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "AWS instance class."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address used to connect to it."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port."
+        },
+        "engine": {
+          "$ref": "#/definitions/v1DiscoverRDSEngine",
+          "description": "Instance engine."
+        },
+        "engine_version": {
+          "type": "string",
+          "description": "Engine version."
+        }
+      },
+      "description": "DiscoverRDSInstance models an unique RDS instance for the list of instances returned by Discovery."
+    },
+    "v1DiscoverRDSRequest": {
+      "type": "object",
+      "properties": {
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access key. Optional."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "description": "AWS Secret key. Optional."
+        }
+      }
+    },
+    "v1DiscoverRDSResponse": {
+      "type": "object",
+      "properties": {
+        "rds_instances": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1DiscoverRDSInstance"
+          }
+        }
+      }
+    },
+    "v1ExternalExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "If disabled, metrics from this exporter will not be collected."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        }
+      },
+      "description": "ExternalExporter runs on any Node type, including Remote Node."
+    },
+    "v1ExternalService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this service instance runs."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "group": {
+          "type": "string",
+          "description": "Group name of external service."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP)."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port."
+        }
+      },
+      "description": "ExternalService represents a generic External service instance."
+    },
+    "v1ExternalServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1ExternalService"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        }
+      }
+    },
+    "v1GenericNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "is_pmm_server_node": {
+          "type": "boolean",
+          "description": "True if this node is a PMM Server node (HA mode)."
+        }
+      },
+      "description": "GenericNode represents a bare metal server or virtual machine."
+    },
+    "v1GetNodeResponse": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/v1UniversalNode"
+        }
+      }
+    },
+    "v1HAProxyService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this service instance runs."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      },
+      "description": "HAProxyService represents a generic HAProxy service instance."
+    },
+    "v1HAProxyServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1HAProxyService"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        }
+      }
+    },
+    "v1ListAgentVersionsResponse": {
+      "type": "object",
+      "properties": {
+        "agent_versions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AgentVersions"
+          },
+          "description": "List of Agent versions."
+        }
+      }
+    },
+    "v1ListAgentsResponse": {
+      "type": "object",
+      "properties": {
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1UniversalAgent"
+          },
+          "description": "List of Agents."
+        }
+      }
+    },
+    "v1ListNodesResponse": {
+      "type": "object",
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1UniversalNode"
+          }
+        }
+      }
+    },
+    "v1ListServicesResponse": {
+      "type": "object",
+      "properties": {
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1UniversalService"
+          },
+          "description": "List of Services."
+        }
+      }
+    },
+    "v1LogLevel": {
+      "type": "string",
+      "enum": [
+        "LOG_LEVEL_UNSPECIFIED",
+        "LOG_LEVEL_FATAL",
+        "LOG_LEVEL_ERROR",
+        "LOG_LEVEL_WARN",
+        "LOG_LEVEL_INFO",
+        "LOG_LEVEL_DEBUG"
+      ],
+      "default": "LOG_LEVEL_UNSPECIFIED",
+      "description": "- LOG_LEVEL_UNSPECIFIED: Auto",
+      "title": "Log level for exporters"
+    },
+    "v1MetricsMode": {
+      "type": "string",
+      "enum": [
+        "METRICS_MODE_UNSPECIFIED",
+        "METRICS_MODE_PULL",
+        "METRICS_MODE_PUSH"
+      ],
+      "default": "METRICS_MODE_UNSPECIFIED",
+      "description": "MetricsMode defines desired metrics mode for agent,\nit can be pull, push or auto mode chosen by server.\n\n - METRICS_MODE_UNSPECIFIED: Auto"
+    },
+    "v1MongoDBExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of colletions to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "Enable all collectors."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names passed to the exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MongoDBExporter runs on Generic or Container Node and exposes MongoDB Service metrics."
+    },
+    "v1MongoDBService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MongoDB version."
+        }
+      },
+      "description": "MongoDBService represents a generic MongoDB instance."
+    },
+    "v1MongoDBServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1MongoDBService"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "qan_mongodb_profiler": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        }
+      }
+    },
+    "v1MySQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MySQL version."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra parameters to be added to the DSN."
+        }
+      },
+      "description": "MySQLService represents a generic MySQL instance."
+    },
+    "v1MySQLServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1MySQLService"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "qan_mysql_perfschema": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "table_count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual table count at the moment of adding."
+        }
+      }
+    },
+    "v1MySQLdExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors are disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "table_count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual table count at the moment of adding."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "tablestats_group_disabled": {
+          "type": "boolean",
+          "description": "True if tablestats group collectors are currently disabled."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MySQLdExporter runs on Generic or Container Node and exposes MySQL Service metrics."
+    },
+    "v1NodeType": {
+      "type": "string",
+      "enum": [
+        "NODE_TYPE_UNSPECIFIED",
+        "NODE_TYPE_GENERIC_NODE",
+        "NODE_TYPE_CONTAINER_NODE",
+        "NODE_TYPE_REMOTE_NODE",
+        "NODE_TYPE_REMOTE_RDS_NODE",
+        "NODE_TYPE_REMOTE_AZURE_DATABASE_NODE"
+      ],
+      "default": "NODE_TYPE_UNSPECIFIED",
+      "description": "NodeType describes supported Node types."
+    },
+    "v1PMMAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "connected": {
+          "type": "boolean",
+          "description": "True if Agent is running and connected to pmm-managed."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        }
+      },
+      "description": "PMMAgent runs on Generic or Container Node."
+    },
+    "v1PostgreSQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "PostgreSQL version."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        }
+      },
+      "description": "PostgreSQLService represents a generic PostgreSQL instance."
+    },
+    "v1PostgreSQLServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1PostgreSQLService"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "warning": {
+          "type": "string",
+          "description": "Warning message."
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1PostgresExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "PostgresExporter runs on Generic or Container Node and exposes PostgreSQL Service metrics."
+    },
+    "v1ProxySQLExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ProxySQLExporter runs on Generic or Container Node and exposes ProxySQL Service metrics."
+    },
+    "v1ProxySQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "ProxySQL version."
+        }
+      },
+      "description": "ProxySQLService represents a generic ProxySQL instance."
+    },
+    "v1ProxySQLServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1ProxySQLService"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        }
+      }
+    },
+    "v1QANMongoDBMongologAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBMongologAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMongoDBProfilerAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBProfilerAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLPerfSchemaAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLPerfSchemaAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLSlowlogAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Limit query length in QAN (default: server-defined; -1: no limit)"
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Slowlog file is rotated at this size if \u003e 0."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "title": "mod tidy"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLSlowlogAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatMonitorAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatMonitorAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatementsAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatementsAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1RDSExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status (the same for several configurations)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics (the same for several configurations)."
+        },
+        "basic_metrics_disabled": {
+          "type": "boolean",
+          "description": "Basic metrics are disabled."
+        },
+        "enhanced_metrics_disabled": {
+          "type": "boolean",
+          "description": "Enhanced metrics are disabled."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "RDSExporter runs on Generic or Container Node and exposes RemoteRDS Node metrics."
+    },
+    "v1RDSServiceResult": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/v1RemoteRDSNode"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "mysql": {
+          "$ref": "#/definitions/v1MySQLService"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "qan_mysql_perfschema": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "postgresql": {
+          "$ref": "#/definitions/v1PostgreSQLService"
+        },
+        "postgresql_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "qan_postgresql_pgstatements": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        }
+      }
+    },
+    "v1RTAMongoDBAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RTAOptions": {
+      "type": "object",
+      "properties": {
+        "collect_interval": {
+          "type": "string",
+          "description": "Query collect interval (default 2s is set by server)."
+        }
+      },
+      "description": "RTAOptions holds Real-Time Query Analytics agent options."
+    },
+    "v1RTAPostgreSQLAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting session data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      },
+      "description": "RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RegisterNodeRequest": {
+      "type": "object",
+      "properties": {
+        "node_type": {
+          "$ref": "#/definitions/v1NodeType",
+          "description": "Node type to be registered."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "A user-defined name unique across all Nodes."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "Container identifier. If specified, must be a unique Docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Node."
+        },
+        "reregister": {
+          "type": "boolean",
+          "description": "If true, and Node with that name already exist, it will be removed with all dependent Services and Agents."
+        },
+        "metrics_mode": {
+          "$ref": "#/definitions/v1MetricsMode",
+          "description": "Defines metrics flow model for node_exporter being added by this request.\nMetrics could be pushed to the server with vmagent,\npulled by the server, or the server could choose behavior automatically."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "AWS instance ID."
+        }
+      }
+    },
+    "v1RegisterNodeResponse": {
+      "type": "object",
+      "properties": {
+        "generic_node": {
+          "$ref": "#/definitions/v1GenericNode"
+        },
+        "container_node": {
+          "$ref": "#/definitions/v1ContainerNode"
+        },
+        "pmm_agent": {
+          "$ref": "#/definitions/v1PMMAgent"
+        },
+        "token": {
+          "type": "string",
+          "description": "Token represents token for vmagent auth config."
+        },
+        "warning": {
+          "type": "string",
+          "description": "Warning message."
+        }
+      }
+    },
+    "v1RemoteRDSNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Unique across all Nodes user-defined name."
+        },
+        "address": {
+          "type": "string",
+          "description": "DB instance identifier."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "AWS instance ID."
+        }
+      },
+      "description": "RemoteRDSNode represents remote RDS Node. Agents can't run on Remote RDS Nodes."
+    },
+    "v1RemoveServiceResponse": {
+      "type": "object"
+    },
+    "v1ServiceType": {
+      "type": "string",
+      "enum": [
+        "SERVICE_TYPE_UNSPECIFIED",
+        "SERVICE_TYPE_MYSQL_SERVICE",
+        "SERVICE_TYPE_MONGODB_SERVICE",
+        "SERVICE_TYPE_POSTGRESQL_SERVICE",
+        "SERVICE_TYPE_VALKEY_SERVICE",
+        "SERVICE_TYPE_PROXYSQL_SERVICE",
+        "SERVICE_TYPE_HAPROXY_SERVICE",
+        "SERVICE_TYPE_EXTERNAL_SERVICE"
+      ],
+      "default": "SERVICE_TYPE_UNSPECIFIED",
+      "description": "ServiceType describes supported Service types."
+    },
+    "v1UniversalAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "is_agent_password_set": {
+          "type": "boolean",
+          "description": "True if the agent password is set."
+        },
+        "agent_type": {
+          "type": "string",
+          "description": "Agent type."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "is_aws_secret_key_set": {
+          "type": "boolean",
+          "description": "True if AWS Secret Key is set."
+        },
+        "azure_options": {
+          "$ref": "#/definitions/UniversalAgentAzureOptions",
+          "description": "Options used for connecting to Azure."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation timestamp."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN."
+        },
+        "max_query_log_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Limit query log size in QAN."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "metrics_scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "mongo_db_options": {
+          "$ref": "#/definitions/UniversalAgentMongoDBOptions",
+          "description": "TLS and other options for connecting to MongoDB."
+        },
+        "mysql_options": {
+          "$ref": "#/definitions/UniversalAgentMySQLOptions",
+          "description": "TLS and other options for connecting to MySQL."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "A unique node identifier."
+        },
+        "is_password_set": {
+          "type": "boolean",
+          "description": "True if password for connecting the agent to the database is set."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier."
+        },
+        "postgresql_options": {
+          "$ref": "#/definitions/UniversalAgentPostgreSQLOptions",
+          "description": "TLS options for connecting to PostgreSQL."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "comments_parsing_disabled": {
+          "type": "boolean",
+          "description": "True if query comments parsing is disabled."
+        },
+        "rds_basic_metrics_disabled": {
+          "type": "boolean",
+          "description": "True if RDS basic metrics are disdabled."
+        },
+        "rds_enhanced_metrics_disabled": {
+          "type": "boolean",
+          "description": "True if RDS enhanced metrics are disdabled."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "status": {
+          "type": "string",
+          "description": "Actual Agent status."
+        },
+        "table_count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Last known table count."
+        },
+        "table_count_tablestats_group_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors are disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last update timestamp."
+        },
+        "version": {
+          "type": "string",
+          "description": "Agent version."
+        },
+        "is_connected": {
+          "type": "boolean",
+          "description": "True if Agent is running and connected to pmm-managed."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "description": "True if an exporter agent is exposed on all host addresses."
+        },
+        "valkey_options": {
+          "$ref": "#/definitions/UniversalAgentValkeyOptions",
+          "description": "Options for connecting to Valkey."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1UniversalNode": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "description": "Unique Node identifier."
+        },
+        "node_type": {
+          "type": "string",
+          "description": "Node type."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "User-defined node name."
+        },
+        "machine_id": {
+          "type": "string",
+          "description": "Linux machine-id."
+        },
+        "distro": {
+          "type": "string",
+          "description": "Linux distribution name and version."
+        },
+        "node_model": {
+          "type": "string",
+          "description": "Node model."
+        },
+        "container_id": {
+          "type": "string",
+          "description": "A node's unique docker container identifier."
+        },
+        "container_name": {
+          "type": "string",
+          "description": "Container name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Node address (DNS name or IP)."
+        },
+        "region": {
+          "type": "string",
+          "description": "Node region."
+        },
+        "az": {
+          "type": "string",
+          "description": "Node availability zone."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Node."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation timestamp."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last update timestamp."
+        },
+        "status": {
+          "$ref": "#/definitions/v1UniversalNodeStatus",
+          "description": "The health status of the node."
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/UniversalNodeAgent"
+          },
+          "description": "List of agents related to this node."
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/UniversalNodeService"
+          },
+          "description": "List of services running on this node."
+        },
+        "instance_id": {
+          "type": "string",
+          "description": "Instance ID for cloud providers (e.g. AWS RDS)."
+        },
+        "is_pmm_server_node": {
+          "type": "boolean",
+          "description": "True if this node is a PMM Server node (HA mode)."
+        }
+      }
+    },
+    "v1UniversalNodeStatus": {
+      "type": "string",
+      "enum": [
+        "STATUS_UNSPECIFIED",
+        "STATUS_UP",
+        "STATUS_DOWN",
+        "STATUS_UNKNOWN"
+      ],
+      "default": "STATUS_UNSPECIFIED",
+      "description": "Node status.\n\n - STATUS_UNSPECIFIED: Invalid status.\n - STATUS_UP: The node is up.\n - STATUS_DOWN: The node is down.\n - STATUS_UNKNOWN: The node's status cannot be known (e.g. there are no metrics yet)."
+    },
+    "v1UniversalService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique service identifier."
+        },
+        "service_type": {
+          "type": "string",
+          "description": "Service type."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "User-defined name unique across all Services."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "node_name": {
+          "type": "string",
+          "description": "Node name where this instance runs."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels for Service."
+        },
+        "external_group": {
+          "type": "string",
+          "description": "External group name."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation timestamp."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last update timestamp."
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1UniversalAgent"
+          },
+          "description": "List of agents related to this service."
+        },
+        "status": {
+          "$ref": "#/definitions/v1UniversalServiceStatus",
+          "description": "The health status of the service."
+        },
+        "version": {
+          "type": "string",
+          "description": "The service/database version."
+        }
+      }
+    },
+    "v1UniversalServiceStatus": {
+      "type": "string",
+      "enum": [
+        "STATUS_UNSPECIFIED",
+        "STATUS_UP",
+        "STATUS_DOWN",
+        "STATUS_UNKNOWN"
+      ],
+      "default": "STATUS_UNSPECIFIED",
+      "description": "Service status.\n\n - STATUS_UNSPECIFIED: In case we don't support the db vendor yet.\n - STATUS_UP: The service is up.\n - STATUS_DOWN: The service is down.\n - STATUS_UNKNOWN: The service's status cannot be known (e.g. there are no metrics yet)."
+    },
+    "v1UnregisterNodeResponse": {
+      "type": "object",
+      "properties": {
+        "warning": {
+          "type": "string",
+          "description": "Warning message if there are more service tokens attached to service account."
+        }
+      }
+    },
+    "v1UpdateSeverity": {
+      "type": "string",
+      "enum": [
+        "UPDATE_SEVERITY_UNSPECIFIED",
+        "UPDATE_SEVERITY_UNSUPPORTED",
+        "UPDATE_SEVERITY_UP_TO_DATE",
+        "UPDATE_SEVERITY_REQUIRED",
+        "UPDATE_SEVERITY_CRITICAL"
+      ],
+      "default": "UPDATE_SEVERITY_UNSPECIFIED",
+      "description": " - UPDATE_SEVERITY_UNSUPPORTED: The client version is newer than the server version.\n - UPDATE_SEVERITY_UP_TO_DATE: The client version matches the server version.\n - UPDATE_SEVERITY_REQUIRED: The client's minor or patch version is older.\n - UPDATE_SEVERITY_CRITICAL: The client's major version is older."
+    },
+    "v1ValkeyExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ValkeyExporter runs on Generic or Container Node and exposes Valkey Service metrics."
+    },
+    "v1ValkeyService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "Valkey version."
+        }
+      },
+      "description": "ValkeyService represents a generic Valkey instance."
+    },
+    "v1ValkeyServiceResult": {
+      "type": "object",
+      "properties": {
+        "service": {
+          "$ref": "#/definitions/v1ValkeyService"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        }
+      }
+    }
+  }
+}

--- a/api/management/v1/service_grpc.pb.go
+++ b/api/management/v1/service_grpc.pb.go
@@ -8,7 +8,6 @@ package managementv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -252,51 +251,39 @@ type UnimplementedManagementServiceServer struct{}
 func (UnimplementedManagementServiceServer) AddAnnotation(context.Context, *AddAnnotationRequest) (*AddAnnotationResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddAnnotation not implemented")
 }
-
 func (UnimplementedManagementServiceServer) ListAgents(context.Context, *ListAgentsRequest) (*ListAgentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAgents not implemented")
 }
-
 func (UnimplementedManagementServiceServer) ListAgentVersions(context.Context, *ListAgentVersionsRequest) (*ListAgentVersionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAgentVersions not implemented")
 }
-
 func (UnimplementedManagementServiceServer) RegisterNode(context.Context, *RegisterNodeRequest) (*RegisterNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterNode not implemented")
 }
-
 func (UnimplementedManagementServiceServer) UnregisterNode(context.Context, *UnregisterNodeRequest) (*UnregisterNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UnregisterNode not implemented")
 }
-
 func (UnimplementedManagementServiceServer) ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNodes not implemented")
 }
-
 func (UnimplementedManagementServiceServer) GetNode(context.Context, *GetNodeRequest) (*GetNodeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetNode not implemented")
 }
-
 func (UnimplementedManagementServiceServer) AddService(context.Context, *AddServiceRequest) (*AddServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddService not implemented")
 }
-
 func (UnimplementedManagementServiceServer) ListServices(context.Context, *ListServicesRequest) (*ListServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListServices not implemented")
 }
-
 func (UnimplementedManagementServiceServer) DiscoverRDS(context.Context, *DiscoverRDSRequest) (*DiscoverRDSResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DiscoverRDS not implemented")
 }
-
 func (UnimplementedManagementServiceServer) DiscoverAzureDatabase(context.Context, *DiscoverAzureDatabaseRequest) (*DiscoverAzureDatabaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DiscoverAzureDatabase not implemented")
 }
-
 func (UnimplementedManagementServiceServer) AddAzureDatabase(context.Context, *AddAzureDatabaseRequest) (*AddAzureDatabaseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddAzureDatabase not implemented")
 }
-
 func (UnimplementedManagementServiceServer) RemoveService(context.Context, *RemoveServiceRequest) (*RemoveServiceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveService not implemented")
 }

--- a/api/management/v1/severity.pb.go
+++ b/api/management/v1/severity.pb.go
@@ -7,12 +7,11 @@
 package managementv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -119,13 +118,10 @@ func file_management_v1_severity_proto_rawDescGZIP() []byte {
 	return file_management_v1_severity_proto_rawDescData
 }
 
-var (
-	file_management_v1_severity_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_management_v1_severity_proto_goTypes   = []any{
-		Severity(0), // 0: management.v1.Severity
-	}
-)
-
+var file_management_v1_severity_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_management_v1_severity_proto_goTypes = []any{
+	(Severity)(0), // 0: management.v1.Severity
+}
 var file_management_v1_severity_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/management/v1/severity.swagger.json
+++ b/api/management/v1/severity.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/severity.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/management/v1/valkey.pb.go
+++ b/api/management/v1/valkey.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -403,21 +401,18 @@ func file_management_v1_valkey_proto_rawDescGZIP() []byte {
 	return file_management_v1_valkey_proto_rawDescData
 }
 
-var (
-	file_management_v1_valkey_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_valkey_proto_goTypes  = []any{
-		(*AddValkeyServiceParams)(nil), // 0: management.v1.AddValkeyServiceParams
-		(*ValkeyServiceResult)(nil),    // 1: management.v1.ValkeyServiceResult
-		nil,                            // 2: management.v1.AddValkeyServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),          // 3: management.v1.AddNodeParams
-		MetricsMode(0),                 // 4: management.v1.MetricsMode
-		v1.LogLevel(0),                 // 5: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),    // 6: google.protobuf.Duration
-		(*v1.ValkeyService)(nil),       // 7: inventory.v1.ValkeyService
-		(*v1.ValkeyExporter)(nil),      // 8: inventory.v1.ValkeyExporter
-	}
-)
-
+var file_management_v1_valkey_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_valkey_proto_goTypes = []any{
+	(*AddValkeyServiceParams)(nil), // 0: management.v1.AddValkeyServiceParams
+	(*ValkeyServiceResult)(nil),    // 1: management.v1.ValkeyServiceResult
+	nil,                            // 2: management.v1.AddValkeyServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),          // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),               // 4: management.v1.MetricsMode
+	(v1.LogLevel)(0),               // 5: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),    // 6: google.protobuf.Duration
+	(*v1.ValkeyService)(nil),       // 7: inventory.v1.ValkeyService
+	(*v1.ValkeyExporter)(nil),      // 8: inventory.v1.ValkeyExporter
+}
 var file_management_v1_valkey_proto_depIdxs = []int32{
 	3, // 0: management.v1.AddValkeyServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2, // 1: management.v1.AddValkeyServiceParams.custom_labels:type_name -> management.v1.AddValkeyServiceParams.CustomLabelsEntry

--- a/api/management/v1/valkey.pb.validate.go
+++ b/api/management/v1/valkey.pb.validate.go
@@ -62,6 +62,7 @@ func (m *AddValkeyServiceParams) validate(all bool) error {
 	var errors []error
 
 	if m.GetNodeId() != "" {
+
 		if utf8.RuneCountInString(m.GetNodeId()) < 1 {
 			err := AddValkeyServiceParamsValidationError{
 				field:  "NodeId",
@@ -72,9 +73,11 @@ func (m *AddValkeyServiceParams) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.GetNodeName() != "" {
+
 		if utf8.RuneCountInString(m.GetNodeName()) < 1 {
 			err := AddValkeyServiceParamsValidationError{
 				field:  "NodeName",
@@ -85,6 +88,7 @@ func (m *AddValkeyServiceParams) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if all {
@@ -273,8 +277,7 @@ func (e AddValkeyServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddValkeyServiceParamsValidationError{}
@@ -434,8 +437,7 @@ func (e ValkeyServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ValkeyServiceResultValidationError{}

--- a/api/management/v1/valkey.swagger.json
+++ b/api/management/v1/valkey.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/valkey.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/qan/v1/collector.pb.go
+++ b/api/qan/v1/collector.pb.go
@@ -7,16 +7,14 @@
 package qanv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/visibility"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -2744,20 +2742,17 @@ func file_qan_v1_collector_proto_rawDescGZIP() []byte {
 	return file_qan_v1_collector_proto_rawDescData
 }
 
-var (
-	file_qan_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-	file_qan_v1_collector_proto_goTypes  = []any{
-		(*CollectRequest)(nil),  // 0: qan.v1.CollectRequest
-		(*MetricsBucket)(nil),   // 1: qan.v1.MetricsBucket
-		(*CollectResponse)(nil), // 2: qan.v1.CollectResponse
-		nil,                     // 3: qan.v1.MetricsBucket.LabelsEntry
-		nil,                     // 4: qan.v1.MetricsBucket.WarningsEntry
-		nil,                     // 5: qan.v1.MetricsBucket.ErrorsEntry
-		v1.AgentType(0),         // 6: inventory.v1.AgentType
-		ExampleType(0),          // 7: qan.v1.ExampleType
-	}
-)
-
+var file_qan_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_qan_v1_collector_proto_goTypes = []any{
+	(*CollectRequest)(nil),  // 0: qan.v1.CollectRequest
+	(*MetricsBucket)(nil),   // 1: qan.v1.MetricsBucket
+	(*CollectResponse)(nil), // 2: qan.v1.CollectResponse
+	nil,                     // 3: qan.v1.MetricsBucket.LabelsEntry
+	nil,                     // 4: qan.v1.MetricsBucket.WarningsEntry
+	nil,                     // 5: qan.v1.MetricsBucket.ErrorsEntry
+	(v1.AgentType)(0),       // 6: inventory.v1.AgentType
+	(ExampleType)(0),        // 7: qan.v1.ExampleType
+}
 var file_qan_v1_collector_proto_depIdxs = []int32{
 	1, // 0: qan.v1.CollectRequest.metrics_bucket:type_name -> qan.v1.MetricsBucket
 	6, // 1: qan.v1.MetricsBucket.agent_type:type_name -> inventory.v1.AgentType

--- a/api/qan/v1/collector.pb.validate.go
+++ b/api/qan/v1/collector.pb.validate.go
@@ -160,8 +160,7 @@ func (e CollectRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectRequestValidationError{}
@@ -797,8 +796,7 @@ func (e MetricsBucketValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsBucketValidationError{}
@@ -898,8 +896,7 @@ func (e CollectResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectResponseValidationError{}

--- a/api/qan/v1/collector.swagger.json
+++ b/api/qan/v1/collector.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/collector.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/qan/v1/collector_grpc.pb.go
+++ b/api/qan/v1/collector_grpc.pb.go
@@ -8,7 +8,6 @@ package qanv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/api/qan/v1/filters.pb.go
+++ b/api/qan/v1/filters.pb.go
@@ -7,13 +7,12 @@
 package qanv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -281,19 +280,16 @@ func file_qan_v1_filters_proto_rawDescGZIP() []byte {
 	return file_qan_v1_filters_proto_rawDescData
 }
 
-var (
-	file_qan_v1_filters_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-	file_qan_v1_filters_proto_goTypes  = []any{
-		(*GetFilteredMetricsNamesRequest)(nil),  // 0: qan.v1.GetFilteredMetricsNamesRequest
-		(*GetFilteredMetricsNamesResponse)(nil), // 1: qan.v1.GetFilteredMetricsNamesResponse
-		(*ListLabels)(nil),                      // 2: qan.v1.ListLabels
-		(*Values)(nil),                          // 3: qan.v1.Values
-		nil,                                     // 4: qan.v1.GetFilteredMetricsNamesResponse.LabelsEntry
-		(*timestamppb.Timestamp)(nil),           // 5: google.protobuf.Timestamp
-		(*MapFieldEntry)(nil),                   // 6: qan.v1.MapFieldEntry
-	}
-)
-
+var file_qan_v1_filters_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_qan_v1_filters_proto_goTypes = []any{
+	(*GetFilteredMetricsNamesRequest)(nil),  // 0: qan.v1.GetFilteredMetricsNamesRequest
+	(*GetFilteredMetricsNamesResponse)(nil), // 1: qan.v1.GetFilteredMetricsNamesResponse
+	(*ListLabels)(nil),                      // 2: qan.v1.ListLabels
+	(*Values)(nil),                          // 3: qan.v1.Values
+	nil,                                     // 4: qan.v1.GetFilteredMetricsNamesResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),           // 5: google.protobuf.Timestamp
+	(*MapFieldEntry)(nil),                   // 6: qan.v1.MapFieldEntry
+}
 var file_qan_v1_filters_proto_depIdxs = []int32{
 	5, // 0: qan.v1.GetFilteredMetricsNamesRequest.period_start_from:type_name -> google.protobuf.Timestamp
 	5, // 1: qan.v1.GetFilteredMetricsNamesRequest.period_start_to:type_name -> google.protobuf.Timestamp

--- a/api/qan/v1/filters.pb.validate.go
+++ b/api/qan/v1/filters.pb.validate.go
@@ -219,8 +219,7 @@ func (e GetFilteredMetricsNamesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetFilteredMetricsNamesRequestValidationError{}
@@ -369,8 +368,7 @@ func (e GetFilteredMetricsNamesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetFilteredMetricsNamesResponseValidationError{}
@@ -503,8 +501,7 @@ func (e ListLabelsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListLabelsValidationError{}
@@ -608,8 +605,7 @@ func (e ValuesValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ValuesValidationError{}

--- a/api/qan/v1/filters.swagger.json
+++ b/api/qan/v1/filters.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/filters.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/qan/v1/object_details.pb.go
+++ b/api/qan/v1/object_details.pb.go
@@ -7,15 +7,13 @@
 package qanv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	_ "github.com/percona/pmm/api/extensions/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1610,42 +1608,39 @@ func file_qan_v1_object_details_proto_rawDescGZIP() []byte {
 	return file_qan_v1_object_details_proto_rawDescData
 }
 
-var (
-	file_qan_v1_object_details_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
-	file_qan_v1_object_details_proto_goTypes  = []any{
-		(*GetMetricsRequest)(nil),                   // 0: qan.v1.GetMetricsRequest
-		(*GetMetricsResponse)(nil),                  // 1: qan.v1.GetMetricsResponse
-		(*MetricValues)(nil),                        // 2: qan.v1.MetricValues
-		(*Labels)(nil),                              // 3: qan.v1.Labels
-		(*GetQueryExampleRequest)(nil),              // 4: qan.v1.GetQueryExampleRequest
-		(*GetQueryExampleResponse)(nil),             // 5: qan.v1.GetQueryExampleResponse
-		(*QueryExample)(nil),                        // 6: qan.v1.QueryExample
-		(*GetLabelsRequest)(nil),                    // 7: qan.v1.GetLabelsRequest
-		(*GetLabelsResponse)(nil),                   // 8: qan.v1.GetLabelsResponse
-		(*ListLabelValues)(nil),                     // 9: qan.v1.ListLabelValues
-		(*GetQueryPlanRequest)(nil),                 // 10: qan.v1.GetQueryPlanRequest
-		(*GetQueryPlanResponse)(nil),                // 11: qan.v1.GetQueryPlanResponse
-		(*GetHistogramRequest)(nil),                 // 12: qan.v1.GetHistogramRequest
-		(*GetHistogramResponse)(nil),                // 13: qan.v1.GetHistogramResponse
-		(*HistogramItem)(nil),                       // 14: qan.v1.HistogramItem
-		(*QueryExistsRequest)(nil),                  // 15: qan.v1.QueryExistsRequest
-		(*QueryExistsResponse)(nil),                 // 16: qan.v1.QueryExistsResponse
-		(*SchemaByQueryIDRequest)(nil),              // 17: qan.v1.SchemaByQueryIDRequest
-		(*SchemaByQueryIDResponse)(nil),             // 18: qan.v1.SchemaByQueryIDResponse
-		(*ExplainFingerprintByQueryIDRequest)(nil),  // 19: qan.v1.ExplainFingerprintByQueryIDRequest
-		(*ExplainFingerprintByQueryIDResponse)(nil), // 20: qan.v1.ExplainFingerprintByQueryIDResponse
-		(*GetSelectedQueryMetadataResponse)(nil),    // 21: qan.v1.GetSelectedQueryMetadataResponse
-		nil,                                         // 22: qan.v1.GetMetricsResponse.MetricsEntry
-		nil,                                         // 23: qan.v1.GetMetricsResponse.TextMetricsEntry
-		nil,                                         // 24: qan.v1.GetMetricsResponse.TotalsEntry
-		nil,                                         // 25: qan.v1.GetLabelsResponse.LabelsEntry
-		(*timestamppb.Timestamp)(nil),               // 26: google.protobuf.Timestamp
-		(*MapFieldEntry)(nil),                       // 27: qan.v1.MapFieldEntry
-		(*Point)(nil),                               // 28: qan.v1.Point
-		ExampleType(0),                              // 29: qan.v1.ExampleType
-	}
-)
-
+var file_qan_v1_object_details_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_qan_v1_object_details_proto_goTypes = []any{
+	(*GetMetricsRequest)(nil),                   // 0: qan.v1.GetMetricsRequest
+	(*GetMetricsResponse)(nil),                  // 1: qan.v1.GetMetricsResponse
+	(*MetricValues)(nil),                        // 2: qan.v1.MetricValues
+	(*Labels)(nil),                              // 3: qan.v1.Labels
+	(*GetQueryExampleRequest)(nil),              // 4: qan.v1.GetQueryExampleRequest
+	(*GetQueryExampleResponse)(nil),             // 5: qan.v1.GetQueryExampleResponse
+	(*QueryExample)(nil),                        // 6: qan.v1.QueryExample
+	(*GetLabelsRequest)(nil),                    // 7: qan.v1.GetLabelsRequest
+	(*GetLabelsResponse)(nil),                   // 8: qan.v1.GetLabelsResponse
+	(*ListLabelValues)(nil),                     // 9: qan.v1.ListLabelValues
+	(*GetQueryPlanRequest)(nil),                 // 10: qan.v1.GetQueryPlanRequest
+	(*GetQueryPlanResponse)(nil),                // 11: qan.v1.GetQueryPlanResponse
+	(*GetHistogramRequest)(nil),                 // 12: qan.v1.GetHistogramRequest
+	(*GetHistogramResponse)(nil),                // 13: qan.v1.GetHistogramResponse
+	(*HistogramItem)(nil),                       // 14: qan.v1.HistogramItem
+	(*QueryExistsRequest)(nil),                  // 15: qan.v1.QueryExistsRequest
+	(*QueryExistsResponse)(nil),                 // 16: qan.v1.QueryExistsResponse
+	(*SchemaByQueryIDRequest)(nil),              // 17: qan.v1.SchemaByQueryIDRequest
+	(*SchemaByQueryIDResponse)(nil),             // 18: qan.v1.SchemaByQueryIDResponse
+	(*ExplainFingerprintByQueryIDRequest)(nil),  // 19: qan.v1.ExplainFingerprintByQueryIDRequest
+	(*ExplainFingerprintByQueryIDResponse)(nil), // 20: qan.v1.ExplainFingerprintByQueryIDResponse
+	(*GetSelectedQueryMetadataResponse)(nil),    // 21: qan.v1.GetSelectedQueryMetadataResponse
+	nil,                                         // 22: qan.v1.GetMetricsResponse.MetricsEntry
+	nil,                                         // 23: qan.v1.GetMetricsResponse.TextMetricsEntry
+	nil,                                         // 24: qan.v1.GetMetricsResponse.TotalsEntry
+	nil,                                         // 25: qan.v1.GetLabelsResponse.LabelsEntry
+	(*timestamppb.Timestamp)(nil),               // 26: google.protobuf.Timestamp
+	(*MapFieldEntry)(nil),                       // 27: qan.v1.MapFieldEntry
+	(*Point)(nil),                               // 28: qan.v1.Point
+	(ExampleType)(0),                            // 29: qan.v1.ExampleType
+}
 var file_qan_v1_object_details_proto_depIdxs = []int32{
 	26, // 0: qan.v1.GetMetricsRequest.period_start_from:type_name -> google.protobuf.Timestamp
 	26, // 1: qan.v1.GetMetricsRequest.period_start_to:type_name -> google.protobuf.Timestamp

--- a/api/qan/v1/object_details.pb.validate.go
+++ b/api/qan/v1/object_details.pb.validate.go
@@ -222,8 +222,7 @@ func (e GetMetricsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetMetricsRequestValidationError{}
@@ -484,8 +483,7 @@ func (e GetMetricsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetMetricsResponseValidationError{}
@@ -600,8 +598,7 @@ func (e MetricValuesValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricValuesValidationError{}
@@ -699,8 +696,7 @@ func (e LabelsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LabelsValidationError{}
@@ -900,8 +896,7 @@ func (e GetQueryExampleRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetQueryExampleRequestValidationError{}
@@ -1037,8 +1032,7 @@ func (e GetQueryExampleResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetQueryExampleResponseValidationError{}
@@ -1157,8 +1151,7 @@ func (e QueryExampleValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryExampleValidationError{}
@@ -1320,8 +1313,7 @@ func (e GetLabelsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetLabelsRequestValidationError{}
@@ -1469,8 +1461,7 @@ func (e GetLabelsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetLabelsResponseValidationError{}
@@ -1570,8 +1561,7 @@ func (e ListLabelValuesValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListLabelValuesValidationError{}
@@ -1675,8 +1665,7 @@ func (e GetQueryPlanRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetQueryPlanRequestValidationError{}
@@ -1782,8 +1771,7 @@ func (e GetQueryPlanResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetQueryPlanResponseValidationError{}
@@ -1979,8 +1967,7 @@ func (e GetHistogramRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetHistogramRequestValidationError{}
@@ -2116,8 +2103,7 @@ func (e GetHistogramResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetHistogramResponseValidationError{}
@@ -2221,8 +2207,7 @@ func (e HistogramItemValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HistogramItemValidationError{}
@@ -2328,8 +2313,7 @@ func (e QueryExistsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryExistsRequestValidationError{}
@@ -2433,8 +2417,7 @@ func (e QueryExistsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryExistsResponseValidationError{}
@@ -2540,8 +2523,7 @@ func (e SchemaByQueryIDRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SchemaByQueryIDRequestValidationError{}
@@ -2645,8 +2627,7 @@ func (e SchemaByQueryIDResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SchemaByQueryIDResponseValidationError{}
@@ -2755,8 +2736,7 @@ func (e ExplainFingerprintByQueryIDRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExplainFingerprintByQueryIDRequestValidationError{}
@@ -2865,8 +2845,7 @@ func (e ExplainFingerprintByQueryIDResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExplainFingerprintByQueryIDResponseValidationError{}
@@ -2995,8 +2974,7 @@ func (e GetSelectedQueryMetadataResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSelectedQueryMetadataResponseValidationError{}

--- a/api/qan/v1/object_details.swagger.json
+++ b/api/qan/v1/object_details.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/object_details.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/qan/v1/profile.pb.go
+++ b/api/qan/v1/profile.pb.go
@@ -7,13 +7,12 @@
 package qanv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -584,21 +583,18 @@ func file_qan_v1_profile_proto_rawDescGZIP() []byte {
 	return file_qan_v1_profile_proto_rawDescData
 }
 
-var (
-	file_qan_v1_profile_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-	file_qan_v1_profile_proto_goTypes  = []any{
-		(*GetReportRequest)(nil),      // 0: qan.v1.GetReportRequest
-		(*ReportMapFieldEntry)(nil),   // 1: qan.v1.ReportMapFieldEntry
-		(*GetReportResponse)(nil),     // 2: qan.v1.GetReportResponse
-		(*Row)(nil),                   // 3: qan.v1.Row
-		(*Metric)(nil),                // 4: qan.v1.Metric
-		(*Stat)(nil),                  // 5: qan.v1.Stat
-		nil,                           // 6: qan.v1.Row.MetricsEntry
-		(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
-		(*Point)(nil),                 // 8: qan.v1.Point
-	}
-)
-
+var file_qan_v1_profile_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_qan_v1_profile_proto_goTypes = []any{
+	(*GetReportRequest)(nil),      // 0: qan.v1.GetReportRequest
+	(*ReportMapFieldEntry)(nil),   // 1: qan.v1.ReportMapFieldEntry
+	(*GetReportResponse)(nil),     // 2: qan.v1.GetReportResponse
+	(*Row)(nil),                   // 3: qan.v1.Row
+	(*Metric)(nil),                // 4: qan.v1.Metric
+	(*Stat)(nil),                  // 5: qan.v1.Stat
+	nil,                           // 6: qan.v1.Row.MetricsEntry
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
+	(*Point)(nil),                 // 8: qan.v1.Point
+}
 var file_qan_v1_profile_proto_depIdxs = []int32{
 	7, // 0: qan.v1.GetReportRequest.period_start_from:type_name -> google.protobuf.Timestamp
 	7, // 1: qan.v1.GetReportRequest.period_start_to:type_name -> google.protobuf.Timestamp

--- a/api/qan/v1/profile.pb.validate.go
+++ b/api/qan/v1/profile.pb.validate.go
@@ -226,8 +226,7 @@ func (e GetReportRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReportRequestValidationError{}
@@ -331,8 +330,7 @@ func (e ReportMapFieldEntryValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReportMapFieldEntryValidationError{}
@@ -474,8 +472,7 @@ func (e GetReportResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReportResponseValidationError{}
@@ -667,8 +664,7 @@ func (e RowValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RowValidationError{}
@@ -795,8 +791,7 @@ func (e MetricValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricValidationError{}
@@ -910,8 +905,7 @@ func (e StatValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StatValidationError{}

--- a/api/qan/v1/profile.swagger.json
+++ b/api/qan/v1/profile.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/profile.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/qan/v1/qan.pb.go
+++ b/api/qan/v1/qan.pb.go
@@ -7,12 +7,11 @@
 package qanv1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -991,16 +990,13 @@ func file_qan_v1_qan_proto_rawDescGZIP() []byte {
 	return file_qan_v1_qan_proto_rawDescData
 }
 
-var (
-	file_qan_v1_qan_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_qan_v1_qan_proto_msgTypes  = make([]protoimpl.MessageInfo, 2)
-	file_qan_v1_qan_proto_goTypes   = []any{
-		ExampleType(0),        // 0: qan.v1.ExampleType
-		(*Point)(nil),         // 1: qan.v1.Point
-		(*MapFieldEntry)(nil), // 2: qan.v1.MapFieldEntry
-	}
-)
-
+var file_qan_v1_qan_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_qan_v1_qan_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_qan_v1_qan_proto_goTypes = []any{
+	(ExampleType)(0),      // 0: qan.v1.ExampleType
+	(*Point)(nil),         // 1: qan.v1.Point
+	(*MapFieldEntry)(nil), // 2: qan.v1.MapFieldEntry
+}
 var file_qan_v1_qan_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type

--- a/api/qan/v1/qan.pb.validate.go
+++ b/api/qan/v1/qan.pb.validate.go
@@ -278,8 +278,7 @@ func (e PointValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PointValidationError{}
@@ -381,8 +380,7 @@ func (e MapFieldEntryValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MapFieldEntryValidationError{}

--- a/api/qan/v1/qan.swagger.json
+++ b/api/qan/v1/qan.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/qan.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/qan/v1/service.pb.go
+++ b/api/qan/v1/service.pb.go
@@ -7,14 +7,13 @@
 package qanv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -228,37 +227,34 @@ func file_qan_v1_service_proto_rawDescGZIP() []byte {
 	return file_qan_v1_service_proto_rawDescData
 }
 
-var (
-	file_qan_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-	file_qan_v1_service_proto_goTypes  = []any{
-		(*GetMetricsNamesRequest)(nil),              // 0: qan.v1.GetMetricsNamesRequest
-		(*GetMetricsNamesResponse)(nil),             // 1: qan.v1.GetMetricsNamesResponse
-		(*HealthCheckRequest)(nil),                  // 2: qan.v1.HealthCheckRequest
-		(*HealthCheckResponse)(nil),                 // 3: qan.v1.HealthCheckResponse
-		nil,                                         // 4: qan.v1.GetMetricsNamesResponse.DataEntry
-		(*GetReportRequest)(nil),                    // 5: qan.v1.GetReportRequest
-		(*GetFilteredMetricsNamesRequest)(nil),      // 6: qan.v1.GetFilteredMetricsNamesRequest
-		(*GetMetricsRequest)(nil),                   // 7: qan.v1.GetMetricsRequest
-		(*GetLabelsRequest)(nil),                    // 8: qan.v1.GetLabelsRequest
-		(*GetHistogramRequest)(nil),                 // 9: qan.v1.GetHistogramRequest
-		(*ExplainFingerprintByQueryIDRequest)(nil),  // 10: qan.v1.ExplainFingerprintByQueryIDRequest
-		(*GetQueryPlanRequest)(nil),                 // 11: qan.v1.GetQueryPlanRequest
-		(*QueryExistsRequest)(nil),                  // 12: qan.v1.QueryExistsRequest
-		(*SchemaByQueryIDRequest)(nil),              // 13: qan.v1.SchemaByQueryIDRequest
-		(*GetQueryExampleRequest)(nil),              // 14: qan.v1.GetQueryExampleRequest
-		(*GetReportResponse)(nil),                   // 15: qan.v1.GetReportResponse
-		(*GetFilteredMetricsNamesResponse)(nil),     // 16: qan.v1.GetFilteredMetricsNamesResponse
-		(*GetMetricsResponse)(nil),                  // 17: qan.v1.GetMetricsResponse
-		(*GetLabelsResponse)(nil),                   // 18: qan.v1.GetLabelsResponse
-		(*GetHistogramResponse)(nil),                // 19: qan.v1.GetHistogramResponse
-		(*ExplainFingerprintByQueryIDResponse)(nil), // 20: qan.v1.ExplainFingerprintByQueryIDResponse
-		(*GetQueryPlanResponse)(nil),                // 21: qan.v1.GetQueryPlanResponse
-		(*QueryExistsResponse)(nil),                 // 22: qan.v1.QueryExistsResponse
-		(*SchemaByQueryIDResponse)(nil),             // 23: qan.v1.SchemaByQueryIDResponse
-		(*GetQueryExampleResponse)(nil),             // 24: qan.v1.GetQueryExampleResponse
-	}
-)
-
+var file_qan_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_qan_v1_service_proto_goTypes = []any{
+	(*GetMetricsNamesRequest)(nil),              // 0: qan.v1.GetMetricsNamesRequest
+	(*GetMetricsNamesResponse)(nil),             // 1: qan.v1.GetMetricsNamesResponse
+	(*HealthCheckRequest)(nil),                  // 2: qan.v1.HealthCheckRequest
+	(*HealthCheckResponse)(nil),                 // 3: qan.v1.HealthCheckResponse
+	nil,                                         // 4: qan.v1.GetMetricsNamesResponse.DataEntry
+	(*GetReportRequest)(nil),                    // 5: qan.v1.GetReportRequest
+	(*GetFilteredMetricsNamesRequest)(nil),      // 6: qan.v1.GetFilteredMetricsNamesRequest
+	(*GetMetricsRequest)(nil),                   // 7: qan.v1.GetMetricsRequest
+	(*GetLabelsRequest)(nil),                    // 8: qan.v1.GetLabelsRequest
+	(*GetHistogramRequest)(nil),                 // 9: qan.v1.GetHistogramRequest
+	(*ExplainFingerprintByQueryIDRequest)(nil),  // 10: qan.v1.ExplainFingerprintByQueryIDRequest
+	(*GetQueryPlanRequest)(nil),                 // 11: qan.v1.GetQueryPlanRequest
+	(*QueryExistsRequest)(nil),                  // 12: qan.v1.QueryExistsRequest
+	(*SchemaByQueryIDRequest)(nil),              // 13: qan.v1.SchemaByQueryIDRequest
+	(*GetQueryExampleRequest)(nil),              // 14: qan.v1.GetQueryExampleRequest
+	(*GetReportResponse)(nil),                   // 15: qan.v1.GetReportResponse
+	(*GetFilteredMetricsNamesResponse)(nil),     // 16: qan.v1.GetFilteredMetricsNamesResponse
+	(*GetMetricsResponse)(nil),                  // 17: qan.v1.GetMetricsResponse
+	(*GetLabelsResponse)(nil),                   // 18: qan.v1.GetLabelsResponse
+	(*GetHistogramResponse)(nil),                // 19: qan.v1.GetHistogramResponse
+	(*ExplainFingerprintByQueryIDResponse)(nil), // 20: qan.v1.ExplainFingerprintByQueryIDResponse
+	(*GetQueryPlanResponse)(nil),                // 21: qan.v1.GetQueryPlanResponse
+	(*QueryExistsResponse)(nil),                 // 22: qan.v1.QueryExistsResponse
+	(*SchemaByQueryIDResponse)(nil),             // 23: qan.v1.SchemaByQueryIDResponse
+	(*GetQueryExampleResponse)(nil),             // 24: qan.v1.GetQueryExampleResponse
+}
 var file_qan_v1_service_proto_depIdxs = []int32{
 	4,  // 0: qan.v1.GetMetricsNamesResponse.data:type_name -> qan.v1.GetMetricsNamesResponse.DataEntry
 	5,  // 1: qan.v1.QANService.GetReport:input_type -> qan.v1.GetReportRequest

--- a/api/qan/v1/service.pb.validate.go
+++ b/api/qan/v1/service.pb.validate.go
@@ -124,8 +124,7 @@ func (e GetMetricsNamesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetMetricsNamesRequestValidationError{}
@@ -229,8 +228,7 @@ func (e GetMetricsNamesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetMetricsNamesResponseValidationError{}
@@ -332,8 +330,7 @@ func (e HealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HealthCheckRequestValidationError{}
@@ -435,8 +432,7 @@ func (e HealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HealthCheckResponseValidationError{}

--- a/api/qan/v1/service.swagger.json
+++ b/api/qan/v1/service.swagger.json
@@ -1,0 +1,1568 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "qan/v1/service.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "QANService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/qan/health": {
+      "get": {
+        "summary": "Health Check",
+        "description": "Returns readiness of QAN API2 service.",
+        "operationId": "HealthCheck",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1HealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/metrics:getFilters": {
+      "post": {
+        "summary": "Get Filters",
+        "description": "Provides a filtered map of metrics names.",
+        "operationId": "GetFilteredMetricsNames",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetFilteredMetricsNamesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetFilteredMetricsNamesRequest contains period for which we need filters.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetFilteredMetricsNamesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/metrics:getNames": {
+      "post": {
+        "summary": "Get Metrics Names",
+        "description": "Provides a map of all metrics names.",
+        "operationId": "GetMetricsNames",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMetricsNamesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "MetricsNamesRequest is empty.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMetricsNamesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/metrics:getReport": {
+      "post": {
+        "summary": "Get Report",
+        "description": "Returns a list of metrics grouped by queryid or other dimensions.",
+        "operationId": "GetReport",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetReportResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ReportRequest defines filtering of metrics report for db server or other dimentions.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetReportRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/query/{queryid}/plan": {
+      "get": {
+        "summary": "Get Query Plan",
+        "description": "Provides a query plan and plan id for specific filtering.",
+        "operationId": "GetQueryPlan",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetQueryPlanResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "queryid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/query:exists": {
+      "post": {
+        "summary": "Check Query Existence",
+        "description": "Checks if query exists in clickhouse.",
+        "operationId": "QueryExists",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1QueryExistsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "QueryExistsRequest check if provided query exists or not.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1QueryExistsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/query:getExample": {
+      "post": {
+        "summary": "Get Query Example",
+        "description": "Provides a list of query examples.",
+        "operationId": "GetQueryExample",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetQueryExampleResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetQueryExampleRequest defines filtering of query examples for specific value of\ndimension (ex.: host=hostname1 or queryid=1D410B4BE5060972.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetQueryExampleRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan/query:getSchema": {
+      "post": {
+        "summary": "Get Schema",
+        "description": "Provides the schema for a given queryID and serviceID.",
+        "operationId": "SchemaByQueryID",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SchemaByQueryIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "SchemaByQueryIDRequest returns schema for given query ID and service ID.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1SchemaByQueryIDRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan:explainFingerprint": {
+      "post": {
+        "summary": "Get Explain Fingerprint",
+        "description": "Provides an explain fingerprint for given query ID.",
+        "operationId": "ExplainFingerprintByQueryID",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ExplainFingerprintByQueryIDResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "ExplainFingerprintByQueryIDRequest get explain fingerprint for given query ID.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ExplainFingerprintByQueryIDRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan:getHistogram": {
+      "post": {
+        "summary": "Get Histogram",
+        "description": "Provides histogram items for specific filtering.",
+        "operationId": "GetHistogram",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetHistogramResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetHistogramRequest defines filtering by time range, labels and queryid.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetHistogramRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan:getLabels": {
+      "post": {
+        "summary": "Get Labels",
+        "description": "Provides a list of labels for object details.",
+        "operationId": "GetLabels",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetLabelsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetLabelsRequest defines filtering of object detail's labels for specific value of\ndimension (ex.: host=hostname1 or queryid=1D410B4BE5060972.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetLabelsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    },
+    "/v1/qan:getMetrics": {
+      "post": {
+        "summary": "Get Metrics",
+        "description": "Provides a map of metrics for specific filtering.",
+        "operationId": "GetMetrics",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetMetricsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "GetMetricsRequest defines filtering of metrics for specific value of dimension (ex.: host=hostname1 or queryid=1D410B4BE5060972.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1GetMetricsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "QANService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1ExampleType": {
+      "type": "string",
+      "enum": [
+        "EXAMPLE_TYPE_UNSPECIFIED",
+        "EXAMPLE_TYPE_RANDOM",
+        "EXAMPLE_TYPE_SLOWEST",
+        "EXAMPLE_TYPE_FASTEST",
+        "EXAMPLE_TYPE_WITH_ERROR"
+      ],
+      "default": "EXAMPLE_TYPE_UNSPECIFIED",
+      "description": "ExampleType is a type of query example selected for this query class in given period of time."
+    },
+    "v1ExplainFingerprintByQueryIDRequest": {
+      "type": "object",
+      "properties": {
+        "serviceid": {
+          "type": "string"
+        },
+        "query_id": {
+          "type": "string"
+        }
+      },
+      "description": "ExplainFingerprintByQueryIDRequest get explain fingerprint for given query ID."
+    },
+    "v1ExplainFingerprintByQueryIDResponse": {
+      "type": "object",
+      "properties": {
+        "explain_fingerprint": {
+          "type": "string"
+        },
+        "placeholders_count": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "description": "ExplainFingerprintByQueryIDResponse is explain fingerprint and placeholders count for given query ID."
+    },
+    "v1GetFilteredMetricsNamesRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "main_metric_name": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MapFieldEntry"
+          }
+        }
+      },
+      "description": "GetFilteredMetricsNamesRequest contains period for which we need filters."
+    },
+    "v1GetFilteredMetricsNamesResponse": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1ListLabels"
+          }
+        }
+      },
+      "description": "GetFilteredMetricsNamesResponse is map of labels for given period by key.\nKey is label's name and value is label's value and how many times it occur."
+    },
+    "v1GetHistogramRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MapFieldEntry"
+          }
+        },
+        "queryid": {
+          "type": "string"
+        }
+      },
+      "description": "GetHistogramRequest defines filtering by time range, labels and queryid."
+    },
+    "v1GetHistogramResponse": {
+      "type": "object",
+      "properties": {
+        "histogram_items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1HistogramItem"
+          }
+        }
+      },
+      "description": "GetHistogramResponse is histogram items as a list."
+    },
+    "v1GetLabelsRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "filter_by": {
+          "type": "string",
+          "description": "dimension value: ex: queryid - 1D410B4BE5060972."
+        },
+        "group_by": {
+          "type": "string",
+          "description": "one of dimension: queryid | host ..."
+        }
+      },
+      "description": "GetLabelsRequest defines filtering of object detail's labels for specific value of\ndimension (ex.: host=hostname1 or queryid=1D410B4BE5060972."
+    },
+    "v1GetLabelsResponse": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1ListLabelValues"
+          }
+        }
+      },
+      "description": "GetLabelsResponse is a map of labels names as keys and labels values as a list."
+    },
+    "v1GetMetricsNamesRequest": {
+      "type": "object",
+      "description": "MetricsNamesRequest is empty."
+    },
+    "v1GetMetricsNamesResponse": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "MetricsNamesReply is map of stored metrics:\nkey is root of metric name in db (Ex:. [m_]query_time[_sum]);\nvalue - Human readable name of metrics."
+    },
+    "v1GetMetricsRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "filter_by": {
+          "type": "string",
+          "description": "dimension value: ex: queryid - 1D410B4BE5060972."
+        },
+        "group_by": {
+          "type": "string",
+          "description": "one of dimension: queryid | host ..."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MapFieldEntry"
+          }
+        },
+        "include_only_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "totals": {
+          "type": "boolean",
+          "title": "retrieve only values for totals, excluding N/A values"
+        }
+      },
+      "description": "GetMetricsRequest defines filtering of metrics for specific value of dimension (ex.: host=hostname1 or queryid=1D410B4BE5060972."
+    },
+    "v1GetMetricsResponse": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1MetricValues"
+          }
+        },
+        "text_metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "sparkline": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Point"
+          }
+        },
+        "totals": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1MetricValues"
+          }
+        },
+        "fingerprint": {
+          "type": "string"
+        },
+        "metadata": {
+          "$ref": "#/definitions/v1GetSelectedQueryMetadataResponse"
+        }
+      },
+      "description": "GetMetricsResponse defines metrics for specific value of dimension (ex.: host=hostname1 or queryid=1D410B4BE5060972."
+    },
+    "v1GetQueryExampleRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "filter_by": {
+          "type": "string",
+          "description": "dimension value: ex: queryid - 1D410B4BE5060972."
+        },
+        "group_by": {
+          "type": "string",
+          "description": "one of dimension: queryid | host ..."
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MapFieldEntry"
+          }
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "description": "GetQueryExampleRequest defines filtering of query examples for specific value of\ndimension (ex.: host=hostname1 or queryid=1D410B4BE5060972."
+    },
+    "v1GetQueryExampleResponse": {
+      "type": "object",
+      "properties": {
+        "query_examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QueryExample"
+          }
+        }
+      },
+      "description": "GetQueryExampleResponse list of query examples."
+    },
+    "v1GetQueryPlanResponse": {
+      "type": "object",
+      "properties": {
+        "planid": {
+          "type": "string"
+        },
+        "query_plan": {
+          "type": "string"
+        }
+      },
+      "description": "GetQueryPlanResponse contains planid and query_plan."
+    },
+    "v1GetReportRequest": {
+      "type": "object",
+      "properties": {
+        "period_start_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "period_start_to": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "group_by": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ReportMapFieldEntry"
+          }
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "order_by": {
+          "type": "string"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "main_metric": {
+          "type": "string"
+        },
+        "search": {
+          "type": "string"
+        }
+      },
+      "description": "ReportRequest defines filtering of metrics report for db server or other dimentions."
+    },
+    "v1GetReportResponse": {
+      "type": "object",
+      "properties": {
+        "total_rows": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "offset": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "rows": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Row"
+          }
+        }
+      },
+      "description": "ReportReply is list of reports per quieryids, hosts etc."
+    },
+    "v1GetSelectedQueryMetadataResponse": {
+      "type": "object",
+      "properties": {
+        "service_name": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "replication_set": {
+          "type": "string"
+        },
+        "cluster": {
+          "type": "string"
+        },
+        "service_type": {
+          "type": "string"
+        },
+        "service_id": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string"
+        },
+        "node_id": {
+          "type": "string"
+        },
+        "node_name": {
+          "type": "string"
+        },
+        "node_type": {
+          "type": "string"
+        }
+      },
+      "description": "GetSlecetedQueryMetadataResponse consists selected query metadata to show in details for given query ID."
+    },
+    "v1HealthCheckResponse": {
+      "type": "object",
+      "description": "HealthCheckResponse is empty, based on returned error qan-api2 is ready or not."
+    },
+    "v1HistogramItem": {
+      "type": "object",
+      "properties": {
+        "range": {
+          "type": "string"
+        },
+        "frequency": {
+          "type": "integer",
+          "format": "int64"
+        }
+      },
+      "description": "HistogramItem represents one item in histogram."
+    },
+    "v1ListLabelValues": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "ListLabelValues is list of label's values."
+    },
+    "v1ListLabels": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Values"
+          }
+        }
+      },
+      "description": "ListLabels is list of label's values: duplicates are impossible."
+    },
+    "v1MapFieldEntry": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "MapFieldEntry allows to pass labels/dimensions in form like {\"server\": [\"db1\", \"db2\"...]}."
+    },
+    "v1Metric": {
+      "type": "object",
+      "properties": {
+        "stats": {
+          "$ref": "#/definitions/v1Stat"
+        }
+      },
+      "description": "Metric cell."
+    },
+    "v1MetricValues": {
+      "type": "object",
+      "properties": {
+        "rate": {
+          "type": "number",
+          "format": "float"
+        },
+        "cnt": {
+          "type": "number",
+          "format": "float"
+        },
+        "sum": {
+          "type": "number",
+          "format": "float"
+        },
+        "min": {
+          "type": "number",
+          "format": "float"
+        },
+        "max": {
+          "type": "number",
+          "format": "float"
+        },
+        "avg": {
+          "type": "number",
+          "format": "float"
+        },
+        "p99": {
+          "type": "number",
+          "format": "float"
+        },
+        "percent_of_total": {
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "description": "MetricValues is statistics of specific metric."
+    },
+    "v1Point": {
+      "type": "object",
+      "properties": {
+        "point": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The serial number of the chart point from the largest time in the time interval to the lowest time in the time range."
+        },
+        "time_frame": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Duration beetween two points."
+        },
+        "timestamp": {
+          "type": "string",
+          "description": "Time of point in format RFC3339."
+        },
+        "load": {
+          "type": "number",
+          "format": "float",
+          "description": "load is query_time / time_range."
+        },
+        "num_queries_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "number of queries in bucket."
+        },
+        "num_queries_with_errors_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "number of queries with errors."
+        },
+        "num_queries_with_warnings_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "number of queries with warnings."
+        },
+        "m_query_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The statement execution time in seconds."
+        },
+        "m_lock_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The time to acquire locks in seconds."
+        },
+        "m_rows_sent_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of rows sent to the client."
+        },
+        "m_rows_examined_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of rows scanned - SELECT."
+        },
+        "m_rows_affected_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of rows changed - UPDATE, DELETE, INSERT."
+        },
+        "m_rows_read_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of rows read from tables."
+        },
+        "m_merge_passes_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of merge passes that the sort algorithm has had to do."
+        },
+        "m_innodb_io_r_ops_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Counts the number of page read operations scheduled."
+        },
+        "m_innodb_io_r_bytes_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Similar to innodb_IO_r_ops, but the unit is bytes."
+        },
+        "m_innodb_io_r_wait_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Shows how long (in seconds) it took InnoDB to actually read the data from storage."
+        },
+        "m_innodb_rec_lock_wait_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Shows how long (in seconds) the query waited for row locks."
+        },
+        "m_innodb_queue_wait_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Shows how long (in seconds) the query spent either waiting to enter the InnoDB queue or inside that queue waiting for execution."
+        },
+        "m_innodb_pages_distinct_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Counts approximately the number of unique pages the query accessed."
+        },
+        "m_query_length_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Shows how long the query is."
+        },
+        "m_bytes_sent_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of bytes sent to all clients."
+        },
+        "m_tmp_tables_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of temporary tables created on memory for the query."
+        },
+        "m_tmp_disk_tables_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of temporary tables created on disk for the query."
+        },
+        "m_tmp_table_sizes_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total Size in bytes for all temporary tables used in the query."
+        },
+        "m_qc_hit_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Query Cache hits."
+        },
+        "m_full_scan_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The query performed a full table scan."
+        },
+        "m_full_join_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The query performed a full join (a join without indexes)."
+        },
+        "m_tmp_table_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The query created an implicit internal temporary table."
+        },
+        "m_tmp_table_on_disk_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The querys temporary table was stored on disk."
+        },
+        "m_filesort_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The query used a filesort."
+        },
+        "m_filesort_on_disk_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The filesort was performed on disk."
+        },
+        "m_select_full_range_join_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of joins that used a range search on a reference table."
+        },
+        "m_select_range_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of joins that used ranges on the first table."
+        },
+        "m_select_range_check_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of joins without keys that check for key usage after each row."
+        },
+        "m_sort_range_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of sorts that were done using ranges."
+        },
+        "m_sort_rows_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of sorted rows."
+        },
+        "m_sort_scan_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of sorts that were done by scanning the table."
+        },
+        "m_no_index_used_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of queries without index."
+        },
+        "m_no_good_index_used_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of queries without good index."
+        },
+        "m_docs_returned_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of returned documents."
+        },
+        "m_response_length_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The response length of the query result in bytes."
+        },
+        "m_docs_scanned_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "The number of scanned documents."
+        },
+        "m_docs_examined_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of documents scanned during query execution."
+        },
+        "m_keys_examined_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of index keys scanned during query execution."
+        },
+        "m_locks_global_acquire_count_read_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of times a global read lock was acquired during query execution."
+        },
+        "m_locks_global_acquire_count_write_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of times a global write lock was acquired during query execution."
+        },
+        "m_locks_database_acquire_count_read_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of times a read lock was acquired at the database level during query execution."
+        },
+        "m_locks_database_acquire_wait_count_read_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of times a read lock at the database level was requested but had to wait before being granted."
+        },
+        "m_locks_database_time_acquiring_micros_read_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates the time, spent acquiring a read lock at the database level during an operation."
+        },
+        "m_locks_collection_acquire_count_read_shared_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Number of times a read lock was acquired on a specific collection during operations."
+        },
+        "m_storage_bytes_read_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of bytes read from storage during a specific operation."
+        },
+        "m_storage_time_reading_micros_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Indicates the time, spent reading data from storage during an operation."
+        },
+        "m_shared_blks_hit_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of shared block cache hits by the statement."
+        },
+        "m_shared_blks_read_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of shared blocks read by the statement."
+        },
+        "m_shared_blks_dirtied_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of shared blocks dirtied by the statement."
+        },
+        "m_shared_blks_written_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of shared blocks written by the statement."
+        },
+        "m_shared_blk_read_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent reading shared blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_shared_blk_write_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent writing shared blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_local_blk_read_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent reading shared blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_local_blk_write_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent writing shared blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_local_blks_hit_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of local block cache hits by the statement."
+        },
+        "m_local_blks_read_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of local blocks read by the statement."
+        },
+        "m_local_blks_dirtied_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of local blocks dirtied by the statement."
+        },
+        "m_local_blks_written_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of local blocks written by the statement."
+        },
+        "m_temp_blks_read_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of temp blocks read by the statement."
+        },
+        "m_temp_blks_written_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of temp blocks written by the statement."
+        },
+        "m_blk_read_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent reading blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_blk_write_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time the statement spent writing blocks, in milliseconds (if track_io_timing is enabled, otherwise zero)."
+        },
+        "m_cpu_user_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time user spent in query."
+        },
+        "m_cpu_sys_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total time system spent in query."
+        },
+        "m_plans_calls_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of planned calls."
+        },
+        "m_wal_records_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of WAL (Write-ahead logging) records."
+        },
+        "m_wal_fpi_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of FPI (full page images) in WAL (Write-ahead logging) records."
+        },
+        "m_wal_bytes_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total bytes of WAL (Write-ahead logging) records."
+        },
+        "m_wal_buffers_full_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of times WAL buffers become full."
+        },
+        "m_parallel_workers_to_launch_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of parallel workers to launch."
+        },
+        "m_parallel_workers_launched_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Total number of parallel workers launched."
+        },
+        "m_plan_time_sum_per_sec": {
+          "type": "number",
+          "format": "float",
+          "description": "Plan time in per seconds."
+        }
+      },
+      "description": "Point contains values that represents abscissa (time) and ordinate (volume etc.)\nof every point in a coordinate system of Sparklines."
+    },
+    "v1QueryExample": {
+      "type": "object",
+      "properties": {
+        "example": {
+          "type": "string"
+        },
+        "example_type": {
+          "$ref": "#/definitions/v1ExampleType"
+        },
+        "is_truncated": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "placeholders_count": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "explain_fingerprint": {
+          "type": "string"
+        },
+        "query_id": {
+          "type": "string"
+        },
+        "example_metrics": {
+          "type": "string"
+        },
+        "service_id": {
+          "type": "string"
+        },
+        "service_type": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "QueryExample shows query examples and their metrics."
+    },
+    "v1QueryExistsRequest": {
+      "type": "object",
+      "properties": {
+        "serviceid": {
+          "type": "string"
+        },
+        "query": {
+          "type": "string"
+        }
+      },
+      "description": "QueryExistsRequest check if provided query exists or not."
+    },
+    "v1QueryExistsResponse": {
+      "type": "object",
+      "properties": {
+        "exists": {
+          "type": "boolean"
+        }
+      },
+      "description": "QueryExistsResponse returns true if query exists."
+    },
+    "v1ReportMapFieldEntry": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "ReportMapFieldEntry allows to pass labels/dimentions in form like {\"server\": [\"db1\", \"db2\"...]}."
+    },
+    "v1Row": {
+      "type": "object",
+      "properties": {
+        "rank": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "dimension": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/v1Metric"
+          }
+        },
+        "sparkline": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Point"
+          }
+        },
+        "fingerprint": {
+          "type": "string"
+        },
+        "num_queries": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "qps": {
+          "type": "number",
+          "format": "float"
+        },
+        "load": {
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "description": "Row define metrics for selected dimention."
+    },
+    "v1SchemaByQueryIDRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string"
+        },
+        "query_id": {
+          "type": "string"
+        }
+      },
+      "description": "SchemaByQueryIDRequest returns schema for given query ID and service ID."
+    },
+    "v1SchemaByQueryIDResponse": {
+      "type": "object",
+      "properties": {
+        "schema": {
+          "type": "string"
+        }
+      },
+      "description": "SchemaByQueryIDResponse is schema for given query ID and service ID."
+    },
+    "v1Stat": {
+      "type": "object",
+      "properties": {
+        "rate": {
+          "type": "number",
+          "format": "float"
+        },
+        "cnt": {
+          "type": "number",
+          "format": "float"
+        },
+        "sum": {
+          "type": "number",
+          "format": "float"
+        },
+        "min": {
+          "type": "number",
+          "format": "float"
+        },
+        "max": {
+          "type": "number",
+          "format": "float"
+        },
+        "p99": {
+          "type": "number",
+          "format": "float"
+        },
+        "avg": {
+          "type": "number",
+          "format": "float"
+        },
+        "sum_per_sec": {
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "description": "Stat is statistics of specific metric."
+    },
+    "v1Values": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "main_metric_percent": {
+          "type": "number",
+          "format": "float"
+        },
+        "main_metric_per_sec": {
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "description": "Values is label values and main metric percent and per second."
+    }
+  }
+}

--- a/api/qan/v1/service_grpc.pb.go
+++ b/api/qan/v1/service_grpc.pb.go
@@ -8,7 +8,6 @@ package qanv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -237,47 +236,36 @@ type UnimplementedQANServiceServer struct{}
 func (UnimplementedQANServiceServer) GetReport(context.Context, *GetReportRequest) (*GetReportResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetReport not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetFilteredMetricsNames(context.Context, *GetFilteredMetricsNamesRequest) (*GetFilteredMetricsNamesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetFilteredMetricsNames not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetMetricsNames(context.Context, *GetMetricsNamesRequest) (*GetMetricsNamesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMetricsNames not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetMetrics(context.Context, *GetMetricsRequest) (*GetMetricsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMetrics not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetLabels(context.Context, *GetLabelsRequest) (*GetLabelsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetLabels not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetHistogram(context.Context, *GetHistogramRequest) (*GetHistogramResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetHistogram not implemented")
 }
-
 func (UnimplementedQANServiceServer) ExplainFingerprintByQueryID(context.Context, *ExplainFingerprintByQueryIDRequest) (*ExplainFingerprintByQueryIDResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ExplainFingerprintByQueryID not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetQueryPlan(context.Context, *GetQueryPlanRequest) (*GetQueryPlanResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetQueryPlan not implemented")
 }
-
 func (UnimplementedQANServiceServer) QueryExists(context.Context, *QueryExistsRequest) (*QueryExistsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method QueryExists not implemented")
 }
-
 func (UnimplementedQANServiceServer) SchemaByQueryID(context.Context, *SchemaByQueryIDRequest) (*SchemaByQueryIDResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SchemaByQueryID not implemented")
 }
-
 func (UnimplementedQANServiceServer) GetQueryExample(context.Context, *GetQueryExampleRequest) (*GetQueryExampleResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetQueryExample not implemented")
 }
-
 func (UnimplementedQANServiceServer) HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method HealthCheck not implemented")
 }

--- a/api/realtimeanalytics/v1/collector.pb.go
+++ b/api/realtimeanalytics/v1/collector.pb.go
@@ -7,13 +7,12 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "google.golang.org/genproto/googleapis/api/visibility"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -132,15 +131,12 @@ func file_realtimeanalytics_v1_collector_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_collector_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-	file_realtimeanalytics_v1_collector_proto_goTypes  = []any{
-		(*CollectRequest)(nil),  // 0: realtimeanalytics.v1.CollectRequest
-		(*CollectResponse)(nil), // 1: realtimeanalytics.v1.CollectResponse
-		(*QueryData)(nil),       // 2: realtimeanalytics.v1.QueryData
-	}
-)
-
+var file_realtimeanalytics_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_realtimeanalytics_v1_collector_proto_goTypes = []any{
+	(*CollectRequest)(nil),  // 0: realtimeanalytics.v1.CollectRequest
+	(*CollectResponse)(nil), // 1: realtimeanalytics.v1.CollectResponse
+	(*QueryData)(nil),       // 2: realtimeanalytics.v1.QueryData
+}
 var file_realtimeanalytics_v1_collector_proto_depIdxs = []int32{
 	2, // 0: realtimeanalytics.v1.CollectRequest.queries:type_name -> realtimeanalytics.v1.QueryData
 	0, // 1: realtimeanalytics.v1.CollectorService.Collect:input_type -> realtimeanalytics.v1.CollectRequest

--- a/api/realtimeanalytics/v1/collector.pb.validate.go
+++ b/api/realtimeanalytics/v1/collector.pb.validate.go
@@ -156,8 +156,7 @@ func (e CollectRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectRequestValidationError{}
@@ -257,8 +256,7 @@ func (e CollectResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectResponseValidationError{}

--- a/api/realtimeanalytics/v1/collector.swagger.json
+++ b/api/realtimeanalytics/v1/collector.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/collector.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/collector_grpc.pb.go
+++ b/api/realtimeanalytics/v1/collector_grpc.pb.go
@@ -8,7 +8,6 @@ package realtimeanalyticsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/api/realtimeanalytics/v1/query.pb.go
+++ b/api/realtimeanalytics/v1/query.pb.go
@@ -7,16 +7,14 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	_ "github.com/percona/pmm/api/extensions/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -25,6 +23,260 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// LockChainLink represents one link in a PostgreSQL lock chain (blocker -> blocked).
+type LockChainLink struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PID of the blocking backend.
+	BlockerPid int32 `protobuf:"varint,1,opt,name=blocker_pid,json=blockerPid,proto3" json:"blocker_pid,omitempty"`
+	// PID of the blocked backend.
+	BlockedPid int32 `protobuf:"varint,2,opt,name=blocked_pid,json=blockedPid,proto3" json:"blocked_pid,omitempty"`
+	// Lock mode held or requested.
+	LockMode string `protobuf:"bytes,3,opt,name=lock_mode,json=lockMode,proto3" json:"lock_mode,omitempty"`
+	// Relation name when available.
+	RelationName string `protobuf:"bytes,4,opt,name=relation_name,json=relationName,proto3" json:"relation_name,omitempty"`
+	// Query text of the blocking backend.
+	BlockerQueryText string `protobuf:"bytes,5,opt,name=blocker_query_text,json=blockerQueryText,proto3" json:"blocker_query_text,omitempty"`
+	// Duration of the blocking query.
+	BlockerDuration *durationpb.Duration `protobuf:"bytes,6,opt,name=blocker_duration,json=blockerDuration,proto3" json:"blocker_duration,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *LockChainLink) Reset() {
+	*x = LockChainLink{}
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LockChainLink) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LockChainLink) ProtoMessage() {}
+
+func (x *LockChainLink) ProtoReflect() protoreflect.Message {
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LockChainLink.ProtoReflect.Descriptor instead.
+func (*LockChainLink) Descriptor() ([]byte, []int) {
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *LockChainLink) GetBlockerPid() int32 {
+	if x != nil {
+		return x.BlockerPid
+	}
+	return 0
+}
+
+func (x *LockChainLink) GetBlockedPid() int32 {
+	if x != nil {
+		return x.BlockedPid
+	}
+	return 0
+}
+
+func (x *LockChainLink) GetLockMode() string {
+	if x != nil {
+		return x.LockMode
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetRelationName() string {
+	if x != nil {
+		return x.RelationName
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetBlockerQueryText() string {
+	if x != nil {
+		return x.BlockerQueryText
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetBlockerDuration() *durationpb.Duration {
+	if x != nil {
+		return x.BlockerDuration
+	}
+	return nil
+}
+
+// QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information.
+type QueryPostgreSQLData struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PostgreSQL instance address (host:port).
+	DbInstanceAddress string `protobuf:"bytes,1,opt,name=db_instance_address,json=dbInstanceAddress,proto3" json:"db_instance_address,omitempty"`
+	// Database name.
+	DatabaseName string `protobuf:"bytes,2,opt,name=database_name,json=databaseName,proto3" json:"database_name,omitempty"`
+	// PostgreSQL username.
+	Username string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
+	// Client application name.
+	ApplicationName string `protobuf:"bytes,4,opt,name=application_name,json=applicationName,proto3" json:"application_name,omitempty"`
+	// Backend state (active, idle in transaction, etc.).
+	SessionState string `protobuf:"bytes,5,opt,name=session_state,json=sessionState,proto3" json:"session_state,omitempty"`
+	// Transaction start time (used for idle in transaction duration).
+	TransactionStartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=transaction_start_time,json=transactionStartTime,proto3" json:"transaction_start_time,omitempty"`
+	// Current query start time.
+	QueryStartTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=query_start_time,json=queryStartTime,proto3" json:"query_start_time,omitempty"`
+	// Wait event type when waiting.
+	WaitEventType string `protobuf:"bytes,8,opt,name=wait_event_type,json=waitEventType,proto3" json:"wait_event_type,omitempty"`
+	// Wait event name when waiting.
+	WaitEvent string `protobuf:"bytes,9,opt,name=wait_event,json=waitEvent,proto3" json:"wait_event,omitempty"`
+	// Backend PID.
+	BackendPid int32 `protobuf:"varint,10,opt,name=backend_pid,json=backendPid,proto3" json:"backend_pid,omitempty"`
+	// Leader PID for parallel workers (0 if not a worker).
+	LeaderPid int32 `protobuf:"varint,11,opt,name=leader_pid,json=leaderPid,proto3" json:"leader_pid,omitempty"`
+	// True when query text was truncated by track_activity_query_size.
+	QueryTextTruncated bool `protobuf:"varint,12,opt,name=query_text_truncated,json=queryTextTruncated,proto3" json:"query_text_truncated,omitempty"`
+	// Configured track_activity_query_size value.
+	TrackActivityQuerySize int32 `protobuf:"varint,13,opt,name=track_activity_query_size,json=trackActivityQuerySize,proto3" json:"track_activity_query_size,omitempty"`
+	// Lock chain links when this backend is blocked.
+	LockChain     []*LockChainLink `protobuf:"bytes,14,rep,name=lock_chain,json=lockChain,proto3" json:"lock_chain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryPostgreSQLData) Reset() {
+	*x = QueryPostgreSQLData{}
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryPostgreSQLData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryPostgreSQLData) ProtoMessage() {}
+
+func (x *QueryPostgreSQLData) ProtoReflect() protoreflect.Message {
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryPostgreSQLData.ProtoReflect.Descriptor instead.
+func (*QueryPostgreSQLData) Descriptor() ([]byte, []int) {
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *QueryPostgreSQLData) GetDbInstanceAddress() string {
+	if x != nil {
+		return x.DbInstanceAddress
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetDatabaseName() string {
+	if x != nil {
+		return x.DatabaseName
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetApplicationName() string {
+	if x != nil {
+		return x.ApplicationName
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetSessionState() string {
+	if x != nil {
+		return x.SessionState
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetTransactionStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.TransactionStartTime
+	}
+	return nil
+}
+
+func (x *QueryPostgreSQLData) GetQueryStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.QueryStartTime
+	}
+	return nil
+}
+
+func (x *QueryPostgreSQLData) GetWaitEventType() string {
+	if x != nil {
+		return x.WaitEventType
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetWaitEvent() string {
+	if x != nil {
+		return x.WaitEvent
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetBackendPid() int32 {
+	if x != nil {
+		return x.BackendPid
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetLeaderPid() int32 {
+	if x != nil {
+		return x.LeaderPid
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetQueryTextTruncated() bool {
+	if x != nil {
+		return x.QueryTextTruncated
+	}
+	return false
+}
+
+func (x *QueryPostgreSQLData) GetTrackActivityQuerySize() int32 {
+	if x != nil {
+		return x.TrackActivityQuerySize
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetLockChain() []*LockChainLink {
+	if x != nil {
+		return x.LockChain
+	}
+	return nil
+}
 
 // QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information.
 type QueryMongoDBData struct {
@@ -51,7 +303,7 @@ type QueryMongoDBData struct {
 
 func (x *QueryMongoDBData) Reset() {
 	*x = QueryMongoDBData{}
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63,7 +315,7 @@ func (x *QueryMongoDBData) String() string {
 func (*QueryMongoDBData) ProtoMessage() {}
 
 func (x *QueryMongoDBData) ProtoReflect() protoreflect.Message {
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -76,7 +328,7 @@ func (x *QueryMongoDBData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryMongoDBData.ProtoReflect.Descriptor instead.
 func (*QueryMongoDBData) Descriptor() ([]byte, []int) {
-	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{0}
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *QueryMongoDBData) GetDbInstanceAddress() string {
@@ -160,6 +412,7 @@ type QueryData struct {
 	// Types that are valid to be assigned to Payload:
 	//
 	//	*QueryData_MongoDbPayload
+	//	*QueryData_PostgresPayload
 	Payload       isQueryData_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -167,7 +420,7 @@ type QueryData struct {
 
 func (x *QueryData) Reset() {
 	*x = QueryData{}
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -179,7 +432,7 @@ func (x *QueryData) String() string {
 func (*QueryData) ProtoMessage() {}
 
 func (x *QueryData) ProtoReflect() protoreflect.Message {
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -192,7 +445,7 @@ func (x *QueryData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryData.ProtoReflect.Descriptor instead.
 func (*QueryData) Descriptor() ([]byte, []int) {
-	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{1}
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *QueryData) GetServiceId() string {
@@ -267,6 +520,15 @@ func (x *QueryData) GetMongoDbPayload() *QueryMongoDBData {
 	return nil
 }
 
+func (x *QueryData) GetPostgresPayload() *QueryPostgreSQLData {
+	if x != nil {
+		if x, ok := x.Payload.(*QueryData_PostgresPayload); ok {
+			return x.PostgresPayload
+		}
+	}
+	return nil
+}
+
 type isQueryData_Payload interface {
 	isQueryData_Payload()
 }
@@ -276,13 +538,49 @@ type QueryData_MongoDbPayload struct {
 	MongoDbPayload *QueryMongoDBData `protobuf:"bytes,9,opt,name=mongo_db_payload,json=mongoDbPayload,proto3,oneof"`
 }
 
+type QueryData_PostgresPayload struct {
+	// PostgreSQL-specific query data.
+	PostgresPayload *QueryPostgreSQLData `protobuf:"bytes,10,opt,name=postgres_payload,json=postgresPayload,proto3,oneof"`
+}
+
 func (*QueryData_MongoDbPayload) isQueryData_Payload() {}
+
+func (*QueryData_PostgresPayload) isQueryData_Payload() {}
 
 var File_realtimeanalytics_v1_query_proto protoreflect.FileDescriptor
 
 const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\n" +
-	" realtimeanalytics/v1/query.proto\x12\x14realtimeanalytics.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe0\x02\n" +
+	" realtimeanalytics/v1/query.proto\x12\x14realtimeanalytics.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x87\x02\n" +
+	"\rLockChainLink\x12\x1f\n" +
+	"\vblocker_pid\x18\x01 \x01(\x05R\n" +
+	"blockerPid\x12\x1f\n" +
+	"\vblocked_pid\x18\x02 \x01(\x05R\n" +
+	"blockedPid\x12\x1b\n" +
+	"\tlock_mode\x18\x03 \x01(\tR\blockMode\x12#\n" +
+	"\rrelation_name\x18\x04 \x01(\tR\frelationName\x12,\n" +
+	"\x12blocker_query_text\x18\x05 \x01(\tR\x10blockerQueryText\x12D\n" +
+	"\x10blocker_duration\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x0fblockerDuration\"\xac\x05\n" +
+	"\x13QueryPostgreSQLData\x12.\n" +
+	"\x13db_instance_address\x18\x01 \x01(\tR\x11dbInstanceAddress\x12#\n" +
+	"\rdatabase_name\x18\x02 \x01(\tR\fdatabaseName\x12 \n" +
+	"\busername\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12)\n" +
+	"\x10application_name\x18\x04 \x01(\tR\x0fapplicationName\x12#\n" +
+	"\rsession_state\x18\x05 \x01(\tR\fsessionState\x12P\n" +
+	"\x16transaction_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x14transactionStartTime\x12D\n" +
+	"\x10query_start_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0equeryStartTime\x12&\n" +
+	"\x0fwait_event_type\x18\b \x01(\tR\rwaitEventType\x12\x1d\n" +
+	"\n" +
+	"wait_event\x18\t \x01(\tR\twaitEvent\x12\x1f\n" +
+	"\vbackend_pid\x18\n" +
+	" \x01(\x05R\n" +
+	"backendPid\x12\x1d\n" +
+	"\n" +
+	"leader_pid\x18\v \x01(\x05R\tleaderPid\x120\n" +
+	"\x14query_text_truncated\x18\f \x01(\bR\x12queryTextTruncated\x129\n" +
+	"\x19track_activity_query_size\x18\r \x01(\x05R\x16trackActivityQuerySize\x12B\n" +
+	"\n" +
+	"lock_chain\x18\x0e \x03(\v2#.realtimeanalytics.v1.LockChainLinkR\tlockChain\"\xe0\x02\n" +
 	"\x10QueryMongoDBData\x12.\n" +
 	"\x13db_instance_address\x18\x01 \x01(\tR\x11dbInstanceAddress\x12&\n" +
 	"\x0fclient_app_name\x18\x02 \x01(\tR\rclientAppName\x12#\n" +
@@ -293,7 +591,7 @@ const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\toperation\x18\x05 \x01(\tR\toperation\x12L\n" +
 	"\x14operation_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x12operationStartTime\x12 \n" +
 	"\busername\x18\a \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12!\n" +
-	"\fplan_summary\x18\b \x01(\tR\vplanSummary\"\xd2\x03\n" +
+	"\fplan_summary\x18\b \x01(\tR\vplanSummary\"\xaa\x04\n" +
 	"\tQueryData\x12\x1d\n" +
 	"\n" +
 	"service_id\x18\x01 \x01(\tR\tserviceId\x12!\n" +
@@ -305,7 +603,9 @@ const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\x18query_execution_duration\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x16queryExecutionDuration\x12H\n" +
 	"\x12query_collect_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x10queryCollectTime\x12%\n" +
 	"\x0eclient_address\x18\b \x01(\tR\rclientAddress\x12R\n" +
-	"\x10mongo_db_payload\x18\t \x01(\v2&.realtimeanalytics.v1.QueryMongoDBDataH\x00R\x0emongoDbPayloadB\t\n" +
+	"\x10mongo_db_payload\x18\t \x01(\v2&.realtimeanalytics.v1.QueryMongoDBDataH\x00R\x0emongoDbPayload\x12V\n" +
+	"\x10postgres_payload\x18\n" +
+	" \x01(\v2).realtimeanalytics.v1.QueryPostgreSQLDataH\x00R\x0fpostgresPayloadB\t\n" +
 	"\apayloadB\xdc\x01\n" +
 	"\x18com.realtimeanalytics.v1B\n" +
 	"QueryProtoP\x01ZCgithub.com/percona/pmm/api/realtimeanalytics/v1;realtimeanalyticsv1\xa2\x02\x03RXX\xaa\x02\x14Realtimeanalytics.V1\xca\x02\x14Realtimeanalytics\\V1\xe2\x02 Realtimeanalytics\\V1\\GPBMetadata\xea\x02\x15Realtimeanalytics::V1b\x06proto3"
@@ -322,26 +622,30 @@ func file_realtimeanalytics_v1_query_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_query_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-	file_realtimeanalytics_v1_query_proto_goTypes  = []any{
-		(*QueryMongoDBData)(nil),      // 0: realtimeanalytics.v1.QueryMongoDBData
-		(*QueryData)(nil),             // 1: realtimeanalytics.v1.QueryData
-		(*timestamppb.Timestamp)(nil), // 2: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),   // 3: google.protobuf.Duration
-	}
-)
-
+var file_realtimeanalytics_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_realtimeanalytics_v1_query_proto_goTypes = []any{
+	(*LockChainLink)(nil),         // 0: realtimeanalytics.v1.LockChainLink
+	(*QueryPostgreSQLData)(nil),   // 1: realtimeanalytics.v1.QueryPostgreSQLData
+	(*QueryMongoDBData)(nil),      // 2: realtimeanalytics.v1.QueryMongoDBData
+	(*QueryData)(nil),             // 3: realtimeanalytics.v1.QueryData
+	(*durationpb.Duration)(nil),   // 4: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+}
 var file_realtimeanalytics_v1_query_proto_depIdxs = []int32{
-	2, // 0: realtimeanalytics.v1.QueryMongoDBData.operation_start_time:type_name -> google.protobuf.Timestamp
-	3, // 1: realtimeanalytics.v1.QueryData.query_execution_duration:type_name -> google.protobuf.Duration
-	2, // 2: realtimeanalytics.v1.QueryData.query_collect_time:type_name -> google.protobuf.Timestamp
-	0, // 3: realtimeanalytics.v1.QueryData.mongo_db_payload:type_name -> realtimeanalytics.v1.QueryMongoDBData
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 0: realtimeanalytics.v1.LockChainLink.blocker_duration:type_name -> google.protobuf.Duration
+	5, // 1: realtimeanalytics.v1.QueryPostgreSQLData.transaction_start_time:type_name -> google.protobuf.Timestamp
+	5, // 2: realtimeanalytics.v1.QueryPostgreSQLData.query_start_time:type_name -> google.protobuf.Timestamp
+	0, // 3: realtimeanalytics.v1.QueryPostgreSQLData.lock_chain:type_name -> realtimeanalytics.v1.LockChainLink
+	5, // 4: realtimeanalytics.v1.QueryMongoDBData.operation_start_time:type_name -> google.protobuf.Timestamp
+	4, // 5: realtimeanalytics.v1.QueryData.query_execution_duration:type_name -> google.protobuf.Duration
+	5, // 6: realtimeanalytics.v1.QueryData.query_collect_time:type_name -> google.protobuf.Timestamp
+	2, // 7: realtimeanalytics.v1.QueryData.mongo_db_payload:type_name -> realtimeanalytics.v1.QueryMongoDBData
+	1, // 8: realtimeanalytics.v1.QueryData.postgres_payload:type_name -> realtimeanalytics.v1.QueryPostgreSQLData
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_realtimeanalytics_v1_query_proto_init() }
@@ -349,8 +653,9 @@ func file_realtimeanalytics_v1_query_proto_init() {
 	if File_realtimeanalytics_v1_query_proto != nil {
 		return
 	}
-	file_realtimeanalytics_v1_query_proto_msgTypes[1].OneofWrappers = []any{
+	file_realtimeanalytics_v1_query_proto_msgTypes[3].OneofWrappers = []any{
 		(*QueryData_MongoDbPayload)(nil),
+		(*QueryData_PostgresPayload)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -358,7 +663,7 @@ func file_realtimeanalytics_v1_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_realtimeanalytics_v1_query_proto_rawDesc), len(file_realtimeanalytics_v1_query_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/realtimeanalytics/v1/query.pb.validate.go
+++ b/api/realtimeanalytics/v1/query.pb.validate.go
@@ -35,6 +35,361 @@ var (
 	_ = sort.Sort
 )
 
+// Validate checks the field values on LockChainLink with the rules defined in
+// the proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *LockChainLink) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on LockChainLink with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in LockChainLinkMultiError, or
+// nil if none found.
+func (m *LockChainLink) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *LockChainLink) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for BlockerPid
+
+	// no validation rules for BlockedPid
+
+	// no validation rules for LockMode
+
+	// no validation rules for RelationName
+
+	// no validation rules for BlockerQueryText
+
+	if all {
+		switch v := interface{}(m.GetBlockerDuration()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, LockChainLinkValidationError{
+					field:  "BlockerDuration",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, LockChainLinkValidationError{
+					field:  "BlockerDuration",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetBlockerDuration()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return LockChainLinkValidationError{
+				field:  "BlockerDuration",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return LockChainLinkMultiError(errors)
+	}
+
+	return nil
+}
+
+// LockChainLinkMultiError is an error wrapping multiple validation errors
+// returned by LockChainLink.ValidateAll() if the designated constraints
+// aren't met.
+type LockChainLinkMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m LockChainLinkMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m LockChainLinkMultiError) AllErrors() []error { return m }
+
+// LockChainLinkValidationError is the validation error returned by
+// LockChainLink.Validate if the designated constraints aren't met.
+type LockChainLinkValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e LockChainLinkValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e LockChainLinkValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e LockChainLinkValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e LockChainLinkValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e LockChainLinkValidationError) ErrorName() string { return "LockChainLinkValidationError" }
+
+// Error satisfies the builtin error interface
+func (e LockChainLinkValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sLockChainLink.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = LockChainLinkValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = LockChainLinkValidationError{}
+
+// Validate checks the field values on QueryPostgreSQLData with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *QueryPostgreSQLData) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on QueryPostgreSQLData with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// QueryPostgreSQLDataMultiError, or nil if none found.
+func (m *QueryPostgreSQLData) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *QueryPostgreSQLData) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for DbInstanceAddress
+
+	// no validation rules for DatabaseName
+
+	// no validation rules for Username
+
+	// no validation rules for ApplicationName
+
+	// no validation rules for SessionState
+
+	if all {
+		switch v := interface{}(m.GetTransactionStartTime()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "TransactionStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "TransactionStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetTransactionStartTime()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return QueryPostgreSQLDataValidationError{
+				field:  "TransactionStartTime",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetQueryStartTime()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "QueryStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "QueryStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetQueryStartTime()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return QueryPostgreSQLDataValidationError{
+				field:  "QueryStartTime",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for WaitEventType
+
+	// no validation rules for WaitEvent
+
+	// no validation rules for BackendPid
+
+	// no validation rules for LeaderPid
+
+	// no validation rules for QueryTextTruncated
+
+	// no validation rules for TrackActivityQuerySize
+
+	for idx, item := range m.GetLockChain() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, QueryPostgreSQLDataValidationError{
+						field:  fmt.Sprintf("LockChain[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, QueryPostgreSQLDataValidationError{
+						field:  fmt.Sprintf("LockChain[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return QueryPostgreSQLDataValidationError{
+					field:  fmt.Sprintf("LockChain[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return QueryPostgreSQLDataMultiError(errors)
+	}
+
+	return nil
+}
+
+// QueryPostgreSQLDataMultiError is an error wrapping multiple validation
+// errors returned by QueryPostgreSQLData.ValidateAll() if the designated
+// constraints aren't met.
+type QueryPostgreSQLDataMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m QueryPostgreSQLDataMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m QueryPostgreSQLDataMultiError) AllErrors() []error { return m }
+
+// QueryPostgreSQLDataValidationError is the validation error returned by
+// QueryPostgreSQLData.Validate if the designated constraints aren't met.
+type QueryPostgreSQLDataValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e QueryPostgreSQLDataValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e QueryPostgreSQLDataValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e QueryPostgreSQLDataValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e QueryPostgreSQLDataValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e QueryPostgreSQLDataValidationError) ErrorName() string {
+	return "QueryPostgreSQLDataValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e QueryPostgreSQLDataValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sQueryPostgreSQLData.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = QueryPostgreSQLDataValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = QueryPostgreSQLDataValidationError{}
+
 // Validate checks the field values on QueryMongoDBData with the rules defined
 // in the proto definition for this message. If any rules are violated, the
 // first error encountered is returned, or nil if there are no violations.
@@ -165,8 +520,7 @@ func (e QueryMongoDBDataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryMongoDBDataValidationError{}
@@ -313,6 +667,47 @@ func (m *QueryData) validate(all bool) error {
 			}
 		}
 
+	case *QueryData_PostgresPayload:
+		if v == nil {
+			err := QueryDataValidationError{
+				field:  "Payload",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetPostgresPayload()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, QueryDataValidationError{
+						field:  "PostgresPayload",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, QueryDataValidationError{
+						field:  "PostgresPayload",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetPostgresPayload()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return QueryDataValidationError{
+					field:  "PostgresPayload",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -381,8 +776,7 @@ func (e QueryDataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryDataValidationError{}

--- a/api/realtimeanalytics/v1/query.proto
+++ b/api/realtimeanalytics/v1/query.proto
@@ -6,6 +6,54 @@ import "extensions/v1/redact.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+// LockChainLink represents one link in a PostgreSQL lock chain (blocker -> blocked).
+message LockChainLink {
+  // PID of the blocking backend.
+  int32 blocker_pid = 1;
+  // PID of the blocked backend.
+  int32 blocked_pid = 2;
+  // Lock mode held or requested.
+  string lock_mode = 3;
+  // Relation name when available.
+  string relation_name = 4;
+  // Query text of the blocking backend.
+  string blocker_query_text = 5;
+  // Duration of the blocking query.
+  google.protobuf.Duration blocker_duration = 6;
+}
+
+// QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information.
+message QueryPostgreSQLData {
+  // PostgreSQL instance address (host:port).
+  string db_instance_address = 1;
+  // Database name.
+  string database_name = 2;
+  // PostgreSQL username.
+  string username = 3 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Client application name.
+  string application_name = 4;
+  // Backend state (active, idle in transaction, etc.).
+  string session_state = 5;
+  // Transaction start time (used for idle in transaction duration).
+  google.protobuf.Timestamp transaction_start_time = 6;
+  // Current query start time.
+  google.protobuf.Timestamp query_start_time = 7;
+  // Wait event type when waiting.
+  string wait_event_type = 8;
+  // Wait event name when waiting.
+  string wait_event = 9;
+  // Backend PID.
+  int32 backend_pid = 10;
+  // Leader PID for parallel workers (0 if not a worker).
+  int32 leader_pid = 11;
+  // True when query text was truncated by track_activity_query_size.
+  bool query_text_truncated = 12;
+  // Configured track_activity_query_size value.
+  int32 track_activity_query_size = 13;
+  // Lock chain links when this backend is blocked.
+  repeated LockChainLink lock_chain = 14;
+}
+
 // QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information.
 message QueryMongoDBData {
   // MongoDB instance address(host:port) that processing the query.
@@ -49,5 +97,7 @@ message QueryData {
   oneof payload {
     // MongoDB-specific query data.
     QueryMongoDBData mongo_db_payload = 9;
+    // PostgreSQL-specific query data.
+    QueryPostgreSQLData postgres_payload = 10;
   }
 }

--- a/api/realtimeanalytics/v1/query.swagger.json
+++ b/api/realtimeanalytics/v1/query.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/query.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/realtimeanalytics.pb.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics.pb.go
@@ -7,19 +7,17 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -131,8 +129,9 @@ func (x *ListServicesRequest) GetServiceType() v1.ServiceType {
 }
 
 type ListServicesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mongodb       []*v1.MongoDBService   `protobuf:"bytes,1,rep,name=mongodb,proto3" json:"mongodb,omitempty"`
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Mongodb       []*v1.MongoDBService    `protobuf:"bytes,1,rep,name=mongodb,proto3" json:"mongodb,omitempty"`
+	Postgresql    []*v1.PostgreSQLService `protobuf:"bytes,2,rep,name=postgresql,proto3" json:"postgresql,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -170,6 +169,13 @@ func (*ListServicesResponse) Descriptor() ([]byte, []int) {
 func (x *ListServicesResponse) GetMongodb() []*v1.MongoDBService {
 	if x != nil {
 		return x.Mongodb
+	}
+	return nil
+}
+
+func (x *ListServicesResponse) GetPostgresql() []*v1.PostgreSQLService {
+	if x != nil {
+		return x.Postgresql
 	}
 	return nil
 }
@@ -638,9 +644,12 @@ const file_realtimeanalytics_v1_realtimeanalytics_proto_rawDesc = "" +
 	"\n" +
 	",realtimeanalytics/v1/realtimeanalytics.proto\x12\x14realtimeanalytics.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1binventory/v1/services.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\x1a realtimeanalytics/v1/query.proto\x1a\x17validate/validate.proto\"S\n" +
 	"\x13ListServicesRequest\x12<\n" +
-	"\fservice_type\x18\x01 \x01(\x0e2\x19.inventory.v1.ServiceTypeR\vserviceType\"N\n" +
+	"\fservice_type\x18\x01 \x01(\x0e2\x19.inventory.v1.ServiceTypeR\vserviceType\"\x8f\x01\n" +
 	"\x14ListServicesResponse\x126\n" +
-	"\amongodb\x18\x01 \x03(\v2\x1c.inventory.v1.MongoDBServiceR\amongodb\"\xac\x02\n" +
+	"\amongodb\x18\x01 \x03(\v2\x1c.inventory.v1.MongoDBServiceR\amongodb\x12?\n" +
+	"\n" +
+	"postgresql\x18\x02 \x03(\v2\x1f.inventory.v1.PostgreSQLServiceR\n" +
+	"postgresql\"\xac\x02\n" +
 	"\aSession\x12\x1d\n" +
 	"\n" +
 	"service_id\x18\x01 \x01(\tR\tserviceId\x12!\n" +
@@ -695,54 +704,53 @@ func file_realtimeanalytics_v1_realtimeanalytics_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_realtimeanalytics_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_realtimeanalytics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_realtimeanalytics_v1_realtimeanalytics_proto_msgTypes  = make([]protoimpl.MessageInfo, 11)
-	file_realtimeanalytics_v1_realtimeanalytics_proto_goTypes   = []any{
-		SessionStatus(0),              // 0: realtimeanalytics.v1.SessionStatus
-		(*ListServicesRequest)(nil),   // 1: realtimeanalytics.v1.ListServicesRequest
-		(*ListServicesResponse)(nil),  // 2: realtimeanalytics.v1.ListServicesResponse
-		(*Session)(nil),               // 3: realtimeanalytics.v1.Session
-		(*ListSessionsRequest)(nil),   // 4: realtimeanalytics.v1.ListSessionsRequest
-		(*ListSessionsResponse)(nil),  // 5: realtimeanalytics.v1.ListSessionsResponse
-		(*StartSessionRequest)(nil),   // 6: realtimeanalytics.v1.StartSessionRequest
-		(*StartSessionResponse)(nil),  // 7: realtimeanalytics.v1.StartSessionResponse
-		(*StopSessionRequest)(nil),    // 8: realtimeanalytics.v1.StopSessionRequest
-		(*StopSessionResponse)(nil),   // 9: realtimeanalytics.v1.StopSessionResponse
-		(*SearchQueriesRequest)(nil),  // 10: realtimeanalytics.v1.SearchQueriesRequest
-		(*SearchQueriesResponse)(nil), // 11: realtimeanalytics.v1.SearchQueriesResponse
-		v1.ServiceType(0),             // 12: inventory.v1.ServiceType
-		(*v1.MongoDBService)(nil),     // 13: inventory.v1.MongoDBService
-		(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),   // 15: google.protobuf.Duration
-		(*QueryData)(nil),             // 16: realtimeanalytics.v1.QueryData
-	}
-)
-
+var file_realtimeanalytics_v1_realtimeanalytics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_realtimeanalytics_v1_realtimeanalytics_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_realtimeanalytics_v1_realtimeanalytics_proto_goTypes = []any{
+	(SessionStatus)(0),            // 0: realtimeanalytics.v1.SessionStatus
+	(*ListServicesRequest)(nil),   // 1: realtimeanalytics.v1.ListServicesRequest
+	(*ListServicesResponse)(nil),  // 2: realtimeanalytics.v1.ListServicesResponse
+	(*Session)(nil),               // 3: realtimeanalytics.v1.Session
+	(*ListSessionsRequest)(nil),   // 4: realtimeanalytics.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),  // 5: realtimeanalytics.v1.ListSessionsResponse
+	(*StartSessionRequest)(nil),   // 6: realtimeanalytics.v1.StartSessionRequest
+	(*StartSessionResponse)(nil),  // 7: realtimeanalytics.v1.StartSessionResponse
+	(*StopSessionRequest)(nil),    // 8: realtimeanalytics.v1.StopSessionRequest
+	(*StopSessionResponse)(nil),   // 9: realtimeanalytics.v1.StopSessionResponse
+	(*SearchQueriesRequest)(nil),  // 10: realtimeanalytics.v1.SearchQueriesRequest
+	(*SearchQueriesResponse)(nil), // 11: realtimeanalytics.v1.SearchQueriesResponse
+	(v1.ServiceType)(0),           // 12: inventory.v1.ServiceType
+	(*v1.MongoDBService)(nil),     // 13: inventory.v1.MongoDBService
+	(*v1.PostgreSQLService)(nil),  // 14: inventory.v1.PostgreSQLService
+	(*timestamppb.Timestamp)(nil), // 15: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),   // 16: google.protobuf.Duration
+	(*QueryData)(nil),             // 17: realtimeanalytics.v1.QueryData
+}
 var file_realtimeanalytics_v1_realtimeanalytics_proto_depIdxs = []int32{
 	12, // 0: realtimeanalytics.v1.ListServicesRequest.service_type:type_name -> inventory.v1.ServiceType
 	13, // 1: realtimeanalytics.v1.ListServicesResponse.mongodb:type_name -> inventory.v1.MongoDBService
-	14, // 2: realtimeanalytics.v1.Session.start_time:type_name -> google.protobuf.Timestamp
-	15, // 3: realtimeanalytics.v1.Session.collect_interval:type_name -> google.protobuf.Duration
-	0,  // 4: realtimeanalytics.v1.Session.status:type_name -> realtimeanalytics.v1.SessionStatus
-	3,  // 5: realtimeanalytics.v1.ListSessionsResponse.sessions:type_name -> realtimeanalytics.v1.Session
-	3,  // 6: realtimeanalytics.v1.StartSessionResponse.session:type_name -> realtimeanalytics.v1.Session
-	16, // 7: realtimeanalytics.v1.SearchQueriesResponse.queries:type_name -> realtimeanalytics.v1.QueryData
-	1,  // 8: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:input_type -> realtimeanalytics.v1.ListServicesRequest
-	4,  // 9: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:input_type -> realtimeanalytics.v1.ListSessionsRequest
-	6,  // 10: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:input_type -> realtimeanalytics.v1.StartSessionRequest
-	8,  // 11: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:input_type -> realtimeanalytics.v1.StopSessionRequest
-	10, // 12: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:input_type -> realtimeanalytics.v1.SearchQueriesRequest
-	2,  // 13: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:output_type -> realtimeanalytics.v1.ListServicesResponse
-	5,  // 14: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:output_type -> realtimeanalytics.v1.ListSessionsResponse
-	7,  // 15: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:output_type -> realtimeanalytics.v1.StartSessionResponse
-	9,  // 16: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:output_type -> realtimeanalytics.v1.StopSessionResponse
-	11, // 17: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:output_type -> realtimeanalytics.v1.SearchQueriesResponse
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	14, // 2: realtimeanalytics.v1.ListServicesResponse.postgresql:type_name -> inventory.v1.PostgreSQLService
+	15, // 3: realtimeanalytics.v1.Session.start_time:type_name -> google.protobuf.Timestamp
+	16, // 4: realtimeanalytics.v1.Session.collect_interval:type_name -> google.protobuf.Duration
+	0,  // 5: realtimeanalytics.v1.Session.status:type_name -> realtimeanalytics.v1.SessionStatus
+	3,  // 6: realtimeanalytics.v1.ListSessionsResponse.sessions:type_name -> realtimeanalytics.v1.Session
+	3,  // 7: realtimeanalytics.v1.StartSessionResponse.session:type_name -> realtimeanalytics.v1.Session
+	17, // 8: realtimeanalytics.v1.SearchQueriesResponse.queries:type_name -> realtimeanalytics.v1.QueryData
+	1,  // 9: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:input_type -> realtimeanalytics.v1.ListServicesRequest
+	4,  // 10: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:input_type -> realtimeanalytics.v1.ListSessionsRequest
+	6,  // 11: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:input_type -> realtimeanalytics.v1.StartSessionRequest
+	8,  // 12: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:input_type -> realtimeanalytics.v1.StopSessionRequest
+	10, // 13: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:input_type -> realtimeanalytics.v1.SearchQueriesRequest
+	2,  // 14: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:output_type -> realtimeanalytics.v1.ListServicesResponse
+	5,  // 15: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:output_type -> realtimeanalytics.v1.ListSessionsResponse
+	7,  // 16: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:output_type -> realtimeanalytics.v1.StartSessionResponse
+	9,  // 17: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:output_type -> realtimeanalytics.v1.StopSessionResponse
+	11, // 18: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:output_type -> realtimeanalytics.v1.SearchQueriesResponse
+	14, // [14:19] is the sub-list for method output_type
+	9,  // [9:14] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_realtimeanalytics_v1_realtimeanalytics_proto_init() }

--- a/api/realtimeanalytics/v1/realtimeanalytics.pb.validate.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics.pb.validate.go
@@ -130,8 +130,7 @@ func (e ListServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesRequestValidationError{}
@@ -192,6 +191,40 @@ func (m *ListServicesResponse) validate(all bool) error {
 			if err := v.Validate(); err != nil {
 				return ListServicesResponseValidationError{
 					field:  fmt.Sprintf("Mongodb[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	for idx, item := range m.GetPostgresql() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListServicesResponseValidationError{
+						field:  fmt.Sprintf("Postgresql[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListServicesResponseValidationError{
+						field:  fmt.Sprintf("Postgresql[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListServicesResponseValidationError{
+					field:  fmt.Sprintf("Postgresql[%v]", idx),
 					reason: "embedded message failed validation",
 					cause:  err,
 				}
@@ -267,8 +300,7 @@ func (e ListServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesResponseValidationError{}
@@ -432,8 +464,7 @@ func (e SessionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SessionValidationError{}
@@ -537,8 +568,7 @@ func (e ListSessionsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListSessionsRequestValidationError{}
@@ -674,8 +704,7 @@ func (e ListSessionsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListSessionsResponseValidationError{}
@@ -788,8 +817,7 @@ func (e StartSessionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartSessionRequestValidationError{}
@@ -920,8 +948,7 @@ func (e StartSessionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartSessionResponseValidationError{}
@@ -1034,8 +1061,7 @@ func (e StopSessionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopSessionRequestValidationError{}
@@ -1137,8 +1163,7 @@ func (e StopSessionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopSessionResponseValidationError{}
@@ -1274,8 +1299,7 @@ func (e SearchQueriesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SearchQueriesRequestValidationError{}
@@ -1411,8 +1435,7 @@ func (e SearchQueriesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SearchQueriesResponseValidationError{}

--- a/api/realtimeanalytics/v1/realtimeanalytics.proto
+++ b/api/realtimeanalytics/v1/realtimeanalytics.proto
@@ -19,6 +19,7 @@ message ListServicesRequest {
 
 message ListServicesResponse {
   repeated inventory.v1.MongoDBService mongodb = 1;
+  repeated inventory.v1.PostgreSQLService postgresql = 2;
 }
 
 // Session related messages

--- a/api/realtimeanalytics/v1/realtimeanalytics.swagger.json
+++ b/api/realtimeanalytics/v1/realtimeanalytics.swagger.json
@@ -1,0 +1,693 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/realtimeanalytics.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "RealtimeAnalyticsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/realtimeanalytics/queries:search": {
+      "post": {
+        "summary": "List Running Database Queries in a particular services",
+        "description": "Returns list of currently running Database queries in a particular services",
+        "operationId": "SearchQueries",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SearchQueriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "SearchQueriesRequest contains optional filters for listing active Real-Time Analytics session Queries.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1SearchQueriesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/services": {
+      "get": {
+        "summary": "List Services that support Real-Time Analytics",
+        "description": "Returns a list of Services that support Real-Time Analytics filtered by type.",
+        "operationId": "ListServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_type",
+            "description": "Return only services filtered by service type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SERVICE_TYPE_UNSPECIFIED",
+              "SERVICE_TYPE_MYSQL_SERVICE",
+              "SERVICE_TYPE_MONGODB_SERVICE",
+              "SERVICE_TYPE_POSTGRESQL_SERVICE",
+              "SERVICE_TYPE_VALKEY_SERVICE",
+              "SERVICE_TYPE_PROXYSQL_SERVICE",
+              "SERVICE_TYPE_HAPROXY_SERVICE",
+              "SERVICE_TYPE_EXTERNAL_SERVICE"
+            ],
+            "default": "SERVICE_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions": {
+      "get": {
+        "summary": "List Running Real-Time Analytics Sessions",
+        "description": "Returns the list of all currently running Real-Time Analytics sessions with their details including service, cluster and status information.",
+        "operationId": "ListSessions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSessionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "cluster_name",
+            "description": "Optional filter by cluster name.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions:start": {
+      "post": {
+        "summary": "Start Real-Time Analytics session",
+        "description": "Start Real-Time Analytics session for a specified service.",
+        "operationId": "StartSession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartSessionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "StartSessionRequest contains parameters for starting Real-Time Analytics session.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartSessionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions:stop": {
+      "post": {
+        "summary": "Stop Real-Time Analytics session",
+        "description": "Stop Real-Time Analytics session for a specified service.",
+        "operationId": "StopSession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StopSessionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "StopSessionRequest contains parameters for stopping Real-Time Analytics session.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StopSessionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1ListServicesResponse": {
+      "type": "object",
+      "properties": {
+        "mongodb": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBService"
+          }
+        },
+        "postgresql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PostgreSQLService"
+          }
+        }
+      }
+    },
+    "v1ListSessionsResponse": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Session"
+          },
+          "description": "List of active Real-Time Analytics Sessions."
+        }
+      },
+      "description": "ListSessionsResponse returns the list of currently active Real-Time Analytics Sessions."
+    },
+    "v1LockChainLink": {
+      "type": "object",
+      "properties": {
+        "blocker_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "PID of the blocking backend."
+        },
+        "blocked_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "PID of the blocked backend."
+        },
+        "lock_mode": {
+          "type": "string",
+          "description": "Lock mode held or requested."
+        },
+        "relation_name": {
+          "type": "string",
+          "description": "Relation name when available."
+        },
+        "blocker_query_text": {
+          "type": "string",
+          "description": "Query text of the blocking backend."
+        },
+        "blocker_duration": {
+          "type": "string",
+          "description": "Duration of the blocking query."
+        }
+      },
+      "description": "LockChainLink represents one link in a PostgreSQL lock chain (blocker -\u003e blocked)."
+    },
+    "v1MongoDBService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MongoDB version."
+        }
+      },
+      "description": "MongoDBService represents a generic MongoDB instance."
+    },
+    "v1PostgreSQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "PostgreSQL version."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        }
+      },
+      "description": "PostgreSQLService represents a generic PostgreSQL instance."
+    },
+    "v1QueryData": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "PMM Service identifier that reported the query."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "PMM Service name that reported the query."
+        },
+        "query_id": {
+          "type": "string",
+          "description": "Unique identifier for the query."
+        },
+        "query_text": {
+          "type": "string",
+          "description": "The text of the query."
+        },
+        "query_raw_json": {
+          "type": "string",
+          "description": "Raw JSON representation of the query."
+        },
+        "query_execution_duration": {
+          "type": "string",
+          "description": "Current query current execution time."
+        },
+        "query_collect_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the query data was collected by Real-Time Analytics agent."
+        },
+        "client_address": {
+          "type": "string",
+          "description": "Client address (host:port)."
+        },
+        "mongo_db_payload": {
+          "$ref": "#/definitions/v1QueryMongoDBData",
+          "description": "MongoDB-specific query data."
+        },
+        "postgres_payload": {
+          "$ref": "#/definitions/v1QueryPostgreSQLData",
+          "description": "PostgreSQL-specific query data."
+        }
+      },
+      "description": "QueryData represents a single Real-Time Analytics query data point.\nIt includes general query information and a payload for database-specific details."
+    },
+    "v1QueryMongoDBData": {
+      "type": "object",
+      "properties": {
+        "db_instance_address": {
+          "type": "string",
+          "description": "MongoDB instance address(host:port) that processing the query."
+        },
+        "client_app_name": {
+          "type": "string",
+          "description": "Client application name from the MongoDB query."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "collection": {
+          "type": "string",
+          "description": "Collection name."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Query operation (\"find\", \"aggregate\", \"update\", etc)."
+        },
+        "operation_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the operation."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB user name associated with the query."
+        },
+        "plan_summary": {
+          "type": "string",
+          "description": "Indicates if an index (COLLSCAN vs IXSCAN) was utilized in the query."
+        }
+      },
+      "description": "QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information."
+    },
+    "v1QueryPostgreSQLData": {
+      "type": "object",
+      "properties": {
+        "db_instance_address": {
+          "type": "string",
+          "description": "PostgreSQL instance address (host:port)."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username."
+        },
+        "application_name": {
+          "type": "string",
+          "description": "Client application name."
+        },
+        "session_state": {
+          "type": "string",
+          "description": "Backend state (active, idle in transaction, etc.)."
+        },
+        "transaction_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Transaction start time (used for idle in transaction duration)."
+        },
+        "query_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Current query start time."
+        },
+        "wait_event_type": {
+          "type": "string",
+          "description": "Wait event type when waiting."
+        },
+        "wait_event": {
+          "type": "string",
+          "description": "Wait event name when waiting."
+        },
+        "backend_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Backend PID."
+        },
+        "leader_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Leader PID for parallel workers (0 if not a worker)."
+        },
+        "query_text_truncated": {
+          "type": "boolean",
+          "description": "True when query text was truncated by track_activity_query_size."
+        },
+        "track_activity_query_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Configured track_activity_query_size value."
+        },
+        "lock_chain": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1LockChainLink"
+          },
+          "description": "Lock chain links when this backend is blocked."
+        }
+      },
+      "description": "QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information."
+    },
+    "v1SearchQueriesRequest": {
+      "type": "object",
+      "properties": {
+        "service_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional filter by Service identifiers."
+        },
+        "limit": {
+          "type": "string",
+          "format": "int64",
+          "description": "Optional limit the number of queries in response."
+        }
+      },
+      "description": "SearchQueriesRequest contains optional filters for listing active Real-Time Analytics session Queries."
+    },
+    "v1SearchQueriesResponse": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QueryData"
+          },
+          "description": "List of active Real-Time Analytics session Queries."
+        }
+      },
+      "description": "SearchQueriesResponse returns the list of currently active Real-Time Analytics session Queries."
+    },
+    "v1ServiceType": {
+      "type": "string",
+      "enum": [
+        "SERVICE_TYPE_UNSPECIFIED",
+        "SERVICE_TYPE_MYSQL_SERVICE",
+        "SERVICE_TYPE_MONGODB_SERVICE",
+        "SERVICE_TYPE_POSTGRESQL_SERVICE",
+        "SERVICE_TYPE_VALKEY_SERVICE",
+        "SERVICE_TYPE_PROXYSQL_SERVICE",
+        "SERVICE_TYPE_HAPROXY_SERVICE",
+        "SERVICE_TYPE_EXTERNAL_SERVICE"
+      ],
+      "default": "SERVICE_TYPE_UNSPECIFIED",
+      "description": "ServiceType describes supported Service types."
+    },
+    "v1Session": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier that has enabled Real-Time Analytics session."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "cluster_name": {
+          "type": "string",
+          "description": "Cluster name the service belongs to."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the Real-Time Analytics session started."
+        },
+        "collect_interval": {
+          "type": "string",
+          "description": "Query collect interval."
+        },
+        "status": {
+          "$ref": "#/definitions/v1SessionStatus",
+          "description": "Current status of the Real-Time Analytics session."
+        }
+      },
+      "description": "Session represents an active Real-Time Analytics session."
+    },
+    "v1SessionStatus": {
+      "type": "string",
+      "enum": [
+        "SESSION_STATUS_UNSPECIFIED",
+        "SESSION_STATUS_ERROR",
+        "SESSION_STATUS_RUNNING",
+        "SESSION_STATUS_DOWN"
+      ],
+      "default": "SESSION_STATUS_UNSPECIFIED",
+      "description": "Status represents actual Real-Time Analytics session status.\n\n - SESSION_STATUS_ERROR: Session encountered an error.\n - SESSION_STATUS_RUNNING: Session is running.\n - SESSION_STATUS_DOWN: Session has been stopped or disabled."
+    },
+    "v1StartSessionRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Required service identifier the Real-Time Analytics session shall be started for."
+        }
+      },
+      "description": "StartSessionRequest contains parameters for starting Real-Time Analytics session."
+    },
+    "v1StartSessionResponse": {
+      "type": "object",
+      "properties": {
+        "session": {
+          "$ref": "#/definitions/v1Session"
+        }
+      },
+      "description": "StartSessionResponse is the response for starting Real-Time Analytics session."
+    },
+    "v1StopSessionRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Required service identifier the Real-Time Analytics session shall be stopped for."
+        }
+      },
+      "description": "StopSessionRequest contains parameters for stopping Real-Time Analytics session."
+    },
+    "v1StopSessionResponse": {
+      "type": "object",
+      "description": "StopSessionResponse is the response for stopping Real-Time Analytics session.\n\nEmpty response for now."
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/realtimeanalytics_grpc.pb.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics_grpc.pb.go
@@ -8,7 +8,6 @@ package realtimeanalyticsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -132,23 +131,18 @@ type UnimplementedRealtimeAnalyticsServiceServer struct{}
 func (UnimplementedRealtimeAnalyticsServiceServer) ListServices(context.Context, *ListServicesRequest) (*ListServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListServices not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSessions not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) StartSession(context.Context, *StartSessionRequest) (*StartSessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartSession not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) StopSession(context.Context, *StopSessionRequest) (*StopSessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StopSession not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) SearchQueries(context.Context, *SearchQueriesRequest) (*SearchQueriesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SearchQueries not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) mustEmbedUnimplementedRealtimeAnalyticsServiceServer() {
 }
 func (UnimplementedRealtimeAnalyticsServiceServer) testEmbeddedByValue() {}

--- a/api/server/v1/httperror.pb.go
+++ b/api/server/v1/httperror.pb.go
@@ -7,13 +7,12 @@
 package serverv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	anypb "google.golang.org/protobuf/types/known/anypb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -120,14 +119,11 @@ func file_server_v1_httperror_proto_rawDescGZIP() []byte {
 	return file_server_v1_httperror_proto_rawDescData
 }
 
-var (
-	file_server_v1_httperror_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-	file_server_v1_httperror_proto_goTypes  = []any{
-		(*HttpError)(nil), // 0: server.v1.HttpError
-		(*anypb.Any)(nil), // 1: google.protobuf.Any
-	}
-)
-
+var file_server_v1_httperror_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_server_v1_httperror_proto_goTypes = []any{
+	(*HttpError)(nil), // 0: server.v1.HttpError
+	(*anypb.Any)(nil), // 1: google.protobuf.Any
+}
 var file_server_v1_httperror_proto_depIdxs = []int32{
 	1, // 0: server.v1.HttpError.details:type_name -> google.protobuf.Any
 	1, // [1:1] is the sub-list for method output_type

--- a/api/server/v1/httperror.pb.validate.go
+++ b/api/server/v1/httperror.pb.validate.go
@@ -161,8 +161,7 @@ func (e HttpErrorValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = HttpErrorValidationError{}

--- a/api/server/v1/httperror.swagger.json
+++ b/api/server/v1/httperror.swagger.json
@@ -1,0 +1,46 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "server/v1/httperror.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -7,19 +7,17 @@
 package serverv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	common "github.com/percona/pmm/api/common"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	common "github.com/percona/pmm/api/common"
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -1916,43 +1914,40 @@ func file_server_v1_server_proto_rawDescGZIP() []byte {
 	return file_server_v1_server_proto_rawDescData
 }
 
-var (
-	file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_server_v1_server_proto_msgTypes  = make([]protoimpl.MessageInfo, 26)
-	file_server_v1_server_proto_goTypes   = []any{
-		DistributionMethod(0),               // 0: server.v1.DistributionMethod
-		(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
-		(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
-		(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
-		(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
-		(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
-		(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
-		(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
-		(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
-		(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
-		(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
-		(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
-		(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
-		(*StartUpdateRequest)(nil),          // 13: server.v1.StartUpdateRequest
-		(*StartUpdateResponse)(nil),         // 14: server.v1.StartUpdateResponse
-		(*UpdateStatusRequest)(nil),         // 15: server.v1.UpdateStatusRequest
-		(*UpdateStatusResponse)(nil),        // 16: server.v1.UpdateStatusResponse
-		(*MetricsResolutions)(nil),          // 17: server.v1.MetricsResolutions
-		(*AdvisorRunIntervals)(nil),         // 18: server.v1.AdvisorRunIntervals
-		(*Settings)(nil),                    // 19: server.v1.Settings
-		(*ReadOnlySettings)(nil),            // 20: server.v1.ReadOnlySettings
-		(*GetSettingsRequest)(nil),          // 21: server.v1.GetSettingsRequest
-		(*GetReadOnlySettingsRequest)(nil),  // 22: server.v1.GetReadOnlySettingsRequest
-		(*GetSettingsResponse)(nil),         // 23: server.v1.GetSettingsResponse
-		(*GetReadOnlySettingsResponse)(nil), // 24: server.v1.GetReadOnlySettingsResponse
-		(*ChangeSettingsRequest)(nil),       // 25: server.v1.ChangeSettingsRequest
-		(*ChangeSettingsResponse)(nil),      // 26: server.v1.ChangeSettingsResponse
-		(*timestamppb.Timestamp)(nil),       // 27: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),         // 28: google.protobuf.Duration
-		(*common.StringArray)(nil),          // 29: common.StringArray
-	}
-)
-
+var file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_server_v1_server_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_server_v1_server_proto_goTypes = []any{
+	(DistributionMethod)(0),             // 0: server.v1.DistributionMethod
+	(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
+	(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
+	(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
+	(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
+	(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
+	(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
+	(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
+	(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
+	(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
+	(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
+	(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
+	(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
+	(*StartUpdateRequest)(nil),          // 13: server.v1.StartUpdateRequest
+	(*StartUpdateResponse)(nil),         // 14: server.v1.StartUpdateResponse
+	(*UpdateStatusRequest)(nil),         // 15: server.v1.UpdateStatusRequest
+	(*UpdateStatusResponse)(nil),        // 16: server.v1.UpdateStatusResponse
+	(*MetricsResolutions)(nil),          // 17: server.v1.MetricsResolutions
+	(*AdvisorRunIntervals)(nil),         // 18: server.v1.AdvisorRunIntervals
+	(*Settings)(nil),                    // 19: server.v1.Settings
+	(*ReadOnlySettings)(nil),            // 20: server.v1.ReadOnlySettings
+	(*GetSettingsRequest)(nil),          // 21: server.v1.GetSettingsRequest
+	(*GetReadOnlySettingsRequest)(nil),  // 22: server.v1.GetReadOnlySettingsRequest
+	(*GetSettingsResponse)(nil),         // 23: server.v1.GetSettingsResponse
+	(*GetReadOnlySettingsResponse)(nil), // 24: server.v1.GetReadOnlySettingsResponse
+	(*ChangeSettingsRequest)(nil),       // 25: server.v1.ChangeSettingsRequest
+	(*ChangeSettingsResponse)(nil),      // 26: server.v1.ChangeSettingsResponse
+	(*timestamppb.Timestamp)(nil),       // 27: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),         // 28: google.protobuf.Duration
+	(*common.StringArray)(nil),          // 29: common.StringArray
+}
 var file_server_v1_server_proto_depIdxs = []int32{
 	27, // 0: server.v1.VersionInfo.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 1: server.v1.VersionResponse.server:type_name -> server.v1.VersionInfo

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -154,8 +154,7 @@ func (e VersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionInfoValidationError{}
@@ -257,8 +256,7 @@ func (e VersionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionRequestValidationError{}
@@ -420,8 +418,7 @@ func (e VersionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionResponseValidationError{}
@@ -521,8 +518,7 @@ func (e ReadinessRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessRequestValidationError{}
@@ -624,8 +620,7 @@ func (e ReadinessResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessResponseValidationError{}
@@ -727,8 +722,7 @@ func (e LeaderHealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckRequestValidationError{}
@@ -830,8 +824,7 @@ func (e LeaderHealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckResponseValidationError{}
@@ -937,8 +930,7 @@ func (e CheckUpdatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesRequestValidationError{}
@@ -1077,8 +1069,7 @@ func (e DockerVersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DockerVersionInfoValidationError{}
@@ -1271,8 +1262,7 @@ func (e CheckUpdatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesResponseValidationError{}
@@ -1374,8 +1364,7 @@ func (e ListChangeLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsRequestValidationError{}
@@ -1540,8 +1529,7 @@ func (e ListChangeLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsResponseValidationError{}
@@ -1645,8 +1633,7 @@ func (e StartUpdateRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartUpdateRequestValidationError{}
@@ -1752,8 +1739,7 @@ func (e StartUpdateResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartUpdateResponseValidationError{}
@@ -1859,8 +1845,7 @@ func (e UpdateStatusRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateStatusRequestValidationError{}
@@ -1966,8 +1951,7 @@ func (e UpdateStatusResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateStatusResponseValidationError{}
@@ -2156,8 +2140,7 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsResolutionsValidationError{}
@@ -2346,8 +2329,7 @@ func (e AdvisorRunIntervalsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorRunIntervalsValidationError{}
@@ -2588,8 +2570,7 @@ func (e SettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SettingsValidationError{}
@@ -2705,8 +2686,7 @@ func (e ReadOnlySettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadOnlySettingsValidationError{}
@@ -2808,8 +2788,7 @@ func (e GetSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsRequestValidationError{}
@@ -2911,8 +2890,7 @@ func (e GetReadOnlySettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsRequestValidationError{}
@@ -3043,8 +3021,7 @@ func (e GetSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsResponseValidationError{}
@@ -3176,8 +3153,7 @@ func (e GetReadOnlySettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsResponseValidationError{}
@@ -3341,6 +3317,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 	}
 
 	if m.AwsPartitions != nil {
+
 		if all {
 			switch v := interface{}(m.GetAwsPartitions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -3369,6 +3346,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnableAdvisor != nil {
@@ -3466,8 +3444,7 @@ func (e ChangeSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsRequestValidationError{}
@@ -3598,8 +3575,7 @@ func (e ChangeSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsResponseValidationError{}

--- a/api/server/v1/server.swagger.json
+++ b/api/server/v1/server.swagger.json
@@ -1,0 +1,798 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "server/v1/server.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "ServerService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/server/leaderHealthCheck": {
+      "get": {
+        "summary": "Check Leadership",
+        "description": "Checks if the instance is the leader in a cluster. Returns an error if the instance isn't the leader.",
+        "operationId": "LeaderHealthCheck",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1LeaderHealthCheckResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/readyz": {
+      "get": {
+        "summary": "Check server readiness",
+        "description": "Returns an error when Server components being restarted are not ready yet. Use this API for checking the health of Docker containers and for probing Kubernetes readiness.",
+        "operationId": "Readiness",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ReadinessResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/settings": {
+      "get": {
+        "summary": "Get settings",
+        "description": "Returns current PMM Server settings.",
+        "operationId": "GetSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetSettingsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ServerService"
+        ]
+      },
+      "put": {
+        "summary": "Change settings",
+        "description": "Changes PMM Server settings.",
+        "operationId": "ChangeSettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeSettingsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1ChangeSettingsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/settings/readonly": {
+      "get": {
+        "summary": "Get read-only settings",
+        "description": "Returns a stripped version of PMM Server settings.",
+        "operationId": "GetReadOnlySettings",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetReadOnlySettingsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/updates": {
+      "get": {
+        "summary": "Check updates",
+        "description": "Checks for available PMM Server updates.",
+        "operationId": "CheckUpdates",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CheckUpdatesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "force",
+            "description": "If false, cached information may be returned.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "only_installed_version",
+            "description": "If true, only installed version will be in response.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/updates/changelogs": {
+      "get": {
+        "summary": "Get the changelog",
+        "description": "Display a changelog comparing the installed version to the latest available version.",
+        "operationId": "ListChangeLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListChangeLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/updates:getStatus": {
+      "post": {
+        "summary": "Update status",
+        "description": "Returns PMM Server update status.",
+        "operationId": "UpdateStatus",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateStatusResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateStatusRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/updates:start": {
+      "post": {
+        "summary": "Start update",
+        "description": "Starts PMM Server update.",
+        "operationId": "StartUpdate",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartUpdateResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartUpdateRequest"
+            }
+          }
+        ],
+        "tags": [
+          "ServerService"
+        ]
+      }
+    },
+    "/v1/server/version": {
+      "get": {
+        "summary": "Version",
+        "description": "Returns PMM Server versions.",
+        "operationId": "Version",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1VersionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "dummy",
+            "description": "Dummy parameter for internal testing. Do not use.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "ServerService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "commonStringArray": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "A wrapper for a string array. This type allows to distinguish between an empty array and a null value."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "description": "A URL/resource name that uniquely identifies the type of the serialized\nprotocol buffer message. This string must contain at least\none \"/\" character. The last segment of the URL's path must represent\nthe fully qualified name of the type (as in\n`path/google.protobuf.Duration`). The name should be in a canonical form\n(e.g., leading \".\" is not accepted).\n\nIn practice, teams usually precompile into the binary all types that they\nexpect it to use in the context of Any. However, for URLs which use the\nscheme `http`, `https`, or no scheme, one can optionally set up a type\nserver that maps type URLs to message definitions as follows:\n\n* If no scheme is provided, `https` is assumed.\n* An HTTP GET on the URL must yield a [google.protobuf.Type][]\n  value in binary format, or produce an error.\n* Applications are allowed to cache lookup results based on the\n  URL, or have them precompiled into a binary to avoid any\n  lookup. Therefore, binary compatibility needs to be preserved\n  on changes to types. (Use versioned type names to manage\n  breaking changes.)\n\nNote: this functionality is not currently available in the official\nprotobuf release, and it is not used for type URLs beginning with\ntype.googleapis.com. As of May 2023, there are no widely used type server\nimplementations and no plans to implement one.\n\nSchemes other than `http`, `https` (or the empty scheme) might be\nused with implementation specific semantics."
+        }
+      },
+      "additionalProperties": {},
+      "description": "`Any` contains an arbitrary serialized protocol buffer message along with a\nURL that describes the type of the serialized message.\n\nProtobuf library provides support to pack/unpack Any values in the form\nof utility functions or additional generated methods of the Any type.\n\nExample 1: Pack and unpack a message in C++.\n\n    Foo foo = ...;\n    Any any;\n    any.PackFrom(foo);\n    ...\n    if (any.UnpackTo(\u0026foo)) {\n      ...\n    }\n\nExample 2: Pack and unpack a message in Java.\n\n    Foo foo = ...;\n    Any any = Any.pack(foo);\n    ...\n    if (any.is(Foo.class)) {\n      foo = any.unpack(Foo.class);\n    }\n    // or ...\n    if (any.isSameTypeAs(Foo.getDefaultInstance())) {\n      foo = any.unpack(Foo.getDefaultInstance());\n    }\n\n Example 3: Pack and unpack a message in Python.\n\n    foo = Foo(...)\n    any = Any()\n    any.Pack(foo)\n    ...\n    if any.Is(Foo.DESCRIPTOR):\n      any.Unpack(foo)\n      ...\n\n Example 4: Pack and unpack a message in Go\n\n     foo := \u0026pb.Foo{...}\n     any, err := anypb.New(foo)\n     if err != nil {\n       ...\n     }\n     ...\n     foo := \u0026pb.Foo{}\n     if err := any.UnmarshalTo(foo); err != nil {\n       ...\n     }\n\nThe pack methods provided by protobuf library will by default use\n'type.googleapis.com/full.type.name' as the type URL and the unpack\nmethods only use the fully qualified type name after the last '/'\nin the type URL, for example \"foo.bar.com/x/y.z\" will yield type\nname \"y.z\".\n\nJSON\n====\nThe JSON representation of an `Any` value uses the regular\nrepresentation of the deserialized, embedded message, with an\nadditional field `@type` which contains the type URL. Example:\n\n    package google.profile;\n    message Person {\n      string first_name = 1;\n      string last_name = 2;\n    }\n\n    {\n      \"@type\": \"type.googleapis.com/google.profile.Person\",\n      \"firstName\": \u003cstring\u003e,\n      \"lastName\": \u003cstring\u003e\n    }\n\nIf the embedded message type is well-known and has a custom JSON\nrepresentation, that representation will be embedded adding a field\n`value` which holds the custom JSON in addition to the `@type`\nfield. Example (for message [google.protobuf.Duration][]):\n\n    {\n      \"@type\": \"type.googleapis.com/google.protobuf.Duration\",\n      \"value\": \"1.212s\"\n    }"
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AdvisorRunIntervals": {
+      "type": "object",
+      "properties": {
+        "standard_interval": {
+          "type": "string",
+          "description": "Standard check interval."
+        },
+        "rare_interval": {
+          "type": "string",
+          "description": "Interval for rare check runs."
+        },
+        "frequent_interval": {
+          "type": "string",
+          "description": "Interval for frequent check runs."
+        }
+      },
+      "description": "AdvisorRunIntervals represents intervals between each run of Advisor checks."
+    },
+    "v1ChangeSettingsRequest": {
+      "type": "object",
+      "properties": {
+        "enable_updates": {
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "enable_telemetry": {
+          "type": "boolean",
+          "x-nullable": true
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/v1MetricsResolutions"
+        },
+        "data_retention": {
+          "type": "string",
+          "description": "A number of full days for Prometheus and QAN data retention. Should have a suffix in JSON: 2592000s, 43200m, 720h."
+        },
+        "ssh_key": {
+          "type": "string",
+          "x-nullable": true
+        },
+        "aws_partitions": {
+          "$ref": "#/definitions/commonStringArray",
+          "x-nullable": true
+        },
+        "enable_advisor": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable Advisor."
+        },
+        "enable_alerting": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable Alerting."
+        },
+        "pmm_public_address": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PMM Server public address."
+        },
+        "advisor_run_intervals": {
+          "$ref": "#/definitions/v1AdvisorRunIntervals",
+          "description": "Intervals between Advisor runs."
+        },
+        "enable_azurediscover": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable Azure Discover."
+        },
+        "enable_backup_management": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable Backup Management."
+        },
+        "enable_access_control": {
+          "type": "boolean",
+          "x-nullable": true,
+          "title": "Enable Access Control"
+        },
+        "enable_internal_pg_qan": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable Query Analytics for PMM's internal PG database."
+        },
+        "update_snooze_duration": {
+          "type": "string",
+          "description": "A number of full days for which an update is snoozed, i.e. a multiple of 24h: 2592000s, 43200m, 720h."
+        }
+      }
+    },
+    "v1ChangeSettingsResponse": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "$ref": "#/definitions/v1Settings"
+        }
+      }
+    },
+    "v1CheckUpdatesResponse": {
+      "type": "object",
+      "properties": {
+        "installed": {
+          "$ref": "#/definitions/v1VersionInfo",
+          "description": "Currently installed PMM Server version."
+        },
+        "latest": {
+          "$ref": "#/definitions/v1DockerVersionInfo",
+          "description": "Latest available PMM Server version."
+        },
+        "update_available": {
+          "type": "boolean",
+          "description": "True if there is a PMM Server update available."
+        },
+        "latest_news_url": {
+          "type": "string",
+          "description": "Latest available PMM Server release announcement URL."
+        },
+        "last_check": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last check time."
+        }
+      }
+    },
+    "v1DistributionMethod": {
+      "type": "string",
+      "enum": [
+        "DISTRIBUTION_METHOD_UNSPECIFIED",
+        "DISTRIBUTION_METHOD_DOCKER",
+        "DISTRIBUTION_METHOD_OVF",
+        "DISTRIBUTION_METHOD_AMI",
+        "DISTRIBUTION_METHOD_AZURE",
+        "DISTRIBUTION_METHOD_DO"
+      ],
+      "default": "DISTRIBUTION_METHOD_UNSPECIFIED",
+      "description": "DistributionMethod defines PMM Server distribution method: Docker image, OVF/OVA, or AMI."
+    },
+    "v1DockerVersionInfo": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "PMM Version."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Docker image tag."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Release date."
+        },
+        "release_notes_url": {
+          "type": "string",
+          "description": "Release notes URL for the version (if available)."
+        },
+        "release_notes_text": {
+          "type": "string",
+          "description": "Release notes text for the version (if available)."
+        }
+      }
+    },
+    "v1GetReadOnlySettingsResponse": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "$ref": "#/definitions/v1ReadOnlySettings"
+        }
+      }
+    },
+    "v1GetSettingsResponse": {
+      "type": "object",
+      "properties": {
+        "settings": {
+          "$ref": "#/definitions/v1Settings"
+        }
+      }
+    },
+    "v1LeaderHealthCheckResponse": {
+      "type": "object",
+      "description": "This probe is available without authentication, so it should not contain any data."
+    },
+    "v1ListChangeLogsResponse": {
+      "type": "object",
+      "properties": {
+        "updates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1DockerVersionInfo"
+          },
+          "description": "List of available updates."
+        },
+        "last_check": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last check time."
+        }
+      }
+    },
+    "v1MetricsResolutions": {
+      "type": "object",
+      "properties": {
+        "hr": {
+          "type": "string",
+          "description": "High resolution. Should have a suffix in JSON: 1s, 1m, 1h."
+        },
+        "mr": {
+          "type": "string",
+          "description": "Medium resolution. Should have a suffix in JSON: 1s, 1m, 1h."
+        },
+        "lr": {
+          "type": "string",
+          "description": "Low resolution. Should have a suffix in JSON: 1s, 1m, 1h."
+        }
+      },
+      "description": "MetricsResolutions represents Prometheus exporters metrics resolutions."
+    },
+    "v1ReadOnlySettings": {
+      "type": "object",
+      "properties": {
+        "updates_enabled": {
+          "type": "boolean",
+          "description": "True if updates are enabled."
+        },
+        "telemetry_enabled": {
+          "type": "boolean",
+          "description": "True if telemetry is enabled."
+        },
+        "advisor_enabled": {
+          "type": "boolean",
+          "description": "True if Advisor is enabled."
+        },
+        "alerting_enabled": {
+          "type": "boolean",
+          "description": "True if Alerting is enabled."
+        },
+        "pmm_public_address": {
+          "type": "string",
+          "description": "PMM Server public address."
+        },
+        "backup_management_enabled": {
+          "type": "boolean",
+          "description": "True if Backup Management is enabled."
+        },
+        "azurediscover_enabled": {
+          "type": "boolean",
+          "description": "True if Azure Discover is enabled."
+        },
+        "enable_access_control": {
+          "type": "boolean",
+          "description": "True if Access Control is enabled."
+        }
+      },
+      "description": "ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles."
+    },
+    "v1ReadinessResponse": {
+      "type": "object",
+      "description": "This probe is available without authentication, so it should not contain any data."
+    },
+    "v1Settings": {
+      "type": "object",
+      "properties": {
+        "updates_enabled": {
+          "type": "boolean",
+          "description": "True if updates are enabled."
+        },
+        "telemetry_enabled": {
+          "type": "boolean",
+          "description": "True if telemetry is enabled."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/v1MetricsResolutions"
+        },
+        "data_retention": {
+          "type": "string"
+        },
+        "ssh_key": {
+          "type": "string"
+        },
+        "aws_partitions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "advisor_enabled": {
+          "type": "boolean",
+          "description": "True if Advisor is enabled."
+        },
+        "platform_email": {
+          "type": "string"
+        },
+        "alerting_enabled": {
+          "type": "boolean",
+          "description": "True if Alerting is enabled."
+        },
+        "pmm_public_address": {
+          "type": "string",
+          "description": "PMM Server public address."
+        },
+        "advisor_run_intervals": {
+          "$ref": "#/definitions/v1AdvisorRunIntervals",
+          "description": "Intervals between Advisor runs."
+        },
+        "backup_management_enabled": {
+          "type": "boolean",
+          "description": "True if Backup Management is enabled."
+        },
+        "azurediscover_enabled": {
+          "type": "boolean",
+          "description": "True if Azure Discover is enabled."
+        },
+        "connected_to_platform": {
+          "type": "boolean",
+          "title": "True if the PMM instance is connected to Platform"
+        },
+        "telemetry_summaries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Includes list of collected telemetry"
+        },
+        "enable_access_control": {
+          "type": "boolean",
+          "description": "True if Access Control is enabled."
+        },
+        "default_role_id": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Default Access Control role ID for new users."
+        },
+        "enable_internal_pg_qan": {
+          "type": "boolean",
+          "description": "True if Query Analytics for PMM's internal PG database is enabled."
+        },
+        "update_snooze_duration": {
+          "type": "string",
+          "title": "Duration for which an update is snoozed"
+        }
+      },
+      "description": "Settings represents PMM Server settings."
+    },
+    "v1StartUpdateRequest": {
+      "type": "object",
+      "properties": {
+        "new_image": {
+          "type": "string"
+        }
+      }
+    },
+    "v1StartUpdateResponse": {
+      "type": "object",
+      "properties": {
+        "auth_token": {
+          "type": "string",
+          "description": "Authentication token for getting update statuses."
+        },
+        "log_offset": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Progress log offset."
+        }
+      }
+    },
+    "v1UpdateStatusRequest": {
+      "type": "object",
+      "properties": {
+        "auth_token": {
+          "type": "string",
+          "description": "Authentication token."
+        },
+        "log_offset": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Progress log offset."
+        }
+      }
+    },
+    "v1UpdateStatusResponse": {
+      "type": "object",
+      "properties": {
+        "log_lines": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Progress log lines."
+        },
+        "log_offset": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Progress log offset for the next request."
+        },
+        "done": {
+          "type": "boolean",
+          "description": "True when update is done."
+        }
+      }
+    },
+    "v1VersionInfo": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "User-visible version."
+        },
+        "full_version": {
+          "type": "string",
+          "description": "Full version for debugging."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Build or release date."
+        }
+      },
+      "description": "VersionInfo describes component version, or PMM Server as a whole."
+    },
+    "v1VersionResponse": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "PMM Server version."
+        },
+        "server": {
+          "$ref": "#/definitions/v1VersionInfo",
+          "description": "Detailed PMM Server version information."
+        },
+        "managed": {
+          "$ref": "#/definitions/v1VersionInfo",
+          "description": "pmm-managed version information for debugging."
+        },
+        "distribution_method": {
+          "$ref": "#/definitions/v1DistributionMethod",
+          "description": "PMM Server distribution method.\n\nTODO Versions and statuses of Grafana, Prometheus, PostgreSQL, qan-api2, ClickHouse, pmm-agent, etc."
+        }
+      }
+    }
+  }
+}

--- a/api/server/v1/server_grpc.pb.go
+++ b/api/server/v1/server_grpc.pb.go
@@ -8,7 +8,6 @@ package serverv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -209,39 +208,30 @@ type UnimplementedServerServiceServer struct{}
 func (UnimplementedServerServiceServer) Version(context.Context, *VersionRequest) (*VersionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Version not implemented")
 }
-
 func (UnimplementedServerServiceServer) Readiness(context.Context, *ReadinessRequest) (*ReadinessResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Readiness not implemented")
 }
-
 func (UnimplementedServerServiceServer) LeaderHealthCheck(context.Context, *LeaderHealthCheckRequest) (*LeaderHealthCheckResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method LeaderHealthCheck not implemented")
 }
-
 func (UnimplementedServerServiceServer) CheckUpdates(context.Context, *CheckUpdatesRequest) (*CheckUpdatesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CheckUpdates not implemented")
 }
-
 func (UnimplementedServerServiceServer) ListChangeLogs(context.Context, *ListChangeLogsRequest) (*ListChangeLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListChangeLogs not implemented")
 }
-
 func (UnimplementedServerServiceServer) StartUpdate(context.Context, *StartUpdateRequest) (*StartUpdateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartUpdate not implemented")
 }
-
 func (UnimplementedServerServiceServer) UpdateStatus(context.Context, *UpdateStatusRequest) (*UpdateStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateStatus not implemented")
 }
-
 func (UnimplementedServerServiceServer) GetSettings(context.Context, *GetSettingsRequest) (*GetSettingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetSettings not implemented")
 }
-
 func (UnimplementedServerServiceServer) GetReadOnlySettings(context.Context, *GetReadOnlySettingsRequest) (*GetReadOnlySettingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetReadOnlySettings not implemented")
 }
-
 func (UnimplementedServerServiceServer) ChangeSettings(context.Context, *ChangeSettingsRequest) (*ChangeSettingsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeSettings not implemented")
 }

--- a/api/user/v1/user.pb.go
+++ b/api/user/v1/user.pb.go
@@ -7,15 +7,14 @@
 package userv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -494,20 +493,17 @@ func file_user_v1_user_proto_rawDescGZIP() []byte {
 	return file_user_v1_user_proto_rawDescData
 }
 
-var (
-	file_user_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-	file_user_v1_user_proto_goTypes  = []any{
-		(*GetUserRequest)(nil),               // 0: user.v1.GetUserRequest
-		(*GetUserResponse)(nil),              // 1: user.v1.GetUserResponse
-		(*UpdateUserRequest)(nil),            // 2: user.v1.UpdateUserRequest
-		(*UpdateUserResponse)(nil),           // 3: user.v1.UpdateUserResponse
-		(*ListUsersRequest)(nil),             // 4: user.v1.ListUsersRequest
-		(*ListUsersResponse)(nil),            // 5: user.v1.ListUsersResponse
-		(*ListUsersResponse_UserDetail)(nil), // 6: user.v1.ListUsersResponse.UserDetail
-		(*timestamppb.Timestamp)(nil),        // 7: google.protobuf.Timestamp
-	}
-)
-
+var file_user_v1_user_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_user_v1_user_proto_goTypes = []any{
+	(*GetUserRequest)(nil),               // 0: user.v1.GetUserRequest
+	(*GetUserResponse)(nil),              // 1: user.v1.GetUserResponse
+	(*UpdateUserRequest)(nil),            // 2: user.v1.UpdateUserRequest
+	(*UpdateUserResponse)(nil),           // 3: user.v1.UpdateUserResponse
+	(*ListUsersRequest)(nil),             // 4: user.v1.ListUsersRequest
+	(*ListUsersResponse)(nil),            // 5: user.v1.ListUsersResponse
+	(*ListUsersResponse_UserDetail)(nil), // 6: user.v1.ListUsersResponse.UserDetail
+	(*timestamppb.Timestamp)(nil),        // 7: google.protobuf.Timestamp
+}
 var file_user_v1_user_proto_depIdxs = []int32{
 	7, // 0: user.v1.GetUserResponse.snoozed_at:type_name -> google.protobuf.Timestamp
 	7, // 1: user.v1.UpdateUserResponse.snoozed_at:type_name -> google.protobuf.Timestamp

--- a/api/user/v1/user.pb.validate.go
+++ b/api/user/v1/user.pb.validate.go
@@ -122,8 +122,7 @@ func (e GetUserRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetUserRequestValidationError{}
@@ -262,8 +261,7 @@ func (e GetUserResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetUserResponseValidationError{}
@@ -377,8 +375,7 @@ func (e UpdateUserRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateUserRequestValidationError{}
@@ -519,8 +516,7 @@ func (e UpdateUserResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = UpdateUserResponseValidationError{}
@@ -620,8 +616,7 @@ func (e ListUsersRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListUsersRequestValidationError{}
@@ -757,8 +752,7 @@ func (e ListUsersResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListUsersResponseValidationError{}
@@ -863,8 +857,7 @@ func (e ListUsersResponse_UserDetailValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListUsersResponse_UserDetailValidationError{}

--- a/api/user/v1/user.swagger.json
+++ b/api/user/v1/user.swagger.json
@@ -1,0 +1,243 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "User API",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "UserService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/users": {
+      "get": {
+        "summary": "List all users",
+        "description": "Retrieve user details for all users from PMM server",
+        "operationId": "ListUsers",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListUsersResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      }
+    },
+    "/v1/users/me": {
+      "get": {
+        "summary": "Get user details",
+        "description": "Retrieve user details from PMM server",
+        "operationId": "GetUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "UserService"
+        ]
+      },
+      "put": {
+        "summary": "Update a user",
+        "description": "Update user details in PMM server",
+        "operationId": "UpdateUser",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1UpdateUserRequest"
+            }
+          }
+        ],
+        "tags": [
+          "UserService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ListUsersResponseUserDetail": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "role_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "description": "List of role IDs assigned to the user."
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1GetUserResponse": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "format": "int64",
+          "title": "User ID"
+        },
+        "product_tour_completed": {
+          "type": "boolean",
+          "title": "Product Tour"
+        },
+        "alerting_tour_completed": {
+          "type": "boolean",
+          "title": "Alerting Tour"
+        },
+        "snoozed_pmm_version": {
+          "type": "string",
+          "title": "Snoozed PMM version update"
+        },
+        "snoozed_at": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp of last snooze"
+        },
+        "snooze_count": {
+          "type": "integer",
+          "format": "int64",
+          "title": "Number of times the update was snoozed"
+        }
+      }
+    },
+    "v1ListUsersResponse": {
+      "type": "object",
+      "properties": {
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/ListUsersResponseUserDetail"
+          }
+        }
+      }
+    },
+    "v1UpdateUserRequest": {
+      "type": "object",
+      "properties": {
+        "product_tour_completed": {
+          "type": "boolean",
+          "x-nullable": true,
+          "title": "Product Tour"
+        },
+        "alerting_tour_completed": {
+          "type": "boolean",
+          "x-nullable": true,
+          "title": "Alerting Tour"
+        },
+        "snoozed_pmm_version": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Snooze update alert for a PMM version"
+        }
+      }
+    },
+    "v1UpdateUserResponse": {
+      "type": "object",
+      "properties": {
+        "user_id": {
+          "type": "integer",
+          "format": "int64",
+          "title": "User ID"
+        },
+        "product_tour_completed": {
+          "type": "boolean",
+          "title": "Product Tour"
+        },
+        "alerting_tour_completed": {
+          "type": "boolean",
+          "title": "Alerting Tour"
+        },
+        "snoozed_pmm_version": {
+          "type": "string",
+          "title": "Snooze update alert for a PMM version"
+        },
+        "snoozed_at": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Timestamp of last snooze"
+        },
+        "snooze_count": {
+          "type": "integer",
+          "format": "int64",
+          "title": "Number of times the update was snoozed"
+        }
+      }
+    }
+  }
+}

--- a/api/user/v1/user_grpc.pb.go
+++ b/api/user/v1/user_grpc.pb.go
@@ -8,7 +8,6 @@ package userv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -96,11 +95,9 @@ type UnimplementedUserServiceServer struct{}
 func (UnimplementedUserServiceServer) GetUser(context.Context, *GetUserRequest) (*GetUserResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetUser not implemented")
 }
-
 func (UnimplementedUserServiceServer) UpdateUser(context.Context, *UpdateUserRequest) (*UpdateUserResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method UpdateUser not implemented")
 }
-
 func (UnimplementedUserServiceServer) ListUsers(context.Context, *ListUsersRequest) (*ListUsersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUsers not implemented")
 }

--- a/managed/models/agent_helpers.go
+++ b/managed/models/agent_helpers.go
@@ -362,6 +362,7 @@ func FindDBConfigForService(q *reform.Querier, serviceID string) (*DBConfig, err
 			PostgresExporterType,
 			QANPostgreSQLPgStatementsAgentType,
 			QANPostgreSQLPgStatMonitorAgentType,
+			RTAPostgreSQLAgentType,
 		}
 	case MongoDBServiceType:
 		agentTypes = []AgentType{
@@ -875,6 +876,9 @@ func compatibleServiceAndAgent(serviceType ServiceType, agentType AgentType) boo
 		RTAMongoDBAgentType: {
 			MongoDBServiceType,
 		},
+		RTAPostgreSQLAgentType: {
+			PostgreSQLServiceType,
+		},
 		PostgresExporterType: {
 			PostgreSQLServiceType,
 		},
@@ -982,7 +986,7 @@ func CreateAgent(q *reform.Querier, agentType AgentType, params *CreateAgentPara
 
 	switch agentType {
 	// For the time being only RTA MangoDB Agent has RTA options.
-	case RTAMongoDBAgentType:
+	case RTAMongoDBAgentType, RTAPostgreSQLAgentType:
 		row.RTAOptions = RTAOptions{
 			// default value
 			CollectInterval: new(2 * time.Second), //nolint:mnd

--- a/managed/models/agent_model.go
+++ b/managed/models/agent_model.go
@@ -82,13 +82,14 @@ const (
 	NomadAgentType                      AgentType = "nomad-agent"
 	ValkeyExporterType                  AgentType = "valkey_exporter"
 	RTAMongoDBAgentType                 AgentType = "rta-mongodb-agent"
+	RTAPostgreSQLAgentType              AgentType = "rta-postgresql-agent"
 )
 
 // GetRTAAgentTypes returns all Real-Time Analytics Agent types.
 func GetRTAAgentTypes() []AgentType {
 	return []AgentType{
 		RTAMongoDBAgentType,
-		// Add more types here once they are implemented.
+		RTAPostgreSQLAgentType,
 	}
 }
 
@@ -721,7 +722,7 @@ func (a *Agent) DSN(service *Service, dsnParams DSNParams, tdp *DelimiterPair, p
 		dsn = strings.ReplaceAll(dsn, url.QueryEscape(tdp.Right), tdp.Right)
 		return dsn
 
-	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType:
+	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType, RTAPostgreSQLAgentType:
 		q := make(url.Values)
 
 		sslmode := DisableSSLMode
@@ -931,7 +932,7 @@ func (a Agent) Files() map[string]string { //nolint:gocognit
 		}
 
 		return nil
-	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType:
+	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType, RTAPostgreSQLAgentType:
 		files := make(map[string]string)
 
 		if a.PostgreSQLOptions.SSLCa != "" {

--- a/managed/models/dsn_helpers.go
+++ b/managed/models/dsn_helpers.go
@@ -63,6 +63,7 @@ func FindDSNByServiceIDandPMMAgentID(q *reform.Querier, serviceID, pmmAgentID, d
 			QANPostgreSQLPgStatementsAgentType,
 			QANPostgreSQLPgStatMonitorAgentType,
 			PostgresExporterType,
+			RTAPostgreSQLAgentType,
 		)
 		dsnParams.PostgreSQLSupportsSSLSNI, err = IsPostgreSQLSSLSniSupported(q, pmmAgentID)
 		if err != nil {

--- a/managed/services/agents/postgresql.go
+++ b/managed/services/agents/postgresql.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	agentv1 "github.com/percona/pmm/api/agent/v1"
 	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
@@ -214,6 +215,34 @@ func qanPostgreSQLPgStatMonitorAgentConfig(service *models.Service, agent *model
 		DisableQueryExamples:   agent.QANOptions.QueryExamplesDisabled,
 		MaxQueryLength:         agent.QANOptions.MaxQueryLength,
 		DisableCommentsParsing: agent.QANOptions.CommentsParsingDisabled,
+		TextFiles: &agentv1.TextFiles{
+			Files:              agent.Files(),
+			TemplateLeftDelim:  tdp.Left,
+			TemplateRightDelim: tdp.Right,
+		},
+	}
+}
+
+// rtaPostgreSQLAgentConfig returns desired configuration of rta-postgresql-agent RTA agent.
+func rtaPostgreSQLAgentConfig(service *models.Service, agent *models.Agent, pmmAgentVersion *version.Parsed) *agentv1.SetStateRequest_BuiltinAgent {
+	tdp := agent.TemplateDelimiters(service)
+	dsnParams := models.DSNParams{
+		DialTimeout:              5 * time.Second,
+		Database:                 service.DatabaseName,
+		PostgreSQLSupportsSSLSNI: !pmmAgentVersion.Less(postgresSSLSniVersion),
+	}
+
+	apiRTAOptions := &inventoryv1.RTAOptions{}
+	if agent.RTAOptions.CollectInterval != nil {
+		apiRTAOptions.CollectInterval = durationpb.New(*agent.RTAOptions.CollectInterval)
+	}
+
+	return &agentv1.SetStateRequest_BuiltinAgent{
+		Type:        inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT,
+		Dsn:         agent.DSN(service, dsnParams, nil, pmmAgentVersion),
+		RtaOptions:  apiRTAOptions,
+		ServiceId:   service.ServiceID,
+		ServiceName: service.ServiceName,
 		TextFiles: &agentv1.TextFiles{
 			Files:              agent.Files(),
 			TemplateLeftDelim:  tdp.Left,

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -243,7 +243,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			models.ValkeyExporterType, models.QANMySQLPerfSchemaAgentType, models.QANMySQLSlowlogAgentType,
 			models.QANMongoDBProfilerAgentType, models.QANMongoDBMongologAgentType,
 			models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType,
-			models.RTAMongoDBAgentType:
+			models.RTAMongoDBAgentType, models.RTAPostgreSQLAgentType:
 			service, err := models.FindServiceByID(u.db.Querier, pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
@@ -286,6 +286,8 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 				builtinAgents[row.AgentID] = qanPostgreSQLPgStatMonitorAgentConfig(service, row, pmmAgentVersion)
 			case models.RTAMongoDBAgentType:
 				builtinAgents[row.AgentID] = rtaMongoDBAgentConfig(service, row, pmmAgentVersion)
+			case models.RTAPostgreSQLAgentType:
+				builtinAgents[row.AgentID] = rtaPostgreSQLAgentConfig(service, row, pmmAgentVersion)
 			}
 
 		default:

--- a/managed/services/converters.go
+++ b/managed/services/converters.go
@@ -605,6 +605,20 @@ func ToAPIAgent(q *reform.Querier, agent *models.Agent) (inventoryv1.Agent, erro
 			LogLevel:      inventoryv1.LogLevelAPIValue(agent.LogLevel),
 			RtaOptions:    ToAPIRTAOptions(&agent.RTAOptions),
 		}, nil
+	case models.RTAPostgreSQLAgentType:
+		return &inventoryv1.RTAPostgreSQLAgent{
+			AgentId:       agent.AgentID,
+			PmmAgentId:    pointer.GetString(agent.PMMAgentID),
+			ServiceId:     serviceID,
+			Username:      pointer.GetString(agent.Username),
+			Disabled:      agent.Disabled,
+			Status:        inventoryv1.AgentStatus(inventoryv1.AgentStatus_value[agent.Status]),
+			CustomLabels:  labels,
+			Tls:           agent.TLS,
+			TlsSkipVerify: agent.TLSSkipVerify,
+			LogLevel:      inventoryv1.LogLevelAPIValue(agent.LogLevel),
+			RtaOptions:    ToAPIRTAOptions(&agent.RTAOptions),
+		}, nil
 
 	default:
 		panic(fmt.Errorf("cannot convert unknown agent type %s", agent.AgentType))

--- a/managed/services/inventory/agents.go
+++ b/managed/services/inventory/agents.go
@@ -1914,6 +1914,116 @@ func (as *AgentsService) ChangeRTAMongoDBAgent(
 	return res, nil
 }
 
+// AddRTAPostgreSQLAgent adds PostgreSQL Real-Time Analytics Agent.
+func (as *AgentsService) AddRTAPostgreSQLAgent(ctx context.Context, p *inventoryv1.AddRTAPostgreSQLAgentParams) (*inventoryv1.AddAgentResponse, error) {
+	var agent *inventoryv1.RTAPostgreSQLAgent
+
+	pgOptions := models.PostgreSQLOptions{
+		SSLCa:   p.GetTlsCa(),
+		SSLCert: p.GetTlsCert(),
+		SSLKey:  p.GetTlsKey(),
+	}
+
+	e := as.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		params := &models.CreateAgentParams{
+			PMMAgentID:        p.PmmAgentId,
+			ServiceID:         p.ServiceId,
+			Username:          p.Username,
+			Password:          p.Password,
+			CustomLabels:      p.CustomLabels,
+			TLS:               p.Tls,
+			TLSSkipVerify:     p.TlsSkipVerify,
+			PostgreSQLOptions: pgOptions,
+			LogLevel:          services.SpecifyLogLevel(p.LogLevel, inventoryv1.LogLevel_LOG_LEVEL_FATAL),
+		}
+
+		if p.RtaOptions != nil {
+			params.RTAOptions = *models.RTAOptionsFromRequest(p.RtaOptions)
+		}
+
+		row, err := models.CreateAgent(tx.Querier, models.RTAPostgreSQLAgentType, params)
+		if err != nil {
+			return err
+		}
+
+		if !p.SkipConnectionCheck {
+			service, err := models.FindServiceByID(tx.Querier, p.ServiceId)
+			if err != nil {
+				return err
+			}
+
+			err = as.cc.CheckConnectionToService(ctx, tx.Querier, service, row)
+			if err != nil {
+				return err
+			}
+
+			err = as.sib.GetInfoFromService(ctx, tx.Querier, service, row)
+			if err != nil {
+				return err
+			}
+		}
+
+		aa, err := services.ToAPIAgent(tx.Querier, row)
+		if err != nil {
+			return err
+		}
+
+		agent = aa.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+
+		return nil
+	})
+	if e != nil {
+		return nil, e
+	}
+
+	as.state.RequestStateUpdate(ctx, p.PmmAgentId)
+
+	return &inventoryv1.AddAgentResponse{
+		Agent: &inventoryv1.AddAgentResponse_RtaPostgresqlAgent{
+			RtaPostgresqlAgent: agent,
+		},
+	}, nil
+}
+
+// ChangeRTAPostgreSQLAgent updates PostgreSQL Real-Time Analytics Agent with given parameters.
+func (as *AgentsService) ChangeRTAPostgreSQLAgent(
+	ctx context.Context, agentID string,
+	p *inventoryv1.ChangeRTAPostgreSQLAgentParams,
+) (*inventoryv1.ChangeAgentResponse, error) {
+	changeParams := &models.ChangeAgentParams{
+		Enabled:       p.Enable,
+		Username:      p.Username,
+		Password:      p.Password,
+		TLS:           p.Tls,
+		TLSSkipVerify: p.TlsSkipVerify,
+		LogLevel:      convertLogLevel(p.LogLevel),
+		CustomLabels:  convertCustomLabels(p.CustomLabels),
+		PostgreSQLOptions: &models.ChangePostgreSQLOptions{
+			SSLCa:   p.TlsCa,
+			SSLCert: p.TlsCert,
+			SSLKey:  p.TlsKey,
+		},
+	}
+
+	if p.RtaOptions != nil {
+		changeParams.RTAOptions = models.RTAOptionsFromRequest(p.RtaOptions)
+	}
+
+	ag, err := as.executeAgentChange(ctx, agentID, changeParams)
+	if err != nil {
+		return nil, err
+	}
+
+	agent := ag.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+	as.state.RequestStateUpdate(ctx, agent.PmmAgentId)
+
+	return &inventoryv1.ChangeAgentResponse{
+		Agent: &inventoryv1.ChangeAgentResponse_RtaPostgresqlAgent{
+			RtaPostgresqlAgent: agent,
+		},
+	}, nil
+}
+
 // Remove removes Agent, and sends state update to pmm-agent, or kicks it.
 func (as *AgentsService) Remove(ctx context.Context, id string, force bool) error {
 	var removedAgent *models.Agent

--- a/managed/services/inventory/grpc/agents_server.go
+++ b/managed/services/inventory/grpc/agents_server.go
@@ -58,6 +58,7 @@ var agentTypes = map[inventoryv1.AgentType]models.AgentType{
 	inventoryv1.AgentType_AGENT_TYPE_VM_AGENT:                           models.VMAgentType,
 	inventoryv1.AgentType_AGENT_TYPE_NOMAD_AGENT:                        models.NomadAgentType,
 	inventoryv1.AgentType_AGENT_TYPE_RTA_MONGODB_AGENT:                  models.RTAMongoDBAgentType,
+	inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT:               models.RTAPostgreSQLAgentType,
 }
 
 func agentType(req *inventoryv1.ListAgentsRequest) *models.AgentType {
@@ -121,6 +122,8 @@ func (s *agentsServer) ListAgents(ctx context.Context, req *inventoryv1.ListAgen
 			res.NomadAgent = append(res.NomadAgent, agent)
 		case *inventoryv1.RTAMongoDBAgent:
 			res.RtaMongodbAgent = append(res.RtaMongodbAgent, agent)
+		case *inventoryv1.RTAPostgreSQLAgent:
+			res.RtaPostgresqlAgent = append(res.RtaPostgresqlAgent, agent)
 		default:
 			panic(fmt.Errorf("unhandled inventory Agent type %T", agent))
 		}
@@ -175,6 +178,8 @@ func (s *agentsServer) GetAgent(ctx context.Context, req *inventoryv1.GetAgentRe
 		res.Agent = &inventoryv1.GetAgentResponse_NomadAgent{NomadAgent: agent}
 	case *inventoryv1.RTAMongoDBAgent:
 		res.Agent = &inventoryv1.GetAgentResponse_RtaMongodbAgent{RtaMongodbAgent: agent}
+	case *inventoryv1.RTAPostgreSQLAgent:
+		res.Agent = &inventoryv1.GetAgentResponse_RtaPostgresqlAgent{RtaPostgresqlAgent: agent}
 	default:
 		panic(fmt.Errorf("unhandled inventory Agent type %T", agent))
 	}
@@ -231,6 +236,8 @@ func (s *agentsServer) AddAgent(ctx context.Context, req *inventoryv1.AddAgentRe
 		return s.s.AddQANPostgreSQLPgStatMonitorAgent(ctx, req.GetQanPostgresqlPgstatmonitorAgent())
 	case *inventoryv1.AddAgentRequest_RtaMongodbAgent:
 		return s.s.AddRTAMongoDBAgent(ctx, req.GetRtaMongodbAgent())
+	case *inventoryv1.AddAgentRequest_RtaPostgresqlAgent:
+		return s.s.AddRTAPostgreSQLAgent(ctx, req.GetRtaPostgresqlAgent())
 	default:
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid agent type %T", req.Agent))
 	}
@@ -275,6 +282,8 @@ func (s *agentsServer) ChangeAgent(ctx context.Context, req *inventoryv1.ChangeA
 		return s.s.ChangeNomadAgent(ctx, agentID, req.GetNomadAgent())
 	case *inventoryv1.ChangeAgentRequest_RtaMongodbAgent:
 		return s.s.ChangeRTAMongoDBAgent(ctx, agentID, req.GetRtaMongodbAgent())
+	case *inventoryv1.ChangeAgentRequest_RtaPostgresqlAgent:
+		return s.s.ChangeRTAPostgreSQLAgent(ctx, agentID, req.GetRtaPostgresqlAgent())
 	default:
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid agent type %T", req.Agent))
 	}

--- a/managed/services/management/agent.go
+++ b/managed/services/management/agent.go
@@ -219,7 +219,7 @@ func (s *ManagementService) agentToAPI(agent *models.Agent) (*managementv1.Unive
 		if len(agent.MySQLOptions.ExtraDSNParams) != 0 {
 			ua.MysqlOptions.ExtraDsnParams = agent.MySQLOptions.ExtraDSNParams
 		}
-	case models.PostgresExporterType, models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType:
+	case models.PostgresExporterType, models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType, models.RTAPostgreSQLAgentType:
 		ua.PostgresqlOptions = &managementv1.UniversalAgent_PostgreSQLOptions{
 			IsSslKeySet:            agent.PostgreSQLOptions.SSLKey != "",
 			AutoDiscoveryLimit:     pointer.GetInt32(agent.PostgreSQLOptions.AutoDiscoveryLimit),

--- a/managed/services/management/postgresql.go
+++ b/managed/services/management/postgresql.go
@@ -165,6 +165,28 @@ func (s *ManagementService) addPostgreSQL(ctx context.Context, req *managementv1
 			postgres.QanPostgresqlPgstatmonitorAgent = agent.(*inventoryv1.QANPostgreSQLPgStatMonitorAgent) //nolint:forcetypeassert
 		}
 
+		if req.RtaPostgresqlAgent {
+			row, err = models.CreateAgent(tx.Querier, models.RTAPostgreSQLAgentType, &models.CreateAgentParams{
+				PMMAgentID:        req.PmmAgentId,
+				ServiceID:         service.ServiceID,
+				Username:          req.Username,
+				Password:          req.Password,
+				TLS:               req.Tls,
+				TLSSkipVerify:     req.TlsSkipVerify,
+				PostgreSQLOptions: models.PostgreSQLOptionsFromRequest(req),
+				LogLevel:          services.SpecifyLogLevel(req.LogLevel, inventoryv1.LogLevel_LOG_LEVEL_FATAL),
+			})
+			if err != nil {
+				return err
+			}
+
+			agent, err = services.ToAPIAgent(tx.Querier, row)
+			if err != nil {
+				return err
+			}
+			postgres.RtaPostgresqlAgent = agent.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+		}
+
 		return nil
 	})
 

--- a/managed/services/realtimeanalytics/service.go
+++ b/managed/services/realtimeanalytics/service.go
@@ -150,13 +150,17 @@ func (s *Service) ListServices(ctx context.Context, req *rtav1.ListServicesReque
 		switch apiSvc := apiSvc.(type) {
 		case *inventoryv1.MongoDBService:
 			res.Mongodb = append(res.Mongodb, apiSvc)
-		// Add other service types once RTA is supported for them
+		case *inventoryv1.PostgreSQLService:
+			res.Postgresql = append(res.Postgresql, apiSvc)
 		default:
 			return nil, fmt.Errorf("unhandled inventory Service type %T", apiSvc)
 		}
 	}
 
 	slices.SortStableFunc(res.Mongodb, func(a, b *inventoryv1.MongoDBService) int {
+		return strings.Compare(a.ServiceName, b.ServiceName)
+	})
+	slices.SortStableFunc(res.Postgresql, func(a, b *inventoryv1.PostgreSQLService) int {
 		return strings.Compare(a.ServiceName, b.ServiceName)
 	})
 
@@ -615,6 +619,8 @@ func getRTAAgentTypeForServiceType(serviceType models.ServiceType) (models.Agent
 	switch serviceType {
 	case models.MongoDBServiceType:
 		return models.RTAMongoDBAgentType, nil
+	case models.PostgreSQLServiceType:
+		return models.RTAPostgreSQLAgentType, nil
 	default:
 		return "", fmt.Errorf("service of type %s does not support Real-Time Analytics", serviceType)
 	}

--- a/managed/services/telemetry/config.default.yml
+++ b/managed/services/telemetry/config.default.yml
@@ -1025,6 +1025,41 @@ telemetry:
       - metric_name: "rta_mongo_agents_disabled"
         column: "agent_count"
 
+  - id: RTAPostgresAgentsRegisteredTotalCount
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent';
+    summary: "Total count of RTA PostgreSQL agents ever registered (including stopped/disabled ones)"
+    data:
+      - metric_name: "rta_postgres_agents_total_count"
+        column: "agent_count"
+
+  - id: RTAPostgresAgentsEnabled
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent'
+        AND disabled = false;
+    summary: "Count of Real-Time Analytics PostgreSQL agents currently enabled (disabled=false)"
+    data:
+      - metric_name: "rta_postgres_agents_enabled"
+        column: "agent_count"
+
+  - id: RTAPostgresAgentsDisabled
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent'
+        AND disabled = true;
+    summary: "Count of Real-Time Analytics PostgreSQL agents currently disabled (disabled=true)"
+    data:
+      - metric_name: "rta_postgres_agents_disabled"
+        column: "agent_count"
+
   # Real-Time Analytics (RTA) agents details
   # Per-agent rows; agent_type is the row marker (consumer assumes 4 lines per agent).
   # COALESCE keeps row alignment when version/collect_interval are NULL (empty values would be dropped by removeEmpty).

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
@@ -1,0 +1,181 @@
+# Design: PostgreSQL Real-Time Query Analytics
+
+## Approach
+
+Extend the existing MongoDB RTA architecture to PostgreSQL by adding a parallel agent type and protobuf payload while reusing server-side session management, in-memory store, and UI shell. The implementation follows established PMM patterns: inventory agent registration → pmm-agent polling loop → gRPC collector stream → `managed/services/realtimeanalytics` store → REST API → React UI.
+
+### Data collection (pmm-agent)
+
+The PostgreSQL RTA agent runs inside pmm-agent and connects using the same DSN/credentials as the PostgreSQL exporter for the monitored service (with optional override via inventory, matching MongoDB RTA behavior).
+
+On each collect interval (default 2s, configurable 1–5s via `RTAOptions.collect_interval`):
+
+1. Query `pg_stat_activity` for non-idle backends (include `idle in transaction` as a distinct state).
+2. Query `pg_locks` joined with `pg_stat_activity` to build blocker → blocked lock chains.
+3. Normalize each active backend into a `QueryData` message with `postgres_payload`.
+4. Send changes over the existing RTA collector gRPC stream (`CollectorService`).
+
+**Primary SQL sources:**
+
+```sql
+-- pg_stat_activity: session identity, state, query text, timings, wait events
+SELECT pid, datname, usename, application_name, client_addr, client_port,
+       backend_type, state, query, query_id, backend_start, xact_start,
+       query_start, state_change, wait_event_type, wait_event, leader_pid
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND backend_type = 'client backend'
+  AND state <> 'idle';
+
+-- pg_locks: lock mode, relation, granted/blocked
+SELECT ... FROM pg_locks l JOIN pg_stat_activity a ON l.pid = a.pid ...
+```
+
+**PostgreSQL-specific processing:**
+
+| Concern | Handling |
+|---------|----------|
+| `query_id` (PG 14+) | Populate from `pg_stat_activity.query_id`; PG 12–13 use query fingerprint hash |
+| Query text truncation | Set `query_text_truncated=true` when `length(query) >= track_activity_query_size`; include tooltip metadata |
+| `idle in transaction` | Use `xact_start` for duration display (not `query_start`); distinct UI badge |
+| Parallel workers (PG 13+) | Group rows where `leader_pid` is set under leader session; collapsed by default in UI |
+| Lock chains | Build directed graph from `pg_locks` where `granted=false`; attach chain to blocked session payload |
+| Permissions | Require `pg_read_all_stats` (or superuser); return structured agent error if missing |
+
+**Performance target:** <1% additional CPU on PostgreSQL host with ≤200 active backends at 2s polling interval (acceptance criterion).
+
+### Server-side (pmm-managed)
+
+Extend existing components with minimal branching:
+
+| Component | Change |
+|-----------|--------|
+| `models/agent_model.go` | Add `RTAPostgreSQLAgentType` (`rta-postgresql-agent`) |
+| `managed/services/inventory/agents.go` | `AddRTAPostgreSQLAgent`, `ChangeRTAPostgreSQLAgent` |
+| `managed/services/management/postgresql.go` | Auto-register RTA agent when adding PostgreSQL service (optional flag, mirror MongoDB) |
+| `managed/services/realtimeanalytics/service.go` | Map `PostgreSQLServiceType` → `RTAPostgreSQLAgentType` in `getRTAAgentTypeForServiceType`; extend `ListServicesResponse` |
+| `managed/services/realtimeanalytics/store.go` | Store PostgreSQL `QueryData` in existing TTL map (no schema change beyond proto) |
+| `managed/services/telemetry/config.default.yml` | Add PostgreSQL RTA telemetry queries |
+
+MongoDB code paths remain unchanged; service-type dispatch selects agent implementation.
+
+### API (protobuf)
+
+**`api/realtimeanalytics/v1/query.proto`:**
+
+```protobuf
+message QueryPostgreSQLData {
+  string db_instance_address = 1;
+  string database_name = 2;
+  string username = 3;
+  string application_name = 4;
+  string session_state = 5;           // active, idle in transaction, ...
+  google.protobuf.Timestamp transaction_start_time = 6;
+  google.protobuf.Timestamp query_start_time = 7;
+  string wait_event_type = 8;
+  string wait_event = 9;
+  int32 backend_pid = 10;
+  int32 leader_pid = 11;                // 0 if not a parallel worker
+  bool query_text_truncated = 12;
+  int32 track_activity_query_size = 13;
+  repeated LockChainLink lock_chain = 14;
+}
+
+message LockChainLink {
+  int32 blocker_pid = 1;
+  int32 blocked_pid = 2;
+  string lock_mode = 3;
+  string relation_name = 4;
+  string blocker_query_text = 5;
+  google.protobuf.Duration blocker_duration = 6;
+}
+```
+
+**`api/realtimeanalytics/v1/realtimeanalytics.proto`:**
+
+- Extend `ListServicesResponse` with `repeated inventory.v1.PostgreSQLService postgresql = 2;`
+
+**`api/inventory/v1/agents.proto`:**
+
+- Add `RTAPostgreSQLAgent`, `AddRTAPostgreSQLAgentParams`, `ChangeRTAPostgreSQLAgentParams` (mirror MongoDB RTA agent fields minus MongoDB-specific auth; reuse PostgreSQL TLS/ssl fields from existing PostgreSQL agents).
+
+### UI (ui/apps/pmm)
+
+Extend existing RTA pages without new navigation:
+
+| Area | Change |
+|------|--------|
+| `types/rta.types.ts` | Add `QueryPostgreSQLData`, extend `RawQueryData` with `postgresPayload` |
+| `api/rta.ts` | Handle PostgreSQL in `listServices` response |
+| `hooks/api/useRealtime.ts` | Include PostgreSQL services in available-services filter |
+| `pages/rta/overview/table/` | PostgreSQL column set: state, wait event, DB, duration, query |
+| `pages/rta/overview/details-pane/` | Lock chain panel, idle-in-transaction section, raw JSON tab |
+| `pages/rta/components/selection-form/` | Show PostgreSQL services in autocomplete |
+
+Reuse MongoDB patterns for pause/resume, auto-refresh (1–5s), session management, and share links.
+
+### QAN coexistence
+
+RTA polling reads `pg_stat_activity` and `pg_locks` only. QAN agents continue using `pg_stat_statements` / `pg_stat_monitor` independently. No shared state, no ClickHouse writes from RTA. Verify no lock contention or duplicate query collection on the same extensions.
+
+### Cloud provider notes
+
+| Provider | Considerations |
+|----------|----------------|
+| RDS / Aurora | Standard `pg_stat_activity`; grant `pg_read_all_stats` via parameter group / role |
+| Cloud SQL | May require `cloudsqlsuperuser`; document IAM/database user setup |
+| Azure | Flexible Server supports `pg_stat_activity`; document required roles |
+
+Aurora `aurora_stat_activity` is out of scope for v1.
+
+## Files / areas touched
+
+**Agent**
+- `agent/agents/postgres/realtimeanalytics/` (new package)
+- `agent/agents/agents.go` — register RTA PostgreSQL agent
+- `agent/client/client.go` — agent state handling
+
+**API**
+- `api/realtimeanalytics/v1/query.proto`
+- `api/realtimeanalytics/v1/realtimeanalytics.proto`
+- `api/inventory/v1/agents.proto`
+- Regenerated `.pb.go`, swagger, json clients
+
+**Managed**
+- `managed/models/agent_model.go`, `agent_helpers.go`
+- `managed/services/inventory/agents.go`, `grpc/agents_server.go`
+- `managed/services/management/postgresql.go`
+- `managed/services/realtimeanalytics/service.go`, `store.go`
+- `managed/services/converters.go`
+- `managed/services/telemetry/config.default.yml`
+
+**UI**
+- `ui/apps/pmm/src/types/rta.types.ts`
+- `ui/apps/pmm/src/api/rta.ts`
+- `ui/apps/pmm/src/hooks/api/useRealtime.ts`
+- `ui/apps/pmm/src/pages/rta/**`
+
+**Docs**
+- `documentation/docs/use/qan/QAN-realtime-analytics.md` — add PostgreSQL section, remove "MongoDB only" warning
+- New or updated PostgreSQL RTA permissions doc
+
+**Version**
+- `version/features.go` — feature gate constant for PostgreSQL RTA agent support
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| High poll frequency increases DB load | Default 2s interval; configurable 1–5s; benchmark ≤200 backends |
+| `pg_read_all_stats` missing on cloud | Structured error in agent + UI; document per-provider setup |
+| Query text truncated by `track_activity_query_size` | Visual indicator + tooltip; document server restart requirement to increase |
+| Lock chain query cost on busy systems | Limit chain depth; single round-trip join; benchmark under load |
+| Proto/API breaking changes | Additive only; MongoDB payload unchanged |
+| Parallel worker UI complexity | Collapse under leader by default; expand on click |
+
+## Testing strategy
+
+- **Unit:** Agent SQL parsing, lock chain builder, proto converters, store TTL
+- **Integration (pmm-managed):** Start/stop session for PostgreSQL service; SearchQueries returns PG payload
+- **Integration (pmm-qa):** Playwright RTA flow for PostgreSQL service selection, live table refresh, lock chain panel
+- **Manual matrix:** PG 12, 14, 15, 16; Percona Distribution; RDS; verify QAN still works on same instance

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
@@ -1,0 +1,39 @@
+# PMM-15167 [RTA] Real-Time Query Analytics for PostgreSQL
+
+## Why
+
+PMM already provides Query Analytics (QAN) for PostgreSQL using `pg_stat_statements` and `pg_stat_monitor`, but QAN aggregates completed queries into one-minute buckets in ClickHouse with 1–2 minutes of end-to-end lag. During live incidents—lock pile-ups, long-running transactions blocking writes, or idle-in-transaction sessions holding locks—DBAs must leave PMM and run manual queries against `pg_stat_activity` and `pg_locks`.
+
+Real-Time Analytics (RTA) for MongoDB shipped in PMM 3.7.0 with a proven architecture: dedicated agent type, `RealtimeAnalyticsService` (gRPC + REST), in-memory TTL store, and a UI under **Query Analytics → Real-time**. PostgreSQL users need the same live visibility inside PMM, extended with PostgreSQL-specific diagnostics (lock chains, wait events, idle-in-transaction detection, parallel worker grouping).
+
+## What changes
+
+- Add **RTA PostgreSQL agent** (`rta-postgresql-agent`) in pmm-agent that polls `pg_stat_activity` and `pg_locks` every 1–5 seconds and streams session records to PMM Server.
+- Extend **Inventory API** with `RTAPostgreSQLAgent` (add/change/list/get) mirroring the MongoDB RTA agent pattern; reuse existing PostgreSQL exporter credentials where possible.
+- Extend **RealtimeAnalyticsService** and `QueryData` protobuf with a PostgreSQL payload (`QueryPostgreSQLData`) including session state, wait events, lock chains, transaction duration, and parallel-worker metadata.
+- Update **UI Real-time tab** to list PostgreSQL services alongside MongoDB, render PostgreSQL-specific columns and panels (lock chain, idle-in-transaction badge, parallel worker collapse), and surface permission/truncation errors clearly.
+- Add **telemetry** counters for PostgreSQL RTA agents (registered, enabled, disabled).
+- Document PostgreSQL RTA in official PMM docs with version matrix (`query_id`, cloud permissions) and known limitations.
+
+## Out of scope
+
+- `EXPLAIN` / execution plan capture in the real-time view (future; may leverage `pg_stat_monitor` separately).
+- `pg_wait_sampling` and `pgsentinel` integration.
+- Cancel / terminate query action from RTA UI.
+- ASH-style persistence for PostgreSQL RTA data.
+- Aurora-specific `aurora_stat_activity` extended view integration.
+- PostgreSQL logical replication lag monitoring in RTA.
+
+## Related work
+
+- Epic: PMM-14550 (MongoDB RTA MVP — reference architecture).
+- Jira: [PMM-15167](https://perconadev.atlassian.net/browse/PMM-15167)
+
+## Phases (delivery)
+
+| Phase | Scope | Done when |
+|-------|-------|-----------|
+| 1 — Agent | Collect from `pg_stat_activity` + `pg_locks` | Agent produces session records with lock chains and idle-in-transaction info; verified on PG 12, 14, 15, 16, and Percona Distribution for PostgreSQL |
+| 2 — Server & API | Extend RealtimeAnalyticsService + Inventory | Server routes PostgreSQL RTA data via existing REST/gRPC API; MongoDB behavior unchanged |
+| 3 — UI | Real-time tab integration | User selects PostgreSQL service and sees live sessions at 1–5s refresh with PG-specific visuals |
+| 4 — Hardening & GA | Tests, docs, cloud variants | Feature enabled for registered PostgreSQL services; integration tests pass; docs published |

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-agent.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-agent.md
@@ -1,0 +1,80 @@
+# PostgreSQL RTA Agent
+
+Capability: pmm-agent collects live PostgreSQL session data and streams it to PMM Server.
+
+## Requirements
+
+### REQ-PG-AGENT-001: Poll active sessions
+
+The RTA PostgreSQL agent SHALL poll `pg_stat_activity` at a configurable interval between 1 and 5 seconds (default 2 seconds) when its session is running.
+
+### REQ-PG-AGENT-002: Exclude idle backends
+
+The agent SHALL include backends in states `active`, `idle in transaction`, and other non-`idle` client backend states. Pure `idle` backends SHALL be excluded unless they are `idle in transaction`.
+
+### REQ-PG-AGENT-003: Collect lock information
+
+The agent SHALL query `pg_locks` (joined with `pg_stat_activity`) on each collection cycle to determine lock contention and build blocker → blocked relationships.
+
+### REQ-PG-AGENT-004: Reuse PostgreSQL credentials
+
+The agent SHALL connect using credentials from the PostgreSQL exporter for the same PMM service unless explicitly overridden in inventory agent configuration.
+
+### REQ-PG-AGENT-005: Permission error handling
+
+When the monitoring user lacks `pg_read_all_stats` (and is not a superuser), the agent SHALL report a structured error with an actionable message rather than returning empty data silently.
+
+### REQ-PG-AGENT-006: Query identification
+
+- On PostgreSQL 14+, the agent SHALL populate `query_id` from `pg_stat_activity.query_id`.
+- On PostgreSQL 12–13, the agent SHALL fall back to a stable query fingerprint hash.
+
+### REQ-PG-AGENT-007: Query text truncation
+
+When query text length equals or exceeds `track_activity_query_size`, the agent SHALL set a truncation flag and include the configured `track_activity_query_size` value in the payload.
+
+### REQ-PG-AGENT-008: Parallel worker metadata
+
+On PostgreSQL 13+, the agent SHALL include `leader_pid` for parallel worker backends.
+
+### REQ-PG-AGENT-009: Performance budget
+
+At a 2-second collect interval with ≤200 active backends, the agent SHALL add less than 1% additional CPU utilization on the PostgreSQL host.
+
+## Scenarios
+
+### Scenario: Active query appears in stream
+
+**GIVEN** a running RTA session for a PostgreSQL service with an active `SELECT` query  
+**WHEN** the agent completes a collection cycle  
+**THEN** a `QueryData` message is emitted with `session_state=active`, non-empty `query_text`, and `query_execution_duration` reflecting elapsed query time
+
+### Scenario: Idle in transaction session
+
+**GIVEN** a backend in state `idle in transaction` with `xact_start` 30 seconds ago  
+**WHEN** the agent collects session data  
+**THEN** the payload includes `session_state=idle in transaction` and duration is computed from `xact_start`, not `query_start`
+
+### Scenario: Lock chain detected
+
+**GIVEN** session A holds a lock and session B is blocked waiting on A  
+**WHEN** the agent collects lock data  
+**THEN** session B's payload includes a lock chain with A as blocker, including A's query text and duration
+
+### Scenario: Missing pg_read_all_stats
+
+**GIVEN** the monitoring user cannot read all rows in `pg_stat_activity`  
+**WHEN** the agent attempts collection  
+**THEN** the agent status reports an error containing guidance to grant `pg_read_all_stats` or use a superuser role
+
+### Scenario: Truncated query text
+
+**GIVEN** `track_activity_query_size=1024` and a query longer than 1024 characters  
+**WHEN** the agent collects the session  
+**THEN** `query_text_truncated=true` and `track_activity_query_size=1024` are set in the payload
+
+### Scenario: Parallel worker grouping metadata
+
+**GIVEN** PostgreSQL 15 with a parallel query where worker PID 12345 has `leader_pid=12340`  
+**WHEN** the agent collects sessions  
+**THEN** the worker record includes `leader_pid=12340` and `backend_pid=12345`

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-server-api.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-server-api.md
@@ -1,0 +1,79 @@
+# PostgreSQL RTA Server & API
+
+Capability: PMM Server registers PostgreSQL RTA agents, accepts streamed session data, and exposes it via RealtimeAnalyticsService.
+
+## Requirements
+
+### REQ-PG-SRV-001: Inventory agent type
+
+PMM SHALL support `rta-postgresql-agent` in the Inventory API with add, change, list, and get operations mirroring `rta-mongodb-agent` (PostgreSQL-appropriate connection fields).
+
+### REQ-PG-SRV-002: Service type mapping
+
+`RealtimeAnalyticsService.ListServices` with `service_type=POSTGRESQL` SHALL return PostgreSQL services eligible for RTA (registered, with running pmm-agent, not already in an active session unless listed as running).
+
+### REQ-PG-SRV-003: Session lifecycle
+
+Starting and stopping RTA sessions for PostgreSQL services SHALL use the same REST/gRPC endpoints as MongoDB (`/v1/realtimeanalytics/sessions:start`, `sessions:stop`, `sessions`, `queries:search`).
+
+### REQ-PG-SRV-004: PostgreSQL query payload
+
+`SearchQueries` responses for PostgreSQL services SHALL include `QueryData.postgres_payload` with session state, wait events, lock chain, and PostgreSQL-specific timestamps.
+
+### REQ-PG-SRV-005: In-memory store
+
+PostgreSQL RTA data SHALL be stored in the existing in-memory TTL store with the same retention semantics as MongoDB RTA (no persistence to ClickHouse).
+
+### REQ-PG-SRV-006: MongoDB compatibility
+
+Existing MongoDB RTA behavior, API contracts, and stored MongoDB payloads SHALL remain unchanged.
+
+### REQ-PG-SRV-007: QAN independence
+
+PostgreSQL RTA SHALL NOT write to ClickHouse or interfere with QAN agents (`pg_stat_statements`, `pg_stat_monitor`) on the same service.
+
+### REQ-PG-SRV-008: Telemetry
+
+PMM SHALL emit telemetry metrics for PostgreSQL RTA agents: total registered, currently enabled (running session), and disabled counts.
+
+### REQ-PG-SRV-009: Access control
+
+Starting and stopping PostgreSQL RTA sessions SHALL require Admin role; viewing live data from running sessions SHALL follow the same role rules as MongoDB RTA.
+
+## Scenarios
+
+### Scenario: List PostgreSQL RTA services
+
+**GIVEN** two registered PostgreSQL services and one without pmm-agent  
+**WHEN** a user calls `ListServices` with `service_type=POSTGRESQL`  
+**THEN** only services with a eligible pmm-agent and no conflicting active session are returned
+
+### Scenario: Start PostgreSQL session
+
+**GIVEN** an Admin user and a registered PostgreSQL service with RTA agent configured  
+**WHEN** the user calls `StartSession` with the service ID  
+**THEN** the RTA agent is enabled, session status is `RUNNING`, and collect interval is applied from agent RTAOptions
+
+### Scenario: Search queries returns PostgreSQL payload
+
+**GIVEN** a running PostgreSQL RTA session with active queries  
+**WHEN** the user calls `SearchQueries` with the service ID  
+**THEN** the response contains `QueryData` entries with populated `postgres_payload` including lock chain when contention exists
+
+### Scenario: Stop session disables agent
+
+**GIVEN** a running PostgreSQL RTA session  
+**WHEN** an Admin calls `StopSession`  
+**THEN** the session status becomes `DOWN`, the agent is disabled, and in-memory queries for that service are evicted per existing TTL rules
+
+### Scenario: MongoDB session unaffected
+
+**GIVEN** an active MongoDB RTA session  
+**WHEN** a PostgreSQL RTA session is started on a different service  
+**THEN** MongoDB `SearchQueries` responses continue to return `mongo_db_payload` without schema or behavior changes
+
+### Scenario: Concurrent QAN collection
+
+**GIVEN** a PostgreSQL service with both QAN (pg_stat_monitor) and RTA agents enabled  
+**WHEN** both agents run for 10 minutes  
+**THEN** QAN continues to receive completed query metrics in ClickHouse and RTA streams live sessions without duplicate or corrupted data

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-ui.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-ui.md
@@ -1,0 +1,99 @@
+# PostgreSQL RTA UI
+
+Capability: Query Analytics → Real-time tab displays live PostgreSQL sessions with PostgreSQL-specific diagnostics.
+
+## Requirements
+
+### REQ-PG-UI-001: Service selection
+
+The Real-time tab service selector SHALL list registered PostgreSQL services alongside MongoDB services. Users SHALL start RTA sessions for PostgreSQL without navigating to a new page.
+
+### REQ-PG-UI-002: Live refresh
+
+The overview table SHALL refresh at the user-selected auto-refresh interval (1–5 seconds, default 2 seconds) with end-to-end latency ≤5 seconds.
+
+### REQ-PG-UI-003: Overview columns
+
+For PostgreSQL sessions, the overview table SHALL display at minimum: session state, database, username/application, wait event (type + name), elapsed duration, and query text.
+
+### REQ-PG-UI-004: Lock chain panel
+
+The Details pane SHALL include a lock chain visualization showing blocker → blocked relationships with query text and duration for each link in the chain.
+
+### REQ-PG-UI-005: Idle in transaction
+
+Sessions in state `idle in transaction` SHALL be visually distinguished (badge or row styling) and SHALL display transaction duration derived from `xact_start`, not query duration.
+
+### REQ-PG-UI-006: Parallel workers
+
+On PostgreSQL 13+, parallel worker sessions (where `leader_pid` is set) SHALL be collapsed under their leader row by default with an expand control to show workers.
+
+### REQ-PG-UI-007: Truncated query indicator
+
+When `query_text_truncated` is true, the UI SHALL indicate truncation (icon or label) and show a tooltip explaining `track_activity_query_size` and that increasing it requires a PostgreSQL server restart.
+
+### REQ-PG-UI-008: Permission error
+
+When the agent reports missing `pg_read_all_stats`, the UI SHALL display a specific actionable error message instead of an empty table or generic failure.
+
+### REQ-PG-UI-009: Raw data tab
+
+The Raw data tab SHALL show the full JSON snapshot from the agent (pg_stat_activity and lock fields) for troubleshooting.
+
+### REQ-PG-UI-010: MongoDB parity features
+
+PostgreSQL RTA SHALL support the same pause/resume, share link, multi-session, and session management flows as MongoDB RTA.
+
+### REQ-PG-UI-011: No regression
+
+Existing MongoDB RTA UI behavior and styling SHALL remain unchanged when no PostgreSQL services are present.
+
+## Scenarios
+
+### Scenario: Start PostgreSQL RTA from Real-time tab
+
+**GIVEN** an Admin on Query Analytics → Real-time with no active sessions  
+**WHEN** they select a PostgreSQL service and click Start session  
+**THEN** the live operations table appears and begins auto-refreshing with PostgreSQL session rows
+
+### Scenario: View lock chain in Details
+
+**GIVEN** a PostgreSQL session blocked by another backend  
+**WHEN** the user clicks the blocked session row and opens Details  
+**THEN** the lock chain panel shows the blocker PID, blocker query text, blocker duration, and lock mode
+
+### Scenario: Idle in transaction badge
+
+**GIVEN** a session in state `idle in transaction` running for 45 seconds  
+**WHEN** displayed in the overview table  
+**THEN** the row shows an idle-in-transaction indicator and duration of 45s based on transaction start time
+
+### Scenario: Expand parallel workers
+
+**GIVEN** a parallel query leader with two worker backends  
+**WHEN** the overview table renders  
+**THEN** workers are hidden under the collapsed leader row; clicking expand reveals worker rows with their PIDs and wait events
+
+### Scenario: Truncated query tooltip
+
+**GIVEN** a query with `query_text_truncated=true` and `track_activity_query_size=1024`  
+**WHEN** the user hovers the truncation indicator  
+**THEN** a tooltip explains the query was truncated at 1024 bytes and increasing `track_activity_query_size` requires a server restart
+
+### Scenario: Permission error displayed
+
+**GIVEN** the RTA agent reports insufficient privileges for pg_stat_activity  
+**WHEN** the Real-time page loads  
+**THEN** an error banner explains that `pg_read_all_stats` (or superuser) is required with a link to documentation
+
+### Scenario: Pause preserves PostgreSQL view
+
+**GIVEN** an active PostgreSQL RTA session with auto-refresh enabled  
+**WHEN** the user clicks Pause  
+**THEN** the table freezes on the current snapshot while the agent continues collecting in the background
+
+### Scenario: Share link with PostgreSQL filter
+
+**GIVEN** a user viewing PostgreSQL service X in RTA overview  
+**WHEN** they click Share  
+**THEN** the copied URL includes the service filter and opens Real-time with PostgreSQL service X selected

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
@@ -1,0 +1,65 @@
+# Tasks
+
+Check off items as implemented. Phases align with Jira epic delivery order.
+
+## Phase 1 — PostgreSQL RTA Agent
+
+- [ ] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
+- [ ] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
+- [ ] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
+- [ ] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
+- [ ] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
+- [ ] 1.6 Detect query text truncation vs track_activity_query_size
+- [ ] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
+- [ ] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
+- [ ] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
+
+## Phase 2 — Server-Side & API Extension
+
+- [ ] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
+- [ ] 2.2 Extend ListServicesResponse with postgresql services
+- [ ] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
+- [ ] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
+- [ ] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
+- [ ] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
+- [ ] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
+- [ ] 2.8 Integration tests: start session, collect queries, stop session for PostgreSQL
+- [ ] 2.9 Verify MongoDB RTA regression tests still pass
+
+## Phase 3 — UI Integration
+
+- [ ] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
+- [ ] 3.2 Include PostgreSQL services in Real-time service selector and session modal
+- [ ] 3.3 Overview table: PostgreSQL columns (state, wait event, DB, duration, query)
+- [ ] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
+- [ ] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
+- [ ] 3.6 Collapse parallel workers under leader by default (PG 13+)
+- [ ] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
+- [ ] 3.8 Permission error banner when pg_read_all_stats missing
+- [ ] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
+- [ ] 3.10 Component tests for PostgreSQL-specific rendering
+
+## Phase 4 — Testing, Hardening & GA
+
+- [ ] 4.1 Benchmark agent CPU overhead at 2s interval (≤200 backends, <1% target)
+- [ ] 4.2 Verify QAN (pg_stat_statements + pg_stat_monitor) unaffected on same instance
+- [ ] 4.3 Test matrix: PG 12, 14, 15, 16; Percona Distribution; RDS; Aurora; Cloud SQL; Azure
+- [ ] 4.4 Update QAN-realtime-analytics.md (PostgreSQL section, remove MongoDB-only warning)
+- [ ] 4.5 Document cloud permission setup and query_id version matrix
+- [ ] 4.6 pmm-qa Playwright scenarios for PostgreSQL RTA happy path and error states
+- [ ] 4.7 Enable feature by default for registered PostgreSQL services (or document opt-in if required)
+
+## Verification checklist (acceptance criteria mapping)
+
+- [ ] AC-1: PostgreSQL service selectable; sessions refresh ≤5s
+- [ ] AC-2: RTA + QAN coexist without conflict on same instance
+- [ ] AC-3: Works on PG 12+, Percona Distribution, RDS, Aurora, Cloud SQL, Azure
+- [ ] AC-4: Lock chain panel shows blocker → blocked with query text and duration
+- [ ] AC-5: idle in transaction visually distinct; shows transaction duration
+- [ ] AC-6: Parallel workers collapsed under leader (PG 13+)
+- [ ] AC-7: query_id on PG 14+; fingerprint fallback on 12–13
+- [ ] AC-8: Truncated query text indicated with tooltip
+- [ ] AC-9: Missing pg_read_all_stats shows actionable error
+- [ ] AC-10: No regressions in MongoDB RTA or PostgreSQL QAN
+- [ ] AC-11: <1% CPU overhead at 2s polling (≤200 backends)
+- [ ] AC-12: Official docs updated with version matrix and cloud permissions

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
@@ -4,39 +4,39 @@ Check off items as implemented. Phases align with Jira epic delivery order.
 
 ## Phase 1 — PostgreSQL RTA Agent
 
-- [ ] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
-- [ ] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
-- [ ] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
-- [ ] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
-- [ ] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
-- [ ] 1.6 Detect query text truncation vs track_activity_query_size
-- [ ] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
-- [ ] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
-- [ ] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
+- [x] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
+- [x] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
+- [x] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
+- [x] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
+- [x] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
+- [x] 1.6 Detect query text truncation vs track_activity_query_size
+- [x] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
+- [x] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
+- [x] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
 
 ## Phase 2 — Server-Side & API Extension
 
-- [ ] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
-- [ ] 2.2 Extend ListServicesResponse with postgresql services
-- [ ] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
-- [ ] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
-- [ ] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
-- [ ] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
-- [ ] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
+- [x] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
+- [x] 2.2 Extend ListServicesResponse with postgresql services
+- [x] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
+- [x] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
+- [x] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
+- [x] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
+- [x] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
 - [ ] 2.8 Integration tests: start session, collect queries, stop session for PostgreSQL
 - [ ] 2.9 Verify MongoDB RTA regression tests still pass
 
 ## Phase 3 — UI Integration
 
-- [ ] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
-- [ ] 3.2 Include PostgreSQL services in Real-time service selector and session modal
+- [x] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
+- [x] 3.2 Include PostgreSQL services in Real-time service selector and session modal
 - [ ] 3.3 Overview table: PostgreSQL columns (state, wait event, DB, duration, query)
-- [ ] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
-- [ ] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
+- [x] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
+- [x] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
 - [ ] 3.6 Collapse parallel workers under leader by default (PG 13+)
-- [ ] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
+- [x] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
 - [ ] 3.8 Permission error banner when pg_read_all_stats missing
-- [ ] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
+- [x] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
 - [ ] 3.10 Component tests for PostgreSQL-specific rendering
 
 ## Phase 4 — Testing, Hardening & GA

--- a/ui/apps/pmm/src/pages/rta/overview/details-pane/QueryAndDetails.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/details-pane/QueryAndDetails.tsx
@@ -1,9 +1,13 @@
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { FC } from 'react';
 import { format, formatDuration } from 'date-fns';
 import { tz } from '@date-fns/tz';
 import { SyntaxHighlighter } from 'components/syntax-highlighter';
-import { QueryData } from 'types/rta.types';
+import { isPostgresQuery, QueryData } from 'types/rta.types';
 import DetailsMetric from './DetailsMetric';
 import BigNumberMetric from './BigNumberMetric';
 import { Messages } from './QueryAndDetails.messages';
@@ -20,43 +24,160 @@ const GridItem = ({ children }: { children: React.ReactNode }) => (
   </Grid>
 );
 
-const QueryAndDetails: FC<Props> = ({
-  queryData: {
+const formatElapsed = (queryExecutionDurationMs?: number | null) => {
+  if (!queryExecutionDurationMs) {
+    return { mainText: undefined, subText: undefined };
+  }
+
+  const formatted = formatDuration(
+    { seconds: queryExecutionDurationMs },
+    { format: ['seconds'] }
+  );
+  const parts = formatted.split(' ');
+
+  return {
+    mainText: parts.length > 1 ? parts[0] : undefined,
+    subText: parts.length > 1 ? parts[1] : undefined,
+  };
+};
+
+const PostgresDetails: FC<Props> = ({ queryData }) => {
+  const { user } = useUser();
+  const timezone = user?.preferences?.timezone || 'UTC';
+  const payload = queryData.postgresPayload!;
+  const elapsed = formatElapsed(queryData.queryExecutionDurationMs);
+  const isIdleInTransaction = payload.sessionState === 'idle in transaction';
+
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Grid container spacing={3}>
+          <GridItem>
+            <DetailsMetric title="Session state" tooltip="PostgreSQL backend state">
+              <Stack direction="row" spacing={1} alignItems="center">
+                <BigNumberMetric mainText={payload.sessionState} dataTestId="session-state-value" />
+                {isIdleInTransaction && (
+                  <Chip label="idle in transaction" color="warning" size="small" />
+                )}
+              </Stack>
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.operationId} tooltip={Messages.tooltips.operationId}>
+              <BigNumberMetric mainText={queryData.queryId} dataTestId="operation-id-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.elapsedExecTime} tooltip={Messages.tooltips.elapsedExecTime}>
+              <BigNumberMetric {...elapsed} dataTestId="elapsed-time-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title="Wait event" tooltip="PostgreSQL wait event type and name">
+              <BigNumberMetric
+                mainText={[payload.waitEventType, payload.waitEvent].filter(Boolean).join(' / ') || undefined}
+                dataTestId="wait-event-value"
+              />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.databaseName} tooltip={Messages.tooltips.databaseName}>
+              <BigNumberMetric mainText={payload.databaseName} size="small" dataTestId="database-name-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.username} tooltip={Messages.tooltips.username}>
+              <BigNumberMetric mainText={payload.username} size="small" dataTestId="username-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.clientAppName} tooltip={Messages.tooltips.clientAppName}>
+              <BigNumberMetric mainText={payload.applicationName} size="small" dataTestId="client-app-name-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.clientAddress} tooltip={Messages.tooltips.clientAddress}>
+              <BigNumberMetric mainText={queryData.clientAddress} size="small" dataTestId="client-address-value" />
+            </DetailsMetric>
+          </GridItem>
+          {payload.lockChain && payload.lockChain.length > 0 && (
+            <Grid size={{ xs: 12 }}>
+              <DetailsMetric title="Lock chain" tooltip="Blocker to blocked lock relationships">
+                <Stack spacing={1}>
+                  {payload.lockChain.map((link, index) => (
+                    <Typography key={`${link.blockerPid}-${index}`} variant="body2">
+                      PID {link.blockerPid} blocks {link.blockedPid} ({link.lockMode}
+                      {link.relationName ? ` on ${link.relationName}` : ''})
+                      {link.blockerQueryText ? `: ${link.blockerQueryText}` : ''}
+                    </Typography>
+                  ))}
+                </Stack>
+              </DetailsMetric>
+            </Grid>
+          )}
+          <GridItem>
+            <DetailsMetric title={Messages.titles.dataCaptureTime} tooltip={Messages.tooltips.dataCaptureTime}>
+              <BigNumberMetric
+                mainText={format(new Date(queryData.queryCollectTime), TIME_FORMAT, { in: tz(timezone) })}
+                size="small"
+                dataTestId="data-capture-time-value"
+              />
+            </DetailsMetric>
+          </GridItem>
+        </Grid>
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }} sx={{ maxHeight: '70vh', overflow: 'auto' }}>
+        {payload.queryTextTruncated && (
+          <Tooltip
+            title={`Query text truncated at ${payload.trackActivityQuerySize} bytes. Increase track_activity_query_size and restart PostgreSQL to capture longer queries.`}
+          >
+            <Chip label="Truncated query" color="warning" size="small" sx={{ mb: 1 }} />
+          </Tooltip>
+        )}
+        <SyntaxHighlighter language="sql" showLineNumbers showCopyButton content={queryData.queryText} />
+      </Grid>
+    </Grid>
+  );
+};
+
+const QueryAndDetails: FC<Props> = ({ queryData }) => {
+  if (isPostgresQuery(queryData)) {
+    return <PostgresDetails queryData={queryData} />;
+  }
+
+  const {
     queryText,
     queryId,
     queryExecutionDurationMs,
     queryCollectTime,
     serviceName,
     clientAddress,
-    mongoDbPayload: {
-      planSummary,
-      databaseName,
-      collection,
-      operation,
-      username,
-      dbInstanceAddress,
-      clientAppName,
-      operationStartTime,
+    mongoDbPayload = {
+      planSummary: '',
+      databaseName: '',
+      collection: '',
+      operation: '',
+      username: '',
+      dbInstanceAddress: '',
+      clientAppName: '',
+      operationStartTime: '',
     },
-  },
-}) => {
+  } = queryData;
+
+  const {
+    planSummary,
+    databaseName,
+    collection,
+    operation,
+    username,
+    dbInstanceAddress,
+    clientAppName,
+    operationStartTime,
+  } = mongoDbPayload;
+
   const { user } = useUser();
   const timezone = user?.preferences?.timezone || 'UTC';
-
-  const formattedQueryExecutionDuration = queryExecutionDurationMs
-    ? formatDuration(
-        {
-          seconds: queryExecutionDurationMs,
-        },
-        {
-          format: ['seconds'],
-        }
-      )
-    : '';
-
-  const formattedQueryExecutionDurationParts = formattedQueryExecutionDuration
-    ? formattedQueryExecutionDuration.split(' ')
-    : [];
+  const elapsed = formatElapsed(queryExecutionDurationMs);
 
   return (
     <Grid container spacing={3}>
@@ -67,10 +188,7 @@ const QueryAndDetails: FC<Props> = ({
               title={Messages.titles.operationId}
               tooltip={Messages.tooltips.operationId}
             >
-              <BigNumberMetric
-                mainText={queryId}
-                dataTestId="operation-id-value"
-              />
+              <BigNumberMetric mainText={queryId} dataTestId="operation-id-value" />
             </DetailsMetric>
           </GridItem>
           <GridItem>
@@ -78,19 +196,7 @@ const QueryAndDetails: FC<Props> = ({
               title={Messages.titles.elapsedExecTime}
               tooltip={Messages.tooltips.elapsedExecTime}
             >
-              <BigNumberMetric
-                mainText={
-                  formattedQueryExecutionDurationParts.length > 1
-                    ? formattedQueryExecutionDurationParts[0]
-                    : undefined
-                }
-                subText={
-                  formattedQueryExecutionDurationParts.length > 1
-                    ? formattedQueryExecutionDurationParts[1]
-                    : undefined
-                }
-                dataTestId="elapsed-time-value"
-              />
+              <BigNumberMetric {...elapsed} dataTestId="elapsed-time-value" />
             </DetailsMetric>
           </GridItem>
           <GridItem>

--- a/ui/apps/pmm/src/pages/rta/selection/RealtimeSelection.tsx
+++ b/ui/apps/pmm/src/pages/rta/selection/RealtimeSelection.tsx
@@ -23,7 +23,10 @@ export const RealtimeSelection: FC = () => {
   const { user } = useUser();
   const navigate = useNavigate();
   // TODO: Add other service types when available
-  const { isLoading } = useAvailableServices([ServiceType.mongodb]);
+  const { isLoading } = useAvailableServices([
+    ServiceType.mongodb,
+    ServiceType.postgresql,
+  ]);
   const { data: sessions, isLoading: isLoadingSessions } =
     useRealtimeSessions();
 

--- a/ui/apps/pmm/src/types/rta.types.ts
+++ b/ui/apps/pmm/src/types/rta.types.ts
@@ -40,21 +40,14 @@ export interface SearchQueriesResponse {
   queries: RawQueryData[];
 }
 
-export interface RawQueryData {
-  serviceId: string;
-  serviceName: string;
-  queryId: string;
-  queryText: string;
-  queryExecutionDuration?: string | null;
-  queryCollectTime: string;
-  clientAddress: string;
-  queryRawJson: string;
-  mongoDbPayload: QueryMongoDBData;
+export interface LockChainLink {
+  blockerPid: number;
+  blockedPid: number;
+  lockMode: string;
+  relationName: string;
+  blockerQueryText: string;
+  blockerDuration?: string | null;
 }
-
-export type QueryData = Exclude<RawQueryData, 'queryExecutionDuration'> & {
-  queryExecutionDurationMs?: number | null;
-};
 
 export interface QueryMongoDBData {
   dbInstanceAddress: string;
@@ -67,7 +60,47 @@ export interface QueryMongoDBData {
   collection?: string;
 }
 
-// TODO: Add other service types when available
+export interface QueryPostgreSQLData {
+  dbInstanceAddress: string;
+  databaseName: string;
+  username: string;
+  applicationName: string;
+  sessionState: string;
+  transactionStartTime?: string;
+  queryStartTime?: string;
+  waitEventType: string;
+  waitEvent: string;
+  backendPid: number;
+  leaderPid: number;
+  queryTextTruncated: boolean;
+  trackActivityQuerySize: number;
+  lockChain?: LockChainLink[];
+}
+
+export interface RawQueryData {
+  serviceId: string;
+  serviceName: string;
+  queryId: string;
+  queryText: string;
+  queryExecutionDuration?: string | null;
+  queryCollectTime: string;
+  clientAddress: string;
+  queryRawJson: string;
+  mongoDbPayload?: QueryMongoDBData;
+  postgresPayload?: QueryPostgreSQLData;
+}
+
+export type QueryData = Exclude<RawQueryData, 'queryExecutionDuration'> & {
+  queryExecutionDurationMs?: number | null;
+};
+
 export interface AvailableServicesResponse {
   mongodb: VersionedService[];
+  postgresql: VersionedService[];
 }
+
+export const isPostgresQuery = (query: QueryData): boolean =>
+  !!query.postgresPayload && Object.keys(query.postgresPayload).length > 0;
+
+export const isMongoQuery = (query: QueryData): boolean =>
+  !!query.mongoDbPayload && Object.keys(query.mongoDbPayload).length > 0;

--- a/version/features.go
+++ b/version/features.go
@@ -33,6 +33,7 @@ var (
 	MysqlExporterPluginCollector  FeatureVersion = V2_36_0
 	NomadAgentSupportVersion      FeatureVersion = V3_2_0
 	MongoDBRtaAgentSupportVersion FeatureVersion = V3_7_0
+	PostgreSQLRtaAgentSupportVersion FeatureVersion = V3_7_0
 )
 
 // IsFeatureSupported checks if the feature is supported by the version.


### PR DESCRIPTION
## Summary

Implements **PMM-15167**: Real-Time Query Analytics (RTA) for PostgreSQL.

- Adds `rta-postgresql-agent` polling `pg_stat_activity` and `pg_locks`
- Extends RealtimeAnalytics API with `QueryPostgreSQLData` and lock chain payload
- Wires inventory, session management, telemetry, and UI for PostgreSQL services
- OpenSpec: `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/`

## Test plan

- [x] Unit tests: `go test ./agent/agents/postgres/realtimeanalytics/...`
- [ ] Integration: start/stop RTA session for PostgreSQL service
- [ ] Manual: lock chain panel, idle-in-transaction badge, truncated query tooltip
- [ ] Regression: MongoDB RTA unchanged
- [ ] Docs update (Phase 4)

Jira: https://perconadev.atlassian.net/browse/PMM-15167
