### PR TITLE
PMM-15167: Change

### DIFF
--- a/agent/agents/postgres/realtimeanalytics/collector.go
+++ b/agent/agents/postgres/realtimeanalytics/collector.go
@@ -1,0 +1,317 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+const (
+	activityQuery = `
+SELECT pid, datname, usename, application_name,
+       COALESCE(host(client_addr), '') AS client_host,
+       client_port, state, query,
+       query_id, backend_start, xact_start, query_start,
+       wait_event_type, wait_event, leader_pid
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND backend_type = 'client backend'
+  AND state <> 'idle'`
+
+	locksQuery = `
+SELECT blocked_locks.pid AS blocked_pid,
+       blocking_locks.pid AS blocker_pid,
+       blocked_locks.mode AS lock_mode,
+       COALESCE(blocked_relation.relname, '') AS relation_name,
+       blocking_activity.query AS blocker_query,
+       blocking_activity.query_start AS blocker_query_start
+FROM pg_catalog.pg_locks blocked_locks
+JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+JOIN pg_catalog.pg_locks blocking_locks
+  ON blocking_locks.locktype = blocked_locks.locktype
+ AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+ AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+ AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+ AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+ AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+ AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+ AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+ AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+ AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+ AND blocking_locks.pid != blocked_locks.pid
+JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+LEFT JOIN pg_catalog.pg_class blocked_relation ON blocked_relation.oid = blocked_locks.relation
+WHERE NOT blocked_locks.granted`
+
+	trackActivityQuerySizeSQL = `SELECT current_setting('track_activity_query_size')::int`
+)
+
+var errMissingPgReadAllStats = errors.New("monitoring user lacks pg_read_all_stats role; grant pg_read_all_stats or use a superuser account")
+
+func collectSessions(ctx context.Context, db *sql.DB) ([]*rtav1.QueryData, error) {
+	trackSize, err := readTrackActivityQuerySize(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	sessions, err := readActivityRows(ctx, db, trackSize)
+	if err != nil {
+		if isPermissionError(err) {
+			return nil, errMissingPgReadAllStats
+		}
+		return nil, err
+	}
+
+	lockRows, err := readLockRows(ctx, db)
+	if err != nil && !isPermissionError(err) {
+		return nil, err
+	}
+
+	sessionMap := make(map[int32]*sessionRow, len(sessions))
+	for i := range sessions {
+		sessionMap[sessions[i].PID] = &sessions[i]
+	}
+
+	lockChains := buildLockChains(lockRows, sessionMap)
+	now := time.Now()
+
+	results := make([]*rtav1.QueryData, 0, len(sessions))
+	for _, session := range sessions {
+		queryID := sessionQueryID(session)
+		duration := sessionDuration(session, now)
+
+		payload := &rtav1.QueryPostgreSQLData{
+			DatabaseName:            session.DatabaseName,
+			Username:                session.Username,
+			ApplicationName:         session.ApplicationName,
+			SessionState:            session.State,
+			WaitEventType:           session.WaitEventType,
+			WaitEvent:               session.WaitEvent,
+			BackendPid:              session.PID,
+			LeaderPid:               session.LeaderPID,
+			QueryTextTruncated:      session.QueryTextTruncated,
+			TrackActivityQuerySize:  session.TrackActivitySize,
+			LockChain:               lockChains[session.PID],
+		}
+
+		if !session.TransactionStart.IsZero() {
+			payload.TransactionStartTime = timestamppb.New(session.TransactionStart)
+		}
+		if !session.QueryStart.IsZero() {
+			payload.QueryStartTime = timestamppb.New(session.QueryStart)
+		}
+		if session.ClientAddress != "" {
+			payload.DbInstanceAddress = session.ClientAddress
+		}
+
+		results = append(results, &rtav1.QueryData{
+			QueryId:                 queryID,
+			QueryText:               strings.TrimSpace(session.Query),
+			QueryRawJson:            session.RawJSON,
+			QueryExecutionDuration:  durationpb.New(duration),
+			ClientAddress:           session.ClientAddress,
+			Payload:                 &rtav1.QueryData_PostgresPayload{PostgresPayload: payload},
+		})
+	}
+
+	return results, nil
+}
+
+func readTrackActivityQuerySize(ctx context.Context, db *sql.DB) (int32, error) {
+	var size int32
+	err := db.QueryRowContext(ctx, trackActivityQuerySizeSQL).Scan(&size)
+	if err != nil {
+		return 1024, nil //nolint:mnd
+	}
+	return size, nil
+}
+
+func readActivityRows(ctx context.Context, db *sql.DB, trackSize int32) ([]sessionRow, error) {
+	rows, err := db.QueryContext(ctx, activityQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var sessions []sessionRow
+	for rows.Next() {
+		var (
+			session       sessionRow
+			clientHost    sql.NullString
+			clientPort    sql.NullInt64
+			queryID       sql.NullInt64
+			backendStart  sql.NullTime
+			xactStart     sql.NullTime
+			queryStart    sql.NullTime
+			waitEventType sql.NullString
+			waitEvent     sql.NullString
+			leaderPID     sql.NullInt64
+		)
+
+		err = rows.Scan(
+			&session.PID,
+			&session.DatabaseName,
+			&session.Username,
+			&session.ApplicationName,
+			&clientHost,
+			&clientPort,
+			&session.State,
+			&session.Query,
+			&queryID,
+			&backendStart,
+			&xactStart,
+			&queryStart,
+			&waitEventType,
+			&waitEvent,
+			&leaderPID,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if clientHost.Valid {
+			if clientPort.Valid && clientPort.Int64 > 0 {
+				session.ClientAddress = fmt.Sprintf("%s:%d", clientHost.String, clientPort.Int64)
+			} else {
+				session.ClientAddress = clientHost.String
+			}
+		}
+
+		if queryID.Valid {
+			session.QueryID = queryID.Int64
+			session.HasQueryID = true
+		}
+		if backendStart.Valid {
+			session.BackendStart = backendStart.Time
+		}
+		if xactStart.Valid {
+			session.TransactionStart = xactStart.Time
+		}
+		if queryStart.Valid {
+			session.QueryStart = queryStart.Time
+		}
+		if waitEventType.Valid {
+			session.WaitEventType = waitEventType.String
+		}
+		if waitEvent.Valid {
+			session.WaitEvent = waitEvent.String
+		}
+		if leaderPID.Valid {
+			session.LeaderPID = int32(leaderPID.Int64) //nolint:gosec
+		}
+
+		session.TrackActivitySize = trackSize
+		if trackSize > 0 && len(session.Query) >= int(trackSize) {
+			session.QueryTextTruncated = true
+		}
+
+		raw, _ := json.Marshal(map[string]any{
+			"pid":              session.PID,
+			"datname":          session.DatabaseName,
+			"usename":          session.Username,
+			"application_name": session.ApplicationName,
+			"client_addr":      session.ClientAddress,
+			"state":            session.State,
+			"query":            session.Query,
+			"query_id":         session.QueryID,
+			"xact_start":       session.TransactionStart,
+			"query_start":      session.QueryStart,
+			"wait_event_type":  session.WaitEventType,
+			"wait_event":       session.WaitEvent,
+			"leader_pid":       session.LeaderPID,
+		})
+		session.RawJSON = string(raw)
+
+		sessions = append(sessions, session)
+	}
+
+	return sessions, rows.Err()
+}
+
+func readLockRows(ctx context.Context, db *sql.DB) ([]lockRow, error) {
+	rows, err := db.QueryContext(ctx, locksQuery)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var result []lockRow
+	for rows.Next() {
+		var row lockRow
+		var blockerQueryStart sql.NullTime
+		err = rows.Scan(
+			&row.BlockedPID,
+			&row.BlockerPID,
+			&row.LockMode,
+			&row.RelationName,
+			&row.BlockerQuery,
+			&blockerQueryStart,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if blockerQueryStart.Valid {
+			row.BlockerQueryAt = blockerQueryStart.Time
+		}
+		result = append(result, row)
+	}
+
+	return result, rows.Err()
+}
+
+func sessionQueryID(session sessionRow) string {
+	if session.HasQueryID {
+		return strconv.FormatInt(session.QueryID, 10)
+	}
+
+	sum := sha256.Sum256([]byte(strings.TrimSpace(session.Query)))
+	return hex.EncodeToString(sum[:8])
+}
+
+func sessionDuration(session sessionRow, now time.Time) time.Duration {
+	if session.State == "idle in transaction" && !session.TransactionStart.IsZero() {
+		return now.Sub(session.TransactionStart)
+	}
+	if !session.QueryStart.IsZero() {
+		return now.Sub(session.QueryStart)
+	}
+	if !session.BackendStart.IsZero() {
+		return now.Sub(session.BackendStart)
+	}
+	return 0
+}
+
+func isPermissionError(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "42501" // insufficient_privilege
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "permission denied")
+}

--- a/agent/agents/postgres/realtimeanalytics/locks.go
+++ b/agent/agents/postgres/realtimeanalytics/locks.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+type lockRow struct {
+	BlockedPID     int32
+	BlockerPID     int32
+	LockMode       string
+	RelationName   string
+	BlockerQuery   string
+	BlockerQueryAt time.Time
+}
+
+type sessionRow struct {
+	PID                  int32
+	DatabaseName         string
+	Username             string
+	ApplicationName      string
+	ClientAddress        string
+	State                string
+	Query                string
+	QueryID              int64
+	HasQueryID           bool
+	BackendStart         time.Time
+	TransactionStart     time.Time
+	QueryStart           time.Time
+	WaitEventType        string
+	WaitEvent            string
+	LeaderPID            int32
+	TrackActivitySize    int32
+	QueryTextTruncated   bool
+	RawJSON              string
+}
+
+func buildLockChains(rows []lockRow, sessions map[int32]*sessionRow) map[int32][]*rtav1.LockChainLink {
+	chains := make(map[int32][]*rtav1.LockChainLink)
+	now := time.Now()
+
+	for _, row := range rows {
+		link := &rtav1.LockChainLink{
+			BlockerPid:       row.BlockerPID,
+			BlockedPid:       row.BlockedPID,
+			LockMode:         row.LockMode,
+			RelationName:     row.RelationName,
+			BlockerQueryText: row.BlockerQuery,
+		}
+
+		if blocker, ok := sessions[row.BlockerPID]; ok && !blocker.QueryStart.IsZero() {
+			link.BlockerDuration = durationpb.New(now.Sub(blocker.QueryStart))
+		} else if !row.BlockerQueryAt.IsZero() {
+			link.BlockerDuration = durationpb.New(now.Sub(row.BlockerQueryAt))
+		}
+
+		chains[row.BlockedPID] = append(chains[row.BlockedPID], link)
+	}
+
+	return chains
+}

--- a/agent/agents/postgres/realtimeanalytics/postgresql.go
+++ b/agent/agents/postgres/realtimeanalytics/postgresql.go
@@ -1,0 +1,165 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package realtimeanalytics runs built-in Real-Time Analytics Agent for PostgreSQL.
+package realtimeanalytics
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	_ "github.com/lib/pq" // register postgres driver
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/percona/pmm/agent/agents"
+	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
+	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
+)
+
+const changesBufferSize = 10
+
+// PostgreSQLRTA extracts Real-Time Analytics data from PostgreSQL.
+type PostgreSQLRTA struct {
+	agentID         string
+	serviceID       string
+	serviceName     string
+	l               *logrus.Entry
+	changes         chan agents.Change
+	dsn             string
+	collectInterval time.Duration
+}
+
+// Params represent Agent parameters.
+type Params struct {
+	AgentID         string
+	DSN             string
+	ServiceID       string
+	ServiceName     string
+	CollectInterval time.Duration
+}
+
+// New creates new PostgreSQLRTA service.
+func New(params *Params, l *logrus.Entry) (*PostgreSQLRTA, error) {
+	if params.DSN == "" {
+		return nil, fmt.Errorf("empty DSN")
+	}
+
+	return &PostgreSQLRTA{
+		agentID:         params.AgentID,
+		serviceID:       params.ServiceID,
+		serviceName:     params.ServiceName,
+		dsn:             params.DSN,
+		collectInterval: params.CollectInterval,
+		l:               l,
+		changes:         make(chan agents.Change, changesBufferSize),
+	}, nil
+}
+
+// Run extracts currently running DB sessions from PostgreSQL until ctx is canceled.
+func (p *PostgreSQLRTA) Run(ctx context.Context) {
+	p.l.Info("Starting PostgreSQL RTA agent")
+
+	p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STARTING}
+
+	defer func() {
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_DONE}
+		close(p.changes)
+	}()
+
+	db, err := sql.Open("postgres", p.dsn)
+	if err != nil {
+		p.l.Errorf("Can't run Real-Time Analytics agent, reason: %v", err)
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+		return
+	}
+	defer db.Close() //nolint:errcheck
+
+	db.SetMaxOpenConns(2)
+	db.SetConnMaxLifetime(5 * time.Minute) //nolint:mnd
+
+	if err = db.PingContext(ctx); err != nil {
+		p.l.Errorf("Can't connect to PostgreSQL for RTA: %v", err)
+		p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+		return
+	}
+
+	p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_RUNNING}
+
+	ticker := time.NewTicker(p.collectInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			p.l.Info("Stopping PostgreSQL RTA agent")
+			p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_STOPPING}
+			return
+		case <-ticker.C:
+			go func(curCtx context.Context) {
+				bucket, collectErr := p.collect(curCtx, db)
+				if collectErr != nil {
+					if collectErr == errMissingPgReadAllStats {
+						p.l.Error(collectErr.Error())
+						p.changes <- agents.Change{Status: inventoryv1.AgentStatus_AGENT_STATUS_WAITING}
+						return
+					}
+					p.l.Warnf("pg_stat_activity collection failed: %v", collectErr)
+					return
+				}
+
+				select {
+				case <-curCtx.Done():
+					return
+				default:
+					if len(bucket) != 0 {
+						p.changes <- agents.Change{RTAQueriesBucket: bucket}
+					}
+				}
+			}(ctx)
+		}
+	}
+}
+
+func (p *PostgreSQLRTA) collect(ctx context.Context, db *sql.DB) ([]*rtav1.QueryData, error) {
+	results, err := collectSessions(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	collectTime := timestamppb.New(time.Now())
+	for _, query := range results {
+		query.ServiceId = p.serviceID
+		query.ServiceName = p.serviceName
+		query.QueryCollectTime = collectTime
+	}
+
+	return results, nil
+}
+
+// Changes returns channel that should be read until it is closed.
+func (p *PostgreSQLRTA) Changes() <-chan agents.Change {
+	return p.changes
+}
+
+// Describe implements prometheus.Collector.
+func (p *PostgreSQLRTA) Describe(_ chan<- *prometheus.Desc) {}
+
+// Collect implement prometheus.Collector.
+func (p *PostgreSQLRTA) Collect(_ chan<- prometheus.Metric) {}
+
+var _ prometheus.Collector = (*PostgreSQLRTA)(nil)

--- a/agent/agents/postgres/realtimeanalytics/postgresql_test.go
+++ b/agent/agents/postgres/realtimeanalytics/postgresql_test.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2023 Percona LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realtimeanalytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildLockChains(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	sessions := map[int32]*sessionRow{
+		100: {PID: 100, QueryStart: now.Add(-30 * time.Second)},
+		200: {PID: 200, QueryStart: now.Add(-10 * time.Second)},
+	}
+
+	rows := []lockRow{{
+		BlockedPID:   200,
+		BlockerPID:   100,
+		LockMode:     "ShareLock",
+		RelationName: "orders",
+		BlockerQuery: "UPDATE orders SET status = 1",
+	}}
+
+	chains := buildLockChains(rows, sessions)
+	require.Len(t, chains[200], 1)
+	assert.Equal(t, int32(100), chains[200][0].BlockerPid)
+	assert.Equal(t, "ShareLock", chains[200][0].LockMode)
+	assert.Equal(t, "orders", chains[200][0].RelationName)
+}
+
+func TestSessionQueryID(t *testing.T) {
+	t.Parallel()
+
+	withID := sessionRow{HasQueryID: true, QueryID: 42}
+	assert.Equal(t, "42", sessionQueryID(withID))
+
+	withoutID := sessionRow{Query: "SELECT 1"}
+	assert.NotEmpty(t, sessionQueryID(withoutID))
+}
+
+func TestSessionDurationIdleInTransaction(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := sessionRow{
+		State:            "idle in transaction",
+		TransactionStart: now.Add(-45 * time.Second),
+		QueryStart:       now.Add(-5 * time.Second),
+	}
+
+	duration := sessionDuration(session, now)
+	assert.InDelta(t, 45.0, duration.Seconds(), 0.1)
+}
+
+func TestSessionDurationActiveQuery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	session := sessionRow{
+		State:      "active",
+		QueryStart: now.Add(-12 * time.Second),
+	}
+
+	duration := sessionDuration(session, now)
+	assert.InDelta(t, 12.0, duration.Seconds(), 0.1)
+}
+
+func TestQueryTextTruncation(t *testing.T) {
+	t.Parallel()
+
+	session := sessionRow{Query: "SELECT 1", TrackActivitySize: 8}
+	assert.True(t, len(session.Query) >= int(session.TrackActivitySize))
+	session.QueryTextTruncated = len(session.Query) >= int(session.TrackActivitySize)
+	assert.True(t, session.QueryTextTruncated)
+}

--- a/agent/agents/supervisor/supervisor.go
+++ b/agent/agents/supervisor/supervisor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/percona/pmm/agent/agents/mongodb/mongolog"
 	mongoprofiler "github.com/percona/pmm/agent/agents/mongodb/profiler"
 	mongorta "github.com/percona/pmm/agent/agents/mongodb/realtimeanalytics"
+	postgresrta "github.com/percona/pmm/agent/agents/postgres/realtimeanalytics"
 	"github.com/percona/pmm/agent/agents/mysql/perfschema"
 	"github.com/percona/pmm/agent/agents/mysql/slowlog"
 	"github.com/percona/pmm/agent/agents/noop"
@@ -672,6 +673,16 @@ func (s *Supervisor) startBuiltin(agentID string, builtinAgent *agentv1.SetState
 			CollectInterval: builtinAgent.RtaOptions.GetCollectInterval().AsDuration(),
 		}
 		agent, err = mongorta.New(params, l)
+
+	case inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT:
+		params := &postgresrta.Params{
+			DSN:             dsn,
+			AgentID:         agentID,
+			ServiceID:       builtinAgent.ServiceId,
+			ServiceName:     builtinAgent.ServiceName,
+			CollectInterval: builtinAgent.RtaOptions.GetCollectInterval().AsDuration(),
+		}
+		agent, err = postgresrta.New(params, l)
 
 	case type_TEST_NOOP:
 		agent = noop.New()

--- a/api/inventory/v1/agents.go
+++ b/api/inventory/v1/agents.go
@@ -44,3 +44,4 @@ func (*ExternalExporter) sealedAgent()                {}
 func (*AzureDatabaseExporter) sealedAgent()           {}
 func (*ValkeyExporter) sealedAgent()                  {}
 func (*RTAMongoDBAgent) sealedAgent()                 {}
+func (*RTAPostgreSQLAgent) sealedAgent()              {}

--- a/api/inventory/v1/agents.pb.go
+++ b/api/inventory/v1/agents.pb.go
@@ -7,19 +7,17 @@
 package inventoryv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	common "github.com/percona/pmm/api/common"
+	_ "github.com/percona/pmm/api/extensions/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	common "github.com/percona/pmm/api/common"
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -53,6 +51,7 @@ const (
 	AgentType_AGENT_TYPE_AZURE_DATABASE_EXPORTER            AgentType = 15
 	AgentType_AGENT_TYPE_NOMAD_AGENT                        AgentType = 16
 	AgentType_AGENT_TYPE_RTA_MONGODB_AGENT                  AgentType = 19
+	AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT               AgentType = 20
 )
 
 // Enum value maps for AgentType.
@@ -78,6 +77,7 @@ var (
 		15: "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
 		16: "AGENT_TYPE_NOMAD_AGENT",
 		19: "AGENT_TYPE_RTA_MONGODB_AGENT",
+		20: "AGENT_TYPE_RTA_POSTGRESQL_AGENT",
 	}
 	AgentType_value = map[string]int32{
 		"AGENT_TYPE_UNSPECIFIED":                        0,
@@ -100,6 +100,7 @@ var (
 		"AGENT_TYPE_AZURE_DATABASE_EXPORTER":            15,
 		"AGENT_TYPE_NOMAD_AGENT":                        16,
 		"AGENT_TYPE_RTA_MONGODB_AGENT":                  19,
+		"AGENT_TYPE_RTA_POSTGRESQL_AGENT":               20,
 	}
 )
 
@@ -2335,6 +2336,142 @@ func (x *RTAOptions) GetCollectInterval() *durationpb.Duration {
 	return nil
 }
 
+// RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server.
+type RTAPostgreSQLAgent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Unique agent identifier.
+	AgentId string `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	// The pmm-agent identifier which runs this instance.
+	PmmAgentId string `protobuf:"bytes,2,opt,name=pmm_agent_id,json=pmmAgentId,proto3" json:"pmm_agent_id,omitempty"`
+	// Desired Agent status: enabled (false) or disabled (true).
+	Disabled bool `protobuf:"varint,3,opt,name=disabled,proto3" json:"disabled,omitempty"`
+	// Service identifier.
+	ServiceId string `protobuf:"bytes,4,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username string `protobuf:"bytes,5,opt,name=username,proto3" json:"username,omitempty"`
+	// Use TLS for database connections.
+	Tls bool `protobuf:"varint,6,opt,name=tls,proto3" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify bool `protobuf:"varint,7,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3" json:"tls_skip_verify,omitempty"`
+	// Custom user-assigned labels.
+	CustomLabels map[string]string `protobuf:"bytes,8,rep,name=custom_labels,json=customLabels,proto3" json:"custom_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Real-Time Analytics options.
+	RtaOptions *RTAOptions `protobuf:"bytes,9,opt,name=rta_options,json=rtaOptions,proto3" json:"rta_options,omitempty"`
+	// Actual Agent status.
+	Status AgentStatus `protobuf:"varint,10,opt,name=status,proto3,enum=inventory.v1.AgentStatus" json:"status,omitempty"`
+	// Log level for agent.
+	LogLevel      LogLevel `protobuf:"varint,11,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel" json:"log_level,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RTAPostgreSQLAgent) Reset() {
+	*x = RTAPostgreSQLAgent{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RTAPostgreSQLAgent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RTAPostgreSQLAgent) ProtoMessage() {}
+
+func (x *RTAPostgreSQLAgent) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RTAPostgreSQLAgent.ProtoReflect.Descriptor instead.
+func (*RTAPostgreSQLAgent) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *RTAPostgreSQLAgent) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetPmmAgentId() string {
+	if x != nil {
+		return x.PmmAgentId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetDisabled() bool {
+	if x != nil {
+		return x.Disabled
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *RTAPostgreSQLAgent) GetTls() bool {
+	if x != nil {
+		return x.Tls
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetTlsSkipVerify() bool {
+	if x != nil {
+		return x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *RTAPostgreSQLAgent) GetCustomLabels() map[string]string {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *RTAPostgreSQLAgent) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
+func (x *RTAPostgreSQLAgent) GetStatus() AgentStatus {
+	if x != nil {
+		return x.Status
+	}
+	return AgentStatus_AGENT_STATUS_UNSPECIFIED
+}
+
+func (x *RTAPostgreSQLAgent) GetLogLevel() LogLevel {
+	if x != nil {
+		return x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
 // RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server.
 type RTAMongoDBAgent struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -2366,7 +2503,7 @@ type RTAMongoDBAgent struct {
 
 func (x *RTAMongoDBAgent) Reset() {
 	*x = RTAMongoDBAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	mi := &file_inventory_v1_agents_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2378,7 +2515,7 @@ func (x *RTAMongoDBAgent) String() string {
 func (*RTAMongoDBAgent) ProtoMessage() {}
 
 func (x *RTAMongoDBAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[14]
+	mi := &file_inventory_v1_agents_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2391,7 +2528,7 @@ func (x *RTAMongoDBAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RTAMongoDBAgent.ProtoReflect.Descriptor instead.
 func (*RTAMongoDBAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{14}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *RTAMongoDBAgent) GetAgentId() string {
@@ -2506,7 +2643,7 @@ type QANPostgreSQLPgStatementsAgent struct {
 
 func (x *QANPostgreSQLPgStatementsAgent) Reset() {
 	*x = QANPostgreSQLPgStatementsAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[15]
+	mi := &file_inventory_v1_agents_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2518,7 +2655,7 @@ func (x *QANPostgreSQLPgStatementsAgent) String() string {
 func (*QANPostgreSQLPgStatementsAgent) ProtoMessage() {}
 
 func (x *QANPostgreSQLPgStatementsAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[15]
+	mi := &file_inventory_v1_agents_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2531,7 +2668,7 @@ func (x *QANPostgreSQLPgStatementsAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QANPostgreSQLPgStatementsAgent.ProtoReflect.Descriptor instead.
 func (*QANPostgreSQLPgStatementsAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{15}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *QANPostgreSQLPgStatementsAgent) GetAgentId() string {
@@ -2662,7 +2799,7 @@ type QANPostgreSQLPgStatMonitorAgent struct {
 
 func (x *QANPostgreSQLPgStatMonitorAgent) Reset() {
 	*x = QANPostgreSQLPgStatMonitorAgent{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[16]
+	mi := &file_inventory_v1_agents_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2674,7 +2811,7 @@ func (x *QANPostgreSQLPgStatMonitorAgent) String() string {
 func (*QANPostgreSQLPgStatMonitorAgent) ProtoMessage() {}
 
 func (x *QANPostgreSQLPgStatMonitorAgent) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[16]
+	mi := &file_inventory_v1_agents_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2687,7 +2824,7 @@ func (x *QANPostgreSQLPgStatMonitorAgent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QANPostgreSQLPgStatMonitorAgent.ProtoReflect.Descriptor instead.
 func (*QANPostgreSQLPgStatMonitorAgent) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{16}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *QANPostgreSQLPgStatMonitorAgent) GetAgentId() string {
@@ -2827,7 +2964,7 @@ type RDSExporter struct {
 
 func (x *RDSExporter) Reset() {
 	*x = RDSExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[17]
+	mi := &file_inventory_v1_agents_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2839,7 +2976,7 @@ func (x *RDSExporter) String() string {
 func (*RDSExporter) ProtoMessage() {}
 
 func (x *RDSExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[17]
+	mi := &file_inventory_v1_agents_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2852,7 +2989,7 @@ func (x *RDSExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RDSExporter.ProtoReflect.Descriptor instead.
 func (*RDSExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{17}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *RDSExporter) GetAgentId() string {
@@ -2997,7 +3134,7 @@ type ExternalExporter struct {
 
 func (x *ExternalExporter) Reset() {
 	*x = ExternalExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[18]
+	mi := &file_inventory_v1_agents_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3009,7 +3146,7 @@ func (x *ExternalExporter) String() string {
 func (*ExternalExporter) ProtoMessage() {}
 
 func (x *ExternalExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[18]
+	mi := &file_inventory_v1_agents_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3022,7 +3159,7 @@ func (x *ExternalExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExternalExporter.ProtoReflect.Descriptor instead.
 func (*ExternalExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{18}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ExternalExporter) GetAgentId() string {
@@ -3158,7 +3295,7 @@ type AzureDatabaseExporter struct {
 
 func (x *AzureDatabaseExporter) Reset() {
 	*x = AzureDatabaseExporter{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[19]
+	mi := &file_inventory_v1_agents_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3170,7 +3307,7 @@ func (x *AzureDatabaseExporter) String() string {
 func (*AzureDatabaseExporter) ProtoMessage() {}
 
 func (x *AzureDatabaseExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[19]
+	mi := &file_inventory_v1_agents_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3183,7 +3320,7 @@ func (x *AzureDatabaseExporter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AzureDatabaseExporter.ProtoReflect.Descriptor instead.
 func (*AzureDatabaseExporter) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{19}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *AzureDatabaseExporter) GetAgentId() string {
@@ -3294,7 +3431,7 @@ type ChangeCommonAgentParams struct {
 
 func (x *ChangeCommonAgentParams) Reset() {
 	*x = ChangeCommonAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[20]
+	mi := &file_inventory_v1_agents_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3306,7 +3443,7 @@ func (x *ChangeCommonAgentParams) String() string {
 func (*ChangeCommonAgentParams) ProtoMessage() {}
 
 func (x *ChangeCommonAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[20]
+	mi := &file_inventory_v1_agents_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3319,7 +3456,7 @@ func (x *ChangeCommonAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeCommonAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeCommonAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{20}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ChangeCommonAgentParams) GetEnable() bool {
@@ -3369,7 +3506,7 @@ type ListAgentsRequest struct {
 
 func (x *ListAgentsRequest) Reset() {
 	*x = ListAgentsRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[21]
+	mi := &file_inventory_v1_agents_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3381,7 +3518,7 @@ func (x *ListAgentsRequest) String() string {
 func (*ListAgentsRequest) ProtoMessage() {}
 
 func (x *ListAgentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[21]
+	mi := &file_inventory_v1_agents_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3394,7 +3531,7 @@ func (x *ListAgentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAgentsRequest.ProtoReflect.Descriptor instead.
 func (*ListAgentsRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{21}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *ListAgentsRequest) GetPmmAgentId() string {
@@ -3446,13 +3583,14 @@ type ListAgentsResponse struct {
 	NomadAgent                      []*NomadAgent                      `protobuf:"bytes,16,rep,name=nomad_agent,json=nomadAgent,proto3" json:"nomad_agent,omitempty"`
 	ValkeyExporter                  []*ValkeyExporter                  `protobuf:"bytes,17,rep,name=valkey_exporter,json=valkeyExporter,proto3" json:"valkey_exporter,omitempty"`
 	RtaMongodbAgent                 []*RTAMongoDBAgent                 `protobuf:"bytes,19,rep,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3" json:"rta_mongodb_agent,omitempty"`
+	RtaPostgresqlAgent              []*RTAPostgreSQLAgent              `protobuf:"bytes,20,rep,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
 	unknownFields                   protoimpl.UnknownFields
 	sizeCache                       protoimpl.SizeCache
 }
 
 func (x *ListAgentsResponse) Reset() {
 	*x = ListAgentsResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[22]
+	mi := &file_inventory_v1_agents_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3464,7 +3602,7 @@ func (x *ListAgentsResponse) String() string {
 func (*ListAgentsResponse) ProtoMessage() {}
 
 func (x *ListAgentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[22]
+	mi := &file_inventory_v1_agents_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3477,7 +3615,7 @@ func (x *ListAgentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListAgentsResponse.ProtoReflect.Descriptor instead.
 func (*ListAgentsResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{22}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListAgentsResponse) GetPmmAgent() []*PMMAgent {
@@ -3613,6 +3751,13 @@ func (x *ListAgentsResponse) GetRtaMongodbAgent() []*RTAMongoDBAgent {
 	return nil
 }
 
+func (x *ListAgentsResponse) GetRtaPostgresqlAgent() []*RTAPostgreSQLAgent {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return nil
+}
+
 type GetAgentRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique randomly generated instance identifier.
@@ -3623,7 +3768,7 @@ type GetAgentRequest struct {
 
 func (x *GetAgentRequest) Reset() {
 	*x = GetAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[23]
+	mi := &file_inventory_v1_agents_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3635,7 +3780,7 @@ func (x *GetAgentRequest) String() string {
 func (*GetAgentRequest) ProtoMessage() {}
 
 func (x *GetAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[23]
+	mi := &file_inventory_v1_agents_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3648,7 +3793,7 @@ func (x *GetAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentRequest.ProtoReflect.Descriptor instead.
 func (*GetAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{23}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetAgentRequest) GetAgentId() string {
@@ -3681,6 +3826,7 @@ type GetAgentResponse struct {
 	//	*GetAgentResponse_NomadAgent
 	//	*GetAgentResponse_ValkeyExporter
 	//	*GetAgentResponse_RtaMongodbAgent
+	//	*GetAgentResponse_RtaPostgresqlAgent
 	Agent         isGetAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3688,7 +3834,7 @@ type GetAgentResponse struct {
 
 func (x *GetAgentResponse) Reset() {
 	*x = GetAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[24]
+	mi := &file_inventory_v1_agents_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3700,7 +3846,7 @@ func (x *GetAgentResponse) String() string {
 func (*GetAgentResponse) ProtoMessage() {}
 
 func (x *GetAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[24]
+	mi := &file_inventory_v1_agents_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3713,7 +3859,7 @@ func (x *GetAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentResponse.ProtoReflect.Descriptor instead.
 func (*GetAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{24}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetAgentResponse) GetAgent() isGetAgentResponse_Agent {
@@ -3894,6 +4040,15 @@ func (x *GetAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *GetAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*GetAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isGetAgentResponse_Agent interface {
 	isGetAgentResponse_Agent()
 }
@@ -3974,6 +4129,10 @@ type GetAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,19,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type GetAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,20,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*GetAgentResponse_PmmAgent) isGetAgentResponse_Agent() {}
 
 func (*GetAgentResponse_Vmagent) isGetAgentResponse_Agent() {}
@@ -4012,6 +4171,8 @@ func (*GetAgentResponse_ValkeyExporter) isGetAgentResponse_Agent() {}
 
 func (*GetAgentResponse_RtaMongodbAgent) isGetAgentResponse_Agent() {}
 
+func (*GetAgentResponse_RtaPostgresqlAgent) isGetAgentResponse_Agent() {}
+
 type GetAgentLogsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Unique randomly generated instance identifier.
@@ -4024,7 +4185,7 @@ type GetAgentLogsRequest struct {
 
 func (x *GetAgentLogsRequest) Reset() {
 	*x = GetAgentLogsRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[25]
+	mi := &file_inventory_v1_agents_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4036,7 +4197,7 @@ func (x *GetAgentLogsRequest) String() string {
 func (*GetAgentLogsRequest) ProtoMessage() {}
 
 func (x *GetAgentLogsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[25]
+	mi := &file_inventory_v1_agents_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4049,7 +4210,7 @@ func (x *GetAgentLogsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentLogsRequest.ProtoReflect.Descriptor instead.
 func (*GetAgentLogsRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{25}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *GetAgentLogsRequest) GetAgentId() string {
@@ -4076,7 +4237,7 @@ type GetAgentLogsResponse struct {
 
 func (x *GetAgentLogsResponse) Reset() {
 	*x = GetAgentLogsResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[26]
+	mi := &file_inventory_v1_agents_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4088,7 +4249,7 @@ func (x *GetAgentLogsResponse) String() string {
 func (*GetAgentLogsResponse) ProtoMessage() {}
 
 func (x *GetAgentLogsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[26]
+	mi := &file_inventory_v1_agents_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4101,7 +4262,7 @@ func (x *GetAgentLogsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAgentLogsResponse.ProtoReflect.Descriptor instead.
 func (*GetAgentLogsResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{26}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetAgentLogsResponse) GetLogs() []string {
@@ -4139,6 +4300,7 @@ type AddAgentRequest struct {
 	//	*AddAgentRequest_QanPostgresqlPgstatmonitorAgent
 	//	*AddAgentRequest_ValkeyExporter
 	//	*AddAgentRequest_RtaMongodbAgent
+	//	*AddAgentRequest_RtaPostgresqlAgent
 	Agent         isAddAgentRequest_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4146,7 +4308,7 @@ type AddAgentRequest struct {
 
 func (x *AddAgentRequest) Reset() {
 	*x = AddAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[27]
+	mi := &file_inventory_v1_agents_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4158,7 +4320,7 @@ func (x *AddAgentRequest) String() string {
 func (*AddAgentRequest) ProtoMessage() {}
 
 func (x *AddAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[27]
+	mi := &file_inventory_v1_agents_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4171,7 +4333,7 @@ func (x *AddAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAgentRequest.ProtoReflect.Descriptor instead.
 func (*AddAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{27}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *AddAgentRequest) GetAgent() isAddAgentRequest_Agent {
@@ -4334,6 +4496,15 @@ func (x *AddAgentRequest) GetRtaMongodbAgent() *AddRTAMongoDBAgentParams {
 	return nil
 }
 
+func (x *AddAgentRequest) GetRtaPostgresqlAgent() *AddRTAPostgreSQLAgentParams {
+	if x != nil {
+		if x, ok := x.Agent.(*AddAgentRequest_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isAddAgentRequest_Agent interface {
 	isAddAgentRequest_Agent()
 }
@@ -4406,6 +4577,10 @@ type AddAgentRequest_RtaMongodbAgent struct {
 	RtaMongodbAgent *AddRTAMongoDBAgentParams `protobuf:"bytes,17,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type AddAgentRequest_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *AddRTAPostgreSQLAgentParams `protobuf:"bytes,18,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*AddAgentRequest_PmmAgent) isAddAgentRequest_Agent() {}
 
 func (*AddAgentRequest_NodeExporter) isAddAgentRequest_Agent() {}
@@ -4440,6 +4615,8 @@ func (*AddAgentRequest_ValkeyExporter) isAddAgentRequest_Agent() {}
 
 func (*AddAgentRequest_RtaMongodbAgent) isAddAgentRequest_Agent() {}
 
+func (*AddAgentRequest_RtaPostgresqlAgent) isAddAgentRequest_Agent() {}
+
 type AddAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Agent:
@@ -4461,6 +4638,7 @@ type AddAgentResponse struct {
 	//	*AddAgentResponse_QanPostgresqlPgstatmonitorAgent
 	//	*AddAgentResponse_ValkeyExporter
 	//	*AddAgentResponse_RtaMongodbAgent
+	//	*AddAgentResponse_RtaPostgresqlAgent
 	Agent         isAddAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4468,7 +4646,7 @@ type AddAgentResponse struct {
 
 func (x *AddAgentResponse) Reset() {
 	*x = AddAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[28]
+	mi := &file_inventory_v1_agents_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4658,7 @@ func (x *AddAgentResponse) String() string {
 func (*AddAgentResponse) ProtoMessage() {}
 
 func (x *AddAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[28]
+	mi := &file_inventory_v1_agents_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4671,7 @@ func (x *AddAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAgentResponse.ProtoReflect.Descriptor instead.
 func (*AddAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{28}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *AddAgentResponse) GetAgent() isAddAgentResponse_Agent {
@@ -4656,6 +4834,15 @@ func (x *AddAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *AddAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*AddAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isAddAgentResponse_Agent interface {
 	isAddAgentResponse_Agent()
 }
@@ -4728,6 +4915,10 @@ type AddAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,17,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type AddAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,18,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*AddAgentResponse_PmmAgent) isAddAgentResponse_Agent() {}
 
 func (*AddAgentResponse_NodeExporter) isAddAgentResponse_Agent() {}
@@ -4762,6 +4953,8 @@ func (*AddAgentResponse_ValkeyExporter) isAddAgentResponse_Agent() {}
 
 func (*AddAgentResponse_RtaMongodbAgent) isAddAgentResponse_Agent() {}
 
+func (*AddAgentResponse_RtaPostgresqlAgent) isAddAgentResponse_Agent() {}
+
 type ChangeAgentRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	AgentId string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
@@ -4784,6 +4977,7 @@ type ChangeAgentRequest struct {
 	//	*ChangeAgentRequest_NomadAgent
 	//	*ChangeAgentRequest_ValkeyExporter
 	//	*ChangeAgentRequest_RtaMongodbAgent
+	//	*ChangeAgentRequest_RtaPostgresqlAgent
 	Agent         isChangeAgentRequest_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -4791,7 +4985,7 @@ type ChangeAgentRequest struct {
 
 func (x *ChangeAgentRequest) Reset() {
 	*x = ChangeAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[29]
+	mi := &file_inventory_v1_agents_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4803,7 +4997,7 @@ func (x *ChangeAgentRequest) String() string {
 func (*ChangeAgentRequest) ProtoMessage() {}
 
 func (x *ChangeAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[29]
+	mi := &file_inventory_v1_agents_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4816,7 +5010,7 @@ func (x *ChangeAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeAgentRequest.ProtoReflect.Descriptor instead.
 func (*ChangeAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{29}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *ChangeAgentRequest) GetAgentId() string {
@@ -4986,6 +5180,15 @@ func (x *ChangeAgentRequest) GetRtaMongodbAgent() *ChangeRTAMongoDBAgentParams {
 	return nil
 }
 
+func (x *ChangeAgentRequest) GetRtaPostgresqlAgent() *ChangeRTAPostgreSQLAgentParams {
+	if x != nil {
+		if x, ok := x.Agent.(*ChangeAgentRequest_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isChangeAgentRequest_Agent interface {
 	isChangeAgentRequest_Agent()
 }
@@ -5058,6 +5261,10 @@ type ChangeAgentRequest_RtaMongodbAgent struct {
 	RtaMongodbAgent *ChangeRTAMongoDBAgentParams `protobuf:"bytes,18,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type ChangeAgentRequest_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *ChangeRTAPostgreSQLAgentParams `protobuf:"bytes,19,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*ChangeAgentRequest_NodeExporter) isChangeAgentRequest_Agent() {}
 
 func (*ChangeAgentRequest_MysqldExporter) isChangeAgentRequest_Agent() {}
@@ -5092,6 +5299,8 @@ func (*ChangeAgentRequest_ValkeyExporter) isChangeAgentRequest_Agent() {}
 
 func (*ChangeAgentRequest_RtaMongodbAgent) isChangeAgentRequest_Agent() {}
 
+func (*ChangeAgentRequest_RtaPostgresqlAgent) isChangeAgentRequest_Agent() {}
+
 type ChangeAgentResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Agent:
@@ -5113,6 +5322,7 @@ type ChangeAgentResponse struct {
 	//	*ChangeAgentResponse_NomadAgent
 	//	*ChangeAgentResponse_ValkeyExporter
 	//	*ChangeAgentResponse_RtaMongodbAgent
+	//	*ChangeAgentResponse_RtaPostgresqlAgent
 	Agent         isChangeAgentResponse_Agent `protobuf_oneof:"agent"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5120,7 +5330,7 @@ type ChangeAgentResponse struct {
 
 func (x *ChangeAgentResponse) Reset() {
 	*x = ChangeAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[30]
+	mi := &file_inventory_v1_agents_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5132,7 +5342,7 @@ func (x *ChangeAgentResponse) String() string {
 func (*ChangeAgentResponse) ProtoMessage() {}
 
 func (x *ChangeAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[30]
+	mi := &file_inventory_v1_agents_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5145,7 +5355,7 @@ func (x *ChangeAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeAgentResponse.ProtoReflect.Descriptor instead.
 func (*ChangeAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{30}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *ChangeAgentResponse) GetAgent() isChangeAgentResponse_Agent {
@@ -5308,6 +5518,15 @@ func (x *ChangeAgentResponse) GetRtaMongodbAgent() *RTAMongoDBAgent {
 	return nil
 }
 
+func (x *ChangeAgentResponse) GetRtaPostgresqlAgent() *RTAPostgreSQLAgent {
+	if x != nil {
+		if x, ok := x.Agent.(*ChangeAgentResponse_RtaPostgresqlAgent); ok {
+			return x.RtaPostgresqlAgent
+		}
+	}
+	return nil
+}
+
 type isChangeAgentResponse_Agent interface {
 	isChangeAgentResponse_Agent()
 }
@@ -5380,6 +5599,10 @@ type ChangeAgentResponse_RtaMongodbAgent struct {
 	RtaMongodbAgent *RTAMongoDBAgent `protobuf:"bytes,18,opt,name=rta_mongodb_agent,json=rtaMongodbAgent,proto3,oneof"`
 }
 
+type ChangeAgentResponse_RtaPostgresqlAgent struct {
+	RtaPostgresqlAgent *RTAPostgreSQLAgent `protobuf:"bytes,19,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3,oneof"`
+}
+
 func (*ChangeAgentResponse_NodeExporter) isChangeAgentResponse_Agent() {}
 
 func (*ChangeAgentResponse_MysqldExporter) isChangeAgentResponse_Agent() {}
@@ -5414,6 +5637,8 @@ func (*ChangeAgentResponse_ValkeyExporter) isChangeAgentResponse_Agent() {}
 
 func (*ChangeAgentResponse_RtaMongodbAgent) isChangeAgentResponse_Agent() {}
 
+func (*ChangeAgentResponse_RtaPostgresqlAgent) isChangeAgentResponse_Agent() {}
+
 type AddPMMAgentParams struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Node identifier where this instance runs.
@@ -5426,7 +5651,7 @@ type AddPMMAgentParams struct {
 
 func (x *AddPMMAgentParams) Reset() {
 	*x = AddPMMAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[31]
+	mi := &file_inventory_v1_agents_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5438,7 +5663,7 @@ func (x *AddPMMAgentParams) String() string {
 func (*AddPMMAgentParams) ProtoMessage() {}
 
 func (x *AddPMMAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[31]
+	mi := &file_inventory_v1_agents_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5451,7 +5676,7 @@ func (x *AddPMMAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPMMAgentParams.ProtoReflect.Descriptor instead.
 func (*AddPMMAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{31}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *AddPMMAgentParams) GetRunsOnNodeId() string {
@@ -5488,7 +5713,7 @@ type AddNodeExporterParams struct {
 
 func (x *AddNodeExporterParams) Reset() {
 	*x = AddNodeExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[32]
+	mi := &file_inventory_v1_agents_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5500,7 +5725,7 @@ func (x *AddNodeExporterParams) String() string {
 func (*AddNodeExporterParams) ProtoMessage() {}
 
 func (x *AddNodeExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[32]
+	mi := &file_inventory_v1_agents_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5513,7 +5738,7 @@ func (x *AddNodeExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddNodeExporterParams.ProtoReflect.Descriptor instead.
 func (*AddNodeExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{32}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *AddNodeExporterParams) GetPmmAgentId() string {
@@ -5580,7 +5805,7 @@ type ChangeNodeExporterParams struct {
 
 func (x *ChangeNodeExporterParams) Reset() {
 	*x = ChangeNodeExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[33]
+	mi := &file_inventory_v1_agents_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5592,7 +5817,7 @@ func (x *ChangeNodeExporterParams) String() string {
 func (*ChangeNodeExporterParams) ProtoMessage() {}
 
 func (x *ChangeNodeExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[33]
+	mi := &file_inventory_v1_agents_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5605,7 +5830,7 @@ func (x *ChangeNodeExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeNodeExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeNodeExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{33}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *ChangeNodeExporterParams) GetEnable() bool {
@@ -5705,7 +5930,7 @@ type AddMySQLdExporterParams struct {
 
 func (x *AddMySQLdExporterParams) Reset() {
 	*x = AddMySQLdExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[34]
+	mi := &file_inventory_v1_agents_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5717,7 +5942,7 @@ func (x *AddMySQLdExporterParams) String() string {
 func (*AddMySQLdExporterParams) ProtoMessage() {}
 
 func (x *AddMySQLdExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[34]
+	mi := &file_inventory_v1_agents_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5730,7 +5955,7 @@ func (x *AddMySQLdExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMySQLdExporterParams.ProtoReflect.Descriptor instead.
 func (*AddMySQLdExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{34}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *AddMySQLdExporterParams) GetPmmAgentId() string {
@@ -5910,7 +6135,7 @@ type ChangeMySQLdExporterParams struct {
 
 func (x *ChangeMySQLdExporterParams) Reset() {
 	*x = ChangeMySQLdExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[35]
+	mi := &file_inventory_v1_agents_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5922,7 +6147,7 @@ func (x *ChangeMySQLdExporterParams) String() string {
 func (*ChangeMySQLdExporterParams) ProtoMessage() {}
 
 func (x *ChangeMySQLdExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[35]
+	mi := &file_inventory_v1_agents_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5935,7 +6160,7 @@ func (x *ChangeMySQLdExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeMySQLdExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeMySQLdExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{35}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ChangeMySQLdExporterParams) GetEnable() bool {
@@ -6122,7 +6347,7 @@ type AddMongoDBExporterParams struct {
 
 func (x *AddMongoDBExporterParams) Reset() {
 	*x = AddMongoDBExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[36]
+	mi := &file_inventory_v1_agents_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6134,7 +6359,7 @@ func (x *AddMongoDBExporterParams) String() string {
 func (*AddMongoDBExporterParams) ProtoMessage() {}
 
 func (x *AddMongoDBExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[36]
+	mi := &file_inventory_v1_agents_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6147,7 +6372,7 @@ func (x *AddMongoDBExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddMongoDBExporterParams.ProtoReflect.Descriptor instead.
 func (*AddMongoDBExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{36}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *AddMongoDBExporterParams) GetPmmAgentId() string {
@@ -6363,7 +6588,7 @@ type ChangeMongoDBExporterParams struct {
 
 func (x *ChangeMongoDBExporterParams) Reset() {
 	*x = ChangeMongoDBExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[37]
+	mi := &file_inventory_v1_agents_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6375,7 +6600,7 @@ func (x *ChangeMongoDBExporterParams) String() string {
 func (*ChangeMongoDBExporterParams) ProtoMessage() {}
 
 func (x *ChangeMongoDBExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[37]
+	mi := &file_inventory_v1_agents_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6388,7 +6613,7 @@ func (x *ChangeMongoDBExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeMongoDBExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeMongoDBExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{37}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ChangeMongoDBExporterParams) GetEnable() bool {
@@ -6591,7 +6816,7 @@ type AddPostgresExporterParams struct {
 
 func (x *AddPostgresExporterParams) Reset() {
 	*x = AddPostgresExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[38]
+	mi := &file_inventory_v1_agents_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6603,7 +6828,7 @@ func (x *AddPostgresExporterParams) String() string {
 func (*AddPostgresExporterParams) ProtoMessage() {}
 
 func (x *AddPostgresExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[38]
+	mi := &file_inventory_v1_agents_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6616,7 +6841,7 @@ func (x *AddPostgresExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddPostgresExporterParams.ProtoReflect.Descriptor instead.
 func (*AddPostgresExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{38}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *AddPostgresExporterParams) GetPmmAgentId() string {
@@ -6798,7 +7023,7 @@ type ChangePostgresExporterParams struct {
 
 func (x *ChangePostgresExporterParams) Reset() {
 	*x = ChangePostgresExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[39]
+	mi := &file_inventory_v1_agents_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6810,7 +7035,7 @@ func (x *ChangePostgresExporterParams) String() string {
 func (*ChangePostgresExporterParams) ProtoMessage() {}
 
 func (x *ChangePostgresExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[39]
+	mi := &file_inventory_v1_agents_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6823,7 +7048,7 @@ func (x *ChangePostgresExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangePostgresExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangePostgresExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{39}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ChangePostgresExporterParams) GetEnable() bool {
@@ -6995,7 +7220,7 @@ type AddProxySQLExporterParams struct {
 
 func (x *AddProxySQLExporterParams) Reset() {
 	*x = AddProxySQLExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[40]
+	mi := &file_inventory_v1_agents_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7007,7 +7232,7 @@ func (x *AddProxySQLExporterParams) String() string {
 func (*AddProxySQLExporterParams) ProtoMessage() {}
 
 func (x *AddProxySQLExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[40]
+	mi := &file_inventory_v1_agents_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7020,7 +7245,7 @@ func (x *AddProxySQLExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddProxySQLExporterParams.ProtoReflect.Descriptor instead.
 func (*AddProxySQLExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{40}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AddProxySQLExporterParams) GetPmmAgentId() string {
@@ -7155,7 +7380,7 @@ type ChangeProxySQLExporterParams struct {
 
 func (x *ChangeProxySQLExporterParams) Reset() {
 	*x = ChangeProxySQLExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[41]
+	mi := &file_inventory_v1_agents_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7167,7 +7392,7 @@ func (x *ChangeProxySQLExporterParams) String() string {
 func (*ChangeProxySQLExporterParams) ProtoMessage() {}
 
 func (x *ChangeProxySQLExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[41]
+	mi := &file_inventory_v1_agents_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7180,7 +7405,7 @@ func (x *ChangeProxySQLExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeProxySQLExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeProxySQLExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{41}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ChangeProxySQLExporterParams) GetEnable() bool {
@@ -7314,7 +7539,7 @@ type AddQANMySQLPerfSchemaAgentParams struct {
 
 func (x *AddQANMySQLPerfSchemaAgentParams) Reset() {
 	*x = AddQANMySQLPerfSchemaAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[42]
+	mi := &file_inventory_v1_agents_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7326,7 +7551,7 @@ func (x *AddQANMySQLPerfSchemaAgentParams) String() string {
 func (*AddQANMySQLPerfSchemaAgentParams) ProtoMessage() {}
 
 func (x *AddQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[42]
+	mi := &file_inventory_v1_agents_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7339,7 +7564,7 @@ func (x *AddQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMySQLPerfSchemaAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMySQLPerfSchemaAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{42}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *AddQANMySQLPerfSchemaAgentParams) GetPmmAgentId() string {
@@ -7494,7 +7719,7 @@ type ChangeQANMySQLPerfSchemaAgentParams struct {
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) Reset() {
 	*x = ChangeQANMySQLPerfSchemaAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[43]
+	mi := &file_inventory_v1_agents_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7506,7 +7731,7 @@ func (x *ChangeQANMySQLPerfSchemaAgentParams) String() string {
 func (*ChangeQANMySQLPerfSchemaAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[43]
+	mi := &file_inventory_v1_agents_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7519,7 +7744,7 @@ func (x *ChangeQANMySQLPerfSchemaAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMySQLPerfSchemaAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMySQLPerfSchemaAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{43}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ChangeQANMySQLPerfSchemaAgentParams) GetEnable() bool {
@@ -7677,7 +7902,7 @@ type AddQANMySQLSlowlogAgentParams struct {
 
 func (x *AddQANMySQLSlowlogAgentParams) Reset() {
 	*x = AddQANMySQLSlowlogAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[44]
+	mi := &file_inventory_v1_agents_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7689,7 +7914,7 @@ func (x *AddQANMySQLSlowlogAgentParams) String() string {
 func (*AddQANMySQLSlowlogAgentParams) ProtoMessage() {}
 
 func (x *AddQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[44]
+	mi := &file_inventory_v1_agents_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7702,7 +7927,7 @@ func (x *AddQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMySQLSlowlogAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMySQLSlowlogAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{44}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AddQANMySQLSlowlogAgentParams) GetPmmAgentId() string {
@@ -7866,7 +8091,7 @@ type ChangeQANMySQLSlowlogAgentParams struct {
 
 func (x *ChangeQANMySQLSlowlogAgentParams) Reset() {
 	*x = ChangeQANMySQLSlowlogAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[45]
+	mi := &file_inventory_v1_agents_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7878,7 +8103,7 @@ func (x *ChangeQANMySQLSlowlogAgentParams) String() string {
 func (*ChangeQANMySQLSlowlogAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[45]
+	mi := &file_inventory_v1_agents_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7891,7 +8116,7 @@ func (x *ChangeQANMySQLSlowlogAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeQANMySQLSlowlogAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMySQLSlowlogAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{45}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ChangeQANMySQLSlowlogAgentParams) GetEnable() bool {
@@ -8053,7 +8278,7 @@ type AddQANMongoDBProfilerAgentParams struct {
 
 func (x *AddQANMongoDBProfilerAgentParams) Reset() {
 	*x = AddQANMongoDBProfilerAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[46]
+	mi := &file_inventory_v1_agents_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8065,7 +8290,7 @@ func (x *AddQANMongoDBProfilerAgentParams) String() string {
 func (*AddQANMongoDBProfilerAgentParams) ProtoMessage() {}
 
 func (x *AddQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[46]
+	mi := &file_inventory_v1_agents_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8078,7 +8303,7 @@ func (x *AddQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMongoDBProfilerAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMongoDBProfilerAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{46}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *AddQANMongoDBProfilerAgentParams) GetPmmAgentId() string {
@@ -8224,7 +8449,7 @@ type ChangeQANMongoDBProfilerAgentParams struct {
 
 func (x *ChangeQANMongoDBProfilerAgentParams) Reset() {
 	*x = ChangeQANMongoDBProfilerAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[47]
+	mi := &file_inventory_v1_agents_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8236,7 +8461,7 @@ func (x *ChangeQANMongoDBProfilerAgentParams) String() string {
 func (*ChangeQANMongoDBProfilerAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[47]
+	mi := &file_inventory_v1_agents_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8249,7 +8474,7 @@ func (x *ChangeQANMongoDBProfilerAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMongoDBProfilerAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMongoDBProfilerAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{47}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *ChangeQANMongoDBProfilerAgentParams) GetEnable() bool {
@@ -8397,7 +8622,7 @@ type AddQANMongoDBMongologAgentParams struct {
 
 func (x *AddQANMongoDBMongologAgentParams) Reset() {
 	*x = AddQANMongoDBMongologAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[48]
+	mi := &file_inventory_v1_agents_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8409,7 +8634,7 @@ func (x *AddQANMongoDBMongologAgentParams) String() string {
 func (*AddQANMongoDBMongologAgentParams) ProtoMessage() {}
 
 func (x *AddQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[48]
+	mi := &file_inventory_v1_agents_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8422,7 +8647,7 @@ func (x *AddQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddQANMongoDBMongologAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANMongoDBMongologAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{48}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AddQANMongoDBMongologAgentParams) GetPmmAgentId() string {
@@ -8568,7 +8793,7 @@ type ChangeQANMongoDBMongologAgentParams struct {
 
 func (x *ChangeQANMongoDBMongologAgentParams) Reset() {
 	*x = ChangeQANMongoDBMongologAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[49]
+	mi := &file_inventory_v1_agents_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8580,7 +8805,7 @@ func (x *ChangeQANMongoDBMongologAgentParams) String() string {
 func (*ChangeQANMongoDBMongologAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[49]
+	mi := &file_inventory_v1_agents_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8593,7 +8818,7 @@ func (x *ChangeQANMongoDBMongologAgentParams) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ChangeQANMongoDBMongologAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANMongoDBMongologAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{49}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ChangeQANMongoDBMongologAgentParams) GetEnable() bool {
@@ -8737,7 +8962,7 @@ type AddQANPostgreSQLPgStatementsAgentParams struct {
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) Reset() {
 	*x = AddQANPostgreSQLPgStatementsAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[50]
+	mi := &file_inventory_v1_agents_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8749,7 +8974,7 @@ func (x *AddQANPostgreSQLPgStatementsAgentParams) String() string {
 func (*AddQANPostgreSQLPgStatementsAgentParams) ProtoMessage() {}
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[50]
+	mi := &file_inventory_v1_agents_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8762,7 +8987,7 @@ func (x *AddQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use AddQANPostgreSQLPgStatementsAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANPostgreSQLPgStatementsAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{50}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *AddQANPostgreSQLPgStatementsAgentParams) GetPmmAgentId() string {
@@ -8899,7 +9124,7 @@ type ChangeQANPostgreSQLPgStatementsAgentParams struct {
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) Reset() {
 	*x = ChangeQANPostgreSQLPgStatementsAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[51]
+	mi := &file_inventory_v1_agents_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8911,7 +9136,7 @@ func (x *ChangeQANPostgreSQLPgStatementsAgentParams) String() string {
 func (*ChangeQANPostgreSQLPgStatementsAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[51]
+	mi := &file_inventory_v1_agents_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8924,7 +9149,7 @@ func (x *ChangeQANPostgreSQLPgStatementsAgentParams) ProtoReflect() protoreflect
 
 // Deprecated: Use ChangeQANPostgreSQLPgStatementsAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANPostgreSQLPgStatementsAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{51}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *ChangeQANPostgreSQLPgStatementsAgentParams) GetEnable() bool {
@@ -9063,7 +9288,7 @@ type AddQANPostgreSQLPgStatMonitorAgentParams struct {
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) Reset() {
 	*x = AddQANPostgreSQLPgStatMonitorAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[52]
+	mi := &file_inventory_v1_agents_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9075,7 +9300,7 @@ func (x *AddQANPostgreSQLPgStatMonitorAgentParams) String() string {
 func (*AddQANPostgreSQLPgStatMonitorAgentParams) ProtoMessage() {}
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[52]
+	mi := &file_inventory_v1_agents_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9088,7 +9313,7 @@ func (x *AddQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.M
 
 // Deprecated: Use AddQANPostgreSQLPgStatMonitorAgentParams.ProtoReflect.Descriptor instead.
 func (*AddQANPostgreSQLPgStatMonitorAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{52}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *AddQANPostgreSQLPgStatMonitorAgentParams) GetPmmAgentId() string {
@@ -9234,7 +9459,7 @@ type ChangeQANPostgreSQLPgStatMonitorAgentParams struct {
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) Reset() {
 	*x = ChangeQANPostgreSQLPgStatMonitorAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[53]
+	mi := &file_inventory_v1_agents_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9246,7 +9471,7 @@ func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) String() string {
 func (*ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoMessage() {}
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[53]
+	mi := &file_inventory_v1_agents_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9259,7 +9484,7 @@ func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) ProtoReflect() protoreflec
 
 // Deprecated: Use ChangeQANPostgreSQLPgStatMonitorAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeQANPostgreSQLPgStatMonitorAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{53}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ChangeQANPostgreSQLPgStatMonitorAgentParams) GetEnable() bool {
@@ -9395,7 +9620,7 @@ type AddRDSExporterParams struct {
 
 func (x *AddRDSExporterParams) Reset() {
 	*x = AddRDSExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[54]
+	mi := &file_inventory_v1_agents_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9407,7 +9632,7 @@ func (x *AddRDSExporterParams) String() string {
 func (*AddRDSExporterParams) ProtoMessage() {}
 
 func (x *AddRDSExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[54]
+	mi := &file_inventory_v1_agents_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9420,7 +9645,7 @@ func (x *AddRDSExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRDSExporterParams.ProtoReflect.Descriptor instead.
 func (*AddRDSExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{54}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *AddRDSExporterParams) GetPmmAgentId() string {
@@ -9519,7 +9744,7 @@ type ChangeRDSExporterParams struct {
 
 func (x *ChangeRDSExporterParams) Reset() {
 	*x = ChangeRDSExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[55]
+	mi := &file_inventory_v1_agents_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9531,7 +9756,7 @@ func (x *ChangeRDSExporterParams) String() string {
 func (*ChangeRDSExporterParams) ProtoMessage() {}
 
 func (x *ChangeRDSExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[55]
+	mi := &file_inventory_v1_agents_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9544,7 +9769,7 @@ func (x *ChangeRDSExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRDSExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeRDSExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{55}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ChangeRDSExporterParams) GetEnable() bool {
@@ -9638,7 +9863,7 @@ type AddExternalExporterParams struct {
 
 func (x *AddExternalExporterParams) Reset() {
 	*x = AddExternalExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[56]
+	mi := &file_inventory_v1_agents_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9650,7 +9875,7 @@ func (x *AddExternalExporterParams) String() string {
 func (*AddExternalExporterParams) ProtoMessage() {}
 
 func (x *AddExternalExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[56]
+	mi := &file_inventory_v1_agents_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9663,7 +9888,7 @@ func (x *AddExternalExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddExternalExporterParams.ProtoReflect.Descriptor instead.
 func (*AddExternalExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{56}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *AddExternalExporterParams) GetRunsOnNodeId() string {
@@ -9760,7 +9985,7 @@ type ChangeExternalExporterParams struct {
 
 func (x *ChangeExternalExporterParams) Reset() {
 	*x = ChangeExternalExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[57]
+	mi := &file_inventory_v1_agents_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9772,7 +9997,7 @@ func (x *ChangeExternalExporterParams) String() string {
 func (*ChangeExternalExporterParams) ProtoMessage() {}
 
 func (x *ChangeExternalExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[57]
+	mi := &file_inventory_v1_agents_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9785,7 +10010,7 @@ func (x *ChangeExternalExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeExternalExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeExternalExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{57}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ChangeExternalExporterParams) GetEnable() bool {
@@ -9876,7 +10101,7 @@ type AddAzureDatabaseExporterParams struct {
 
 func (x *AddAzureDatabaseExporterParams) Reset() {
 	*x = AddAzureDatabaseExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[58]
+	mi := &file_inventory_v1_agents_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9888,7 +10113,7 @@ func (x *AddAzureDatabaseExporterParams) String() string {
 func (*AddAzureDatabaseExporterParams) ProtoMessage() {}
 
 func (x *AddAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[58]
+	mi := &file_inventory_v1_agents_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9901,7 +10126,7 @@ func (x *AddAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddAzureDatabaseExporterParams.ProtoReflect.Descriptor instead.
 func (*AddAzureDatabaseExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{58}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *AddAzureDatabaseExporterParams) GetPmmAgentId() string {
@@ -10016,7 +10241,7 @@ type ChangeAzureDatabaseExporterParams struct {
 
 func (x *ChangeAzureDatabaseExporterParams) Reset() {
 	*x = ChangeAzureDatabaseExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[59]
+	mi := &file_inventory_v1_agents_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10028,7 +10253,7 @@ func (x *ChangeAzureDatabaseExporterParams) String() string {
 func (*ChangeAzureDatabaseExporterParams) ProtoMessage() {}
 
 func (x *ChangeAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[59]
+	mi := &file_inventory_v1_agents_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10041,7 +10266,7 @@ func (x *ChangeAzureDatabaseExporterParams) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use ChangeAzureDatabaseExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeAzureDatabaseExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{59}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *ChangeAzureDatabaseExporterParams) GetEnable() bool {
@@ -10124,7 +10349,7 @@ type ChangeNomadAgentParams struct {
 
 func (x *ChangeNomadAgentParams) Reset() {
 	*x = ChangeNomadAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[60]
+	mi := &file_inventory_v1_agents_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10136,7 +10361,7 @@ func (x *ChangeNomadAgentParams) String() string {
 func (*ChangeNomadAgentParams) ProtoMessage() {}
 
 func (x *ChangeNomadAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[60]
+	mi := &file_inventory_v1_agents_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10149,7 +10374,7 @@ func (x *ChangeNomadAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeNomadAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeNomadAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{60}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *ChangeNomadAgentParams) GetEnable() bool {
@@ -10201,7 +10426,7 @@ type AddValkeyExporterParams struct {
 
 func (x *AddValkeyExporterParams) Reset() {
 	*x = AddValkeyExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[61]
+	mi := &file_inventory_v1_agents_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10213,7 +10438,7 @@ func (x *AddValkeyExporterParams) String() string {
 func (*AddValkeyExporterParams) ProtoMessage() {}
 
 func (x *AddValkeyExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[61]
+	mi := &file_inventory_v1_agents_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10226,7 +10451,7 @@ func (x *AddValkeyExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddValkeyExporterParams.ProtoReflect.Descriptor instead.
 func (*AddValkeyExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{61}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *AddValkeyExporterParams) GetPmmAgentId() string {
@@ -10388,7 +10613,7 @@ type ChangeValkeyExporterParams struct {
 
 func (x *ChangeValkeyExporterParams) Reset() {
 	*x = ChangeValkeyExporterParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[62]
+	mi := &file_inventory_v1_agents_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10400,7 +10625,7 @@ func (x *ChangeValkeyExporterParams) String() string {
 func (*ChangeValkeyExporterParams) ProtoMessage() {}
 
 func (x *ChangeValkeyExporterParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[62]
+	mi := &file_inventory_v1_agents_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10413,7 +10638,7 @@ func (x *ChangeValkeyExporterParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeValkeyExporterParams.ProtoReflect.Descriptor instead.
 func (*ChangeValkeyExporterParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{62}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ChangeValkeyExporterParams) GetEnable() bool {
@@ -10567,7 +10792,7 @@ type AddRTAMongoDBAgentParams struct {
 
 func (x *AddRTAMongoDBAgentParams) Reset() {
 	*x = AddRTAMongoDBAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[63]
+	mi := &file_inventory_v1_agents_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10579,7 +10804,7 @@ func (x *AddRTAMongoDBAgentParams) String() string {
 func (*AddRTAMongoDBAgentParams) ProtoMessage() {}
 
 func (x *AddRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[63]
+	mi := &file_inventory_v1_agents_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10592,7 +10817,7 @@ func (x *AddRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddRTAMongoDBAgentParams.ProtoReflect.Descriptor instead.
 func (*AddRTAMongoDBAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{63}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *AddRTAMongoDBAgentParams) GetPmmAgentId() string {
@@ -10725,7 +10950,7 @@ type ChangeRTAMongoDBAgentParams struct {
 
 func (x *ChangeRTAMongoDBAgentParams) Reset() {
 	*x = ChangeRTAMongoDBAgentParams{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[64]
+	mi := &file_inventory_v1_agents_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10737,7 +10962,7 @@ func (x *ChangeRTAMongoDBAgentParams) String() string {
 func (*ChangeRTAMongoDBAgentParams) ProtoMessage() {}
 
 func (x *ChangeRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[64]
+	mi := &file_inventory_v1_agents_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10750,7 +10975,7 @@ func (x *ChangeRTAMongoDBAgentParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChangeRTAMongoDBAgentParams.ProtoReflect.Descriptor instead.
 func (*ChangeRTAMongoDBAgentParams) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{64}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ChangeRTAMongoDBAgentParams) GetEnable() bool {
@@ -10837,6 +11062,294 @@ func (x *ChangeRTAMongoDBAgentParams) GetRtaOptions() *RTAOptions {
 	return nil
 }
 
+type AddRTAPostgreSQLAgentParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The pmm-agent identifier which runs this instance.
+	PmmAgentId string `protobuf:"bytes,1,opt,name=pmm_agent_id,json=pmmAgentId,proto3" json:"pmm_agent_id,omitempty"`
+	// Service identifier.
+	ServiceId string `protobuf:"bytes,2,opt,name=service_id,json=serviceId,proto3" json:"service_id,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
+	// PostgreSQL password for getting session data.
+	Password string `protobuf:"bytes,4,opt,name=password,proto3" json:"password,omitempty"`
+	// Custom user-assigned labels.
+	CustomLabels map[string]string `protobuf:"bytes,5,rep,name=custom_labels,json=customLabels,proto3" json:"custom_labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// Log level for agent.
+	LogLevel LogLevel `protobuf:"varint,6,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel" json:"log_level,omitempty"`
+	// Use TLS for database connections.
+	Tls bool `protobuf:"varint,7,opt,name=tls,proto3" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify bool `protobuf:"varint,8,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3" json:"tls_skip_verify,omitempty"`
+	// TLS CA certificate.
+	TlsCa string `protobuf:"bytes,9,opt,name=tls_ca,json=tlsCa,proto3" json:"tls_ca,omitempty"`
+	// TLS certificate.
+	TlsCert string `protobuf:"bytes,10,opt,name=tls_cert,json=tlsCert,proto3" json:"tls_cert,omitempty"`
+	// TLS certificate key.
+	TlsKey string `protobuf:"bytes,11,opt,name=tls_key,json=tlsKey,proto3" json:"tls_key,omitempty"`
+	// Skip connection check.
+	SkipConnectionCheck bool `protobuf:"varint,12,opt,name=skip_connection_check,json=skipConnectionCheck,proto3" json:"skip_connection_check,omitempty"`
+	// Real-Time Analytics options.
+	RtaOptions    *RTAOptions `protobuf:"bytes,13,opt,name=rta_options,json=rtaOptions,proto3" json:"rta_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AddRTAPostgreSQLAgentParams) Reset() {
+	*x = AddRTAPostgreSQLAgentParams{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AddRTAPostgreSQLAgentParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AddRTAPostgreSQLAgentParams) ProtoMessage() {}
+
+func (x *AddRTAPostgreSQLAgentParams) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AddRTAPostgreSQLAgentParams.ProtoReflect.Descriptor instead.
+func (*AddRTAPostgreSQLAgentParams) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetPmmAgentId() string {
+	if x != nil {
+		return x.PmmAgentId
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetServiceId() string {
+	if x != nil {
+		return x.ServiceId
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetPassword() string {
+	if x != nil {
+		return x.Password
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetCustomLabels() map[string]string {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetLogLevel() LogLevel {
+	if x != nil {
+		return x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTls() bool {
+	if x != nil {
+		return x.Tls
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsSkipVerify() bool {
+	if x != nil {
+		return x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsCa() string {
+	if x != nil {
+		return x.TlsCa
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsCert() string {
+	if x != nil {
+		return x.TlsCert
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetTlsKey() string {
+	if x != nil {
+		return x.TlsKey
+	}
+	return ""
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetSkipConnectionCheck() bool {
+	if x != nil {
+		return x.SkipConnectionCheck
+	}
+	return false
+}
+
+func (x *AddRTAPostgreSQLAgentParams) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
+type ChangeRTAPostgreSQLAgentParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Enable this Agent. Agents are enabled by default when they get added.
+	Enable *bool `protobuf:"varint,1,opt,name=enable,proto3,oneof" json:"enable,omitempty"`
+	// Replace all custom user-assigned labels.
+	CustomLabels *common.StringMap `protobuf:"bytes,2,opt,name=custom_labels,json=customLabels,proto3,oneof" json:"custom_labels,omitempty"`
+	// Log level for agent.
+	LogLevel *LogLevel `protobuf:"varint,3,opt,name=log_level,json=logLevel,proto3,enum=inventory.v1.LogLevel,oneof" json:"log_level,omitempty"`
+	// PostgreSQL username for getting session data.
+	Username *string `protobuf:"bytes,4,opt,name=username,proto3,oneof" json:"username,omitempty"`
+	// PostgreSQL password for getting session data.
+	Password *string `protobuf:"bytes,5,opt,name=password,proto3,oneof" json:"password,omitempty"`
+	// Use TLS for database connections.
+	Tls *bool `protobuf:"varint,6,opt,name=tls,proto3,oneof" json:"tls,omitempty"`
+	// Skip TLS certificate and hostname validation.
+	TlsSkipVerify *bool `protobuf:"varint,7,opt,name=tls_skip_verify,json=tlsSkipVerify,proto3,oneof" json:"tls_skip_verify,omitempty"`
+	// TLS CA certificate.
+	TlsCa *string `protobuf:"bytes,8,opt,name=tls_ca,json=tlsCa,proto3,oneof" json:"tls_ca,omitempty"`
+	// TLS certificate.
+	TlsCert *string `protobuf:"bytes,9,opt,name=tls_cert,json=tlsCert,proto3,oneof" json:"tls_cert,omitempty"`
+	// TLS certificate key.
+	TlsKey *string `protobuf:"bytes,10,opt,name=tls_key,json=tlsKey,proto3,oneof" json:"tls_key,omitempty"`
+	// Real-Time Analytics options.
+	RtaOptions    *RTAOptions `protobuf:"bytes,11,opt,name=rta_options,json=rtaOptions,proto3,oneof" json:"rta_options,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) Reset() {
+	*x = ChangeRTAPostgreSQLAgentParams{}
+	mi := &file_inventory_v1_agents_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChangeRTAPostgreSQLAgentParams) ProtoMessage() {}
+
+func (x *ChangeRTAPostgreSQLAgentParams) ProtoReflect() protoreflect.Message {
+	mi := &file_inventory_v1_agents_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChangeRTAPostgreSQLAgentParams.ProtoReflect.Descriptor instead.
+func (*ChangeRTAPostgreSQLAgentParams) Descriptor() ([]byte, []int) {
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetEnable() bool {
+	if x != nil && x.Enable != nil {
+		return *x.Enable
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetCustomLabels() *common.StringMap {
+	if x != nil {
+		return x.CustomLabels
+	}
+	return nil
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetLogLevel() LogLevel {
+	if x != nil && x.LogLevel != nil {
+		return *x.LogLevel
+	}
+	return LogLevel_LOG_LEVEL_UNSPECIFIED
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetUsername() string {
+	if x != nil && x.Username != nil {
+		return *x.Username
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetPassword() string {
+	if x != nil && x.Password != nil {
+		return *x.Password
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTls() bool {
+	if x != nil && x.Tls != nil {
+		return *x.Tls
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsSkipVerify() bool {
+	if x != nil && x.TlsSkipVerify != nil {
+		return *x.TlsSkipVerify
+	}
+	return false
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsCa() string {
+	if x != nil && x.TlsCa != nil {
+		return *x.TlsCa
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsCert() string {
+	if x != nil && x.TlsCert != nil {
+		return *x.TlsCert
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetTlsKey() string {
+	if x != nil && x.TlsKey != nil {
+		return *x.TlsKey
+	}
+	return ""
+}
+
+func (x *ChangeRTAPostgreSQLAgentParams) GetRtaOptions() *RTAOptions {
+	if x != nil {
+		return x.RtaOptions
+	}
+	return nil
+}
+
 type RemoveAgentRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	AgentId string                 `protobuf:"bytes,1,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
@@ -10848,7 +11361,7 @@ type RemoveAgentRequest struct {
 
 func (x *RemoveAgentRequest) Reset() {
 	*x = RemoveAgentRequest{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[65]
+	mi := &file_inventory_v1_agents_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10860,7 +11373,7 @@ func (x *RemoveAgentRequest) String() string {
 func (*RemoveAgentRequest) ProtoMessage() {}
 
 func (x *RemoveAgentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[65]
+	mi := &file_inventory_v1_agents_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10873,7 +11386,7 @@ func (x *RemoveAgentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAgentRequest.ProtoReflect.Descriptor instead.
 func (*RemoveAgentRequest) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{65}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RemoveAgentRequest) GetAgentId() string {
@@ -10898,7 +11411,7 @@ type RemoveAgentResponse struct {
 
 func (x *RemoveAgentResponse) Reset() {
 	*x = RemoveAgentResponse{}
-	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	mi := &file_inventory_v1_agents_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10910,7 +11423,7 @@ func (x *RemoveAgentResponse) String() string {
 func (*RemoveAgentResponse) ProtoMessage() {}
 
 func (x *RemoveAgentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_inventory_v1_agents_proto_msgTypes[66]
+	mi := &file_inventory_v1_agents_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10923,7 +11436,7 @@ func (x *RemoveAgentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveAgentResponse.ProtoReflect.Descriptor instead.
 func (*RemoveAgentResponse) Descriptor() ([]byte, []int) {
-	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{66}
+	return file_inventory_v1_agents_proto_rawDescGZIP(), []int{69}
 }
 
 var File_inventory_v1_agents_proto protoreflect.FileDescriptor
@@ -11219,7 +11732,26 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\n" +
 	"RTAOptions\x12P\n" +
 	"\x10collect_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationB\n" +
-	"\xfaB\a\xaa\x01\x042\x02\b\x01R\x0fcollectInterval\"\x9f\x04\n" +
+	"\xfaB\a\xaa\x01\x042\x02\b\x01R\x0fcollectInterval\"\xa5\x04\n" +
+	"\x12RTAPostgreSQLAgent\x12\x19\n" +
+	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12 \n" +
+	"\fpmm_agent_id\x18\x02 \x01(\tR\n" +
+	"pmmAgentId\x12\x1a\n" +
+	"\bdisabled\x18\x03 \x01(\bR\bdisabled\x12\x1d\n" +
+	"\n" +
+	"service_id\x18\x04 \x01(\tR\tserviceId\x12 \n" +
+	"\busername\x18\x05 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12\x10\n" +
+	"\x03tls\x18\x06 \x01(\bR\x03tls\x12&\n" +
+	"\x0ftls_skip_verify\x18\a \x01(\bR\rtlsSkipVerify\x12W\n" +
+	"\rcustom_labels\x18\b \x03(\v22.inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntryR\fcustomLabels\x129\n" +
+	"\vrta_options\x18\t \x01(\v2\x18.inventory.v1.RTAOptionsR\n" +
+	"rtaOptions\x121\n" +
+	"\x06status\x18\n" +
+	" \x01(\x0e2\x19.inventory.v1.AgentStatusR\x06status\x123\n" +
+	"\tlog_level\x18\v \x01(\x0e2\x16.inventory.v1.LogLevelR\blogLevel\x1a?\n" +
+	"\x11CustomLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9f\x04\n" +
 	"\x0fRTAMongoDBAgent\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12 \n" +
 	"\fpmm_agent_id\x18\x02 \x01(\tR\n" +
@@ -11358,7 +11890,7 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\n" +
 	"service_id\x18\x03 \x01(\tR\tserviceId\x126\n" +
 	"\n" +
-	"agent_type\x18\x04 \x01(\x0e2\x17.inventory.v1.AgentTypeR\tagentType\"\x98\f\n" +
+	"agent_type\x18\x04 \x01(\x0e2\x17.inventory.v1.AgentTypeR\tagentType\"\xec\f\n" +
 	"\x12ListAgentsResponse\x123\n" +
 	"\tpmm_agent\x18\x01 \x03(\v2\x16.inventory.v1.PMMAgentR\bpmmAgent\x120\n" +
 	"\bvm_agent\x18\x02 \x03(\v2\x15.inventory.v1.VMAgentR\avmAgent\x12?\n" +
@@ -11380,9 +11912,10 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x10 \x03(\v2\x18.inventory.v1.NomadAgentR\n" +
 	"nomadAgent\x12E\n" +
 	"\x0fvalkey_exporter\x18\x11 \x03(\v2\x1c.inventory.v1.ValkeyExporterR\x0evalkeyExporter\x12I\n" +
-	"\x11rta_mongodb_agent\x18\x13 \x03(\v2\x1d.inventory.v1.RTAMongoDBAgentR\x0frtaMongodbAgent\"5\n" +
+	"\x11rta_mongodb_agent\x18\x13 \x03(\v2\x1d.inventory.v1.RTAMongoDBAgentR\x0frtaMongodbAgent\x12R\n" +
+	"\x14rta_postgresql_agent\x18\x14 \x03(\v2 .inventory.v1.RTAPostgreSQLAgentR\x12rtaPostgresqlAgent\"5\n" +
 	"\x0fGetAgentRequest\x12\"\n" +
-	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\"\xc4\f\n" +
+	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\"\x9a\r\n" +
 	"\x10GetAgentResponse\x125\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x16.inventory.v1.PMMAgentH\x00R\bpmmAgent\x121\n" +
 	"\avmagent\x18\x02 \x01(\v2\x15.inventory.v1.VMAgentH\x00R\avmagent\x12A\n" +
@@ -11404,14 +11937,15 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x10 \x01(\v2\x18.inventory.v1.NomadAgentH\x00R\n" +
 	"nomadAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x11 \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x13 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
+	"\x11rta_mongodb_agent\x18\x13 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x14 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
 	"\x05agent\"O\n" +
 	"\x13GetAgentLogsRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10$R\aagentId\x12\x14\n" +
 	"\x05limit\x18\x02 \x01(\rR\x05limit\"j\n" +
 	"\x14GetAgentLogsResponse\x12\x12\n" +
 	"\x04logs\x18\x01 \x03(\tR\x04logs\x12>\n" +
-	"\x1cagent_config_log_lines_count\x18\x02 \x01(\rR\x18agentConfigLogLinesCount\"\xee\f\n" +
+	"\x1cagent_config_log_lines_count\x18\x02 \x01(\rR\x18agentConfigLogLinesCount\"\xcd\r\n" +
 	"\x0fAddAgentRequest\x12>\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x1f.inventory.v1.AddPMMAgentParamsH\x00R\bpmmAgent\x12J\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2#.inventory.v1.AddNodeExporterParamsH\x00R\fnodeExporter\x12P\n" +
@@ -11430,8 +11964,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"!qan_postgresql_pgstatements_agent\x18\r \x01(\v25.inventory.v1.AddQANPostgreSQLPgStatementsAgentParamsH\x00R\x1eqanPostgresqlPgstatementsAgent\x12\x85\x01\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x0e \x01(\v26.inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParamsH\x00R\x1fqanPostgresqlPgstatmonitorAgent\x12P\n" +
 	"\x0fvalkey_exporter\x18\x0f \x01(\v2%.inventory.v1.AddValkeyExporterParamsH\x00R\x0evalkeyExporter\x12T\n" +
-	"\x11rta_mongodb_agent\x18\x11 \x01(\v2&.inventory.v1.AddRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xd4\v\n" +
+	"\x11rta_mongodb_agent\x18\x11 \x01(\v2&.inventory.v1.AddRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgent\x12]\n" +
+	"\x14rta_postgresql_agent\x18\x12 \x01(\v2).inventory.v1.AddRTAPostgreSQLAgentParamsH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xaa\f\n" +
 	"\x10AddAgentResponse\x125\n" +
 	"\tpmm_agent\x18\x01 \x01(\v2\x16.inventory.v1.PMMAgentH\x00R\bpmmAgent\x12A\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2\x1a.inventory.v1.NodeExporterH\x00R\fnodeExporter\x12G\n" +
@@ -11450,8 +11985,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"!qan_postgresql_pgstatements_agent\x18\r \x01(\v2,.inventory.v1.QANPostgreSQLPgStatementsAgentH\x00R\x1eqanPostgresqlPgstatementsAgent\x12|\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x0e \x01(\v2-.inventory.v1.QANPostgreSQLPgStatMonitorAgentH\x00R\x1fqanPostgresqlPgstatmonitorAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x0f \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x11 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xce\r\n" +
+	"\x11rta_mongodb_agent\x18\x11 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x12 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xb0\x0e\n" +
 	"\x12ChangeAgentRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aagentId\x12M\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2&.inventory.v1.ChangeNodeExporterParamsH\x00R\fnodeExporter\x12S\n" +
@@ -11472,8 +12008,9 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x0f \x01(\v2$.inventory.v1.ChangeNomadAgentParamsH\x00R\n" +
 	"nomadAgent\x12S\n" +
 	"\x0fvalkey_exporter\x18\x10 \x01(\v2(.inventory.v1.ChangeValkeyExporterParamsH\x00R\x0evalkeyExporter\x12W\n" +
-	"\x11rta_mongodb_agent\x18\x12 \x01(\v2).inventory.v1.ChangeRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgentB\a\n" +
-	"\x05agent\"\xdd\v\n" +
+	"\x11rta_mongodb_agent\x18\x12 \x01(\v2).inventory.v1.ChangeRTAMongoDBAgentParamsH\x00R\x0frtaMongodbAgent\x12`\n" +
+	"\x14rta_postgresql_agent\x18\x13 \x01(\v2,.inventory.v1.ChangeRTAPostgreSQLAgentParamsH\x00R\x12rtaPostgresqlAgentB\a\n" +
+	"\x05agent\"\xb3\f\n" +
 	"\x13ChangeAgentResponse\x12A\n" +
 	"\rnode_exporter\x18\x02 \x01(\v2\x1a.inventory.v1.NodeExporterH\x00R\fnodeExporter\x12G\n" +
 	"\x0fmysqld_exporter\x18\x03 \x01(\v2\x1c.inventory.v1.MySQLdExporterH\x00R\x0emysqldExporter\x12J\n" +
@@ -11493,7 +12030,8 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\vnomad_agent\x18\x0f \x01(\v2\x18.inventory.v1.NomadAgentH\x00R\n" +
 	"nomadAgent\x12G\n" +
 	"\x0fvalkey_exporter\x18\x10 \x01(\v2\x1c.inventory.v1.ValkeyExporterH\x00R\x0evalkeyExporter\x12K\n" +
-	"\x11rta_mongodb_agent\x18\x12 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgentB\a\n" +
+	"\x11rta_mongodb_agent\x18\x12 \x01(\v2\x1d.inventory.v1.RTAMongoDBAgentH\x00R\x0frtaMongodbAgent\x12T\n" +
+	"\x14rta_postgresql_agent\x18\x13 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentH\x00R\x12rtaPostgresqlAgentB\a\n" +
 	"\x05agent\"\xdc\x01\n" +
 	"\x11AddPMMAgentParams\x12.\n" +
 	"\x0fruns_on_node_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\frunsOnNodeId\x12V\n" +
@@ -12345,11 +12883,60 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\"_tls_certificate_key_file_passwordB\t\n" +
 	"\a_tls_caB\x1b\n" +
 	"\x19_authentication_mechanismB\x0e\n" +
+	"\f_rta_options\"\x8c\x05\n" +
+	"\x1bAddRTAPostgreSQLAgentParams\x12)\n" +
+	"\fpmm_agent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\n" +
+	"pmmAgentId\x12&\n" +
+	"\n" +
+	"service_id\x18\x02 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\tserviceId\x12 \n" +
+	"\busername\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12 \n" +
+	"\bpassword\x18\x04 \x01(\tB\x04\x88\xb5\x18\x01R\bpassword\x12`\n" +
+	"\rcustom_labels\x18\x05 \x03(\v2;.inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntryR\fcustomLabels\x123\n" +
+	"\tlog_level\x18\x06 \x01(\x0e2\x16.inventory.v1.LogLevelR\blogLevel\x12\x10\n" +
+	"\x03tls\x18\a \x01(\bR\x03tls\x12&\n" +
+	"\x0ftls_skip_verify\x18\b \x01(\bR\rtlsSkipVerify\x12\x15\n" +
+	"\x06tls_ca\x18\t \x01(\tR\x05tlsCa\x12\x1f\n" +
+	"\btls_cert\x18\n" +
+	" \x01(\tB\x04\x88\xb5\x18\x01R\atlsCert\x12\x1d\n" +
+	"\atls_key\x18\v \x01(\tB\x04\x88\xb5\x18\x01R\x06tlsKey\x122\n" +
+	"\x15skip_connection_check\x18\f \x01(\bR\x13skipConnectionCheck\x129\n" +
+	"\vrta_options\x18\r \x01(\v2\x18.inventory.v1.RTAOptionsR\n" +
+	"rtaOptions\x1a?\n" +
+	"\x11CustomLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x81\x05\n" +
+	"\x1eChangeRTAPostgreSQLAgentParams\x12\x1b\n" +
+	"\x06enable\x18\x01 \x01(\bH\x00R\x06enable\x88\x01\x01\x12;\n" +
+	"\rcustom_labels\x18\x02 \x01(\v2\x11.common.StringMapH\x01R\fcustomLabels\x88\x01\x01\x128\n" +
+	"\tlog_level\x18\x03 \x01(\x0e2\x16.inventory.v1.LogLevelH\x02R\blogLevel\x88\x01\x01\x12%\n" +
+	"\busername\x18\x04 \x01(\tB\x04\x88\xb5\x18\x01H\x03R\busername\x88\x01\x01\x12%\n" +
+	"\bpassword\x18\x05 \x01(\tB\x04\x88\xb5\x18\x01H\x04R\bpassword\x88\x01\x01\x12\x15\n" +
+	"\x03tls\x18\x06 \x01(\bH\x05R\x03tls\x88\x01\x01\x12+\n" +
+	"\x0ftls_skip_verify\x18\a \x01(\bH\x06R\rtlsSkipVerify\x88\x01\x01\x12\x1a\n" +
+	"\x06tls_ca\x18\b \x01(\tH\aR\x05tlsCa\x88\x01\x01\x12$\n" +
+	"\btls_cert\x18\t \x01(\tB\x04\x88\xb5\x18\x01H\bR\atlsCert\x88\x01\x01\x12\"\n" +
+	"\atls_key\x18\n" +
+	" \x01(\tB\x04\x88\xb5\x18\x01H\tR\x06tlsKey\x88\x01\x01\x12>\n" +
+	"\vrta_options\x18\v \x01(\v2\x18.inventory.v1.RTAOptionsH\n" +
+	"R\n" +
+	"rtaOptions\x88\x01\x01B\t\n" +
+	"\a_enableB\x10\n" +
+	"\x0e_custom_labelsB\f\n" +
+	"\n" +
+	"_log_levelB\v\n" +
+	"\t_usernameB\v\n" +
+	"\t_passwordB\x06\n" +
+	"\x04_tlsB\x12\n" +
+	"\x10_tls_skip_verifyB\t\n" +
+	"\a_tls_caB\v\n" +
+	"\t_tls_certB\n" +
+	"\n" +
+	"\b_tls_keyB\x0e\n" +
 	"\f_rta_options\"N\n" +
 	"\x12RemoveAgentRequest\x12\"\n" +
 	"\bagent_id\x18\x01 \x01(\tB\a\xfaB\x04r\x02\x10\x01R\aagentId\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\"\x15\n" +
-	"\x13RemoveAgentResponse*\xd0\x05\n" +
+	"\x13RemoveAgentResponse*\xf5\x05\n" +
 	"\tAgentType\x12\x1a\n" +
 	"\x16AGENT_TYPE_UNSPECIFIED\x10\x00\x12\x18\n" +
 	"\x14AGENT_TYPE_PMM_AGENT\x10\x01\x12\x17\n" +
@@ -12371,7 +12958,8 @@ const file_inventory_v1_agents_proto_rawDesc = "" +
 	"\x17AGENT_TYPE_RDS_EXPORTER\x10\v\x12&\n" +
 	"\"AGENT_TYPE_AZURE_DATABASE_EXPORTER\x10\x0f\x12\x1a\n" +
 	"\x16AGENT_TYPE_NOMAD_AGENT\x10\x10\x12 \n" +
-	"\x1cAGENT_TYPE_RTA_MONGODB_AGENT\x10\x132\x83\t\n" +
+	"\x1cAGENT_TYPE_RTA_MONGODB_AGENT\x10\x13\x12#\n" +
+	"\x1fAGENT_TYPE_RTA_POSTGRESQL_AGENT\x10\x142\x83\t\n" +
 	"\rAgentsService\x12\x9c\x01\n" +
 	"\n" +
 	"ListAgents\x12\x1f.inventory.v1.ListAgentsRequest\x1a .inventory.v1.ListAgentsResponse\"K\x92A,\x12\vList Agents\x1a\x1dReturns a list of all Agents.\x82\xd3\xe4\x93\x02\x16\x12\x14/v1/inventory/agents\x12\x9f\x01\n" +
@@ -12394,414 +12982,432 @@ func file_inventory_v1_agents_proto_rawDescGZIP() []byte {
 	return file_inventory_v1_agents_proto_rawDescData
 }
 
-var (
-	file_inventory_v1_agents_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_inventory_v1_agents_proto_msgTypes  = make([]protoimpl.MessageInfo, 107)
-	file_inventory_v1_agents_proto_goTypes   = []any{
-		AgentType(0),                                        // 0: inventory.v1.AgentType
-		(*PMMAgent)(nil),                                    // 1: inventory.v1.PMMAgent
-		(*VMAgent)(nil),                                     // 2: inventory.v1.VMAgent
-		(*NomadAgent)(nil),                                  // 3: inventory.v1.NomadAgent
-		(*NodeExporter)(nil),                                // 4: inventory.v1.NodeExporter
-		(*MySQLdExporter)(nil),                              // 5: inventory.v1.MySQLdExporter
-		(*MongoDBExporter)(nil),                             // 6: inventory.v1.MongoDBExporter
-		(*PostgresExporter)(nil),                            // 7: inventory.v1.PostgresExporter
-		(*ProxySQLExporter)(nil),                            // 8: inventory.v1.ProxySQLExporter
-		(*ValkeyExporter)(nil),                              // 9: inventory.v1.ValkeyExporter
-		(*QANMySQLPerfSchemaAgent)(nil),                     // 10: inventory.v1.QANMySQLPerfSchemaAgent
-		(*QANMySQLSlowlogAgent)(nil),                        // 11: inventory.v1.QANMySQLSlowlogAgent
-		(*QANMongoDBProfilerAgent)(nil),                     // 12: inventory.v1.QANMongoDBProfilerAgent
-		(*QANMongoDBMongologAgent)(nil),                     // 13: inventory.v1.QANMongoDBMongologAgent
-		(*RTAOptions)(nil),                                  // 14: inventory.v1.RTAOptions
-		(*RTAMongoDBAgent)(nil),                             // 15: inventory.v1.RTAMongoDBAgent
-		(*QANPostgreSQLPgStatementsAgent)(nil),              // 16: inventory.v1.QANPostgreSQLPgStatementsAgent
-		(*QANPostgreSQLPgStatMonitorAgent)(nil),             // 17: inventory.v1.QANPostgreSQLPgStatMonitorAgent
-		(*RDSExporter)(nil),                                 // 18: inventory.v1.RDSExporter
-		(*ExternalExporter)(nil),                            // 19: inventory.v1.ExternalExporter
-		(*AzureDatabaseExporter)(nil),                       // 20: inventory.v1.AzureDatabaseExporter
-		(*ChangeCommonAgentParams)(nil),                     // 21: inventory.v1.ChangeCommonAgentParams
-		(*ListAgentsRequest)(nil),                           // 22: inventory.v1.ListAgentsRequest
-		(*ListAgentsResponse)(nil),                          // 23: inventory.v1.ListAgentsResponse
-		(*GetAgentRequest)(nil),                             // 24: inventory.v1.GetAgentRequest
-		(*GetAgentResponse)(nil),                            // 25: inventory.v1.GetAgentResponse
-		(*GetAgentLogsRequest)(nil),                         // 26: inventory.v1.GetAgentLogsRequest
-		(*GetAgentLogsResponse)(nil),                        // 27: inventory.v1.GetAgentLogsResponse
-		(*AddAgentRequest)(nil),                             // 28: inventory.v1.AddAgentRequest
-		(*AddAgentResponse)(nil),                            // 29: inventory.v1.AddAgentResponse
-		(*ChangeAgentRequest)(nil),                          // 30: inventory.v1.ChangeAgentRequest
-		(*ChangeAgentResponse)(nil),                         // 31: inventory.v1.ChangeAgentResponse
-		(*AddPMMAgentParams)(nil),                           // 32: inventory.v1.AddPMMAgentParams
-		(*AddNodeExporterParams)(nil),                       // 33: inventory.v1.AddNodeExporterParams
-		(*ChangeNodeExporterParams)(nil),                    // 34: inventory.v1.ChangeNodeExporterParams
-		(*AddMySQLdExporterParams)(nil),                     // 35: inventory.v1.AddMySQLdExporterParams
-		(*ChangeMySQLdExporterParams)(nil),                  // 36: inventory.v1.ChangeMySQLdExporterParams
-		(*AddMongoDBExporterParams)(nil),                    // 37: inventory.v1.AddMongoDBExporterParams
-		(*ChangeMongoDBExporterParams)(nil),                 // 38: inventory.v1.ChangeMongoDBExporterParams
-		(*AddPostgresExporterParams)(nil),                   // 39: inventory.v1.AddPostgresExporterParams
-		(*ChangePostgresExporterParams)(nil),                // 40: inventory.v1.ChangePostgresExporterParams
-		(*AddProxySQLExporterParams)(nil),                   // 41: inventory.v1.AddProxySQLExporterParams
-		(*ChangeProxySQLExporterParams)(nil),                // 42: inventory.v1.ChangeProxySQLExporterParams
-		(*AddQANMySQLPerfSchemaAgentParams)(nil),            // 43: inventory.v1.AddQANMySQLPerfSchemaAgentParams
-		(*ChangeQANMySQLPerfSchemaAgentParams)(nil),         // 44: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
-		(*AddQANMySQLSlowlogAgentParams)(nil),               // 45: inventory.v1.AddQANMySQLSlowlogAgentParams
-		(*ChangeQANMySQLSlowlogAgentParams)(nil),            // 46: inventory.v1.ChangeQANMySQLSlowlogAgentParams
-		(*AddQANMongoDBProfilerAgentParams)(nil),            // 47: inventory.v1.AddQANMongoDBProfilerAgentParams
-		(*ChangeQANMongoDBProfilerAgentParams)(nil),         // 48: inventory.v1.ChangeQANMongoDBProfilerAgentParams
-		(*AddQANMongoDBMongologAgentParams)(nil),            // 49: inventory.v1.AddQANMongoDBMongologAgentParams
-		(*ChangeQANMongoDBMongologAgentParams)(nil),         // 50: inventory.v1.ChangeQANMongoDBMongologAgentParams
-		(*AddQANPostgreSQLPgStatementsAgentParams)(nil),     // 51: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
-		(*ChangeQANPostgreSQLPgStatementsAgentParams)(nil),  // 52: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
-		(*AddQANPostgreSQLPgStatMonitorAgentParams)(nil),    // 53: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
-		(*ChangeQANPostgreSQLPgStatMonitorAgentParams)(nil), // 54: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
-		(*AddRDSExporterParams)(nil),                        // 55: inventory.v1.AddRDSExporterParams
-		(*ChangeRDSExporterParams)(nil),                     // 56: inventory.v1.ChangeRDSExporterParams
-		(*AddExternalExporterParams)(nil),                   // 57: inventory.v1.AddExternalExporterParams
-		(*ChangeExternalExporterParams)(nil),                // 58: inventory.v1.ChangeExternalExporterParams
-		(*AddAzureDatabaseExporterParams)(nil),              // 59: inventory.v1.AddAzureDatabaseExporterParams
-		(*ChangeAzureDatabaseExporterParams)(nil),           // 60: inventory.v1.ChangeAzureDatabaseExporterParams
-		(*ChangeNomadAgentParams)(nil),                      // 61: inventory.v1.ChangeNomadAgentParams
-		(*AddValkeyExporterParams)(nil),                     // 62: inventory.v1.AddValkeyExporterParams
-		(*ChangeValkeyExporterParams)(nil),                  // 63: inventory.v1.ChangeValkeyExporterParams
-		(*AddRTAMongoDBAgentParams)(nil),                    // 64: inventory.v1.AddRTAMongoDBAgentParams
-		(*ChangeRTAMongoDBAgentParams)(nil),                 // 65: inventory.v1.ChangeRTAMongoDBAgentParams
-		(*RemoveAgentRequest)(nil),                          // 66: inventory.v1.RemoveAgentRequest
-		(*RemoveAgentResponse)(nil),                         // 67: inventory.v1.RemoveAgentResponse
-		nil,                                                 // 68: inventory.v1.PMMAgent.CustomLabelsEntry
-		nil,                                                 // 69: inventory.v1.NodeExporter.CustomLabelsEntry
-		nil,                                                 // 70: inventory.v1.MySQLdExporter.CustomLabelsEntry
-		nil,                                                 // 71: inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
-		nil,                                                 // 72: inventory.v1.MongoDBExporter.CustomLabelsEntry
-		nil,                                                 // 73: inventory.v1.PostgresExporter.CustomLabelsEntry
-		nil,                                                 // 74: inventory.v1.ProxySQLExporter.CustomLabelsEntry
-		nil,                                                 // 75: inventory.v1.ValkeyExporter.CustomLabelsEntry
-		nil,                                                 // 76: inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
-		nil,                                                 // 77: inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
-		nil,                                                 // 78: inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
-		nil,                                                 // 79: inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
-		nil,                                                 // 80: inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
-		nil,                                                 // 81: inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
-		nil,                                                 // 82: inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
-		nil,                                                 // 83: inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
-		nil,                                                 // 84: inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
-		nil,                                                 // 85: inventory.v1.RDSExporter.CustomLabelsEntry
-		nil,                                                 // 86: inventory.v1.ExternalExporter.CustomLabelsEntry
-		nil,                                                 // 87: inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
-		nil,                                                 // 88: inventory.v1.AddPMMAgentParams.CustomLabelsEntry
-		nil,                                                 // 89: inventory.v1.AddNodeExporterParams.CustomLabelsEntry
-		nil,                                                 // 90: inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
-		nil,                                                 // 91: inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
-		nil,                                                 // 92: inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
-		nil,                                                 // 93: inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
-		nil,                                                 // 94: inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
-		nil,                                                 // 95: inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
-		nil,                                                 // 96: inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
-		nil,                                                 // 97: inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
-		nil,                                                 // 98: inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
-		nil,                                                 // 99: inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
-		nil,                                                 // 100: inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
-		nil,                                                 // 101: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
-		nil,                                                 // 102: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
-		nil,                                                 // 103: inventory.v1.AddRDSExporterParams.CustomLabelsEntry
-		nil,                                                 // 104: inventory.v1.AddExternalExporterParams.CustomLabelsEntry
-		nil,                                                 // 105: inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
-		nil,                                                 // 106: inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
-		nil,                                                 // 107: inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
-		AgentStatus(0),                                      // 108: inventory.v1.AgentStatus
-		LogLevel(0),                                         // 109: inventory.v1.LogLevel
-		(*common.MetricsResolutions)(nil),                   // 110: common.MetricsResolutions
-		(*durationpb.Duration)(nil),                         // 111: google.protobuf.Duration
-		(*common.StringMap)(nil),                            // 112: common.StringMap
-	}
-)
-
+var file_inventory_v1_agents_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_inventory_v1_agents_proto_msgTypes = make([]protoimpl.MessageInfo, 112)
+var file_inventory_v1_agents_proto_goTypes = []any{
+	(AgentType)(0),                                      // 0: inventory.v1.AgentType
+	(*PMMAgent)(nil),                                    // 1: inventory.v1.PMMAgent
+	(*VMAgent)(nil),                                     // 2: inventory.v1.VMAgent
+	(*NomadAgent)(nil),                                  // 3: inventory.v1.NomadAgent
+	(*NodeExporter)(nil),                                // 4: inventory.v1.NodeExporter
+	(*MySQLdExporter)(nil),                              // 5: inventory.v1.MySQLdExporter
+	(*MongoDBExporter)(nil),                             // 6: inventory.v1.MongoDBExporter
+	(*PostgresExporter)(nil),                            // 7: inventory.v1.PostgresExporter
+	(*ProxySQLExporter)(nil),                            // 8: inventory.v1.ProxySQLExporter
+	(*ValkeyExporter)(nil),                              // 9: inventory.v1.ValkeyExporter
+	(*QANMySQLPerfSchemaAgent)(nil),                     // 10: inventory.v1.QANMySQLPerfSchemaAgent
+	(*QANMySQLSlowlogAgent)(nil),                        // 11: inventory.v1.QANMySQLSlowlogAgent
+	(*QANMongoDBProfilerAgent)(nil),                     // 12: inventory.v1.QANMongoDBProfilerAgent
+	(*QANMongoDBMongologAgent)(nil),                     // 13: inventory.v1.QANMongoDBMongologAgent
+	(*RTAOptions)(nil),                                  // 14: inventory.v1.RTAOptions
+	(*RTAPostgreSQLAgent)(nil),                          // 15: inventory.v1.RTAPostgreSQLAgent
+	(*RTAMongoDBAgent)(nil),                             // 16: inventory.v1.RTAMongoDBAgent
+	(*QANPostgreSQLPgStatementsAgent)(nil),              // 17: inventory.v1.QANPostgreSQLPgStatementsAgent
+	(*QANPostgreSQLPgStatMonitorAgent)(nil),             // 18: inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	(*RDSExporter)(nil),                                 // 19: inventory.v1.RDSExporter
+	(*ExternalExporter)(nil),                            // 20: inventory.v1.ExternalExporter
+	(*AzureDatabaseExporter)(nil),                       // 21: inventory.v1.AzureDatabaseExporter
+	(*ChangeCommonAgentParams)(nil),                     // 22: inventory.v1.ChangeCommonAgentParams
+	(*ListAgentsRequest)(nil),                           // 23: inventory.v1.ListAgentsRequest
+	(*ListAgentsResponse)(nil),                          // 24: inventory.v1.ListAgentsResponse
+	(*GetAgentRequest)(nil),                             // 25: inventory.v1.GetAgentRequest
+	(*GetAgentResponse)(nil),                            // 26: inventory.v1.GetAgentResponse
+	(*GetAgentLogsRequest)(nil),                         // 27: inventory.v1.GetAgentLogsRequest
+	(*GetAgentLogsResponse)(nil),                        // 28: inventory.v1.GetAgentLogsResponse
+	(*AddAgentRequest)(nil),                             // 29: inventory.v1.AddAgentRequest
+	(*AddAgentResponse)(nil),                            // 30: inventory.v1.AddAgentResponse
+	(*ChangeAgentRequest)(nil),                          // 31: inventory.v1.ChangeAgentRequest
+	(*ChangeAgentResponse)(nil),                         // 32: inventory.v1.ChangeAgentResponse
+	(*AddPMMAgentParams)(nil),                           // 33: inventory.v1.AddPMMAgentParams
+	(*AddNodeExporterParams)(nil),                       // 34: inventory.v1.AddNodeExporterParams
+	(*ChangeNodeExporterParams)(nil),                    // 35: inventory.v1.ChangeNodeExporterParams
+	(*AddMySQLdExporterParams)(nil),                     // 36: inventory.v1.AddMySQLdExporterParams
+	(*ChangeMySQLdExporterParams)(nil),                  // 37: inventory.v1.ChangeMySQLdExporterParams
+	(*AddMongoDBExporterParams)(nil),                    // 38: inventory.v1.AddMongoDBExporterParams
+	(*ChangeMongoDBExporterParams)(nil),                 // 39: inventory.v1.ChangeMongoDBExporterParams
+	(*AddPostgresExporterParams)(nil),                   // 40: inventory.v1.AddPostgresExporterParams
+	(*ChangePostgresExporterParams)(nil),                // 41: inventory.v1.ChangePostgresExporterParams
+	(*AddProxySQLExporterParams)(nil),                   // 42: inventory.v1.AddProxySQLExporterParams
+	(*ChangeProxySQLExporterParams)(nil),                // 43: inventory.v1.ChangeProxySQLExporterParams
+	(*AddQANMySQLPerfSchemaAgentParams)(nil),            // 44: inventory.v1.AddQANMySQLPerfSchemaAgentParams
+	(*ChangeQANMySQLPerfSchemaAgentParams)(nil),         // 45: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
+	(*AddQANMySQLSlowlogAgentParams)(nil),               // 46: inventory.v1.AddQANMySQLSlowlogAgentParams
+	(*ChangeQANMySQLSlowlogAgentParams)(nil),            // 47: inventory.v1.ChangeQANMySQLSlowlogAgentParams
+	(*AddQANMongoDBProfilerAgentParams)(nil),            // 48: inventory.v1.AddQANMongoDBProfilerAgentParams
+	(*ChangeQANMongoDBProfilerAgentParams)(nil),         // 49: inventory.v1.ChangeQANMongoDBProfilerAgentParams
+	(*AddQANMongoDBMongologAgentParams)(nil),            // 50: inventory.v1.AddQANMongoDBMongologAgentParams
+	(*ChangeQANMongoDBMongologAgentParams)(nil),         // 51: inventory.v1.ChangeQANMongoDBMongologAgentParams
+	(*AddQANPostgreSQLPgStatementsAgentParams)(nil),     // 52: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
+	(*ChangeQANPostgreSQLPgStatementsAgentParams)(nil),  // 53: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
+	(*AddQANPostgreSQLPgStatMonitorAgentParams)(nil),    // 54: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
+	(*ChangeQANPostgreSQLPgStatMonitorAgentParams)(nil), // 55: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
+	(*AddRDSExporterParams)(nil),                        // 56: inventory.v1.AddRDSExporterParams
+	(*ChangeRDSExporterParams)(nil),                     // 57: inventory.v1.ChangeRDSExporterParams
+	(*AddExternalExporterParams)(nil),                   // 58: inventory.v1.AddExternalExporterParams
+	(*ChangeExternalExporterParams)(nil),                // 59: inventory.v1.ChangeExternalExporterParams
+	(*AddAzureDatabaseExporterParams)(nil),              // 60: inventory.v1.AddAzureDatabaseExporterParams
+	(*ChangeAzureDatabaseExporterParams)(nil),           // 61: inventory.v1.ChangeAzureDatabaseExporterParams
+	(*ChangeNomadAgentParams)(nil),                      // 62: inventory.v1.ChangeNomadAgentParams
+	(*AddValkeyExporterParams)(nil),                     // 63: inventory.v1.AddValkeyExporterParams
+	(*ChangeValkeyExporterParams)(nil),                  // 64: inventory.v1.ChangeValkeyExporterParams
+	(*AddRTAMongoDBAgentParams)(nil),                    // 65: inventory.v1.AddRTAMongoDBAgentParams
+	(*ChangeRTAMongoDBAgentParams)(nil),                 // 66: inventory.v1.ChangeRTAMongoDBAgentParams
+	(*AddRTAPostgreSQLAgentParams)(nil),                 // 67: inventory.v1.AddRTAPostgreSQLAgentParams
+	(*ChangeRTAPostgreSQLAgentParams)(nil),              // 68: inventory.v1.ChangeRTAPostgreSQLAgentParams
+	(*RemoveAgentRequest)(nil),                          // 69: inventory.v1.RemoveAgentRequest
+	(*RemoveAgentResponse)(nil),                         // 70: inventory.v1.RemoveAgentResponse
+	nil,                                                 // 71: inventory.v1.PMMAgent.CustomLabelsEntry
+	nil,                                                 // 72: inventory.v1.NodeExporter.CustomLabelsEntry
+	nil,                                                 // 73: inventory.v1.MySQLdExporter.CustomLabelsEntry
+	nil,                                                 // 74: inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
+	nil,                                                 // 75: inventory.v1.MongoDBExporter.CustomLabelsEntry
+	nil,                                                 // 76: inventory.v1.PostgresExporter.CustomLabelsEntry
+	nil,                                                 // 77: inventory.v1.ProxySQLExporter.CustomLabelsEntry
+	nil,                                                 // 78: inventory.v1.ValkeyExporter.CustomLabelsEntry
+	nil,                                                 // 79: inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
+	nil,                                                 // 80: inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
+	nil,                                                 // 81: inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
+	nil,                                                 // 82: inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
+	nil,                                                 // 83: inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
+	nil,                                                 // 84: inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
+	nil,                                                 // 85: inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntry
+	nil,                                                 // 86: inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
+	nil,                                                 // 87: inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
+	nil,                                                 // 88: inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
+	nil,                                                 // 89: inventory.v1.RDSExporter.CustomLabelsEntry
+	nil,                                                 // 90: inventory.v1.ExternalExporter.CustomLabelsEntry
+	nil,                                                 // 91: inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
+	nil,                                                 // 92: inventory.v1.AddPMMAgentParams.CustomLabelsEntry
+	nil,                                                 // 93: inventory.v1.AddNodeExporterParams.CustomLabelsEntry
+	nil,                                                 // 94: inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
+	nil,                                                 // 95: inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
+	nil,                                                 // 96: inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
+	nil,                                                 // 97: inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
+	nil,                                                 // 98: inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
+	nil,                                                 // 99: inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
+	nil,                                                 // 100: inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
+	nil,                                                 // 101: inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
+	nil,                                                 // 102: inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
+	nil,                                                 // 103: inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
+	nil,                                                 // 104: inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
+	nil,                                                 // 105: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
+	nil,                                                 // 106: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
+	nil,                                                 // 107: inventory.v1.AddRDSExporterParams.CustomLabelsEntry
+	nil,                                                 // 108: inventory.v1.AddExternalExporterParams.CustomLabelsEntry
+	nil,                                                 // 109: inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
+	nil,                                                 // 110: inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
+	nil,                                                 // 111: inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
+	nil,                                                 // 112: inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntry
+	(AgentStatus)(0),                                    // 113: inventory.v1.AgentStatus
+	(LogLevel)(0),                                       // 114: inventory.v1.LogLevel
+	(*common.MetricsResolutions)(nil),                   // 115: common.MetricsResolutions
+	(*durationpb.Duration)(nil),                         // 116: google.protobuf.Duration
+	(*common.StringMap)(nil),                            // 117: common.StringMap
+}
 var file_inventory_v1_agents_proto_depIdxs = []int32{
-	68,  // 0: inventory.v1.PMMAgent.custom_labels:type_name -> inventory.v1.PMMAgent.CustomLabelsEntry
-	108, // 1: inventory.v1.VMAgent.status:type_name -> inventory.v1.AgentStatus
-	108, // 2: inventory.v1.NomadAgent.status:type_name -> inventory.v1.AgentStatus
-	69,  // 3: inventory.v1.NodeExporter.custom_labels:type_name -> inventory.v1.NodeExporter.CustomLabelsEntry
-	108, // 4: inventory.v1.NodeExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 5: inventory.v1.NodeExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 6: inventory.v1.NodeExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	70,  // 7: inventory.v1.MySQLdExporter.custom_labels:type_name -> inventory.v1.MySQLdExporter.CustomLabelsEntry
-	108, // 8: inventory.v1.MySQLdExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 9: inventory.v1.MySQLdExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 10: inventory.v1.MySQLdExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	71,  // 11: inventory.v1.MySQLdExporter.extra_dsn_params:type_name -> inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
-	111, // 12: inventory.v1.MySQLdExporter.connection_timeout:type_name -> google.protobuf.Duration
-	72,  // 13: inventory.v1.MongoDBExporter.custom_labels:type_name -> inventory.v1.MongoDBExporter.CustomLabelsEntry
-	108, // 14: inventory.v1.MongoDBExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 15: inventory.v1.MongoDBExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 16: inventory.v1.MongoDBExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 17: inventory.v1.MongoDBExporter.connection_timeout:type_name -> google.protobuf.Duration
-	73,  // 18: inventory.v1.PostgresExporter.custom_labels:type_name -> inventory.v1.PostgresExporter.CustomLabelsEntry
-	108, // 19: inventory.v1.PostgresExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 20: inventory.v1.PostgresExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 21: inventory.v1.PostgresExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 22: inventory.v1.PostgresExporter.connection_timeout:type_name -> google.protobuf.Duration
-	74,  // 23: inventory.v1.ProxySQLExporter.custom_labels:type_name -> inventory.v1.ProxySQLExporter.CustomLabelsEntry
-	108, // 24: inventory.v1.ProxySQLExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 25: inventory.v1.ProxySQLExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 26: inventory.v1.ProxySQLExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 27: inventory.v1.ProxySQLExporter.connection_timeout:type_name -> google.protobuf.Duration
-	75,  // 28: inventory.v1.ValkeyExporter.custom_labels:type_name -> inventory.v1.ValkeyExporter.CustomLabelsEntry
-	108, // 29: inventory.v1.ValkeyExporter.status:type_name -> inventory.v1.AgentStatus
-	110, // 30: inventory.v1.ValkeyExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	111, // 31: inventory.v1.ValkeyExporter.connection_timeout:type_name -> google.protobuf.Duration
-	76,  // 32: inventory.v1.QANMySQLPerfSchemaAgent.custom_labels:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
-	108, // 33: inventory.v1.QANMySQLPerfSchemaAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 34: inventory.v1.QANMySQLPerfSchemaAgent.log_level:type_name -> inventory.v1.LogLevel
-	77,  // 35: inventory.v1.QANMySQLPerfSchemaAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
-	78,  // 36: inventory.v1.QANMySQLSlowlogAgent.custom_labels:type_name -> inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
-	108, // 37: inventory.v1.QANMySQLSlowlogAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 38: inventory.v1.QANMySQLSlowlogAgent.log_level:type_name -> inventory.v1.LogLevel
-	79,  // 39: inventory.v1.QANMySQLSlowlogAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
-	80,  // 40: inventory.v1.QANMongoDBProfilerAgent.custom_labels:type_name -> inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
-	108, // 41: inventory.v1.QANMongoDBProfilerAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 42: inventory.v1.QANMongoDBProfilerAgent.log_level:type_name -> inventory.v1.LogLevel
-	81,  // 43: inventory.v1.QANMongoDBMongologAgent.custom_labels:type_name -> inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
-	108, // 44: inventory.v1.QANMongoDBMongologAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 45: inventory.v1.QANMongoDBMongologAgent.log_level:type_name -> inventory.v1.LogLevel
-	111, // 46: inventory.v1.RTAOptions.collect_interval:type_name -> google.protobuf.Duration
-	82,  // 47: inventory.v1.RTAMongoDBAgent.custom_labels:type_name -> inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
-	14,  // 48: inventory.v1.RTAMongoDBAgent.rta_options:type_name -> inventory.v1.RTAOptions
-	108, // 49: inventory.v1.RTAMongoDBAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 50: inventory.v1.RTAMongoDBAgent.log_level:type_name -> inventory.v1.LogLevel
-	83,  // 51: inventory.v1.QANPostgreSQLPgStatementsAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
-	108, // 52: inventory.v1.QANPostgreSQLPgStatementsAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 53: inventory.v1.QANPostgreSQLPgStatementsAgent.log_level:type_name -> inventory.v1.LogLevel
-	84,  // 54: inventory.v1.QANPostgreSQLPgStatMonitorAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
-	108, // 55: inventory.v1.QANPostgreSQLPgStatMonitorAgent.status:type_name -> inventory.v1.AgentStatus
-	109, // 56: inventory.v1.QANPostgreSQLPgStatMonitorAgent.log_level:type_name -> inventory.v1.LogLevel
-	85,  // 57: inventory.v1.RDSExporter.custom_labels:type_name -> inventory.v1.RDSExporter.CustomLabelsEntry
-	108, // 58: inventory.v1.RDSExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 59: inventory.v1.RDSExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 60: inventory.v1.RDSExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	86,  // 61: inventory.v1.ExternalExporter.custom_labels:type_name -> inventory.v1.ExternalExporter.CustomLabelsEntry
-	110, // 62: inventory.v1.ExternalExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	108, // 63: inventory.v1.ExternalExporter.status:type_name -> inventory.v1.AgentStatus
-	87,  // 64: inventory.v1.AzureDatabaseExporter.custom_labels:type_name -> inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
-	108, // 65: inventory.v1.AzureDatabaseExporter.status:type_name -> inventory.v1.AgentStatus
-	109, // 66: inventory.v1.AzureDatabaseExporter.log_level:type_name -> inventory.v1.LogLevel
-	110, // 67: inventory.v1.AzureDatabaseExporter.metrics_resolutions:type_name -> common.MetricsResolutions
-	112, // 68: inventory.v1.ChangeCommonAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 69: inventory.v1.ChangeCommonAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	0,   // 70: inventory.v1.ListAgentsRequest.agent_type:type_name -> inventory.v1.AgentType
-	1,   // 71: inventory.v1.ListAgentsResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	2,   // 72: inventory.v1.ListAgentsResponse.vm_agent:type_name -> inventory.v1.VMAgent
-	4,   // 73: inventory.v1.ListAgentsResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 74: inventory.v1.ListAgentsResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 75: inventory.v1.ListAgentsResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 76: inventory.v1.ListAgentsResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 77: inventory.v1.ListAgentsResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	10,  // 78: inventory.v1.ListAgentsResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 79: inventory.v1.ListAgentsResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 80: inventory.v1.ListAgentsResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 81: inventory.v1.ListAgentsResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 82: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 83: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	19,  // 84: inventory.v1.ListAgentsResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 85: inventory.v1.ListAgentsResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 86: inventory.v1.ListAgentsResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	3,   // 87: inventory.v1.ListAgentsResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 88: inventory.v1.ListAgentsResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 89: inventory.v1.ListAgentsResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	1,   // 90: inventory.v1.GetAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	2,   // 91: inventory.v1.GetAgentResponse.vmagent:type_name -> inventory.v1.VMAgent
-	4,   // 92: inventory.v1.GetAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 93: inventory.v1.GetAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 94: inventory.v1.GetAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 95: inventory.v1.GetAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 96: inventory.v1.GetAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	10,  // 97: inventory.v1.GetAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 98: inventory.v1.GetAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 99: inventory.v1.GetAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 100: inventory.v1.GetAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 101: inventory.v1.GetAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 102: inventory.v1.GetAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	19,  // 103: inventory.v1.GetAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 104: inventory.v1.GetAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 105: inventory.v1.GetAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	3,   // 106: inventory.v1.GetAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 107: inventory.v1.GetAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 108: inventory.v1.GetAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	32,  // 109: inventory.v1.AddAgentRequest.pmm_agent:type_name -> inventory.v1.AddPMMAgentParams
-	33,  // 110: inventory.v1.AddAgentRequest.node_exporter:type_name -> inventory.v1.AddNodeExporterParams
-	35,  // 111: inventory.v1.AddAgentRequest.mysqld_exporter:type_name -> inventory.v1.AddMySQLdExporterParams
-	37,  // 112: inventory.v1.AddAgentRequest.mongodb_exporter:type_name -> inventory.v1.AddMongoDBExporterParams
-	39,  // 113: inventory.v1.AddAgentRequest.postgres_exporter:type_name -> inventory.v1.AddPostgresExporterParams
-	41,  // 114: inventory.v1.AddAgentRequest.proxysql_exporter:type_name -> inventory.v1.AddProxySQLExporterParams
-	57,  // 115: inventory.v1.AddAgentRequest.external_exporter:type_name -> inventory.v1.AddExternalExporterParams
-	55,  // 116: inventory.v1.AddAgentRequest.rds_exporter:type_name -> inventory.v1.AddRDSExporterParams
-	59,  // 117: inventory.v1.AddAgentRequest.azure_database_exporter:type_name -> inventory.v1.AddAzureDatabaseExporterParams
-	43,  // 118: inventory.v1.AddAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams
-	45,  // 119: inventory.v1.AddAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams
-	47,  // 120: inventory.v1.AddAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams
-	49,  // 121: inventory.v1.AddAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams
-	51,  // 122: inventory.v1.AddAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
-	53,  // 123: inventory.v1.AddAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
-	62,  // 124: inventory.v1.AddAgentRequest.valkey_exporter:type_name -> inventory.v1.AddValkeyExporterParams
-	64,  // 125: inventory.v1.AddAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.AddRTAMongoDBAgentParams
-	1,   // 126: inventory.v1.AddAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
-	4,   // 127: inventory.v1.AddAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 128: inventory.v1.AddAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 129: inventory.v1.AddAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 130: inventory.v1.AddAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 131: inventory.v1.AddAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	19,  // 132: inventory.v1.AddAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 133: inventory.v1.AddAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 134: inventory.v1.AddAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	10,  // 135: inventory.v1.AddAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 136: inventory.v1.AddAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 137: inventory.v1.AddAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 138: inventory.v1.AddAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 139: inventory.v1.AddAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 140: inventory.v1.AddAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	9,   // 141: inventory.v1.AddAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 142: inventory.v1.AddAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	34,  // 143: inventory.v1.ChangeAgentRequest.node_exporter:type_name -> inventory.v1.ChangeNodeExporterParams
-	36,  // 144: inventory.v1.ChangeAgentRequest.mysqld_exporter:type_name -> inventory.v1.ChangeMySQLdExporterParams
-	38,  // 145: inventory.v1.ChangeAgentRequest.mongodb_exporter:type_name -> inventory.v1.ChangeMongoDBExporterParams
-	40,  // 146: inventory.v1.ChangeAgentRequest.postgres_exporter:type_name -> inventory.v1.ChangePostgresExporterParams
-	42,  // 147: inventory.v1.ChangeAgentRequest.proxysql_exporter:type_name -> inventory.v1.ChangeProxySQLExporterParams
-	58,  // 148: inventory.v1.ChangeAgentRequest.external_exporter:type_name -> inventory.v1.ChangeExternalExporterParams
-	56,  // 149: inventory.v1.ChangeAgentRequest.rds_exporter:type_name -> inventory.v1.ChangeRDSExporterParams
-	60,  // 150: inventory.v1.ChangeAgentRequest.azure_database_exporter:type_name -> inventory.v1.ChangeAzureDatabaseExporterParams
-	44,  // 151: inventory.v1.ChangeAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
-	46,  // 152: inventory.v1.ChangeAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.ChangeQANMySQLSlowlogAgentParams
-	48,  // 153: inventory.v1.ChangeAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.ChangeQANMongoDBProfilerAgentParams
-	50,  // 154: inventory.v1.ChangeAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.ChangeQANMongoDBMongologAgentParams
-	52,  // 155: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
-	54,  // 156: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
-	61,  // 157: inventory.v1.ChangeAgentRequest.nomad_agent:type_name -> inventory.v1.ChangeNomadAgentParams
-	63,  // 158: inventory.v1.ChangeAgentRequest.valkey_exporter:type_name -> inventory.v1.ChangeValkeyExporterParams
-	65,  // 159: inventory.v1.ChangeAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.ChangeRTAMongoDBAgentParams
-	4,   // 160: inventory.v1.ChangeAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
-	5,   // 161: inventory.v1.ChangeAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
-	6,   // 162: inventory.v1.ChangeAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
-	7,   // 163: inventory.v1.ChangeAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
-	8,   // 164: inventory.v1.ChangeAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
-	19,  // 165: inventory.v1.ChangeAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
-	18,  // 166: inventory.v1.ChangeAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
-	20,  // 167: inventory.v1.ChangeAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
-	10,  // 168: inventory.v1.ChangeAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
-	11,  // 169: inventory.v1.ChangeAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
-	12,  // 170: inventory.v1.ChangeAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
-	13,  // 171: inventory.v1.ChangeAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
-	16,  // 172: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
-	17,  // 173: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	3,   // 174: inventory.v1.ChangeAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
-	9,   // 175: inventory.v1.ChangeAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
-	15,  // 176: inventory.v1.ChangeAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
-	88,  // 177: inventory.v1.AddPMMAgentParams.custom_labels:type_name -> inventory.v1.AddPMMAgentParams.CustomLabelsEntry
-	89,  // 178: inventory.v1.AddNodeExporterParams.custom_labels:type_name -> inventory.v1.AddNodeExporterParams.CustomLabelsEntry
-	109, // 179: inventory.v1.AddNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 180: inventory.v1.ChangeNodeExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 181: inventory.v1.ChangeNodeExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 182: inventory.v1.ChangeNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	90,  // 183: inventory.v1.AddMySQLdExporterParams.custom_labels:type_name -> inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
-	109, // 184: inventory.v1.AddMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	91,  // 185: inventory.v1.AddMySQLdExporterParams.extra_dsn_params:type_name -> inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
-	111, // 186: inventory.v1.AddMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 187: inventory.v1.ChangeMySQLdExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 188: inventory.v1.ChangeMySQLdExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 189: inventory.v1.ChangeMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 190: inventory.v1.ChangeMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	92,  // 191: inventory.v1.AddMongoDBExporterParams.custom_labels:type_name -> inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
-	109, // 192: inventory.v1.AddMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 193: inventory.v1.AddMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 194: inventory.v1.ChangeMongoDBExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 195: inventory.v1.ChangeMongoDBExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 196: inventory.v1.ChangeMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 197: inventory.v1.ChangeMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	93,  // 198: inventory.v1.AddPostgresExporterParams.custom_labels:type_name -> inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
-	109, // 199: inventory.v1.AddPostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 200: inventory.v1.AddPostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 201: inventory.v1.ChangePostgresExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 202: inventory.v1.ChangePostgresExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 203: inventory.v1.ChangePostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 204: inventory.v1.ChangePostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	94,  // 205: inventory.v1.AddProxySQLExporterParams.custom_labels:type_name -> inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
-	109, // 206: inventory.v1.AddProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 207: inventory.v1.AddProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 208: inventory.v1.ChangeProxySQLExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 209: inventory.v1.ChangeProxySQLExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 210: inventory.v1.ChangeProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 211: inventory.v1.ChangeProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	95,  // 212: inventory.v1.AddQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
-	109, // 213: inventory.v1.AddQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	96,  // 214: inventory.v1.AddQANMySQLPerfSchemaAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
-	112, // 215: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 216: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 217: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	97,  // 218: inventory.v1.AddQANMySQLSlowlogAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
-	109, // 219: inventory.v1.AddQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	98,  // 220: inventory.v1.AddQANMySQLSlowlogAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
-	112, // 221: inventory.v1.ChangeQANMySQLSlowlogAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 222: inventory.v1.ChangeQANMySQLSlowlogAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 223: inventory.v1.ChangeQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	99,  // 224: inventory.v1.AddQANMongoDBProfilerAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
-	109, // 225: inventory.v1.AddQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 226: inventory.v1.ChangeQANMongoDBProfilerAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 227: inventory.v1.ChangeQANMongoDBProfilerAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 228: inventory.v1.ChangeQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	100, // 229: inventory.v1.AddQANMongoDBMongologAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
-	109, // 230: inventory.v1.AddQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 231: inventory.v1.ChangeQANMongoDBMongologAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 232: inventory.v1.ChangeQANMongoDBMongologAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 233: inventory.v1.ChangeQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	101, // 234: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
-	109, // 235: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 236: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 237: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 238: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	102, // 239: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
-	109, // 240: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 241: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> common.StringMap
-	110, // 242: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 243: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	103, // 244: inventory.v1.AddRDSExporterParams.custom_labels:type_name -> inventory.v1.AddRDSExporterParams.CustomLabelsEntry
-	109, // 245: inventory.v1.AddRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 246: inventory.v1.ChangeRDSExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 247: inventory.v1.ChangeRDSExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 248: inventory.v1.ChangeRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	104, // 249: inventory.v1.AddExternalExporterParams.custom_labels:type_name -> inventory.v1.AddExternalExporterParams.CustomLabelsEntry
-	112, // 250: inventory.v1.ChangeExternalExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 251: inventory.v1.ChangeExternalExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	105, // 252: inventory.v1.AddAzureDatabaseExporterParams.custom_labels:type_name -> inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
-	109, // 253: inventory.v1.AddAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	112, // 254: inventory.v1.ChangeAzureDatabaseExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 255: inventory.v1.ChangeAzureDatabaseExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 256: inventory.v1.ChangeAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	106, // 257: inventory.v1.AddValkeyExporterParams.custom_labels:type_name -> inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
-	109, // 258: inventory.v1.AddValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 259: inventory.v1.AddValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	112, // 260: inventory.v1.ChangeValkeyExporterParams.custom_labels:type_name -> common.StringMap
-	110, // 261: inventory.v1.ChangeValkeyExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
-	109, // 262: inventory.v1.ChangeValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
-	111, // 263: inventory.v1.ChangeValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
-	107, // 264: inventory.v1.AddRTAMongoDBAgentParams.custom_labels:type_name -> inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
-	109, // 265: inventory.v1.AddRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	14,  // 266: inventory.v1.AddRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
-	112, // 267: inventory.v1.ChangeRTAMongoDBAgentParams.custom_labels:type_name -> common.StringMap
-	109, // 268: inventory.v1.ChangeRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
-	14,  // 269: inventory.v1.ChangeRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
-	22,  // 270: inventory.v1.AgentsService.ListAgents:input_type -> inventory.v1.ListAgentsRequest
-	24,  // 271: inventory.v1.AgentsService.GetAgent:input_type -> inventory.v1.GetAgentRequest
-	26,  // 272: inventory.v1.AgentsService.GetAgentLogs:input_type -> inventory.v1.GetAgentLogsRequest
-	28,  // 273: inventory.v1.AgentsService.AddAgent:input_type -> inventory.v1.AddAgentRequest
-	30,  // 274: inventory.v1.AgentsService.ChangeAgent:input_type -> inventory.v1.ChangeAgentRequest
-	66,  // 275: inventory.v1.AgentsService.RemoveAgent:input_type -> inventory.v1.RemoveAgentRequest
-	23,  // 276: inventory.v1.AgentsService.ListAgents:output_type -> inventory.v1.ListAgentsResponse
-	25,  // 277: inventory.v1.AgentsService.GetAgent:output_type -> inventory.v1.GetAgentResponse
-	27,  // 278: inventory.v1.AgentsService.GetAgentLogs:output_type -> inventory.v1.GetAgentLogsResponse
-	29,  // 279: inventory.v1.AgentsService.AddAgent:output_type -> inventory.v1.AddAgentResponse
-	31,  // 280: inventory.v1.AgentsService.ChangeAgent:output_type -> inventory.v1.ChangeAgentResponse
-	67,  // 281: inventory.v1.AgentsService.RemoveAgent:output_type -> inventory.v1.RemoveAgentResponse
-	276, // [276:282] is the sub-list for method output_type
-	270, // [270:276] is the sub-list for method input_type
-	270, // [270:270] is the sub-list for extension type_name
-	270, // [270:270] is the sub-list for extension extendee
-	0,   // [0:270] is the sub-list for field type_name
+	71,  // 0: inventory.v1.PMMAgent.custom_labels:type_name -> inventory.v1.PMMAgent.CustomLabelsEntry
+	113, // 1: inventory.v1.VMAgent.status:type_name -> inventory.v1.AgentStatus
+	113, // 2: inventory.v1.NomadAgent.status:type_name -> inventory.v1.AgentStatus
+	72,  // 3: inventory.v1.NodeExporter.custom_labels:type_name -> inventory.v1.NodeExporter.CustomLabelsEntry
+	113, // 4: inventory.v1.NodeExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 5: inventory.v1.NodeExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 6: inventory.v1.NodeExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	73,  // 7: inventory.v1.MySQLdExporter.custom_labels:type_name -> inventory.v1.MySQLdExporter.CustomLabelsEntry
+	113, // 8: inventory.v1.MySQLdExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 9: inventory.v1.MySQLdExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 10: inventory.v1.MySQLdExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	74,  // 11: inventory.v1.MySQLdExporter.extra_dsn_params:type_name -> inventory.v1.MySQLdExporter.ExtraDsnParamsEntry
+	116, // 12: inventory.v1.MySQLdExporter.connection_timeout:type_name -> google.protobuf.Duration
+	75,  // 13: inventory.v1.MongoDBExporter.custom_labels:type_name -> inventory.v1.MongoDBExporter.CustomLabelsEntry
+	113, // 14: inventory.v1.MongoDBExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 15: inventory.v1.MongoDBExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 16: inventory.v1.MongoDBExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 17: inventory.v1.MongoDBExporter.connection_timeout:type_name -> google.protobuf.Duration
+	76,  // 18: inventory.v1.PostgresExporter.custom_labels:type_name -> inventory.v1.PostgresExporter.CustomLabelsEntry
+	113, // 19: inventory.v1.PostgresExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 20: inventory.v1.PostgresExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 21: inventory.v1.PostgresExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 22: inventory.v1.PostgresExporter.connection_timeout:type_name -> google.protobuf.Duration
+	77,  // 23: inventory.v1.ProxySQLExporter.custom_labels:type_name -> inventory.v1.ProxySQLExporter.CustomLabelsEntry
+	113, // 24: inventory.v1.ProxySQLExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 25: inventory.v1.ProxySQLExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 26: inventory.v1.ProxySQLExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 27: inventory.v1.ProxySQLExporter.connection_timeout:type_name -> google.protobuf.Duration
+	78,  // 28: inventory.v1.ValkeyExporter.custom_labels:type_name -> inventory.v1.ValkeyExporter.CustomLabelsEntry
+	113, // 29: inventory.v1.ValkeyExporter.status:type_name -> inventory.v1.AgentStatus
+	115, // 30: inventory.v1.ValkeyExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	116, // 31: inventory.v1.ValkeyExporter.connection_timeout:type_name -> google.protobuf.Duration
+	79,  // 32: inventory.v1.QANMySQLPerfSchemaAgent.custom_labels:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.CustomLabelsEntry
+	113, // 33: inventory.v1.QANMySQLPerfSchemaAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 34: inventory.v1.QANMySQLPerfSchemaAgent.log_level:type_name -> inventory.v1.LogLevel
+	80,  // 35: inventory.v1.QANMySQLPerfSchemaAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLPerfSchemaAgent.ExtraDsnParamsEntry
+	81,  // 36: inventory.v1.QANMySQLSlowlogAgent.custom_labels:type_name -> inventory.v1.QANMySQLSlowlogAgent.CustomLabelsEntry
+	113, // 37: inventory.v1.QANMySQLSlowlogAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 38: inventory.v1.QANMySQLSlowlogAgent.log_level:type_name -> inventory.v1.LogLevel
+	82,  // 39: inventory.v1.QANMySQLSlowlogAgent.extra_dsn_params:type_name -> inventory.v1.QANMySQLSlowlogAgent.ExtraDsnParamsEntry
+	83,  // 40: inventory.v1.QANMongoDBProfilerAgent.custom_labels:type_name -> inventory.v1.QANMongoDBProfilerAgent.CustomLabelsEntry
+	113, // 41: inventory.v1.QANMongoDBProfilerAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 42: inventory.v1.QANMongoDBProfilerAgent.log_level:type_name -> inventory.v1.LogLevel
+	84,  // 43: inventory.v1.QANMongoDBMongologAgent.custom_labels:type_name -> inventory.v1.QANMongoDBMongologAgent.CustomLabelsEntry
+	113, // 44: inventory.v1.QANMongoDBMongologAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 45: inventory.v1.QANMongoDBMongologAgent.log_level:type_name -> inventory.v1.LogLevel
+	116, // 46: inventory.v1.RTAOptions.collect_interval:type_name -> google.protobuf.Duration
+	85,  // 47: inventory.v1.RTAPostgreSQLAgent.custom_labels:type_name -> inventory.v1.RTAPostgreSQLAgent.CustomLabelsEntry
+	14,  // 48: inventory.v1.RTAPostgreSQLAgent.rta_options:type_name -> inventory.v1.RTAOptions
+	113, // 49: inventory.v1.RTAPostgreSQLAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 50: inventory.v1.RTAPostgreSQLAgent.log_level:type_name -> inventory.v1.LogLevel
+	86,  // 51: inventory.v1.RTAMongoDBAgent.custom_labels:type_name -> inventory.v1.RTAMongoDBAgent.CustomLabelsEntry
+	14,  // 52: inventory.v1.RTAMongoDBAgent.rta_options:type_name -> inventory.v1.RTAOptions
+	113, // 53: inventory.v1.RTAMongoDBAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 54: inventory.v1.RTAMongoDBAgent.log_level:type_name -> inventory.v1.LogLevel
+	87,  // 55: inventory.v1.QANPostgreSQLPgStatementsAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent.CustomLabelsEntry
+	113, // 56: inventory.v1.QANPostgreSQLPgStatementsAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 57: inventory.v1.QANPostgreSQLPgStatementsAgent.log_level:type_name -> inventory.v1.LogLevel
+	88,  // 58: inventory.v1.QANPostgreSQLPgStatMonitorAgent.custom_labels:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent.CustomLabelsEntry
+	113, // 59: inventory.v1.QANPostgreSQLPgStatMonitorAgent.status:type_name -> inventory.v1.AgentStatus
+	114, // 60: inventory.v1.QANPostgreSQLPgStatMonitorAgent.log_level:type_name -> inventory.v1.LogLevel
+	89,  // 61: inventory.v1.RDSExporter.custom_labels:type_name -> inventory.v1.RDSExporter.CustomLabelsEntry
+	113, // 62: inventory.v1.RDSExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 63: inventory.v1.RDSExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 64: inventory.v1.RDSExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	90,  // 65: inventory.v1.ExternalExporter.custom_labels:type_name -> inventory.v1.ExternalExporter.CustomLabelsEntry
+	115, // 66: inventory.v1.ExternalExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	113, // 67: inventory.v1.ExternalExporter.status:type_name -> inventory.v1.AgentStatus
+	91,  // 68: inventory.v1.AzureDatabaseExporter.custom_labels:type_name -> inventory.v1.AzureDatabaseExporter.CustomLabelsEntry
+	113, // 69: inventory.v1.AzureDatabaseExporter.status:type_name -> inventory.v1.AgentStatus
+	114, // 70: inventory.v1.AzureDatabaseExporter.log_level:type_name -> inventory.v1.LogLevel
+	115, // 71: inventory.v1.AzureDatabaseExporter.metrics_resolutions:type_name -> common.MetricsResolutions
+	117, // 72: inventory.v1.ChangeCommonAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 73: inventory.v1.ChangeCommonAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	0,   // 74: inventory.v1.ListAgentsRequest.agent_type:type_name -> inventory.v1.AgentType
+	1,   // 75: inventory.v1.ListAgentsResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	2,   // 76: inventory.v1.ListAgentsResponse.vm_agent:type_name -> inventory.v1.VMAgent
+	4,   // 77: inventory.v1.ListAgentsResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 78: inventory.v1.ListAgentsResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 79: inventory.v1.ListAgentsResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 80: inventory.v1.ListAgentsResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 81: inventory.v1.ListAgentsResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	10,  // 82: inventory.v1.ListAgentsResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 83: inventory.v1.ListAgentsResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 84: inventory.v1.ListAgentsResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 85: inventory.v1.ListAgentsResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 86: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 87: inventory.v1.ListAgentsResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	20,  // 88: inventory.v1.ListAgentsResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 89: inventory.v1.ListAgentsResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 90: inventory.v1.ListAgentsResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	3,   // 91: inventory.v1.ListAgentsResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 92: inventory.v1.ListAgentsResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 93: inventory.v1.ListAgentsResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 94: inventory.v1.ListAgentsResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	1,   // 95: inventory.v1.GetAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	2,   // 96: inventory.v1.GetAgentResponse.vmagent:type_name -> inventory.v1.VMAgent
+	4,   // 97: inventory.v1.GetAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 98: inventory.v1.GetAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 99: inventory.v1.GetAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 100: inventory.v1.GetAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 101: inventory.v1.GetAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	10,  // 102: inventory.v1.GetAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 103: inventory.v1.GetAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 104: inventory.v1.GetAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 105: inventory.v1.GetAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 106: inventory.v1.GetAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 107: inventory.v1.GetAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	20,  // 108: inventory.v1.GetAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 109: inventory.v1.GetAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 110: inventory.v1.GetAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	3,   // 111: inventory.v1.GetAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 112: inventory.v1.GetAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 113: inventory.v1.GetAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 114: inventory.v1.GetAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	33,  // 115: inventory.v1.AddAgentRequest.pmm_agent:type_name -> inventory.v1.AddPMMAgentParams
+	34,  // 116: inventory.v1.AddAgentRequest.node_exporter:type_name -> inventory.v1.AddNodeExporterParams
+	36,  // 117: inventory.v1.AddAgentRequest.mysqld_exporter:type_name -> inventory.v1.AddMySQLdExporterParams
+	38,  // 118: inventory.v1.AddAgentRequest.mongodb_exporter:type_name -> inventory.v1.AddMongoDBExporterParams
+	40,  // 119: inventory.v1.AddAgentRequest.postgres_exporter:type_name -> inventory.v1.AddPostgresExporterParams
+	42,  // 120: inventory.v1.AddAgentRequest.proxysql_exporter:type_name -> inventory.v1.AddProxySQLExporterParams
+	58,  // 121: inventory.v1.AddAgentRequest.external_exporter:type_name -> inventory.v1.AddExternalExporterParams
+	56,  // 122: inventory.v1.AddAgentRequest.rds_exporter:type_name -> inventory.v1.AddRDSExporterParams
+	60,  // 123: inventory.v1.AddAgentRequest.azure_database_exporter:type_name -> inventory.v1.AddAzureDatabaseExporterParams
+	44,  // 124: inventory.v1.AddAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams
+	46,  // 125: inventory.v1.AddAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams
+	48,  // 126: inventory.v1.AddAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams
+	50,  // 127: inventory.v1.AddAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams
+	52,  // 128: inventory.v1.AddAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams
+	54,  // 129: inventory.v1.AddAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams
+	63,  // 130: inventory.v1.AddAgentRequest.valkey_exporter:type_name -> inventory.v1.AddValkeyExporterParams
+	65,  // 131: inventory.v1.AddAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.AddRTAMongoDBAgentParams
+	67,  // 132: inventory.v1.AddAgentRequest.rta_postgresql_agent:type_name -> inventory.v1.AddRTAPostgreSQLAgentParams
+	1,   // 133: inventory.v1.AddAgentResponse.pmm_agent:type_name -> inventory.v1.PMMAgent
+	4,   // 134: inventory.v1.AddAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 135: inventory.v1.AddAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 136: inventory.v1.AddAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 137: inventory.v1.AddAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 138: inventory.v1.AddAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	20,  // 139: inventory.v1.AddAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 140: inventory.v1.AddAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 141: inventory.v1.AddAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	10,  // 142: inventory.v1.AddAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 143: inventory.v1.AddAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 144: inventory.v1.AddAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 145: inventory.v1.AddAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 146: inventory.v1.AddAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 147: inventory.v1.AddAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	9,   // 148: inventory.v1.AddAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 149: inventory.v1.AddAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 150: inventory.v1.AddAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	35,  // 151: inventory.v1.ChangeAgentRequest.node_exporter:type_name -> inventory.v1.ChangeNodeExporterParams
+	37,  // 152: inventory.v1.ChangeAgentRequest.mysqld_exporter:type_name -> inventory.v1.ChangeMySQLdExporterParams
+	39,  // 153: inventory.v1.ChangeAgentRequest.mongodb_exporter:type_name -> inventory.v1.ChangeMongoDBExporterParams
+	41,  // 154: inventory.v1.ChangeAgentRequest.postgres_exporter:type_name -> inventory.v1.ChangePostgresExporterParams
+	43,  // 155: inventory.v1.ChangeAgentRequest.proxysql_exporter:type_name -> inventory.v1.ChangeProxySQLExporterParams
+	59,  // 156: inventory.v1.ChangeAgentRequest.external_exporter:type_name -> inventory.v1.ChangeExternalExporterParams
+	57,  // 157: inventory.v1.ChangeAgentRequest.rds_exporter:type_name -> inventory.v1.ChangeRDSExporterParams
+	61,  // 158: inventory.v1.ChangeAgentRequest.azure_database_exporter:type_name -> inventory.v1.ChangeAzureDatabaseExporterParams
+	45,  // 159: inventory.v1.ChangeAgentRequest.qan_mysql_perfschema_agent:type_name -> inventory.v1.ChangeQANMySQLPerfSchemaAgentParams
+	47,  // 160: inventory.v1.ChangeAgentRequest.qan_mysql_slowlog_agent:type_name -> inventory.v1.ChangeQANMySQLSlowlogAgentParams
+	49,  // 161: inventory.v1.ChangeAgentRequest.qan_mongodb_profiler_agent:type_name -> inventory.v1.ChangeQANMongoDBProfilerAgentParams
+	51,  // 162: inventory.v1.ChangeAgentRequest.qan_mongodb_mongolog_agent:type_name -> inventory.v1.ChangeQANMongoDBMongologAgentParams
+	53,  // 163: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams
+	55,  // 164: inventory.v1.ChangeAgentRequest.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams
+	62,  // 165: inventory.v1.ChangeAgentRequest.nomad_agent:type_name -> inventory.v1.ChangeNomadAgentParams
+	64,  // 166: inventory.v1.ChangeAgentRequest.valkey_exporter:type_name -> inventory.v1.ChangeValkeyExporterParams
+	66,  // 167: inventory.v1.ChangeAgentRequest.rta_mongodb_agent:type_name -> inventory.v1.ChangeRTAMongoDBAgentParams
+	68,  // 168: inventory.v1.ChangeAgentRequest.rta_postgresql_agent:type_name -> inventory.v1.ChangeRTAPostgreSQLAgentParams
+	4,   // 169: inventory.v1.ChangeAgentResponse.node_exporter:type_name -> inventory.v1.NodeExporter
+	5,   // 170: inventory.v1.ChangeAgentResponse.mysqld_exporter:type_name -> inventory.v1.MySQLdExporter
+	6,   // 171: inventory.v1.ChangeAgentResponse.mongodb_exporter:type_name -> inventory.v1.MongoDBExporter
+	7,   // 172: inventory.v1.ChangeAgentResponse.postgres_exporter:type_name -> inventory.v1.PostgresExporter
+	8,   // 173: inventory.v1.ChangeAgentResponse.proxysql_exporter:type_name -> inventory.v1.ProxySQLExporter
+	20,  // 174: inventory.v1.ChangeAgentResponse.external_exporter:type_name -> inventory.v1.ExternalExporter
+	19,  // 175: inventory.v1.ChangeAgentResponse.rds_exporter:type_name -> inventory.v1.RDSExporter
+	21,  // 176: inventory.v1.ChangeAgentResponse.azure_database_exporter:type_name -> inventory.v1.AzureDatabaseExporter
+	10,  // 177: inventory.v1.ChangeAgentResponse.qan_mysql_perfschema_agent:type_name -> inventory.v1.QANMySQLPerfSchemaAgent
+	11,  // 178: inventory.v1.ChangeAgentResponse.qan_mysql_slowlog_agent:type_name -> inventory.v1.QANMySQLSlowlogAgent
+	12,  // 179: inventory.v1.ChangeAgentResponse.qan_mongodb_profiler_agent:type_name -> inventory.v1.QANMongoDBProfilerAgent
+	13,  // 180: inventory.v1.ChangeAgentResponse.qan_mongodb_mongolog_agent:type_name -> inventory.v1.QANMongoDBMongologAgent
+	17,  // 181: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
+	18,  // 182: inventory.v1.ChangeAgentResponse.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	3,   // 183: inventory.v1.ChangeAgentResponse.nomad_agent:type_name -> inventory.v1.NomadAgent
+	9,   // 184: inventory.v1.ChangeAgentResponse.valkey_exporter:type_name -> inventory.v1.ValkeyExporter
+	16,  // 185: inventory.v1.ChangeAgentResponse.rta_mongodb_agent:type_name -> inventory.v1.RTAMongoDBAgent
+	15,  // 186: inventory.v1.ChangeAgentResponse.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	92,  // 187: inventory.v1.AddPMMAgentParams.custom_labels:type_name -> inventory.v1.AddPMMAgentParams.CustomLabelsEntry
+	93,  // 188: inventory.v1.AddNodeExporterParams.custom_labels:type_name -> inventory.v1.AddNodeExporterParams.CustomLabelsEntry
+	114, // 189: inventory.v1.AddNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 190: inventory.v1.ChangeNodeExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 191: inventory.v1.ChangeNodeExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 192: inventory.v1.ChangeNodeExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	94,  // 193: inventory.v1.AddMySQLdExporterParams.custom_labels:type_name -> inventory.v1.AddMySQLdExporterParams.CustomLabelsEntry
+	114, // 194: inventory.v1.AddMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	95,  // 195: inventory.v1.AddMySQLdExporterParams.extra_dsn_params:type_name -> inventory.v1.AddMySQLdExporterParams.ExtraDsnParamsEntry
+	116, // 196: inventory.v1.AddMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 197: inventory.v1.ChangeMySQLdExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 198: inventory.v1.ChangeMySQLdExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 199: inventory.v1.ChangeMySQLdExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 200: inventory.v1.ChangeMySQLdExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	96,  // 201: inventory.v1.AddMongoDBExporterParams.custom_labels:type_name -> inventory.v1.AddMongoDBExporterParams.CustomLabelsEntry
+	114, // 202: inventory.v1.AddMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 203: inventory.v1.AddMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 204: inventory.v1.ChangeMongoDBExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 205: inventory.v1.ChangeMongoDBExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 206: inventory.v1.ChangeMongoDBExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 207: inventory.v1.ChangeMongoDBExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	97,  // 208: inventory.v1.AddPostgresExporterParams.custom_labels:type_name -> inventory.v1.AddPostgresExporterParams.CustomLabelsEntry
+	114, // 209: inventory.v1.AddPostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 210: inventory.v1.AddPostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 211: inventory.v1.ChangePostgresExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 212: inventory.v1.ChangePostgresExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 213: inventory.v1.ChangePostgresExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 214: inventory.v1.ChangePostgresExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	98,  // 215: inventory.v1.AddProxySQLExporterParams.custom_labels:type_name -> inventory.v1.AddProxySQLExporterParams.CustomLabelsEntry
+	114, // 216: inventory.v1.AddProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 217: inventory.v1.AddProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 218: inventory.v1.ChangeProxySQLExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 219: inventory.v1.ChangeProxySQLExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 220: inventory.v1.ChangeProxySQLExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 221: inventory.v1.ChangeProxySQLExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	99,  // 222: inventory.v1.AddQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.CustomLabelsEntry
+	114, // 223: inventory.v1.AddQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	100, // 224: inventory.v1.AddQANMySQLPerfSchemaAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLPerfSchemaAgentParams.ExtraDsnParamsEntry
+	117, // 225: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 226: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 227: inventory.v1.ChangeQANMySQLPerfSchemaAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	101, // 228: inventory.v1.AddQANMySQLSlowlogAgentParams.custom_labels:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.CustomLabelsEntry
+	114, // 229: inventory.v1.AddQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	102, // 230: inventory.v1.AddQANMySQLSlowlogAgentParams.extra_dsn_params:type_name -> inventory.v1.AddQANMySQLSlowlogAgentParams.ExtraDsnParamsEntry
+	117, // 231: inventory.v1.ChangeQANMySQLSlowlogAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 232: inventory.v1.ChangeQANMySQLSlowlogAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 233: inventory.v1.ChangeQANMySQLSlowlogAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	103, // 234: inventory.v1.AddQANMongoDBProfilerAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBProfilerAgentParams.CustomLabelsEntry
+	114, // 235: inventory.v1.AddQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 236: inventory.v1.ChangeQANMongoDBProfilerAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 237: inventory.v1.ChangeQANMongoDBProfilerAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 238: inventory.v1.ChangeQANMongoDBProfilerAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	104, // 239: inventory.v1.AddQANMongoDBMongologAgentParams.custom_labels:type_name -> inventory.v1.AddQANMongoDBMongologAgentParams.CustomLabelsEntry
+	114, // 240: inventory.v1.AddQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 241: inventory.v1.ChangeQANMongoDBMongologAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 242: inventory.v1.ChangeQANMongoDBMongologAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 243: inventory.v1.ChangeQANMongoDBMongologAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	105, // 244: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.CustomLabelsEntry
+	114, // 245: inventory.v1.AddQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 246: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 247: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 248: inventory.v1.ChangeQANPostgreSQLPgStatementsAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	106, // 249: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.CustomLabelsEntry
+	114, // 250: inventory.v1.AddQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 251: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.custom_labels:type_name -> common.StringMap
+	115, // 252: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 253: inventory.v1.ChangeQANPostgreSQLPgStatMonitorAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	107, // 254: inventory.v1.AddRDSExporterParams.custom_labels:type_name -> inventory.v1.AddRDSExporterParams.CustomLabelsEntry
+	114, // 255: inventory.v1.AddRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 256: inventory.v1.ChangeRDSExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 257: inventory.v1.ChangeRDSExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 258: inventory.v1.ChangeRDSExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	108, // 259: inventory.v1.AddExternalExporterParams.custom_labels:type_name -> inventory.v1.AddExternalExporterParams.CustomLabelsEntry
+	117, // 260: inventory.v1.ChangeExternalExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 261: inventory.v1.ChangeExternalExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	109, // 262: inventory.v1.AddAzureDatabaseExporterParams.custom_labels:type_name -> inventory.v1.AddAzureDatabaseExporterParams.CustomLabelsEntry
+	114, // 263: inventory.v1.AddAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	117, // 264: inventory.v1.ChangeAzureDatabaseExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 265: inventory.v1.ChangeAzureDatabaseExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 266: inventory.v1.ChangeAzureDatabaseExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	110, // 267: inventory.v1.AddValkeyExporterParams.custom_labels:type_name -> inventory.v1.AddValkeyExporterParams.CustomLabelsEntry
+	114, // 268: inventory.v1.AddValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 269: inventory.v1.AddValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	117, // 270: inventory.v1.ChangeValkeyExporterParams.custom_labels:type_name -> common.StringMap
+	115, // 271: inventory.v1.ChangeValkeyExporterParams.metrics_resolutions:type_name -> common.MetricsResolutions
+	114, // 272: inventory.v1.ChangeValkeyExporterParams.log_level:type_name -> inventory.v1.LogLevel
+	116, // 273: inventory.v1.ChangeValkeyExporterParams.connection_timeout:type_name -> google.protobuf.Duration
+	111, // 274: inventory.v1.AddRTAMongoDBAgentParams.custom_labels:type_name -> inventory.v1.AddRTAMongoDBAgentParams.CustomLabelsEntry
+	114, // 275: inventory.v1.AddRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 276: inventory.v1.AddRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	117, // 277: inventory.v1.ChangeRTAMongoDBAgentParams.custom_labels:type_name -> common.StringMap
+	114, // 278: inventory.v1.ChangeRTAMongoDBAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 279: inventory.v1.ChangeRTAMongoDBAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	112, // 280: inventory.v1.AddRTAPostgreSQLAgentParams.custom_labels:type_name -> inventory.v1.AddRTAPostgreSQLAgentParams.CustomLabelsEntry
+	114, // 281: inventory.v1.AddRTAPostgreSQLAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 282: inventory.v1.AddRTAPostgreSQLAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	117, // 283: inventory.v1.ChangeRTAPostgreSQLAgentParams.custom_labels:type_name -> common.StringMap
+	114, // 284: inventory.v1.ChangeRTAPostgreSQLAgentParams.log_level:type_name -> inventory.v1.LogLevel
+	14,  // 285: inventory.v1.ChangeRTAPostgreSQLAgentParams.rta_options:type_name -> inventory.v1.RTAOptions
+	23,  // 286: inventory.v1.AgentsService.ListAgents:input_type -> inventory.v1.ListAgentsRequest
+	25,  // 287: inventory.v1.AgentsService.GetAgent:input_type -> inventory.v1.GetAgentRequest
+	27,  // 288: inventory.v1.AgentsService.GetAgentLogs:input_type -> inventory.v1.GetAgentLogsRequest
+	29,  // 289: inventory.v1.AgentsService.AddAgent:input_type -> inventory.v1.AddAgentRequest
+	31,  // 290: inventory.v1.AgentsService.ChangeAgent:input_type -> inventory.v1.ChangeAgentRequest
+	69,  // 291: inventory.v1.AgentsService.RemoveAgent:input_type -> inventory.v1.RemoveAgentRequest
+	24,  // 292: inventory.v1.AgentsService.ListAgents:output_type -> inventory.v1.ListAgentsResponse
+	26,  // 293: inventory.v1.AgentsService.GetAgent:output_type -> inventory.v1.GetAgentResponse
+	28,  // 294: inventory.v1.AgentsService.GetAgentLogs:output_type -> inventory.v1.GetAgentLogsResponse
+	30,  // 295: inventory.v1.AgentsService.AddAgent:output_type -> inventory.v1.AddAgentResponse
+	32,  // 296: inventory.v1.AgentsService.ChangeAgent:output_type -> inventory.v1.ChangeAgentResponse
+	70,  // 297: inventory.v1.AgentsService.RemoveAgent:output_type -> inventory.v1.RemoveAgentResponse
+	292, // [292:298] is the sub-list for method output_type
+	286, // [286:292] is the sub-list for method input_type
+	286, // [286:286] is the sub-list for extension type_name
+	286, // [286:286] is the sub-list for extension extendee
+	0,   // [0:286] is the sub-list for field type_name
 }
 
 func init() { file_inventory_v1_agents_proto_init() }
@@ -12811,8 +13417,8 @@ func file_inventory_v1_agents_proto_init() {
 	}
 	file_inventory_v1_agent_status_proto_init()
 	file_inventory_v1_log_level_proto_init()
-	file_inventory_v1_agents_proto_msgTypes[20].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[24].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[21].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[25].OneofWrappers = []any{
 		(*GetAgentResponse_PmmAgent)(nil),
 		(*GetAgentResponse_Vmagent)(nil),
 		(*GetAgentResponse_NodeExporter)(nil),
@@ -12832,8 +13438,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*GetAgentResponse_NomadAgent)(nil),
 		(*GetAgentResponse_ValkeyExporter)(nil),
 		(*GetAgentResponse_RtaMongodbAgent)(nil),
+		(*GetAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[27].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[28].OneofWrappers = []any{
 		(*AddAgentRequest_PmmAgent)(nil),
 		(*AddAgentRequest_NodeExporter)(nil),
 		(*AddAgentRequest_MysqldExporter)(nil),
@@ -12851,8 +13458,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*AddAgentRequest_QanPostgresqlPgstatmonitorAgent)(nil),
 		(*AddAgentRequest_ValkeyExporter)(nil),
 		(*AddAgentRequest_RtaMongodbAgent)(nil),
+		(*AddAgentRequest_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[28].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[29].OneofWrappers = []any{
 		(*AddAgentResponse_PmmAgent)(nil),
 		(*AddAgentResponse_NodeExporter)(nil),
 		(*AddAgentResponse_MysqldExporter)(nil),
@@ -12870,8 +13478,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*AddAgentResponse_QanPostgresqlPgstatmonitorAgent)(nil),
 		(*AddAgentResponse_ValkeyExporter)(nil),
 		(*AddAgentResponse_RtaMongodbAgent)(nil),
+		(*AddAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[29].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[30].OneofWrappers = []any{
 		(*ChangeAgentRequest_NodeExporter)(nil),
 		(*ChangeAgentRequest_MysqldExporter)(nil),
 		(*ChangeAgentRequest_MongodbExporter)(nil),
@@ -12889,8 +13498,9 @@ func file_inventory_v1_agents_proto_init() {
 		(*ChangeAgentRequest_NomadAgent)(nil),
 		(*ChangeAgentRequest_ValkeyExporter)(nil),
 		(*ChangeAgentRequest_RtaMongodbAgent)(nil),
+		(*ChangeAgentRequest_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[30].OneofWrappers = []any{
+	file_inventory_v1_agents_proto_msgTypes[31].OneofWrappers = []any{
 		(*ChangeAgentResponse_NodeExporter)(nil),
 		(*ChangeAgentResponse_MysqldExporter)(nil),
 		(*ChangeAgentResponse_MongodbExporter)(nil),
@@ -12908,31 +13518,33 @@ func file_inventory_v1_agents_proto_init() {
 		(*ChangeAgentResponse_NomadAgent)(nil),
 		(*ChangeAgentResponse_ValkeyExporter)(nil),
 		(*ChangeAgentResponse_RtaMongodbAgent)(nil),
+		(*ChangeAgentResponse_RtaPostgresqlAgent)(nil),
 	}
-	file_inventory_v1_agents_proto_msgTypes[33].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[35].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[37].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[39].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[41].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[43].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[45].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[47].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[49].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[51].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[53].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[55].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[57].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[59].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[34].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[36].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[38].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[40].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[42].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[44].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[46].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[48].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[50].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[52].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[54].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[56].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[58].OneofWrappers = []any{}
 	file_inventory_v1_agents_proto_msgTypes[60].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[62].OneofWrappers = []any{}
-	file_inventory_v1_agents_proto_msgTypes[64].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[61].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[63].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[65].OneofWrappers = []any{}
+	file_inventory_v1_agents_proto_msgTypes[67].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_inventory_v1_agents_proto_rawDesc), len(file_inventory_v1_agents_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   107,
+			NumMessages:   112,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/inventory/v1/agents.pb.validate.go
+++ b/api/inventory/v1/agents.pb.validate.go
@@ -134,8 +134,7 @@ func (e PMMAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PMMAgentValidationError{}
@@ -243,8 +242,7 @@ func (e VMAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VMAgentValidationError{}
@@ -355,8 +353,7 @@ func (e NomadAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = NomadAgentValidationError{}
@@ -504,8 +501,7 @@ func (e NodeExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = NodeExporterValidationError{}
@@ -705,8 +701,7 @@ func (e MySQLdExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MySQLdExporterValidationError{}
@@ -896,8 +891,7 @@ func (e MongoDBExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MongoDBExporterValidationError{}
@@ -1087,8 +1081,7 @@ func (e PostgresExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PostgresExporterValidationError{}
@@ -1274,8 +1267,7 @@ func (e ProxySQLExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ProxySQLExporterValidationError{}
@@ -1459,8 +1451,7 @@ func (e ValkeyExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ValkeyExporterValidationError{}
@@ -1598,8 +1589,7 @@ func (e QANMySQLPerfSchemaAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMySQLPerfSchemaAgentValidationError{}
@@ -1739,8 +1729,7 @@ func (e QANMySQLSlowlogAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMySQLSlowlogAgentValidationError{}
@@ -1866,8 +1855,7 @@ func (e QANMongoDBProfilerAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMongoDBProfilerAgentValidationError{}
@@ -1993,8 +1981,7 @@ func (e QANMongoDBMongologAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANMongoDBMongologAgentValidationError{}
@@ -2123,8 +2110,7 @@ func (e RTAOptionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RTAOptionsValidationError{}
@@ -2136,6 +2122,157 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = RTAOptionsValidationError{}
+
+// Validate checks the field values on RTAPostgreSQLAgent with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *RTAPostgreSQLAgent) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on RTAPostgreSQLAgent with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// RTAPostgreSQLAgentMultiError, or nil if none found.
+func (m *RTAPostgreSQLAgent) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *RTAPostgreSQLAgent) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for AgentId
+
+	// no validation rules for PmmAgentId
+
+	// no validation rules for Disabled
+
+	// no validation rules for ServiceId
+
+	// no validation rules for Username
+
+	// no validation rules for Tls
+
+	// no validation rules for TlsSkipVerify
+
+	// no validation rules for CustomLabels
+
+	if all {
+		switch v := interface{}(m.GetRtaOptions()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, RTAPostgreSQLAgentValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, RTAPostgreSQLAgentValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return RTAPostgreSQLAgentValidationError{
+				field:  "RtaOptions",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for Status
+
+	// no validation rules for LogLevel
+
+	if len(errors) > 0 {
+		return RTAPostgreSQLAgentMultiError(errors)
+	}
+
+	return nil
+}
+
+// RTAPostgreSQLAgentMultiError is an error wrapping multiple validation errors
+// returned by RTAPostgreSQLAgent.ValidateAll() if the designated constraints
+// aren't met.
+type RTAPostgreSQLAgentMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m RTAPostgreSQLAgentMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m RTAPostgreSQLAgentMultiError) AllErrors() []error { return m }
+
+// RTAPostgreSQLAgentValidationError is the validation error returned by
+// RTAPostgreSQLAgent.Validate if the designated constraints aren't met.
+type RTAPostgreSQLAgentValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e RTAPostgreSQLAgentValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e RTAPostgreSQLAgentValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e RTAPostgreSQLAgentValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e RTAPostgreSQLAgentValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e RTAPostgreSQLAgentValidationError) ErrorName() string {
+	return "RTAPostgreSQLAgentValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e RTAPostgreSQLAgentValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sRTAPostgreSQLAgent.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = RTAPostgreSQLAgentValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = RTAPostgreSQLAgentValidationError{}
 
 // Validate checks the field values on RTAMongoDBAgent with the rules defined
 // in the proto definition for this message. If any rules are violated, the
@@ -2273,8 +2410,7 @@ func (e RTAMongoDBAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RTAMongoDBAgentValidationError{}
@@ -2403,8 +2539,7 @@ func (e QANPostgreSQLPgStatementsAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANPostgreSQLPgStatementsAgentValidationError{}
@@ -2535,8 +2670,7 @@ func (e QANPostgreSQLPgStatMonitorAgentValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QANPostgreSQLPgStatMonitorAgentValidationError{}
@@ -2692,8 +2826,7 @@ func (e RDSExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RDSExporterValidationError{}
@@ -2848,8 +2981,7 @@ func (e ExternalExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ExternalExporterValidationError{}
@@ -3004,8 +3136,7 @@ func (e AzureDatabaseExporterValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AzureDatabaseExporterValidationError{}
@@ -3074,6 +3205,7 @@ func (m *ChangeCommonAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -3102,6 +3234,7 @@ func (m *ChangeCommonAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -3175,8 +3308,7 @@ func (e ChangeCommonAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeCommonAgentParamsValidationError{}
@@ -3286,8 +3418,7 @@ func (e ListAgentsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsRequestValidationError{}
@@ -3968,6 +4099,40 @@ func (m *ListAgentsResponse) validate(all bool) error {
 
 	}
 
+	for idx, item := range m.GetRtaPostgresqlAgent() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListAgentsResponseValidationError{
+						field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListAgentsResponseValidationError{
+						field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListAgentsResponseValidationError{
+					field:  fmt.Sprintf("RtaPostgresqlAgent[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
 	if len(errors) > 0 {
 		return ListAgentsResponseMultiError(errors)
 	}
@@ -4035,8 +4200,7 @@ func (e ListAgentsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListAgentsResponseValidationError{}
@@ -4147,8 +4311,7 @@ func (e GetAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentRequestValidationError{}
@@ -4963,6 +5126,47 @@ func (m *GetAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *GetAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := GetAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, GetAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, GetAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return GetAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -5032,8 +5236,7 @@ func (e GetAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentResponseValidationError{}
@@ -5148,8 +5351,7 @@ func (e GetAgentLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentLogsRequestValidationError{}
@@ -5253,8 +5455,7 @@ func (e GetAgentLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetAgentLogsResponseValidationError{}
@@ -5987,6 +6188,47 @@ func (m *AddAgentRequest) validate(all bool) error {
 			}
 		}
 
+	case *AddAgentRequest_RtaPostgresqlAgent:
+		if v == nil {
+			err := AddAgentRequestValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, AddAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, AddAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return AddAgentRequestValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -6056,8 +6298,7 @@ func (e AddAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAgentRequestValidationError{}
@@ -6790,6 +7031,47 @@ func (m *AddAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *AddAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := AddAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, AddAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, AddAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return AddAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -6859,8 +7141,7 @@ func (e AddAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAgentResponseValidationError{}
@@ -7604,6 +7885,47 @@ func (m *ChangeAgentRequest) validate(all bool) error {
 			}
 		}
 
+	case *ChangeAgentRequest_RtaPostgresqlAgent:
+		if v == nil {
+			err := ChangeAgentRequestValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeAgentRequestValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeAgentRequestValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -7675,8 +7997,7 @@ func (e ChangeAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAgentRequestValidationError{}
@@ -8409,6 +8730,47 @@ func (m *ChangeAgentResponse) validate(all bool) error {
 			}
 		}
 
+	case *ChangeAgentResponse_RtaPostgresqlAgent:
+		if v == nil {
+			err := ChangeAgentResponseValidationError{
+				field:  "Agent",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeAgentResponseValidationError{
+						field:  "RtaPostgresqlAgent",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeAgentResponseValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -8480,8 +8842,7 @@ func (e ChangeAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAgentResponseValidationError{}
@@ -8596,8 +8957,7 @@ func (e AddPMMAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPMMAgentParamsValidationError{}
@@ -8718,8 +9078,7 @@ func (e AddNodeExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddNodeExporterParamsValidationError{}
@@ -8788,6 +9147,7 @@ func (m *ChangeNodeExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -8816,6 +9176,7 @@ func (m *ChangeNodeExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -8897,8 +9258,7 @@ func (e ChangeNodeExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeNodeExporterParamsValidationError{}
@@ -9091,8 +9451,7 @@ func (e AddMySQLdExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMySQLdExporterParamsValidationError{}
@@ -9191,6 +9550,7 @@ func (m *ChangeMySQLdExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -9219,6 +9579,7 @@ func (m *ChangeMySQLdExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -9340,8 +9701,7 @@ func (e ChangeMySQLdExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeMySQLdExporterParamsValidationError{}
@@ -9529,8 +9889,7 @@ func (e AddMongoDBExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddMongoDBExporterParamsValidationError{}
@@ -9629,6 +9988,7 @@ func (m *ChangeMongoDBExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -9657,6 +10017,7 @@ func (m *ChangeMongoDBExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -9791,8 +10152,7 @@ func (e ChangeMongoDBExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeMongoDBExporterParamsValidationError{}
@@ -9985,8 +10345,7 @@ func (e AddPostgresExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPostgresExporterParamsValidationError{}
@@ -10085,6 +10444,7 @@ func (m *ChangePostgresExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10113,6 +10473,7 @@ func (m *ChangePostgresExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -10239,8 +10600,7 @@ func (e ChangePostgresExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangePostgresExporterParamsValidationError{}
@@ -10423,8 +10783,7 @@ func (e AddProxySQLExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddProxySQLExporterParamsValidationError{}
@@ -10523,6 +10882,7 @@ func (m *ChangeProxySQLExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10551,6 +10911,7 @@ func (m *ChangeProxySQLExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -10653,8 +11014,7 @@ func (e ChangeProxySQLExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeProxySQLExporterParamsValidationError{}
@@ -10818,8 +11178,7 @@ func (e AddQANMySQLPerfSchemaAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMySQLPerfSchemaAgentParamsValidationError{}
@@ -10889,6 +11248,7 @@ func (m *ChangeQANMySQLPerfSchemaAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -10917,6 +11277,7 @@ func (m *ChangeQANMySQLPerfSchemaAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11040,8 +11401,7 @@ func (e ChangeQANMySQLPerfSchemaAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMySQLPerfSchemaAgentParamsValidationError{}
@@ -11205,8 +11565,7 @@ func (e AddQANMySQLSlowlogAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMySQLSlowlogAgentParamsValidationError{}
@@ -11276,6 +11635,7 @@ func (m *ChangeQANMySQLSlowlogAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -11304,6 +11664,7 @@ func (m *ChangeQANMySQLSlowlogAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11431,8 +11792,7 @@ func (e ChangeQANMySQLSlowlogAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMySQLSlowlogAgentParamsValidationError{}
@@ -11585,8 +11945,7 @@ func (e AddQANMongoDBProfilerAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMongoDBProfilerAgentParamsValidationError{}
@@ -11656,6 +12015,7 @@ func (m *ChangeQANMongoDBProfilerAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -11684,6 +12044,7 @@ func (m *ChangeQANMongoDBProfilerAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -11803,8 +12164,7 @@ func (e ChangeQANMongoDBProfilerAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMongoDBProfilerAgentParamsValidationError{}
@@ -11957,8 +12317,7 @@ func (e AddQANMongoDBMongologAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANMongoDBMongologAgentParamsValidationError{}
@@ -12028,6 +12387,7 @@ func (m *ChangeQANMongoDBMongologAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12056,6 +12416,7 @@ func (m *ChangeQANMongoDBMongologAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12175,8 +12536,7 @@ func (e ChangeQANMongoDBMongologAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANMongoDBMongologAgentParamsValidationError{}
@@ -12337,8 +12697,7 @@ func (e AddQANPostgreSQLPgStatementsAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANPostgreSQLPgStatementsAgentParamsValidationError{}
@@ -12409,6 +12768,7 @@ func (m *ChangeQANPostgreSQLPgStatementsAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12437,6 +12797,7 @@ func (m *ChangeQANPostgreSQLPgStatementsAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12552,8 +12913,7 @@ func (e ChangeQANPostgreSQLPgStatementsAgentParamsValidationError) Error() strin
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANPostgreSQLPgStatementsAgentParamsValidationError{}
@@ -12716,8 +13076,7 @@ func (e AddQANPostgreSQLPgStatMonitorAgentParamsValidationError) Error() string 
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddQANPostgreSQLPgStatMonitorAgentParamsValidationError{}
@@ -12788,6 +13147,7 @@ func (m *ChangeQANPostgreSQLPgStatMonitorAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -12816,6 +13176,7 @@ func (m *ChangeQANPostgreSQLPgStatMonitorAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -12935,8 +13296,7 @@ func (e ChangeQANPostgreSQLPgStatMonitorAgentParamsValidationError) Error() stri
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeQANPostgreSQLPgStatMonitorAgentParamsValidationError{}
@@ -13076,8 +13436,7 @@ func (e AddRDSExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRDSExporterParamsValidationError{}
@@ -13146,6 +13505,7 @@ func (m *ChangeRDSExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13174,6 +13534,7 @@ func (m *ChangeRDSExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13267,8 +13628,7 @@ func (e ChangeRDSExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeRDSExporterParamsValidationError{}
@@ -13408,8 +13768,7 @@ func (e AddExternalExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddExternalExporterParamsValidationError{}
@@ -13478,6 +13837,7 @@ func (m *ChangeExternalExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13506,6 +13866,7 @@ func (m *ChangeExternalExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13596,8 +13957,7 @@ func (e ChangeExternalExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeExternalExporterParamsValidationError{}
@@ -13751,8 +14111,7 @@ func (e AddAzureDatabaseExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddAzureDatabaseExporterParamsValidationError{}
@@ -13822,6 +14181,7 @@ func (m *ChangeAzureDatabaseExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -13850,6 +14210,7 @@ func (m *ChangeAzureDatabaseExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -13949,8 +14310,7 @@ func (e ChangeAzureDatabaseExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeAzureDatabaseExporterParamsValidationError{}
@@ -14056,8 +14416,7 @@ func (e ChangeNomadAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeNomadAgentParamsValidationError{}
@@ -14255,8 +14614,7 @@ func (e AddValkeyExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddValkeyExporterParamsValidationError{}
@@ -14355,6 +14713,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14383,6 +14742,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnablePushMetrics != nil {
@@ -14390,6 +14750,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 	}
 
 	if m.Username != nil {
+
 		if utf8.RuneCountInString(m.GetUsername()) < 1 {
 			err := ChangeValkeyExporterParamsValidationError{
 				field:  "Username",
@@ -14400,6 +14761,7 @@ func (m *ChangeValkeyExporterParams) validate(all bool) error {
 			}
 			errors = append(errors, err)
 		}
+
 	}
 
 	if m.Password != nil {
@@ -14505,8 +14867,7 @@ func (e ChangeValkeyExporterParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeValkeyExporterParamsValidationError{}
@@ -14681,8 +15042,7 @@ func (e AddRTAMongoDBAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddRTAMongoDBAgentParamsValidationError{}
@@ -14722,6 +15082,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 	}
 
 	if m.CustomLabels != nil {
+
 		if all {
 			switch v := interface{}(m.GetCustomLabels()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14750,6 +15111,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.LogLevel != nil {
@@ -14789,6 +15151,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 	}
 
 	if m.RtaOptions != nil {
+
 		if all {
 			switch v := interface{}(m.GetRtaOptions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -14817,6 +15180,7 @@ func (m *ChangeRTAMongoDBAgentParams) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if len(errors) > 0 {
@@ -14887,8 +15251,7 @@ func (e ChangeRTAMongoDBAgentParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeRTAMongoDBAgentParamsValidationError{}
@@ -14900,6 +15263,385 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = ChangeRTAMongoDBAgentParamsValidationError{}
+
+// Validate checks the field values on AddRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *AddRTAPostgreSQLAgentParams) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on AddRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// AddRTAPostgreSQLAgentParamsMultiError, or nil if none found.
+func (m *AddRTAPostgreSQLAgentParams) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *AddRTAPostgreSQLAgentParams) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if utf8.RuneCountInString(m.GetPmmAgentId()) < 1 {
+		err := AddRTAPostgreSQLAgentParamsValidationError{
+			field:  "PmmAgentId",
+			reason: "value length must be at least 1 runes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if utf8.RuneCountInString(m.GetServiceId()) < 1 {
+		err := AddRTAPostgreSQLAgentParamsValidationError{
+			field:  "ServiceId",
+			reason: "value length must be at least 1 runes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	// no validation rules for Username
+
+	// no validation rules for Password
+
+	// no validation rules for CustomLabels
+
+	// no validation rules for LogLevel
+
+	// no validation rules for Tls
+
+	// no validation rules for TlsSkipVerify
+
+	// no validation rules for TlsCa
+
+	// no validation rules for TlsCert
+
+	// no validation rules for TlsKey
+
+	// no validation rules for SkipConnectionCheck
+
+	if all {
+		switch v := interface{}(m.GetRtaOptions()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, AddRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, AddRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return AddRTAPostgreSQLAgentParamsValidationError{
+				field:  "RtaOptions",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return AddRTAPostgreSQLAgentParamsMultiError(errors)
+	}
+
+	return nil
+}
+
+// AddRTAPostgreSQLAgentParamsMultiError is an error wrapping multiple
+// validation errors returned by AddRTAPostgreSQLAgentParams.ValidateAll() if
+// the designated constraints aren't met.
+type AddRTAPostgreSQLAgentParamsMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m AddRTAPostgreSQLAgentParamsMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m AddRTAPostgreSQLAgentParamsMultiError) AllErrors() []error { return m }
+
+// AddRTAPostgreSQLAgentParamsValidationError is the validation error returned
+// by AddRTAPostgreSQLAgentParams.Validate if the designated constraints
+// aren't met.
+type AddRTAPostgreSQLAgentParamsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e AddRTAPostgreSQLAgentParamsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e AddRTAPostgreSQLAgentParamsValidationError) ErrorName() string {
+	return "AddRTAPostgreSQLAgentParamsValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e AddRTAPostgreSQLAgentParamsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sAddRTAPostgreSQLAgentParams.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = AddRTAPostgreSQLAgentParamsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = AddRTAPostgreSQLAgentParamsValidationError{}
+
+// Validate checks the field values on ChangeRTAPostgreSQLAgentParams with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ChangeRTAPostgreSQLAgentParams) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ChangeRTAPostgreSQLAgentParams with
+// the rules defined in the proto definition for this message. If any rules
+// are violated, the result is a list of violation errors wrapped in
+// ChangeRTAPostgreSQLAgentParamsMultiError, or nil if none found.
+func (m *ChangeRTAPostgreSQLAgentParams) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ChangeRTAPostgreSQLAgentParams) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.Enable != nil {
+		// no validation rules for Enable
+	}
+
+	if m.CustomLabels != nil {
+
+		if all {
+			switch v := interface{}(m.GetCustomLabels()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "CustomLabels",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "CustomLabels",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetCustomLabels()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeRTAPostgreSQLAgentParamsValidationError{
+					field:  "CustomLabels",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if m.LogLevel != nil {
+		// no validation rules for LogLevel
+	}
+
+	if m.Username != nil {
+		// no validation rules for Username
+	}
+
+	if m.Password != nil {
+		// no validation rules for Password
+	}
+
+	if m.Tls != nil {
+		// no validation rules for Tls
+	}
+
+	if m.TlsSkipVerify != nil {
+		// no validation rules for TlsSkipVerify
+	}
+
+	if m.TlsCa != nil {
+		// no validation rules for TlsCa
+	}
+
+	if m.TlsCert != nil {
+		// no validation rules for TlsCert
+	}
+
+	if m.TlsKey != nil {
+		// no validation rules for TlsKey
+	}
+
+	if m.RtaOptions != nil {
+
+		if all {
+			switch v := interface{}(m.GetRtaOptions()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "RtaOptions",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ChangeRTAPostgreSQLAgentParamsValidationError{
+						field:  "RtaOptions",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetRtaOptions()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ChangeRTAPostgreSQLAgentParamsValidationError{
+					field:  "RtaOptions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return ChangeRTAPostgreSQLAgentParamsMultiError(errors)
+	}
+
+	return nil
+}
+
+// ChangeRTAPostgreSQLAgentParamsMultiError is an error wrapping multiple
+// validation errors returned by ChangeRTAPostgreSQLAgentParams.ValidateAll()
+// if the designated constraints aren't met.
+type ChangeRTAPostgreSQLAgentParamsMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ChangeRTAPostgreSQLAgentParamsMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ChangeRTAPostgreSQLAgentParamsMultiError) AllErrors() []error { return m }
+
+// ChangeRTAPostgreSQLAgentParamsValidationError is the validation error
+// returned by ChangeRTAPostgreSQLAgentParams.Validate if the designated
+// constraints aren't met.
+type ChangeRTAPostgreSQLAgentParamsValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) ErrorName() string {
+	return "ChangeRTAPostgreSQLAgentParamsValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ChangeRTAPostgreSQLAgentParamsValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sChangeRTAPostgreSQLAgentParams.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ChangeRTAPostgreSQLAgentParamsValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ChangeRTAPostgreSQLAgentParamsValidationError{}
 
 // Validate checks the field values on RemoveAgentRequest with the rules
 // defined in the proto definition for this message. If any rules are
@@ -15003,8 +15745,7 @@ func (e RemoveAgentRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveAgentRequestValidationError{}
@@ -15106,8 +15847,7 @@ func (e RemoveAgentResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = RemoveAgentResponseValidationError{}

--- a/api/inventory/v1/agents.proto
+++ b/api/inventory/v1/agents.proto
@@ -34,6 +34,7 @@ enum AgentType {
   AGENT_TYPE_AZURE_DATABASE_EXPORTER = 15;
   AGENT_TYPE_NOMAD_AGENT = 16;
   AGENT_TYPE_RTA_MONGODB_AGENT = 19;
+  AGENT_TYPE_RTA_POSTGRESQL_AGENT = 20;
 }
 
 // PMMAgent runs on Generic or Container Node.
@@ -548,6 +549,32 @@ message RTAOptions {
   }];
 }
 
+// RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server.
+message RTAPostgreSQLAgent {
+  // Unique agent identifier.
+  string agent_id = 1;
+  // The pmm-agent identifier which runs this instance.
+  string pmm_agent_id = 2;
+  // Desired Agent status: enabled (false) or disabled (true).
+  bool disabled = 3;
+  // Service identifier.
+  string service_id = 4;
+  // PostgreSQL username for getting session data.
+  string username = 5 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Use TLS for database connections.
+  bool tls = 6;
+  // Skip TLS certificate and hostname validation.
+  bool tls_skip_verify = 7;
+  // Custom user-assigned labels.
+  map<string, string> custom_labels = 8;
+  // Real-Time Analytics options.
+  RTAOptions rta_options = 9;
+  // Actual Agent status.
+  AgentStatus status = 10;
+  // Log level for agent.
+  LogLevel log_level = 11;
+}
+
 // RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server.
 message RTAMongoDBAgent {
   // Unique agent identifier.
@@ -805,6 +832,7 @@ message ListAgentsResponse {
   repeated NomadAgent nomad_agent = 16;
   repeated ValkeyExporter valkey_exporter = 17;
   repeated RTAMongoDBAgent rta_mongodb_agent = 19;
+  repeated RTAPostgreSQLAgent rta_postgresql_agent = 20;
 }
 
 // Get
@@ -835,6 +863,7 @@ message GetAgentResponse {
     NomadAgent nomad_agent = 16;
     ValkeyExporter valkey_exporter = 17;
     RTAMongoDBAgent rta_mongodb_agent = 19;
+    RTAPostgreSQLAgent rta_postgresql_agent = 20;
   }
 }
 
@@ -875,6 +904,7 @@ message AddAgentRequest {
     AddQANPostgreSQLPgStatMonitorAgentParams qan_postgresql_pgstatmonitor_agent = 14;
     AddValkeyExporterParams valkey_exporter = 15;
     AddRTAMongoDBAgentParams rta_mongodb_agent = 17;
+    AddRTAPostgreSQLAgentParams rta_postgresql_agent = 18;
   }
 }
 
@@ -897,6 +927,7 @@ message AddAgentResponse {
     QANPostgreSQLPgStatMonitorAgent qan_postgresql_pgstatmonitor_agent = 14;
     ValkeyExporter valkey_exporter = 15;
     RTAMongoDBAgent rta_mongodb_agent = 17;
+    RTAPostgreSQLAgent rta_postgresql_agent = 18;
   }
 }
 
@@ -923,6 +954,7 @@ message ChangeAgentRequest {
     ChangeNomadAgentParams nomad_agent = 15;
     ChangeValkeyExporterParams valkey_exporter = 16;
     ChangeRTAMongoDBAgentParams rta_mongodb_agent = 18;
+    ChangeRTAPostgreSQLAgentParams rta_postgresql_agent = 19;
   }
 }
 
@@ -947,6 +979,7 @@ message ChangeAgentResponse {
     NomadAgent nomad_agent = 15;
     ValkeyExporter valkey_exporter = 16;
     RTAMongoDBAgent rta_mongodb_agent = 18;
+    RTAPostgreSQLAgent rta_postgresql_agent = 19;
   }
 }
 
@@ -2079,6 +2112,62 @@ message ChangeRTAMongoDBAgentParams {
   optional string authentication_mechanism = 11;
   // Real-Time Analytics options.
   optional RTAOptions rta_options = 12;
+}
+
+// Add/Change RTAPostgreSQLAgent
+
+message AddRTAPostgreSQLAgentParams {
+  // The pmm-agent identifier which runs this instance.
+  string pmm_agent_id = 1 [(validate.rules).string.min_len = 1];
+  // Service identifier.
+  string service_id = 2 [(validate.rules).string.min_len = 1];
+  // PostgreSQL username for getting session data.
+  string username = 3 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // PostgreSQL password for getting session data.
+  string password = 4 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Custom user-assigned labels.
+  map<string, string> custom_labels = 5;
+  // Log level for agent.
+  LogLevel log_level = 6;
+  // Use TLS for database connections.
+  bool tls = 7;
+  // Skip TLS certificate and hostname validation.
+  bool tls_skip_verify = 8;
+  // TLS CA certificate.
+  string tls_ca = 9;
+  // TLS certificate.
+  string tls_cert = 10 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // TLS certificate key.
+  string tls_key = 11 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Skip connection check.
+  bool skip_connection_check = 12;
+  // Real-Time Analytics options.
+  RTAOptions rta_options = 13;
+}
+
+message ChangeRTAPostgreSQLAgentParams {
+  // Enable this Agent. Agents are enabled by default when they get added.
+  optional bool enable = 1;
+  // Replace all custom user-assigned labels.
+  optional common.StringMap custom_labels = 2;
+  // Log level for agent.
+  optional LogLevel log_level = 3;
+  // PostgreSQL username for getting session data.
+  optional string username = 4 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // PostgreSQL password for getting session data.
+  optional string password = 5 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Use TLS for database connections.
+  optional bool tls = 6;
+  // Skip TLS certificate and hostname validation.
+  optional bool tls_skip_verify = 7;
+  // TLS CA certificate.
+  optional string tls_ca = 8;
+  // TLS certificate.
+  optional string tls_cert = 9 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // TLS certificate key.
+  optional string tls_key = 10 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Real-Time Analytics options.
+  optional RTAOptions rta_options = 11;
 }
 
 // Remove

--- a/api/inventory/v1/agents.swagger.json
+++ b/api/inventory/v1/agents.swagger.json
@@ -1,0 +1,4687 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "inventory/v1/agents.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "AgentsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/inventory/agents": {
+      "get": {
+        "summary": "List Agents",
+        "description": "Returns a list of all Agents.",
+        "operationId": "ListAgents",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListAgentsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmm_agent_id",
+            "description": "Return only Agents started by this pmm-agent.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "node_id",
+            "description": "Return only Agents that provide insights for that Node.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "service_id",
+            "description": "Return only Agents that provide insights for that Service.\nExactly one of these parameters should be present: pmm_agent_id, node_id, service_id.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "agent_type",
+            "description": "Return only agents of a particular type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "AGENT_TYPE_UNSPECIFIED",
+              "AGENT_TYPE_PMM_AGENT",
+              "AGENT_TYPE_VM_AGENT",
+              "AGENT_TYPE_NODE_EXPORTER",
+              "AGENT_TYPE_MYSQLD_EXPORTER",
+              "AGENT_TYPE_MONGODB_EXPORTER",
+              "AGENT_TYPE_POSTGRES_EXPORTER",
+              "AGENT_TYPE_PROXYSQL_EXPORTER",
+              "AGENT_TYPE_VALKEY_EXPORTER",
+              "AGENT_TYPE_QAN_MYSQL_PERFSCHEMA_AGENT",
+              "AGENT_TYPE_QAN_MYSQL_SLOWLOG_AGENT",
+              "AGENT_TYPE_QAN_MONGODB_PROFILER_AGENT",
+              "AGENT_TYPE_QAN_MONGODB_MONGOLOG_AGENT",
+              "AGENT_TYPE_QAN_POSTGRESQL_PGSTATEMENTS_AGENT",
+              "AGENT_TYPE_QAN_POSTGRESQL_PGSTATMONITOR_AGENT",
+              "AGENT_TYPE_EXTERNAL_EXPORTER",
+              "AGENT_TYPE_RDS_EXPORTER",
+              "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
+              "AGENT_TYPE_NOMAD_AGENT",
+              "AGENT_TYPE_RTA_MONGODB_AGENT",
+              "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
+            ],
+            "default": "AGENT_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "post": {
+        "summary": "Add an Agent to Inventory",
+        "description": "Adds an Agent to Inventory. Only one agent at a time can be passed.",
+        "operationId": "AddAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1AddAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1AddAgentRequest"
+            }
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    },
+    "/v1/inventory/agents/{agent_id}": {
+      "get": {
+        "summary": "Get Agent",
+        "description": "Returns a single Agent by ID.",
+        "operationId": "GetAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "delete": {
+        "summary": "Remove an Agent from Inventory",
+        "description": "Removes an Agent from Inventory.",
+        "operationId": "RemoveAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1RemoveAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "description": "Remove agent with all dependencies.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      },
+      "put": {
+        "summary": "Update an Agent in Inventory",
+        "description": "Updates an Agent in Inventory. Only one agent at a time can be passed.",
+        "operationId": "ChangeAgent",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ChangeAgentResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentsServiceChangeAgentBody"
+            }
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    },
+    "/v1/inventory/agents/{agent_id}/logs": {
+      "get": {
+        "summary": "Get Agent logs",
+        "description": "Returns Agent logs by ID.",
+        "operationId": "GetAgentLogs",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1GetAgentLogsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "agent_id",
+            "description": "Unique randomly generated instance identifier.",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "description": "Limit the number of log lines to this value. Pass 0 for no limit.",
+            "in": "query",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
+          }
+        ],
+        "tags": [
+          "AgentsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "AgentsServiceChangeAgentBody": {
+      "type": "object",
+      "properties": {
+        "node_exporter": {
+          "$ref": "#/definitions/v1ChangeNodeExporterParams"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1ChangeMySQLdExporterParams"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1ChangeMongoDBExporterParams"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1ChangePostgresExporterParams"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ChangeProxySQLExporterParams"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ChangeExternalExporterParams"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1ChangeRDSExporterParams"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1ChangeAzureDatabaseExporterParams"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1ChangeQANMySQLPerfSchemaAgentParams"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1ChangeQANMySQLSlowlogAgentParams"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1ChangeQANMongoDBProfilerAgentParams"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1ChangeQANMongoDBMongologAgentParams"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1ChangeQANPostgreSQLPgStatementsAgentParams"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1ChangeQANPostgreSQLPgStatMonitorAgentParams"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1ChangeNomadAgentParams"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ChangeValkeyExporterParams"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1ChangeRTAMongoDBAgentParams"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1ChangeRTAPostgreSQLAgentParams"
+        }
+      }
+    },
+    "commonMetricsResolutions": {
+      "type": "object",
+      "properties": {
+        "hr": {
+          "type": "string",
+          "description": "High resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "mr": {
+          "type": "string",
+          "description": "Medium resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        },
+        "lr": {
+          "type": "string",
+          "description": "Low resolution. In JSON should be represented as a string with number of seconds with `s` suffix."
+        }
+      },
+      "description": "MetricsResolutions represents Prometheus exporters metrics resolutions."
+    },
+    "commonStringMap": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "A wrapper for map[string]string. This type allows to distinguish between an empty map and a null value."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1AddAgentRequest": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1AddPMMAgentParams"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1AddNodeExporterParams"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1AddMySQLdExporterParams"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1AddMongoDBExporterParams"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1AddPostgresExporterParams"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1AddProxySQLExporterParams"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1AddExternalExporterParams"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1AddRDSExporterParams"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AddAzureDatabaseExporterParams"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1AddQANMySQLPerfSchemaAgentParams"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1AddQANMySQLSlowlogAgentParams"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1AddQANMongoDBProfilerAgentParams"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1AddQANMongoDBMongologAgentParams"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1AddQANPostgreSQLPgStatementsAgentParams"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1AddQANPostgreSQLPgStatMonitorAgentParams"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1AddValkeyExporterParams"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1AddRTAMongoDBAgentParams"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1AddRTAPostgreSQLAgentParams"
+        }
+      }
+    },
+    "v1AddAgentResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1PMMAgent"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1AddAzureDatabaseExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "azure_client_id": {
+          "type": "string",
+          "title": "Azure client ID"
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "title": "Azure client secret"
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "title": "Azure tanant ID"
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "title": "Azure subscription ID"
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "description": "Azure resource group."
+        },
+        "azure_database_resource_type": {
+          "type": "string",
+          "title": "Azure resource type (mysql, maria, postgres)"
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddExternalExporterParams": {
+      "type": "object",
+      "properties": {
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "The node identifier where this instance is run."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "HTTP basic auth password for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints(default: http)."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI(default: /metrics)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        }
+      }
+    },
+    "v1AddMongoDBExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of colletions to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names to pass to the exporter.\nValues will be resolved from pmm-agent's environment when starting the exporter."
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "Enable all collectors."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddMySQLdExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddNodeExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Expose the node_exporter process on all public interfaces"
+        }
+      }
+    },
+    "v1AddPMMAgentParams": {
+      "type": "object",
+      "properties": {
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        }
+      }
+    },
+    "v1AddPostgresExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddProxySQLExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "ProxySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AddQANMongoDBMongologAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      }
+    },
+    "v1AddQANMongoDBProfilerAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "authentication_database": {
+          "type": "string",
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      }
+    },
+    "v1AddQANMySQLPerfSchemaAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      }
+    },
+    "v1AddQANMySQLSlowlogAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting slowlog data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MySQL password for getting slowlog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Rotate slowlog file at this size if \u003e 0.\nUse zero or negative value to disable rotation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      }
+    },
+    "v1AddQANPostgreSQLPgStatMonitorAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "description": "Disable query examples."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddQANPostgreSQLPgStatementsAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting pg stat statements data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddRDSExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "description": "AWS Secret Key."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "disable_basic_metrics": {
+          "type": "boolean",
+          "description": "Disable basic metrics."
+        },
+        "disable_enhanced_metrics": {
+          "type": "boolean",
+          "description": "Disable enhanced metrics."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1AddRTAMongoDBAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting queries data."
+        },
+        "password": {
+          "type": "string",
+          "description": "MongoDB password for getting queries data."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "MongoDB specific options.\nUse TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "description": "Authentication mechanism.\nSee https://docs.mongodb.com/manual/reference/connection-string/#mongodb-urioption-urioption.authMechanism\nfor details."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1AddRTAPostgreSQLAgentParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting session data."
+        },
+        "password": {
+          "type": "string",
+          "description": "PostgreSQL password for getting session data."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS certificate key."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1AddValkeyExporterParams": {
+      "type": "object",
+      "properties": {
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "description": "Valkey password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "description": "Skip connection check."
+        },
+        "push_metrics": {
+          "type": "boolean",
+          "description": "Enables push metrics mode for exporter."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1AgentStatus": {
+      "type": "string",
+      "enum": [
+        "AGENT_STATUS_UNSPECIFIED",
+        "AGENT_STATUS_STARTING",
+        "AGENT_STATUS_INITIALIZATION_ERROR",
+        "AGENT_STATUS_RUNNING",
+        "AGENT_STATUS_WAITING",
+        "AGENT_STATUS_STOPPING",
+        "AGENT_STATUS_DONE",
+        "AGENT_STATUS_UNKNOWN"
+      ],
+      "default": "AGENT_STATUS_UNSPECIFIED",
+      "description": "AgentStatus represents actual Agent status.\n\n - AGENT_STATUS_STARTING: Agent is starting.\n - AGENT_STATUS_INITIALIZATION_ERROR: Agent encountered error when starting.\n - AGENT_STATUS_RUNNING: Agent is running.\n - AGENT_STATUS_WAITING: Agent encountered error and will be restarted automatically soon.\n - AGENT_STATUS_STOPPING: Agent is stopping.\n - AGENT_STATUS_DONE: Agent has been stopped or disabled.\n - AGENT_STATUS_UNKNOWN: Agent is not connected, we don't know anything about it's state."
+    },
+    "v1AgentType": {
+      "type": "string",
+      "enum": [
+        "AGENT_TYPE_UNSPECIFIED",
+        "AGENT_TYPE_PMM_AGENT",
+        "AGENT_TYPE_VM_AGENT",
+        "AGENT_TYPE_NODE_EXPORTER",
+        "AGENT_TYPE_MYSQLD_EXPORTER",
+        "AGENT_TYPE_MONGODB_EXPORTER",
+        "AGENT_TYPE_POSTGRES_EXPORTER",
+        "AGENT_TYPE_PROXYSQL_EXPORTER",
+        "AGENT_TYPE_VALKEY_EXPORTER",
+        "AGENT_TYPE_QAN_MYSQL_PERFSCHEMA_AGENT",
+        "AGENT_TYPE_QAN_MYSQL_SLOWLOG_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_PROFILER_AGENT",
+        "AGENT_TYPE_QAN_MONGODB_MONGOLOG_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATEMENTS_AGENT",
+        "AGENT_TYPE_QAN_POSTGRESQL_PGSTATMONITOR_AGENT",
+        "AGENT_TYPE_EXTERNAL_EXPORTER",
+        "AGENT_TYPE_RDS_EXPORTER",
+        "AGENT_TYPE_AZURE_DATABASE_EXPORTER",
+        "AGENT_TYPE_NOMAD_AGENT",
+        "AGENT_TYPE_RTA_MONGODB_AGENT",
+        "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
+      ],
+      "default": "AGENT_TYPE_UNSPECIFIED",
+      "description": "AgentType describes supported Agent types."
+    },
+    "v1AzureDatabaseExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "azure_database_subscription_id": {
+          "type": "string",
+          "description": "Azure database subscription ID."
+        },
+        "azure_database_resource_type": {
+          "type": "string",
+          "title": "Azure database resource type (mysql, maria, postgres)"
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status (the same for several configurations)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics (the same for several configurations)."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if the exporter operates in push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "AzureDatabaseExporter runs on Generic or Container Node and exposes RemoteAzure Node metrics."
+    },
+    "v1ChangeAgentResponse": {
+      "type": "object",
+      "properties": {
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1NomadAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1ChangeAzureDatabaseExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "azure_client_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure client ID"
+        },
+        "azure_client_secret": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure client secret"
+        },
+        "azure_tenant_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure tenant ID"
+        },
+        "azure_subscription_id": {
+          "type": "string",
+          "x-nullable": true,
+          "title": "Azure subscription ID"
+        },
+        "azure_resource_group": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Azure resource group."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeExternalExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "Listen port for scraping metrics."
+        }
+      }
+    },
+    "v1ChangeMongoDBExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of collections to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server is less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable all collectors."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeMySQLdExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Tablestats group collectors will be disabled if there are more than that number of tables."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeNodeExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Expose the node_exporter process on all public interfaces."
+        }
+      }
+    },
+    "v1ChangeNomadAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        }
+      }
+    },
+    "v1ChangePostgresExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeProxySQLExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "ProxySQL password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Optionally expose the exporter process on all public interfaces."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ChangeQANMongoDBMongologAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting mongolog data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting mongolog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMongoDBProfilerAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "authentication_database": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication database."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMySQLPerfSchemaAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for getting performance data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANMySQLSlowlogAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL username for getting slowlog data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MySQL password for getting slowlog data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_cert."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "x-nullable": true,
+          "description": "Rotate slowlog file at this size if \u003e 0."
+        },
+        "skip_connection_check": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip connection check."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANPostgreSQLPgStatMonitorAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "disable_query_examples": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable query examples."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeQANPostgreSQLPgStatementsAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting pg stat statements data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": true,
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeRDSExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "AWS Access Key."
+        },
+        "aws_secret_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "AWS Secret Key."
+        },
+        "disable_basic_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable basic metrics."
+        },
+        "disable_enhanced_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Disable enhanced metrics."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        }
+      }
+    },
+    "v1ChangeRTAMongoDBAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB username for getting profile data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "MongoDB password for getting profile data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_certificate_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Client certificate and key."
+        },
+        "tls_certificate_key_file_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Password for decrypting tls_certificate_key."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Certificate Authority certificate chain."
+        },
+        "authentication_mechanism": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Authentication mechanism."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "x-nullable": true,
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1ChangeRTAPostgreSQLAgentParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL username for getting session data."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "PostgreSQL password for getting session data."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS certificate key."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "x-nullable": true,
+          "description": "Real-Time Analytics options."
+        }
+      }
+    },
+    "v1ChangeValkeyExporterParams": {
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enable this Agent. Agents are enabled by default when they get added."
+        },
+        "custom_labels": {
+          "$ref": "#/definitions/commonStringMap",
+          "x-nullable": true,
+          "description": "Replace all custom user-assigned labels."
+        },
+        "enable_push_metrics": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Enables push metrics with vmagent."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "username": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Valkey username for scraping metrics."
+        },
+        "password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Valkey password for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "x-nullable": true,
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of collector names to disable in this exporter."
+        },
+        "tls_ca": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS CA certificate."
+        },
+        "tls_cert": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certifcate."
+        },
+        "tls_key": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "TLS Certificate Key."
+        },
+        "agent_password": {
+          "type": "string",
+          "x-nullable": true,
+          "description": "Custom password for exporter endpoint /metrics."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "x-nullable": true,
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "x-nullable": true,
+          "description": "Log level for exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      }
+    },
+    "v1ExternalExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "If disabled, metrics from this exporter will not be collected."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "HTTP basic auth username for collecting metrics."
+        },
+        "scheme": {
+          "type": "string",
+          "description": "Scheme to generate URI to exporter metrics endpoints."
+        },
+        "metrics_path": {
+          "type": "string",
+          "description": "Path under which metrics are exposed, used to generate URI."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        }
+      },
+      "description": "ExternalExporter runs on any Node type, including Remote Node."
+    },
+    "v1GetAgentLogsResponse": {
+      "type": "object",
+      "properties": {
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "agent_config_log_lines_count": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "v1GetAgentResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "$ref": "#/definitions/v1PMMAgent"
+        },
+        "vmagent": {
+          "$ref": "#/definitions/v1VMAgent"
+        },
+        "node_exporter": {
+          "$ref": "#/definitions/v1NodeExporter"
+        },
+        "mysqld_exporter": {
+          "$ref": "#/definitions/v1MySQLdExporter"
+        },
+        "mongodb_exporter": {
+          "$ref": "#/definitions/v1MongoDBExporter"
+        },
+        "postgres_exporter": {
+          "$ref": "#/definitions/v1PostgresExporter"
+        },
+        "proxysql_exporter": {
+          "$ref": "#/definitions/v1ProxySQLExporter"
+        },
+        "qan_mysql_perfschema_agent": {
+          "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+        },
+        "qan_mysql_slowlog_agent": {
+          "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+        },
+        "qan_mongodb_profiler_agent": {
+          "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+        },
+        "qan_mongodb_mongolog_agent": {
+          "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+        },
+        "external_exporter": {
+          "$ref": "#/definitions/v1ExternalExporter"
+        },
+        "rds_exporter": {
+          "$ref": "#/definitions/v1RDSExporter"
+        },
+        "azure_database_exporter": {
+          "$ref": "#/definitions/v1AzureDatabaseExporter"
+        },
+        "nomad_agent": {
+          "$ref": "#/definitions/v1NomadAgent"
+        },
+        "valkey_exporter": {
+          "$ref": "#/definitions/v1ValkeyExporter"
+        },
+        "rta_mongodb_agent": {
+          "$ref": "#/definitions/v1RTAMongoDBAgent"
+        },
+        "rta_postgresql_agent": {
+          "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+        }
+      }
+    },
+    "v1ListAgentsResponse": {
+      "type": "object",
+      "properties": {
+        "pmm_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PMMAgent"
+          }
+        },
+        "vm_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1VMAgent"
+          }
+        },
+        "node_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NodeExporter"
+          }
+        },
+        "mysqld_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MySQLdExporter"
+          }
+        },
+        "mongodb_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBExporter"
+          }
+        },
+        "postgres_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PostgresExporter"
+          }
+        },
+        "proxysql_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ProxySQLExporter"
+          }
+        },
+        "qan_mysql_perfschema_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMySQLPerfSchemaAgent"
+          }
+        },
+        "qan_mysql_slowlog_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMySQLSlowlogAgent"
+          }
+        },
+        "qan_mongodb_profiler_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMongoDBProfilerAgent"
+          }
+        },
+        "qan_mongodb_mongolog_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANMongoDBMongologAgent"
+          }
+        },
+        "qan_postgresql_pgstatements_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANPostgreSQLPgStatementsAgent"
+          }
+        },
+        "qan_postgresql_pgstatmonitor_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QANPostgreSQLPgStatMonitorAgent"
+          }
+        },
+        "external_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ExternalExporter"
+          }
+        },
+        "rds_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RDSExporter"
+          }
+        },
+        "azure_database_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1AzureDatabaseExporter"
+          }
+        },
+        "nomad_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1NomadAgent"
+          }
+        },
+        "valkey_exporter": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1ValkeyExporter"
+          }
+        },
+        "rta_mongodb_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RTAMongoDBAgent"
+          }
+        },
+        "rta_postgresql_agent": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1RTAPostgreSQLAgent"
+          }
+        }
+      }
+    },
+    "v1LogLevel": {
+      "type": "string",
+      "enum": [
+        "LOG_LEVEL_UNSPECIFIED",
+        "LOG_LEVEL_FATAL",
+        "LOG_LEVEL_ERROR",
+        "LOG_LEVEL_WARN",
+        "LOG_LEVEL_INFO",
+        "LOG_LEVEL_DEBUG"
+      ],
+      "default": "LOG_LEVEL_UNSPECIFIED",
+      "description": "- LOG_LEVEL_UNSPECIFIED: Auto",
+      "title": "Log level for exporters"
+    },
+    "v1MongoDBExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "stats_collections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "List of colletions to get stats from. Can use *"
+        },
+        "collections_limit": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Collections limit. Only get Databases and collection stats if the total number of collections in the server\nis less than this value. 0: no limit"
+        },
+        "enable_all_collectors": {
+          "type": "boolean",
+          "description": "Enable all collectors."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "environment_variable_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Environment variable names passed to the exporter."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MongoDBExporter runs on Generic or Container Node and exposes MongoDB Service metrics."
+    },
+    "v1MySQLdExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "tablestats_group_table_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tablestats group collectors are disabled if there are more than that number of tables.\n0 means tablestats group collectors are always enabled (no limit).\nNegative value means tablestats group collectors are always disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "table_count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Actual table count at the moment of adding."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "tablestats_group_disabled": {
+          "type": "boolean",
+          "description": "True if tablestats group collectors are currently disabled."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "MySQLdExporter runs on Generic or Container Node and exposes MySQL Service metrics."
+    },
+    "v1NodeExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "NodeExporter runs on Generic or Container Node and exposes its metrics."
+    },
+    "v1NomadAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        }
+      }
+    },
+    "v1PMMAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "runs_on_node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "connected": {
+          "type": "boolean",
+          "description": "True if Agent is running and connected to pmm-managed."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        }
+      },
+      "description": "PMMAgent runs on Generic or Container Node."
+    },
+    "v1PostgresExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation. Uses sslmode=required instead of verify-full."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "max_exporter_connections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of connections that exporter can open to the database instance."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "PostgresExporter runs on Generic or Container Node and exposes PostgreSQL Service metrics."
+    },
+    "v1ProxySQLExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "ProxySQL username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ProxySQLExporter runs on Generic or Container Node and exposes ProxySQL Service metrics."
+    },
+    "v1QANMongoDBMongologAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBMongologAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMongoDBProfilerAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANMongoDBProfilerAgent runs within pmm-agent and sends MongoDB Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLPerfSchemaAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLPerfSchemaAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANMySQLSlowlogAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MySQL username for getting performance data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "tls_ca": {
+          "type": "string",
+          "description": "Certificate Authority certificate chain."
+        },
+        "tls_cert": {
+          "type": "string",
+          "description": "Client certificate."
+        },
+        "tls_key": {
+          "type": "string",
+          "description": "Password for decrypting tls_cert."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "title": "Limit query length in QAN (default: server-defined; -1: no limit)"
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "max_slowlog_file_size": {
+          "type": "string",
+          "format": "int64",
+          "description": "Slowlog file is rotated at this size if \u003e 0."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "title": "mod tidy"
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "extra_dsn_params": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra DSN parameters for MySQL connection."
+        }
+      },
+      "description": "QANMySQLSlowlogAgent runs within pmm-agent and sends MySQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatMonitorAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat monitor data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "query_examples_disabled": {
+          "type": "boolean",
+          "description": "True if query examples are disabled."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatMonitorAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1QANPostgreSQLPgStatementsAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting pg stat statements data."
+        },
+        "disable_comments_parsing": {
+          "type": "boolean",
+          "description": "Disable parsing comments from queries and showing them in QAN."
+        },
+        "max_query_length": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit query length in QAN (default: server-defined; -1: no limit)."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "QANPostgreSQLPgStatementsAgent runs within pmm-agent and sends PostgreSQL Query Analytics data to the PMM Server."
+    },
+    "v1RDSExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier."
+        },
+        "aws_access_key": {
+          "type": "string",
+          "description": "AWS Access Key."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status (the same for several configurations)."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics (the same for several configurations)."
+        },
+        "basic_metrics_disabled": {
+          "type": "boolean",
+          "description": "Basic metrics are disabled."
+        },
+        "enhanced_metrics_disabled": {
+          "type": "boolean",
+          "description": "Enhanced metrics are disabled."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        }
+      },
+      "description": "RDSExporter runs on Generic or Container Node and exposes RemoteRDS Node metrics."
+    },
+    "v1RTAMongoDBAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB username for getting profiler data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for exporter."
+        }
+      },
+      "description": "RTAMongoDBAgent runs within pmm-agent and sends MongoDB Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RTAOptions": {
+      "type": "object",
+      "properties": {
+        "collect_interval": {
+          "type": "string",
+          "description": "Query collect interval (default 2s is set by server)."
+        }
+      },
+      "description": "RTAOptions holds Real-Time Query Analytics agent options."
+    },
+    "v1RTAPostgreSQLAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique agent identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username for getting session data."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname validation."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "rta_options": {
+          "$ref": "#/definitions/v1RTAOptions",
+          "description": "Real-Time Analytics options."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "log_level": {
+          "$ref": "#/definitions/v1LogLevel",
+          "description": "Log level for agent."
+        }
+      },
+      "description": "RTAPostgreSQLAgent runs within pmm-agent and sends PostgreSQL Real-Time Query Analytics data to the PMM Server."
+    },
+    "v1RemoveAgentResponse": {
+      "type": "object"
+    },
+    "v1VMAgent": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        }
+      },
+      "description": "VMAgent runs on Generic or Container Node alongside pmm-agent.\nIt scrapes other exporter Agents that are configured with push_metrics_enabled\nand uses Prometheus remote write protocol to push metrics to PMM Server."
+    },
+    "v1ValkeyExporter": {
+      "type": "object",
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "pmm_agent_id": {
+          "type": "string",
+          "description": "The pmm-agent identifier which runs this instance."
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Desired Agent status: enabled (false) or disabled (true)."
+        },
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier."
+        },
+        "username": {
+          "type": "string",
+          "description": "Valkey username for scraping metrics."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "Use TLS for database connections."
+        },
+        "tls_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate and hostname verification."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "push_metrics_enabled": {
+          "type": "boolean",
+          "description": "True if exporter uses push metrics mode."
+        },
+        "disabled_collectors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled collector names."
+        },
+        "status": {
+          "$ref": "#/definitions/v1AgentStatus",
+          "description": "Actual Agent status."
+        },
+        "listen_port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Listen port for scraping metrics."
+        },
+        "process_exec_path": {
+          "type": "string",
+          "description": "Path to exec process."
+        },
+        "expose_exporter": {
+          "type": "boolean",
+          "title": "Optionally expose the exporter process on all public interfaces"
+        },
+        "metrics_resolutions": {
+          "$ref": "#/definitions/commonMetricsResolutions",
+          "description": "Metrics resolution for this agent."
+        },
+        "connection_timeout": {
+          "type": "string",
+          "description": "Connection timeout for exporter (if set)."
+        }
+      },
+      "description": "ValkeyExporter runs on Generic or Container Node and exposes Valkey Service metrics."
+    }
+  }
+}

--- a/api/inventory/v1/agents_grpc.pb.go
+++ b/api/inventory/v1/agents_grpc.pb.go
@@ -8,7 +8,6 @@ package inventoryv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -147,23 +146,18 @@ type UnimplementedAgentsServiceServer struct{}
 func (UnimplementedAgentsServiceServer) ListAgents(context.Context, *ListAgentsRequest) (*ListAgentsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListAgents not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) GetAgent(context.Context, *GetAgentRequest) (*GetAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) GetAgentLogs(context.Context, *GetAgentLogsRequest) (*GetAgentLogsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetAgentLogs not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) AddAgent(context.Context, *AddAgentRequest) (*AddAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) ChangeAgent(context.Context, *ChangeAgentRequest) (*ChangeAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ChangeAgent not implemented")
 }
-
 func (UnimplementedAgentsServiceServer) RemoveAgent(context.Context, *RemoveAgentRequest) (*RemoveAgentResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveAgent not implemented")
 }

--- a/api/inventory/v1/types/agent_types.go
+++ b/api/inventory/v1/types/agent_types.go
@@ -37,6 +37,7 @@ const (
 	AgentTypeExternalExporter                = "AGENT_TYPE_EXTERNAL_EXPORTER"
 	AgentTypeAzureDatabaseExporter           = "AGENT_TYPE_AZURE_DATABASE_EXPORTER"
 	AgentTypeRTAMongoDBAgent                 = "AGENT_TYPE_RTA_MONGODB_AGENT"
+	AgentTypeRTAPostgreSQLAgent              = "AGENT_TYPE_RTA_POSTGRESQL_AGENT"
 )
 
 var agentTypeNames = map[string]string{
@@ -60,6 +61,7 @@ var agentTypeNames = map[string]string{
 	AgentTypeExternalExporter:                "external-exporter",
 	AgentTypeAzureDatabaseExporter:           "azure_database_exporter",
 	AgentTypeRTAMongoDBAgent:                 "rta_mongodb_agent",
+	AgentTypeRTAPostgreSQLAgent:              "rta_postgresql_agent",
 }
 
 // AgentTypeName returns human friendly agent type to be used in reports.

--- a/api/management/v1/postgresql.pb.go
+++ b/api/management/v1/postgresql.pb.go
@@ -7,17 +7,15 @@
 package managementv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
+	_ "github.com/percona/pmm/api/extensions/v1"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -105,8 +103,10 @@ type AddPostgreSQLServiceParams struct {
 	MaxExporterConnections int32 `protobuf:"varint,33,opt,name=max_exporter_connections,json=maxExporterConnections,proto3" json:"max_exporter_connections,omitempty"`
 	// Connection timeout for exporter (if set).
 	ConnectionTimeout *durationpb.Duration `protobuf:"bytes,34,opt,name=connection_timeout,json=connectionTimeout,proto3" json:"connection_timeout,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// If true, adds rta-postgresql-agent for provided service.
+	RtaPostgresqlAgent bool `protobuf:"varint,35,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *AddPostgreSQLServiceParams) Reset() {
@@ -377,6 +377,13 @@ func (x *AddPostgreSQLServiceParams) GetConnectionTimeout() *durationpb.Duration
 	return nil
 }
 
+func (x *AddPostgreSQLServiceParams) GetRtaPostgresqlAgent() bool {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return false
+}
+
 type PostgreSQLServiceResult struct {
 	state                           protoimpl.MessageState              `protogen:"open.v1"`
 	Service                         *v1.PostgreSQLService               `protobuf:"bytes,1,opt,name=service,proto3" json:"service,omitempty"`
@@ -384,9 +391,10 @@ type PostgreSQLServiceResult struct {
 	QanPostgresqlPgstatementsAgent  *v1.QANPostgreSQLPgStatementsAgent  `protobuf:"bytes,3,opt,name=qan_postgresql_pgstatements_agent,json=qanPostgresqlPgstatementsAgent,proto3" json:"qan_postgresql_pgstatements_agent,omitempty"`
 	QanPostgresqlPgstatmonitorAgent *v1.QANPostgreSQLPgStatMonitorAgent `protobuf:"bytes,4,opt,name=qan_postgresql_pgstatmonitor_agent,json=qanPostgresqlPgstatmonitorAgent,proto3" json:"qan_postgresql_pgstatmonitor_agent,omitempty"`
 	// Warning message.
-	Warning       string `protobuf:"bytes,5,opt,name=warning,proto3" json:"warning,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Warning            string                 `protobuf:"bytes,5,opt,name=warning,proto3" json:"warning,omitempty"`
+	RtaPostgresqlAgent *v1.RTAPostgreSQLAgent `protobuf:"bytes,6,opt,name=rta_postgresql_agent,json=rtaPostgresqlAgent,proto3" json:"rta_postgresql_agent,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *PostgreSQLServiceResult) Reset() {
@@ -454,11 +462,18 @@ func (x *PostgreSQLServiceResult) GetWarning() string {
 	return ""
 }
 
+func (x *PostgreSQLServiceResult) GetRtaPostgresqlAgent() *v1.RTAPostgreSQLAgent {
+	if x != nil {
+		return x.RtaPostgresqlAgent
+	}
+	return nil
+}
+
 var File_management_v1_postgresql_proto protoreflect.FileDescriptor
 
 const file_management_v1_postgresql_proto_rawDesc = "" +
 	"\n" +
-	"\x1emanagement/v1/postgresql.proto\x12\rmanagement.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19inventory/v1/agents.proto\x1a\x1cinventory/v1/log_level.proto\x1a\x1binventory/v1/services.proto\x1a\x1bmanagement/v1/metrics.proto\x1a\x18management/v1/node.proto\x1a\x17validate/validate.proto\"\xc7\f\n" +
+	"\x1emanagement/v1/postgresql.proto\x12\rmanagement.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x19inventory/v1/agents.proto\x1a\x1cinventory/v1/log_level.proto\x1a\x1binventory/v1/services.proto\x1a\x1bmanagement/v1/metrics.proto\x1a\x18management/v1/node.proto\x1a\x17validate/validate.proto\"\xf9\f\n" +
 	"\x1aAddPostgreSQLServiceParams\x12\x17\n" +
 	"\anode_id\x18\x01 \x01(\tR\x06nodeId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x127\n" +
@@ -495,16 +510,18 @@ const file_management_v1_postgresql_proto_rawDesc = "" +
 	"\x14auto_discovery_limit\x18\x1f \x01(\x05R\x12autoDiscoveryLimit\x12'\n" +
 	"\x0fexpose_exporter\x18  \x01(\bR\x0eexposeExporter\x128\n" +
 	"\x18max_exporter_connections\x18! \x01(\x05R\x16maxExporterConnections\x12R\n" +
-	"\x12connection_timeout\x18\" \x01(\v2\x19.google.protobuf.DurationB\b\xfaB\x05\xaa\x01\x022\x00R\x11connectionTimeout\x1a?\n" +
+	"\x12connection_timeout\x18\" \x01(\v2\x19.google.protobuf.DurationB\b\xfaB\x05\xaa\x01\x022\x00R\x11connectionTimeout\x120\n" +
+	"\x14rta_postgresql_agent\x18# \x01(\bR\x12rtaPostgresqlAgent\x1a?\n" +
 	"\x11CustomLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb0\x03\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x84\x04\n" +
 	"\x17PostgreSQLServiceResult\x129\n" +
 	"\aservice\x18\x01 \x01(\v2\x1f.inventory.v1.PostgreSQLServiceR\aservice\x12K\n" +
 	"\x11postgres_exporter\x18\x02 \x01(\v2\x1e.inventory.v1.PostgresExporterR\x10postgresExporter\x12w\n" +
 	"!qan_postgresql_pgstatements_agent\x18\x03 \x01(\v2,.inventory.v1.QANPostgreSQLPgStatementsAgentR\x1eqanPostgresqlPgstatementsAgent\x12z\n" +
 	"\"qan_postgresql_pgstatmonitor_agent\x18\x04 \x01(\v2-.inventory.v1.QANPostgreSQLPgStatMonitorAgentR\x1fqanPostgresqlPgstatmonitorAgent\x12\x18\n" +
-	"\awarning\x18\x05 \x01(\tR\awarningB\xb0\x01\n" +
+	"\awarning\x18\x05 \x01(\tR\awarning\x12R\n" +
+	"\x14rta_postgresql_agent\x18\x06 \x01(\v2 .inventory.v1.RTAPostgreSQLAgentR\x12rtaPostgresqlAgentB\xb0\x01\n" +
 	"\x11com.management.v1B\x0fPostgresqlProtoP\x01Z5github.com/percona/pmm/api/management/v1;managementv1\xa2\x02\x03MXX\xaa\x02\rManagement.V1\xca\x02\rManagement\\V1\xe2\x02\x19Management\\V1\\GPBMetadata\xea\x02\x0eManagement::V1b\x06proto3"
 
 var (
@@ -519,23 +536,21 @@ func file_management_v1_postgresql_proto_rawDescGZIP() []byte {
 	return file_management_v1_postgresql_proto_rawDescData
 }
 
-var (
-	file_management_v1_postgresql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_management_v1_postgresql_proto_goTypes  = []any{
-		(*AddPostgreSQLServiceParams)(nil),         // 0: management.v1.AddPostgreSQLServiceParams
-		(*PostgreSQLServiceResult)(nil),            // 1: management.v1.PostgreSQLServiceResult
-		nil,                                        // 2: management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
-		(*AddNodeParams)(nil),                      // 3: management.v1.AddNodeParams
-		MetricsMode(0),                             // 4: management.v1.MetricsMode
-		v1.LogLevel(0),                             // 5: inventory.v1.LogLevel
-		(*durationpb.Duration)(nil),                // 6: google.protobuf.Duration
-		(*v1.PostgreSQLService)(nil),               // 7: inventory.v1.PostgreSQLService
-		(*v1.PostgresExporter)(nil),                // 8: inventory.v1.PostgresExporter
-		(*v1.QANPostgreSQLPgStatementsAgent)(nil),  // 9: inventory.v1.QANPostgreSQLPgStatementsAgent
-		(*v1.QANPostgreSQLPgStatMonitorAgent)(nil), // 10: inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	}
-)
-
+var file_management_v1_postgresql_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_management_v1_postgresql_proto_goTypes = []any{
+	(*AddPostgreSQLServiceParams)(nil),         // 0: management.v1.AddPostgreSQLServiceParams
+	(*PostgreSQLServiceResult)(nil),            // 1: management.v1.PostgreSQLServiceResult
+	nil,                                        // 2: management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
+	(*AddNodeParams)(nil),                      // 3: management.v1.AddNodeParams
+	(MetricsMode)(0),                           // 4: management.v1.MetricsMode
+	(v1.LogLevel)(0),                           // 5: inventory.v1.LogLevel
+	(*durationpb.Duration)(nil),                // 6: google.protobuf.Duration
+	(*v1.PostgreSQLService)(nil),               // 7: inventory.v1.PostgreSQLService
+	(*v1.PostgresExporter)(nil),                // 8: inventory.v1.PostgresExporter
+	(*v1.QANPostgreSQLPgStatementsAgent)(nil),  // 9: inventory.v1.QANPostgreSQLPgStatementsAgent
+	(*v1.QANPostgreSQLPgStatMonitorAgent)(nil), // 10: inventory.v1.QANPostgreSQLPgStatMonitorAgent
+	(*v1.RTAPostgreSQLAgent)(nil),              // 11: inventory.v1.RTAPostgreSQLAgent
+}
 var file_management_v1_postgresql_proto_depIdxs = []int32{
 	3,  // 0: management.v1.AddPostgreSQLServiceParams.add_node:type_name -> management.v1.AddNodeParams
 	2,  // 1: management.v1.AddPostgreSQLServiceParams.custom_labels:type_name -> management.v1.AddPostgreSQLServiceParams.CustomLabelsEntry
@@ -546,11 +561,12 @@ var file_management_v1_postgresql_proto_depIdxs = []int32{
 	8,  // 6: management.v1.PostgreSQLServiceResult.postgres_exporter:type_name -> inventory.v1.PostgresExporter
 	9,  // 7: management.v1.PostgreSQLServiceResult.qan_postgresql_pgstatements_agent:type_name -> inventory.v1.QANPostgreSQLPgStatementsAgent
 	10, // 8: management.v1.PostgreSQLServiceResult.qan_postgresql_pgstatmonitor_agent:type_name -> inventory.v1.QANPostgreSQLPgStatMonitorAgent
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	11, // 9: management.v1.PostgreSQLServiceResult.rta_postgresql_agent:type_name -> inventory.v1.RTAPostgreSQLAgent
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_management_v1_postgresql_proto_init() }

--- a/api/management/v1/postgresql.pb.validate.go
+++ b/api/management/v1/postgresql.pb.validate.go
@@ -209,6 +209,8 @@ func (m *AddPostgreSQLServiceParams) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for RtaPostgresqlAgent
+
 	if len(errors) > 0 {
 		return AddPostgreSQLServiceParamsMultiError(errors)
 	}
@@ -276,8 +278,7 @@ func (e AddPostgreSQLServiceParamsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AddPostgreSQLServiceParamsValidationError{}
@@ -430,6 +431,35 @@ func (m *PostgreSQLServiceResult) validate(all bool) error {
 
 	// no validation rules for Warning
 
+	if all {
+		switch v := interface{}(m.GetRtaPostgresqlAgent()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, PostgreSQLServiceResultValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, PostgreSQLServiceResultValidationError{
+					field:  "RtaPostgresqlAgent",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetRtaPostgresqlAgent()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return PostgreSQLServiceResultValidationError{
+				field:  "RtaPostgresqlAgent",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	if len(errors) > 0 {
 		return PostgreSQLServiceResultMultiError(errors)
 	}
@@ -497,8 +527,7 @@ func (e PostgreSQLServiceResultValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = PostgreSQLServiceResultValidationError{}

--- a/api/management/v1/postgresql.proto
+++ b/api/management/v1/postgresql.proto
@@ -95,6 +95,8 @@ message AddPostgreSQLServiceParams {
   google.protobuf.Duration connection_timeout = 34 [(validate.rules).duration = {
     gte: {seconds: 0}
   }];
+  // If true, adds rta-postgresql-agent for provided service.
+  bool rta_postgresql_agent = 35;
 }
 
 message PostgreSQLServiceResult {
@@ -104,4 +106,5 @@ message PostgreSQLServiceResult {
   inventory.v1.QANPostgreSQLPgStatMonitorAgent qan_postgresql_pgstatmonitor_agent = 4;
   // Warning message.
   string warning = 5;
+  inventory.v1.RTAPostgreSQLAgent rta_postgresql_agent = 6;
 }

--- a/api/management/v1/postgresql.swagger.json
+++ b/api/management/v1/postgresql.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "management/v1/postgresql.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "googleRpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/collector.pb.go
+++ b/api/realtimeanalytics/v1/collector.pb.go
@@ -7,13 +7,12 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "google.golang.org/genproto/googleapis/api/visibility"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -132,15 +131,12 @@ func file_realtimeanalytics_v1_collector_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_collector_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-	file_realtimeanalytics_v1_collector_proto_goTypes  = []any{
-		(*CollectRequest)(nil),  // 0: realtimeanalytics.v1.CollectRequest
-		(*CollectResponse)(nil), // 1: realtimeanalytics.v1.CollectResponse
-		(*QueryData)(nil),       // 2: realtimeanalytics.v1.QueryData
-	}
-)
-
+var file_realtimeanalytics_v1_collector_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_realtimeanalytics_v1_collector_proto_goTypes = []any{
+	(*CollectRequest)(nil),  // 0: realtimeanalytics.v1.CollectRequest
+	(*CollectResponse)(nil), // 1: realtimeanalytics.v1.CollectResponse
+	(*QueryData)(nil),       // 2: realtimeanalytics.v1.QueryData
+}
 var file_realtimeanalytics_v1_collector_proto_depIdxs = []int32{
 	2, // 0: realtimeanalytics.v1.CollectRequest.queries:type_name -> realtimeanalytics.v1.QueryData
 	0, // 1: realtimeanalytics.v1.CollectorService.Collect:input_type -> realtimeanalytics.v1.CollectRequest

--- a/api/realtimeanalytics/v1/collector.pb.validate.go
+++ b/api/realtimeanalytics/v1/collector.pb.validate.go
@@ -156,8 +156,7 @@ func (e CollectRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectRequestValidationError{}
@@ -257,8 +256,7 @@ func (e CollectResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CollectResponseValidationError{}

--- a/api/realtimeanalytics/v1/collector.swagger.json
+++ b/api/realtimeanalytics/v1/collector.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/collector.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/collector_grpc.pb.go
+++ b/api/realtimeanalytics/v1/collector_grpc.pb.go
@@ -8,7 +8,6 @@ package realtimeanalyticsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/api/realtimeanalytics/v1/query.pb.go
+++ b/api/realtimeanalytics/v1/query.pb.go
@@ -7,16 +7,14 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
+	_ "github.com/percona/pmm/api/extensions/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	_ "github.com/percona/pmm/api/extensions/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -25,6 +23,260 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// LockChainLink represents one link in a PostgreSQL lock chain (blocker -> blocked).
+type LockChainLink struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PID of the blocking backend.
+	BlockerPid int32 `protobuf:"varint,1,opt,name=blocker_pid,json=blockerPid,proto3" json:"blocker_pid,omitempty"`
+	// PID of the blocked backend.
+	BlockedPid int32 `protobuf:"varint,2,opt,name=blocked_pid,json=blockedPid,proto3" json:"blocked_pid,omitempty"`
+	// Lock mode held or requested.
+	LockMode string `protobuf:"bytes,3,opt,name=lock_mode,json=lockMode,proto3" json:"lock_mode,omitempty"`
+	// Relation name when available.
+	RelationName string `protobuf:"bytes,4,opt,name=relation_name,json=relationName,proto3" json:"relation_name,omitempty"`
+	// Query text of the blocking backend.
+	BlockerQueryText string `protobuf:"bytes,5,opt,name=blocker_query_text,json=blockerQueryText,proto3" json:"blocker_query_text,omitempty"`
+	// Duration of the blocking query.
+	BlockerDuration *durationpb.Duration `protobuf:"bytes,6,opt,name=blocker_duration,json=blockerDuration,proto3" json:"blocker_duration,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *LockChainLink) Reset() {
+	*x = LockChainLink{}
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LockChainLink) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LockChainLink) ProtoMessage() {}
+
+func (x *LockChainLink) ProtoReflect() protoreflect.Message {
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LockChainLink.ProtoReflect.Descriptor instead.
+func (*LockChainLink) Descriptor() ([]byte, []int) {
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *LockChainLink) GetBlockerPid() int32 {
+	if x != nil {
+		return x.BlockerPid
+	}
+	return 0
+}
+
+func (x *LockChainLink) GetBlockedPid() int32 {
+	if x != nil {
+		return x.BlockedPid
+	}
+	return 0
+}
+
+func (x *LockChainLink) GetLockMode() string {
+	if x != nil {
+		return x.LockMode
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetRelationName() string {
+	if x != nil {
+		return x.RelationName
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetBlockerQueryText() string {
+	if x != nil {
+		return x.BlockerQueryText
+	}
+	return ""
+}
+
+func (x *LockChainLink) GetBlockerDuration() *durationpb.Duration {
+	if x != nil {
+		return x.BlockerDuration
+	}
+	return nil
+}
+
+// QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information.
+type QueryPostgreSQLData struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PostgreSQL instance address (host:port).
+	DbInstanceAddress string `protobuf:"bytes,1,opt,name=db_instance_address,json=dbInstanceAddress,proto3" json:"db_instance_address,omitempty"`
+	// Database name.
+	DatabaseName string `protobuf:"bytes,2,opt,name=database_name,json=databaseName,proto3" json:"database_name,omitempty"`
+	// PostgreSQL username.
+	Username string `protobuf:"bytes,3,opt,name=username,proto3" json:"username,omitempty"`
+	// Client application name.
+	ApplicationName string `protobuf:"bytes,4,opt,name=application_name,json=applicationName,proto3" json:"application_name,omitempty"`
+	// Backend state (active, idle in transaction, etc.).
+	SessionState string `protobuf:"bytes,5,opt,name=session_state,json=sessionState,proto3" json:"session_state,omitempty"`
+	// Transaction start time (used for idle in transaction duration).
+	TransactionStartTime *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=transaction_start_time,json=transactionStartTime,proto3" json:"transaction_start_time,omitempty"`
+	// Current query start time.
+	QueryStartTime *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=query_start_time,json=queryStartTime,proto3" json:"query_start_time,omitempty"`
+	// Wait event type when waiting.
+	WaitEventType string `protobuf:"bytes,8,opt,name=wait_event_type,json=waitEventType,proto3" json:"wait_event_type,omitempty"`
+	// Wait event name when waiting.
+	WaitEvent string `protobuf:"bytes,9,opt,name=wait_event,json=waitEvent,proto3" json:"wait_event,omitempty"`
+	// Backend PID.
+	BackendPid int32 `protobuf:"varint,10,opt,name=backend_pid,json=backendPid,proto3" json:"backend_pid,omitempty"`
+	// Leader PID for parallel workers (0 if not a worker).
+	LeaderPid int32 `protobuf:"varint,11,opt,name=leader_pid,json=leaderPid,proto3" json:"leader_pid,omitempty"`
+	// True when query text was truncated by track_activity_query_size.
+	QueryTextTruncated bool `protobuf:"varint,12,opt,name=query_text_truncated,json=queryTextTruncated,proto3" json:"query_text_truncated,omitempty"`
+	// Configured track_activity_query_size value.
+	TrackActivityQuerySize int32 `protobuf:"varint,13,opt,name=track_activity_query_size,json=trackActivityQuerySize,proto3" json:"track_activity_query_size,omitempty"`
+	// Lock chain links when this backend is blocked.
+	LockChain     []*LockChainLink `protobuf:"bytes,14,rep,name=lock_chain,json=lockChain,proto3" json:"lock_chain,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryPostgreSQLData) Reset() {
+	*x = QueryPostgreSQLData{}
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryPostgreSQLData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryPostgreSQLData) ProtoMessage() {}
+
+func (x *QueryPostgreSQLData) ProtoReflect() protoreflect.Message {
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryPostgreSQLData.ProtoReflect.Descriptor instead.
+func (*QueryPostgreSQLData) Descriptor() ([]byte, []int) {
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *QueryPostgreSQLData) GetDbInstanceAddress() string {
+	if x != nil {
+		return x.DbInstanceAddress
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetDatabaseName() string {
+	if x != nil {
+		return x.DatabaseName
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetApplicationName() string {
+	if x != nil {
+		return x.ApplicationName
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetSessionState() string {
+	if x != nil {
+		return x.SessionState
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetTransactionStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.TransactionStartTime
+	}
+	return nil
+}
+
+func (x *QueryPostgreSQLData) GetQueryStartTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.QueryStartTime
+	}
+	return nil
+}
+
+func (x *QueryPostgreSQLData) GetWaitEventType() string {
+	if x != nil {
+		return x.WaitEventType
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetWaitEvent() string {
+	if x != nil {
+		return x.WaitEvent
+	}
+	return ""
+}
+
+func (x *QueryPostgreSQLData) GetBackendPid() int32 {
+	if x != nil {
+		return x.BackendPid
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetLeaderPid() int32 {
+	if x != nil {
+		return x.LeaderPid
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetQueryTextTruncated() bool {
+	if x != nil {
+		return x.QueryTextTruncated
+	}
+	return false
+}
+
+func (x *QueryPostgreSQLData) GetTrackActivityQuerySize() int32 {
+	if x != nil {
+		return x.TrackActivityQuerySize
+	}
+	return 0
+}
+
+func (x *QueryPostgreSQLData) GetLockChain() []*LockChainLink {
+	if x != nil {
+		return x.LockChain
+	}
+	return nil
+}
 
 // QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information.
 type QueryMongoDBData struct {
@@ -51,7 +303,7 @@ type QueryMongoDBData struct {
 
 func (x *QueryMongoDBData) Reset() {
 	*x = QueryMongoDBData{}
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -63,7 +315,7 @@ func (x *QueryMongoDBData) String() string {
 func (*QueryMongoDBData) ProtoMessage() {}
 
 func (x *QueryMongoDBData) ProtoReflect() protoreflect.Message {
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[0]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -76,7 +328,7 @@ func (x *QueryMongoDBData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryMongoDBData.ProtoReflect.Descriptor instead.
 func (*QueryMongoDBData) Descriptor() ([]byte, []int) {
-	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{0}
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *QueryMongoDBData) GetDbInstanceAddress() string {
@@ -160,6 +412,7 @@ type QueryData struct {
 	// Types that are valid to be assigned to Payload:
 	//
 	//	*QueryData_MongoDbPayload
+	//	*QueryData_PostgresPayload
 	Payload       isQueryData_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -167,7 +420,7 @@ type QueryData struct {
 
 func (x *QueryData) Reset() {
 	*x = QueryData{}
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -179,7 +432,7 @@ func (x *QueryData) String() string {
 func (*QueryData) ProtoMessage() {}
 
 func (x *QueryData) ProtoReflect() protoreflect.Message {
-	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[1]
+	mi := &file_realtimeanalytics_v1_query_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -192,7 +445,7 @@ func (x *QueryData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryData.ProtoReflect.Descriptor instead.
 func (*QueryData) Descriptor() ([]byte, []int) {
-	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{1}
+	return file_realtimeanalytics_v1_query_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *QueryData) GetServiceId() string {
@@ -267,6 +520,15 @@ func (x *QueryData) GetMongoDbPayload() *QueryMongoDBData {
 	return nil
 }
 
+func (x *QueryData) GetPostgresPayload() *QueryPostgreSQLData {
+	if x != nil {
+		if x, ok := x.Payload.(*QueryData_PostgresPayload); ok {
+			return x.PostgresPayload
+		}
+	}
+	return nil
+}
+
 type isQueryData_Payload interface {
 	isQueryData_Payload()
 }
@@ -276,13 +538,49 @@ type QueryData_MongoDbPayload struct {
 	MongoDbPayload *QueryMongoDBData `protobuf:"bytes,9,opt,name=mongo_db_payload,json=mongoDbPayload,proto3,oneof"`
 }
 
+type QueryData_PostgresPayload struct {
+	// PostgreSQL-specific query data.
+	PostgresPayload *QueryPostgreSQLData `protobuf:"bytes,10,opt,name=postgres_payload,json=postgresPayload,proto3,oneof"`
+}
+
 func (*QueryData_MongoDbPayload) isQueryData_Payload() {}
+
+func (*QueryData_PostgresPayload) isQueryData_Payload() {}
 
 var File_realtimeanalytics_v1_query_proto protoreflect.FileDescriptor
 
 const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\n" +
-	" realtimeanalytics/v1/query.proto\x12\x14realtimeanalytics.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe0\x02\n" +
+	" realtimeanalytics/v1/query.proto\x12\x14realtimeanalytics.v1\x1a\x1aextensions/v1/redact.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x87\x02\n" +
+	"\rLockChainLink\x12\x1f\n" +
+	"\vblocker_pid\x18\x01 \x01(\x05R\n" +
+	"blockerPid\x12\x1f\n" +
+	"\vblocked_pid\x18\x02 \x01(\x05R\n" +
+	"blockedPid\x12\x1b\n" +
+	"\tlock_mode\x18\x03 \x01(\tR\blockMode\x12#\n" +
+	"\rrelation_name\x18\x04 \x01(\tR\frelationName\x12,\n" +
+	"\x12blocker_query_text\x18\x05 \x01(\tR\x10blockerQueryText\x12D\n" +
+	"\x10blocker_duration\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x0fblockerDuration\"\xac\x05\n" +
+	"\x13QueryPostgreSQLData\x12.\n" +
+	"\x13db_instance_address\x18\x01 \x01(\tR\x11dbInstanceAddress\x12#\n" +
+	"\rdatabase_name\x18\x02 \x01(\tR\fdatabaseName\x12 \n" +
+	"\busername\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12)\n" +
+	"\x10application_name\x18\x04 \x01(\tR\x0fapplicationName\x12#\n" +
+	"\rsession_state\x18\x05 \x01(\tR\fsessionState\x12P\n" +
+	"\x16transaction_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x14transactionStartTime\x12D\n" +
+	"\x10query_start_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x0equeryStartTime\x12&\n" +
+	"\x0fwait_event_type\x18\b \x01(\tR\rwaitEventType\x12\x1d\n" +
+	"\n" +
+	"wait_event\x18\t \x01(\tR\twaitEvent\x12\x1f\n" +
+	"\vbackend_pid\x18\n" +
+	" \x01(\x05R\n" +
+	"backendPid\x12\x1d\n" +
+	"\n" +
+	"leader_pid\x18\v \x01(\x05R\tleaderPid\x120\n" +
+	"\x14query_text_truncated\x18\f \x01(\bR\x12queryTextTruncated\x129\n" +
+	"\x19track_activity_query_size\x18\r \x01(\x05R\x16trackActivityQuerySize\x12B\n" +
+	"\n" +
+	"lock_chain\x18\x0e \x03(\v2#.realtimeanalytics.v1.LockChainLinkR\tlockChain\"\xe0\x02\n" +
 	"\x10QueryMongoDBData\x12.\n" +
 	"\x13db_instance_address\x18\x01 \x01(\tR\x11dbInstanceAddress\x12&\n" +
 	"\x0fclient_app_name\x18\x02 \x01(\tR\rclientAppName\x12#\n" +
@@ -293,7 +591,7 @@ const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\toperation\x18\x05 \x01(\tR\toperation\x12L\n" +
 	"\x14operation_start_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\x12operationStartTime\x12 \n" +
 	"\busername\x18\a \x01(\tB\x04\x88\xb5\x18\x01R\busername\x12!\n" +
-	"\fplan_summary\x18\b \x01(\tR\vplanSummary\"\xd2\x03\n" +
+	"\fplan_summary\x18\b \x01(\tR\vplanSummary\"\xaa\x04\n" +
 	"\tQueryData\x12\x1d\n" +
 	"\n" +
 	"service_id\x18\x01 \x01(\tR\tserviceId\x12!\n" +
@@ -305,7 +603,9 @@ const file_realtimeanalytics_v1_query_proto_rawDesc = "" +
 	"\x18query_execution_duration\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x16queryExecutionDuration\x12H\n" +
 	"\x12query_collect_time\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\x10queryCollectTime\x12%\n" +
 	"\x0eclient_address\x18\b \x01(\tR\rclientAddress\x12R\n" +
-	"\x10mongo_db_payload\x18\t \x01(\v2&.realtimeanalytics.v1.QueryMongoDBDataH\x00R\x0emongoDbPayloadB\t\n" +
+	"\x10mongo_db_payload\x18\t \x01(\v2&.realtimeanalytics.v1.QueryMongoDBDataH\x00R\x0emongoDbPayload\x12V\n" +
+	"\x10postgres_payload\x18\n" +
+	" \x01(\v2).realtimeanalytics.v1.QueryPostgreSQLDataH\x00R\x0fpostgresPayloadB\t\n" +
 	"\apayloadB\xdc\x01\n" +
 	"\x18com.realtimeanalytics.v1B\n" +
 	"QueryProtoP\x01ZCgithub.com/percona/pmm/api/realtimeanalytics/v1;realtimeanalyticsv1\xa2\x02\x03RXX\xaa\x02\x14Realtimeanalytics.V1\xca\x02\x14Realtimeanalytics\\V1\xe2\x02 Realtimeanalytics\\V1\\GPBMetadata\xea\x02\x15Realtimeanalytics::V1b\x06proto3"
@@ -322,26 +622,30 @@ func file_realtimeanalytics_v1_query_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_query_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-	file_realtimeanalytics_v1_query_proto_goTypes  = []any{
-		(*QueryMongoDBData)(nil),      // 0: realtimeanalytics.v1.QueryMongoDBData
-		(*QueryData)(nil),             // 1: realtimeanalytics.v1.QueryData
-		(*timestamppb.Timestamp)(nil), // 2: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),   // 3: google.protobuf.Duration
-	}
-)
-
+var file_realtimeanalytics_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_realtimeanalytics_v1_query_proto_goTypes = []any{
+	(*LockChainLink)(nil),         // 0: realtimeanalytics.v1.LockChainLink
+	(*QueryPostgreSQLData)(nil),   // 1: realtimeanalytics.v1.QueryPostgreSQLData
+	(*QueryMongoDBData)(nil),      // 2: realtimeanalytics.v1.QueryMongoDBData
+	(*QueryData)(nil),             // 3: realtimeanalytics.v1.QueryData
+	(*durationpb.Duration)(nil),   // 4: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+}
 var file_realtimeanalytics_v1_query_proto_depIdxs = []int32{
-	2, // 0: realtimeanalytics.v1.QueryMongoDBData.operation_start_time:type_name -> google.protobuf.Timestamp
-	3, // 1: realtimeanalytics.v1.QueryData.query_execution_duration:type_name -> google.protobuf.Duration
-	2, // 2: realtimeanalytics.v1.QueryData.query_collect_time:type_name -> google.protobuf.Timestamp
-	0, // 3: realtimeanalytics.v1.QueryData.mongo_db_payload:type_name -> realtimeanalytics.v1.QueryMongoDBData
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 0: realtimeanalytics.v1.LockChainLink.blocker_duration:type_name -> google.protobuf.Duration
+	5, // 1: realtimeanalytics.v1.QueryPostgreSQLData.transaction_start_time:type_name -> google.protobuf.Timestamp
+	5, // 2: realtimeanalytics.v1.QueryPostgreSQLData.query_start_time:type_name -> google.protobuf.Timestamp
+	0, // 3: realtimeanalytics.v1.QueryPostgreSQLData.lock_chain:type_name -> realtimeanalytics.v1.LockChainLink
+	5, // 4: realtimeanalytics.v1.QueryMongoDBData.operation_start_time:type_name -> google.protobuf.Timestamp
+	4, // 5: realtimeanalytics.v1.QueryData.query_execution_duration:type_name -> google.protobuf.Duration
+	5, // 6: realtimeanalytics.v1.QueryData.query_collect_time:type_name -> google.protobuf.Timestamp
+	2, // 7: realtimeanalytics.v1.QueryData.mongo_db_payload:type_name -> realtimeanalytics.v1.QueryMongoDBData
+	1, // 8: realtimeanalytics.v1.QueryData.postgres_payload:type_name -> realtimeanalytics.v1.QueryPostgreSQLData
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_realtimeanalytics_v1_query_proto_init() }
@@ -349,8 +653,9 @@ func file_realtimeanalytics_v1_query_proto_init() {
 	if File_realtimeanalytics_v1_query_proto != nil {
 		return
 	}
-	file_realtimeanalytics_v1_query_proto_msgTypes[1].OneofWrappers = []any{
+	file_realtimeanalytics_v1_query_proto_msgTypes[3].OneofWrappers = []any{
 		(*QueryData_MongoDbPayload)(nil),
+		(*QueryData_PostgresPayload)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -358,7 +663,7 @@ func file_realtimeanalytics_v1_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_realtimeanalytics_v1_query_proto_rawDesc), len(file_realtimeanalytics_v1_query_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/realtimeanalytics/v1/query.pb.validate.go
+++ b/api/realtimeanalytics/v1/query.pb.validate.go
@@ -35,6 +35,361 @@ var (
 	_ = sort.Sort
 )
 
+// Validate checks the field values on LockChainLink with the rules defined in
+// the proto definition for this message. If any rules are violated, the first
+// error encountered is returned, or nil if there are no violations.
+func (m *LockChainLink) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on LockChainLink with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// result is a list of violation errors wrapped in LockChainLinkMultiError, or
+// nil if none found.
+func (m *LockChainLink) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *LockChainLink) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for BlockerPid
+
+	// no validation rules for BlockedPid
+
+	// no validation rules for LockMode
+
+	// no validation rules for RelationName
+
+	// no validation rules for BlockerQueryText
+
+	if all {
+		switch v := interface{}(m.GetBlockerDuration()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, LockChainLinkValidationError{
+					field:  "BlockerDuration",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, LockChainLinkValidationError{
+					field:  "BlockerDuration",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetBlockerDuration()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return LockChainLinkValidationError{
+				field:  "BlockerDuration",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return LockChainLinkMultiError(errors)
+	}
+
+	return nil
+}
+
+// LockChainLinkMultiError is an error wrapping multiple validation errors
+// returned by LockChainLink.ValidateAll() if the designated constraints
+// aren't met.
+type LockChainLinkMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m LockChainLinkMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m LockChainLinkMultiError) AllErrors() []error { return m }
+
+// LockChainLinkValidationError is the validation error returned by
+// LockChainLink.Validate if the designated constraints aren't met.
+type LockChainLinkValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e LockChainLinkValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e LockChainLinkValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e LockChainLinkValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e LockChainLinkValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e LockChainLinkValidationError) ErrorName() string { return "LockChainLinkValidationError" }
+
+// Error satisfies the builtin error interface
+func (e LockChainLinkValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sLockChainLink.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = LockChainLinkValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = LockChainLinkValidationError{}
+
+// Validate checks the field values on QueryPostgreSQLData with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *QueryPostgreSQLData) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on QueryPostgreSQLData with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// QueryPostgreSQLDataMultiError, or nil if none found.
+func (m *QueryPostgreSQLData) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *QueryPostgreSQLData) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for DbInstanceAddress
+
+	// no validation rules for DatabaseName
+
+	// no validation rules for Username
+
+	// no validation rules for ApplicationName
+
+	// no validation rules for SessionState
+
+	if all {
+		switch v := interface{}(m.GetTransactionStartTime()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "TransactionStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "TransactionStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetTransactionStartTime()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return QueryPostgreSQLDataValidationError{
+				field:  "TransactionStartTime",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
+		switch v := interface{}(m.GetQueryStartTime()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "QueryStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, QueryPostgreSQLDataValidationError{
+					field:  "QueryStartTime",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetQueryStartTime()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return QueryPostgreSQLDataValidationError{
+				field:  "QueryStartTime",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	// no validation rules for WaitEventType
+
+	// no validation rules for WaitEvent
+
+	// no validation rules for BackendPid
+
+	// no validation rules for LeaderPid
+
+	// no validation rules for QueryTextTruncated
+
+	// no validation rules for TrackActivityQuerySize
+
+	for idx, item := range m.GetLockChain() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, QueryPostgreSQLDataValidationError{
+						field:  fmt.Sprintf("LockChain[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, QueryPostgreSQLDataValidationError{
+						field:  fmt.Sprintf("LockChain[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return QueryPostgreSQLDataValidationError{
+					field:  fmt.Sprintf("LockChain[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return QueryPostgreSQLDataMultiError(errors)
+	}
+
+	return nil
+}
+
+// QueryPostgreSQLDataMultiError is an error wrapping multiple validation
+// errors returned by QueryPostgreSQLData.ValidateAll() if the designated
+// constraints aren't met.
+type QueryPostgreSQLDataMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m QueryPostgreSQLDataMultiError) Error() string {
+	msgs := make([]string, 0, len(m))
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m QueryPostgreSQLDataMultiError) AllErrors() []error { return m }
+
+// QueryPostgreSQLDataValidationError is the validation error returned by
+// QueryPostgreSQLData.Validate if the designated constraints aren't met.
+type QueryPostgreSQLDataValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e QueryPostgreSQLDataValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e QueryPostgreSQLDataValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e QueryPostgreSQLDataValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e QueryPostgreSQLDataValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e QueryPostgreSQLDataValidationError) ErrorName() string {
+	return "QueryPostgreSQLDataValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e QueryPostgreSQLDataValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sQueryPostgreSQLData.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = QueryPostgreSQLDataValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = QueryPostgreSQLDataValidationError{}
+
 // Validate checks the field values on QueryMongoDBData with the rules defined
 // in the proto definition for this message. If any rules are violated, the
 // first error encountered is returned, or nil if there are no violations.
@@ -165,8 +520,7 @@ func (e QueryMongoDBDataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryMongoDBDataValidationError{}
@@ -313,6 +667,47 @@ func (m *QueryData) validate(all bool) error {
 			}
 		}
 
+	case *QueryData_PostgresPayload:
+		if v == nil {
+			err := QueryDataValidationError{
+				field:  "Payload",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+
+		if all {
+			switch v := interface{}(m.GetPostgresPayload()).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, QueryDataValidationError{
+						field:  "PostgresPayload",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, QueryDataValidationError{
+						field:  "PostgresPayload",
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(m.GetPostgresPayload()).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return QueryDataValidationError{
+					field:  "PostgresPayload",
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
 	default:
 		_ = v // ensures v is used
 	}
@@ -381,8 +776,7 @@ func (e QueryDataValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = QueryDataValidationError{}

--- a/api/realtimeanalytics/v1/query.proto
+++ b/api/realtimeanalytics/v1/query.proto
@@ -6,6 +6,54 @@ import "extensions/v1/redact.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
+// LockChainLink represents one link in a PostgreSQL lock chain (blocker -> blocked).
+message LockChainLink {
+  // PID of the blocking backend.
+  int32 blocker_pid = 1;
+  // PID of the blocked backend.
+  int32 blocked_pid = 2;
+  // Lock mode held or requested.
+  string lock_mode = 3;
+  // Relation name when available.
+  string relation_name = 4;
+  // Query text of the blocking backend.
+  string blocker_query_text = 5;
+  // Duration of the blocking query.
+  google.protobuf.Duration blocker_duration = 6;
+}
+
+// QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information.
+message QueryPostgreSQLData {
+  // PostgreSQL instance address (host:port).
+  string db_instance_address = 1;
+  // Database name.
+  string database_name = 2;
+  // PostgreSQL username.
+  string username = 3 [(extensions.v1.sensitive) = REDACT_TYPE_FULL];
+  // Client application name.
+  string application_name = 4;
+  // Backend state (active, idle in transaction, etc.).
+  string session_state = 5;
+  // Transaction start time (used for idle in transaction duration).
+  google.protobuf.Timestamp transaction_start_time = 6;
+  // Current query start time.
+  google.protobuf.Timestamp query_start_time = 7;
+  // Wait event type when waiting.
+  string wait_event_type = 8;
+  // Wait event name when waiting.
+  string wait_event = 9;
+  // Backend PID.
+  int32 backend_pid = 10;
+  // Leader PID for parallel workers (0 if not a worker).
+  int32 leader_pid = 11;
+  // True when query text was truncated by track_activity_query_size.
+  bool query_text_truncated = 12;
+  // Configured track_activity_query_size value.
+  int32 track_activity_query_size = 13;
+  // Lock chain links when this backend is blocked.
+  repeated LockChainLink lock_chain = 14;
+}
+
 // QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information.
 message QueryMongoDBData {
   // MongoDB instance address(host:port) that processing the query.
@@ -49,5 +97,7 @@ message QueryData {
   oneof payload {
     // MongoDB-specific query data.
     QueryMongoDBData mongo_db_payload = 9;
+    // PostgreSQL-specific query data.
+    QueryPostgreSQLData postgres_payload = 10;
   }
 }

--- a/api/realtimeanalytics/v1/query.swagger.json
+++ b/api/realtimeanalytics/v1/query.swagger.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/query.proto",
+    "version": "version not set"
+  },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {},
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/realtimeanalytics.pb.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics.pb.go
@@ -7,19 +7,17 @@
 package realtimeanalyticsv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/envoyproxy/protoc-gen-validate/validate"
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	v1 "github.com/percona/pmm/api/inventory/v1"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	v1 "github.com/percona/pmm/api/inventory/v1"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -131,8 +129,9 @@ func (x *ListServicesRequest) GetServiceType() v1.ServiceType {
 }
 
 type ListServicesResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mongodb       []*v1.MongoDBService   `protobuf:"bytes,1,rep,name=mongodb,proto3" json:"mongodb,omitempty"`
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Mongodb       []*v1.MongoDBService    `protobuf:"bytes,1,rep,name=mongodb,proto3" json:"mongodb,omitempty"`
+	Postgresql    []*v1.PostgreSQLService `protobuf:"bytes,2,rep,name=postgresql,proto3" json:"postgresql,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -170,6 +169,13 @@ func (*ListServicesResponse) Descriptor() ([]byte, []int) {
 func (x *ListServicesResponse) GetMongodb() []*v1.MongoDBService {
 	if x != nil {
 		return x.Mongodb
+	}
+	return nil
+}
+
+func (x *ListServicesResponse) GetPostgresql() []*v1.PostgreSQLService {
+	if x != nil {
+		return x.Postgresql
 	}
 	return nil
 }
@@ -638,9 +644,12 @@ const file_realtimeanalytics_v1_realtimeanalytics_proto_rawDesc = "" +
 	"\n" +
 	",realtimeanalytics/v1/realtimeanalytics.proto\x12\x14realtimeanalytics.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1binventory/v1/services.proto\x1a.protoc-gen-openapiv2/options/annotations.proto\x1a realtimeanalytics/v1/query.proto\x1a\x17validate/validate.proto\"S\n" +
 	"\x13ListServicesRequest\x12<\n" +
-	"\fservice_type\x18\x01 \x01(\x0e2\x19.inventory.v1.ServiceTypeR\vserviceType\"N\n" +
+	"\fservice_type\x18\x01 \x01(\x0e2\x19.inventory.v1.ServiceTypeR\vserviceType\"\x8f\x01\n" +
 	"\x14ListServicesResponse\x126\n" +
-	"\amongodb\x18\x01 \x03(\v2\x1c.inventory.v1.MongoDBServiceR\amongodb\"\xac\x02\n" +
+	"\amongodb\x18\x01 \x03(\v2\x1c.inventory.v1.MongoDBServiceR\amongodb\x12?\n" +
+	"\n" +
+	"postgresql\x18\x02 \x03(\v2\x1f.inventory.v1.PostgreSQLServiceR\n" +
+	"postgresql\"\xac\x02\n" +
 	"\aSession\x12\x1d\n" +
 	"\n" +
 	"service_id\x18\x01 \x01(\tR\tserviceId\x12!\n" +
@@ -695,54 +704,53 @@ func file_realtimeanalytics_v1_realtimeanalytics_proto_rawDescGZIP() []byte {
 	return file_realtimeanalytics_v1_realtimeanalytics_proto_rawDescData
 }
 
-var (
-	file_realtimeanalytics_v1_realtimeanalytics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_realtimeanalytics_v1_realtimeanalytics_proto_msgTypes  = make([]protoimpl.MessageInfo, 11)
-	file_realtimeanalytics_v1_realtimeanalytics_proto_goTypes   = []any{
-		SessionStatus(0),              // 0: realtimeanalytics.v1.SessionStatus
-		(*ListServicesRequest)(nil),   // 1: realtimeanalytics.v1.ListServicesRequest
-		(*ListServicesResponse)(nil),  // 2: realtimeanalytics.v1.ListServicesResponse
-		(*Session)(nil),               // 3: realtimeanalytics.v1.Session
-		(*ListSessionsRequest)(nil),   // 4: realtimeanalytics.v1.ListSessionsRequest
-		(*ListSessionsResponse)(nil),  // 5: realtimeanalytics.v1.ListSessionsResponse
-		(*StartSessionRequest)(nil),   // 6: realtimeanalytics.v1.StartSessionRequest
-		(*StartSessionResponse)(nil),  // 7: realtimeanalytics.v1.StartSessionResponse
-		(*StopSessionRequest)(nil),    // 8: realtimeanalytics.v1.StopSessionRequest
-		(*StopSessionResponse)(nil),   // 9: realtimeanalytics.v1.StopSessionResponse
-		(*SearchQueriesRequest)(nil),  // 10: realtimeanalytics.v1.SearchQueriesRequest
-		(*SearchQueriesResponse)(nil), // 11: realtimeanalytics.v1.SearchQueriesResponse
-		v1.ServiceType(0),             // 12: inventory.v1.ServiceType
-		(*v1.MongoDBService)(nil),     // 13: inventory.v1.MongoDBService
-		(*timestamppb.Timestamp)(nil), // 14: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),   // 15: google.protobuf.Duration
-		(*QueryData)(nil),             // 16: realtimeanalytics.v1.QueryData
-	}
-)
-
+var file_realtimeanalytics_v1_realtimeanalytics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_realtimeanalytics_v1_realtimeanalytics_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_realtimeanalytics_v1_realtimeanalytics_proto_goTypes = []any{
+	(SessionStatus)(0),            // 0: realtimeanalytics.v1.SessionStatus
+	(*ListServicesRequest)(nil),   // 1: realtimeanalytics.v1.ListServicesRequest
+	(*ListServicesResponse)(nil),  // 2: realtimeanalytics.v1.ListServicesResponse
+	(*Session)(nil),               // 3: realtimeanalytics.v1.Session
+	(*ListSessionsRequest)(nil),   // 4: realtimeanalytics.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),  // 5: realtimeanalytics.v1.ListSessionsResponse
+	(*StartSessionRequest)(nil),   // 6: realtimeanalytics.v1.StartSessionRequest
+	(*StartSessionResponse)(nil),  // 7: realtimeanalytics.v1.StartSessionResponse
+	(*StopSessionRequest)(nil),    // 8: realtimeanalytics.v1.StopSessionRequest
+	(*StopSessionResponse)(nil),   // 9: realtimeanalytics.v1.StopSessionResponse
+	(*SearchQueriesRequest)(nil),  // 10: realtimeanalytics.v1.SearchQueriesRequest
+	(*SearchQueriesResponse)(nil), // 11: realtimeanalytics.v1.SearchQueriesResponse
+	(v1.ServiceType)(0),           // 12: inventory.v1.ServiceType
+	(*v1.MongoDBService)(nil),     // 13: inventory.v1.MongoDBService
+	(*v1.PostgreSQLService)(nil),  // 14: inventory.v1.PostgreSQLService
+	(*timestamppb.Timestamp)(nil), // 15: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),   // 16: google.protobuf.Duration
+	(*QueryData)(nil),             // 17: realtimeanalytics.v1.QueryData
+}
 var file_realtimeanalytics_v1_realtimeanalytics_proto_depIdxs = []int32{
 	12, // 0: realtimeanalytics.v1.ListServicesRequest.service_type:type_name -> inventory.v1.ServiceType
 	13, // 1: realtimeanalytics.v1.ListServicesResponse.mongodb:type_name -> inventory.v1.MongoDBService
-	14, // 2: realtimeanalytics.v1.Session.start_time:type_name -> google.protobuf.Timestamp
-	15, // 3: realtimeanalytics.v1.Session.collect_interval:type_name -> google.protobuf.Duration
-	0,  // 4: realtimeanalytics.v1.Session.status:type_name -> realtimeanalytics.v1.SessionStatus
-	3,  // 5: realtimeanalytics.v1.ListSessionsResponse.sessions:type_name -> realtimeanalytics.v1.Session
-	3,  // 6: realtimeanalytics.v1.StartSessionResponse.session:type_name -> realtimeanalytics.v1.Session
-	16, // 7: realtimeanalytics.v1.SearchQueriesResponse.queries:type_name -> realtimeanalytics.v1.QueryData
-	1,  // 8: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:input_type -> realtimeanalytics.v1.ListServicesRequest
-	4,  // 9: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:input_type -> realtimeanalytics.v1.ListSessionsRequest
-	6,  // 10: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:input_type -> realtimeanalytics.v1.StartSessionRequest
-	8,  // 11: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:input_type -> realtimeanalytics.v1.StopSessionRequest
-	10, // 12: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:input_type -> realtimeanalytics.v1.SearchQueriesRequest
-	2,  // 13: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:output_type -> realtimeanalytics.v1.ListServicesResponse
-	5,  // 14: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:output_type -> realtimeanalytics.v1.ListSessionsResponse
-	7,  // 15: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:output_type -> realtimeanalytics.v1.StartSessionResponse
-	9,  // 16: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:output_type -> realtimeanalytics.v1.StopSessionResponse
-	11, // 17: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:output_type -> realtimeanalytics.v1.SearchQueriesResponse
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	14, // 2: realtimeanalytics.v1.ListServicesResponse.postgresql:type_name -> inventory.v1.PostgreSQLService
+	15, // 3: realtimeanalytics.v1.Session.start_time:type_name -> google.protobuf.Timestamp
+	16, // 4: realtimeanalytics.v1.Session.collect_interval:type_name -> google.protobuf.Duration
+	0,  // 5: realtimeanalytics.v1.Session.status:type_name -> realtimeanalytics.v1.SessionStatus
+	3,  // 6: realtimeanalytics.v1.ListSessionsResponse.sessions:type_name -> realtimeanalytics.v1.Session
+	3,  // 7: realtimeanalytics.v1.StartSessionResponse.session:type_name -> realtimeanalytics.v1.Session
+	17, // 8: realtimeanalytics.v1.SearchQueriesResponse.queries:type_name -> realtimeanalytics.v1.QueryData
+	1,  // 9: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:input_type -> realtimeanalytics.v1.ListServicesRequest
+	4,  // 10: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:input_type -> realtimeanalytics.v1.ListSessionsRequest
+	6,  // 11: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:input_type -> realtimeanalytics.v1.StartSessionRequest
+	8,  // 12: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:input_type -> realtimeanalytics.v1.StopSessionRequest
+	10, // 13: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:input_type -> realtimeanalytics.v1.SearchQueriesRequest
+	2,  // 14: realtimeanalytics.v1.RealtimeAnalyticsService.ListServices:output_type -> realtimeanalytics.v1.ListServicesResponse
+	5,  // 15: realtimeanalytics.v1.RealtimeAnalyticsService.ListSessions:output_type -> realtimeanalytics.v1.ListSessionsResponse
+	7,  // 16: realtimeanalytics.v1.RealtimeAnalyticsService.StartSession:output_type -> realtimeanalytics.v1.StartSessionResponse
+	9,  // 17: realtimeanalytics.v1.RealtimeAnalyticsService.StopSession:output_type -> realtimeanalytics.v1.StopSessionResponse
+	11, // 18: realtimeanalytics.v1.RealtimeAnalyticsService.SearchQueries:output_type -> realtimeanalytics.v1.SearchQueriesResponse
+	14, // [14:19] is the sub-list for method output_type
+	9,  // [9:14] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_realtimeanalytics_v1_realtimeanalytics_proto_init() }

--- a/api/realtimeanalytics/v1/realtimeanalytics.pb.validate.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics.pb.validate.go
@@ -130,8 +130,7 @@ func (e ListServicesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesRequestValidationError{}
@@ -192,6 +191,40 @@ func (m *ListServicesResponse) validate(all bool) error {
 			if err := v.Validate(); err != nil {
 				return ListServicesResponseValidationError{
 					field:  fmt.Sprintf("Mongodb[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	for idx, item := range m.GetPostgresql() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, ListServicesResponseValidationError{
+						field:  fmt.Sprintf("Postgresql[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, ListServicesResponseValidationError{
+						field:  fmt.Sprintf("Postgresql[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return ListServicesResponseValidationError{
+					field:  fmt.Sprintf("Postgresql[%v]", idx),
 					reason: "embedded message failed validation",
 					cause:  err,
 				}
@@ -267,8 +300,7 @@ func (e ListServicesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListServicesResponseValidationError{}
@@ -432,8 +464,7 @@ func (e SessionValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SessionValidationError{}
@@ -537,8 +568,7 @@ func (e ListSessionsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListSessionsRequestValidationError{}
@@ -674,8 +704,7 @@ func (e ListSessionsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListSessionsResponseValidationError{}
@@ -788,8 +817,7 @@ func (e StartSessionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartSessionRequestValidationError{}
@@ -920,8 +948,7 @@ func (e StartSessionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StartSessionResponseValidationError{}
@@ -1034,8 +1061,7 @@ func (e StopSessionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopSessionRequestValidationError{}
@@ -1137,8 +1163,7 @@ func (e StopSessionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = StopSessionResponseValidationError{}
@@ -1274,8 +1299,7 @@ func (e SearchQueriesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SearchQueriesRequestValidationError{}
@@ -1411,8 +1435,7 @@ func (e SearchQueriesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SearchQueriesResponseValidationError{}

--- a/api/realtimeanalytics/v1/realtimeanalytics.proto
+++ b/api/realtimeanalytics/v1/realtimeanalytics.proto
@@ -19,6 +19,7 @@ message ListServicesRequest {
 
 message ListServicesResponse {
   repeated inventory.v1.MongoDBService mongodb = 1;
+  repeated inventory.v1.PostgreSQLService postgresql = 2;
 }
 
 // Session related messages

--- a/api/realtimeanalytics/v1/realtimeanalytics.swagger.json
+++ b/api/realtimeanalytics/v1/realtimeanalytics.swagger.json
@@ -1,0 +1,693 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "realtimeanalytics/v1/realtimeanalytics.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "RealtimeAnalyticsService"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/realtimeanalytics/queries:search": {
+      "post": {
+        "summary": "List Running Database Queries in a particular services",
+        "description": "Returns list of currently running Database queries in a particular services",
+        "operationId": "SearchQueries",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1SearchQueriesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "SearchQueriesRequest contains optional filters for listing active Real-Time Analytics session Queries.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1SearchQueriesRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/services": {
+      "get": {
+        "summary": "List Services that support Real-Time Analytics",
+        "description": "Returns a list of Services that support Real-Time Analytics filtered by type.",
+        "operationId": "ListServices",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListServicesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "service_type",
+            "description": "Return only services filtered by service type.",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "SERVICE_TYPE_UNSPECIFIED",
+              "SERVICE_TYPE_MYSQL_SERVICE",
+              "SERVICE_TYPE_MONGODB_SERVICE",
+              "SERVICE_TYPE_POSTGRESQL_SERVICE",
+              "SERVICE_TYPE_VALKEY_SERVICE",
+              "SERVICE_TYPE_PROXYSQL_SERVICE",
+              "SERVICE_TYPE_HAPROXY_SERVICE",
+              "SERVICE_TYPE_EXTERNAL_SERVICE"
+            ],
+            "default": "SERVICE_TYPE_UNSPECIFIED"
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions": {
+      "get": {
+        "summary": "List Running Real-Time Analytics Sessions",
+        "description": "Returns the list of all currently running Real-Time Analytics sessions with their details including service, cluster and status information.",
+        "operationId": "ListSessions",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1ListSessionsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "cluster_name",
+            "description": "Optional filter by cluster name.",
+            "in": "query",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions:start": {
+      "post": {
+        "summary": "Start Real-Time Analytics session",
+        "description": "Start Real-Time Analytics session for a specified service.",
+        "operationId": "StartSession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StartSessionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "StartSessionRequest contains parameters for starting Real-Time Analytics session.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StartSessionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    },
+    "/v1/realtimeanalytics/sessions:stop": {
+      "post": {
+        "summary": "Stop Real-Time Analytics session",
+        "description": "Stop Real-Time Analytics session for a specified service.",
+        "operationId": "StopSession",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1StopSessionResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "StopSessionRequest contains parameters for stopping Real-Time Analytics session.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1StopSessionRequest"
+            }
+          }
+        ],
+        "tags": [
+          "RealtimeAnalyticsService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    },
+    "v1ListServicesResponse": {
+      "type": "object",
+      "properties": {
+        "mongodb": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1MongoDBService"
+          }
+        },
+        "postgresql": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1PostgreSQLService"
+          }
+        }
+      }
+    },
+    "v1ListSessionsResponse": {
+      "type": "object",
+      "properties": {
+        "sessions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1Session"
+          },
+          "description": "List of active Real-Time Analytics Sessions."
+        }
+      },
+      "description": "ListSessionsResponse returns the list of currently active Real-Time Analytics Sessions."
+    },
+    "v1LockChainLink": {
+      "type": "object",
+      "properties": {
+        "blocker_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "PID of the blocking backend."
+        },
+        "blocked_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "PID of the blocked backend."
+        },
+        "lock_mode": {
+          "type": "string",
+          "description": "Lock mode held or requested."
+        },
+        "relation_name": {
+          "type": "string",
+          "description": "Relation name when available."
+        },
+        "blocker_query_text": {
+          "type": "string",
+          "description": "Query text of the blocking backend."
+        },
+        "blocker_duration": {
+          "type": "string",
+          "description": "Duration of the blocking query."
+        }
+      },
+      "description": "LockChainLink represents one link in a PostgreSQL lock chain (blocker -\u003e blocked)."
+    },
+    "v1MongoDBService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "MongoDB version."
+        }
+      },
+      "description": "MongoDBService represents a generic MongoDB instance."
+    },
+    "v1PostgreSQLService": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Unique randomly generated instance identifier."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Unique across all Services user-defined name."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "node_id": {
+          "type": "string",
+          "description": "Node identifier where this instance runs."
+        },
+        "address": {
+          "type": "string",
+          "description": "Access address (DNS name or IP).\nAddress (and port) or socket is required."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access port.\nPort is required when the address present."
+        },
+        "socket": {
+          "type": "string",
+          "description": "Access unix socket.\nAddress (and port) or socket is required."
+        },
+        "environment": {
+          "type": "string",
+          "description": "Environment name."
+        },
+        "cluster": {
+          "type": "string",
+          "description": "Cluster name."
+        },
+        "replication_set": {
+          "type": "string",
+          "description": "Replication set name."
+        },
+        "custom_labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Custom user-assigned labels."
+        },
+        "version": {
+          "type": "string",
+          "description": "PostgreSQL version."
+        },
+        "auto_discovery_limit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Limit of databases for auto-discovery."
+        }
+      },
+      "description": "PostgreSQLService represents a generic PostgreSQL instance."
+    },
+    "v1QueryData": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "PMM Service identifier that reported the query."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "PMM Service name that reported the query."
+        },
+        "query_id": {
+          "type": "string",
+          "description": "Unique identifier for the query."
+        },
+        "query_text": {
+          "type": "string",
+          "description": "The text of the query."
+        },
+        "query_raw_json": {
+          "type": "string",
+          "description": "Raw JSON representation of the query."
+        },
+        "query_execution_duration": {
+          "type": "string",
+          "description": "Current query current execution time."
+        },
+        "query_collect_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the query data was collected by Real-Time Analytics agent."
+        },
+        "client_address": {
+          "type": "string",
+          "description": "Client address (host:port)."
+        },
+        "mongo_db_payload": {
+          "$ref": "#/definitions/v1QueryMongoDBData",
+          "description": "MongoDB-specific query data."
+        },
+        "postgres_payload": {
+          "$ref": "#/definitions/v1QueryPostgreSQLData",
+          "description": "PostgreSQL-specific query data."
+        }
+      },
+      "description": "QueryData represents a single Real-Time Analytics query data point.\nIt includes general query information and a payload for database-specific details."
+    },
+    "v1QueryMongoDBData": {
+      "type": "object",
+      "properties": {
+        "db_instance_address": {
+          "type": "string",
+          "description": "MongoDB instance address(host:port) that processing the query."
+        },
+        "client_app_name": {
+          "type": "string",
+          "description": "Client application name from the MongoDB query."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "collection": {
+          "type": "string",
+          "description": "Collection name."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Query operation (\"find\", \"aggregate\", \"update\", etc)."
+        },
+        "operation_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the operation."
+        },
+        "username": {
+          "type": "string",
+          "description": "MongoDB user name associated with the query."
+        },
+        "plan_summary": {
+          "type": "string",
+          "description": "Indicates if an index (COLLSCAN vs IXSCAN) was utilized in the query."
+        }
+      },
+      "description": "QueryMongoDBData holds MongoDB-specific Real-Time Analytics query information."
+    },
+    "v1QueryPostgreSQLData": {
+      "type": "object",
+      "properties": {
+        "db_instance_address": {
+          "type": "string",
+          "description": "PostgreSQL instance address (host:port)."
+        },
+        "database_name": {
+          "type": "string",
+          "description": "Database name."
+        },
+        "username": {
+          "type": "string",
+          "description": "PostgreSQL username."
+        },
+        "application_name": {
+          "type": "string",
+          "description": "Client application name."
+        },
+        "session_state": {
+          "type": "string",
+          "description": "Backend state (active, idle in transaction, etc.)."
+        },
+        "transaction_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Transaction start time (used for idle in transaction duration)."
+        },
+        "query_start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Current query start time."
+        },
+        "wait_event_type": {
+          "type": "string",
+          "description": "Wait event type when waiting."
+        },
+        "wait_event": {
+          "type": "string",
+          "description": "Wait event name when waiting."
+        },
+        "backend_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Backend PID."
+        },
+        "leader_pid": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Leader PID for parallel workers (0 if not a worker)."
+        },
+        "query_text_truncated": {
+          "type": "boolean",
+          "description": "True when query text was truncated by track_activity_query_size."
+        },
+        "track_activity_query_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Configured track_activity_query_size value."
+        },
+        "lock_chain": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1LockChainLink"
+          },
+          "description": "Lock chain links when this backend is blocked."
+        }
+      },
+      "description": "QueryPostgreSQLData holds PostgreSQL-specific Real-Time Analytics session information."
+    },
+    "v1SearchQueriesRequest": {
+      "type": "object",
+      "properties": {
+        "service_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional filter by Service identifiers."
+        },
+        "limit": {
+          "type": "string",
+          "format": "int64",
+          "description": "Optional limit the number of queries in response."
+        }
+      },
+      "description": "SearchQueriesRequest contains optional filters for listing active Real-Time Analytics session Queries."
+    },
+    "v1SearchQueriesResponse": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/v1QueryData"
+          },
+          "description": "List of active Real-Time Analytics session Queries."
+        }
+      },
+      "description": "SearchQueriesResponse returns the list of currently active Real-Time Analytics session Queries."
+    },
+    "v1ServiceType": {
+      "type": "string",
+      "enum": [
+        "SERVICE_TYPE_UNSPECIFIED",
+        "SERVICE_TYPE_MYSQL_SERVICE",
+        "SERVICE_TYPE_MONGODB_SERVICE",
+        "SERVICE_TYPE_POSTGRESQL_SERVICE",
+        "SERVICE_TYPE_VALKEY_SERVICE",
+        "SERVICE_TYPE_PROXYSQL_SERVICE",
+        "SERVICE_TYPE_HAPROXY_SERVICE",
+        "SERVICE_TYPE_EXTERNAL_SERVICE"
+      ],
+      "default": "SERVICE_TYPE_UNSPECIFIED",
+      "description": "ServiceType describes supported Service types."
+    },
+    "v1Session": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Service identifier that has enabled Real-Time Analytics session."
+        },
+        "service_name": {
+          "type": "string",
+          "description": "Service name."
+        },
+        "cluster_name": {
+          "type": "string",
+          "description": "Cluster name the service belongs to."
+        },
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the Real-Time Analytics session started."
+        },
+        "collect_interval": {
+          "type": "string",
+          "description": "Query collect interval."
+        },
+        "status": {
+          "$ref": "#/definitions/v1SessionStatus",
+          "description": "Current status of the Real-Time Analytics session."
+        }
+      },
+      "description": "Session represents an active Real-Time Analytics session."
+    },
+    "v1SessionStatus": {
+      "type": "string",
+      "enum": [
+        "SESSION_STATUS_UNSPECIFIED",
+        "SESSION_STATUS_ERROR",
+        "SESSION_STATUS_RUNNING",
+        "SESSION_STATUS_DOWN"
+      ],
+      "default": "SESSION_STATUS_UNSPECIFIED",
+      "description": "Status represents actual Real-Time Analytics session status.\n\n - SESSION_STATUS_ERROR: Session encountered an error.\n - SESSION_STATUS_RUNNING: Session is running.\n - SESSION_STATUS_DOWN: Session has been stopped or disabled."
+    },
+    "v1StartSessionRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Required service identifier the Real-Time Analytics session shall be started for."
+        }
+      },
+      "description": "StartSessionRequest contains parameters for starting Real-Time Analytics session."
+    },
+    "v1StartSessionResponse": {
+      "type": "object",
+      "properties": {
+        "session": {
+          "$ref": "#/definitions/v1Session"
+        }
+      },
+      "description": "StartSessionResponse is the response for starting Real-Time Analytics session."
+    },
+    "v1StopSessionRequest": {
+      "type": "object",
+      "properties": {
+        "service_id": {
+          "type": "string",
+          "description": "Required service identifier the Real-Time Analytics session shall be stopped for."
+        }
+      },
+      "description": "StopSessionRequest contains parameters for stopping Real-Time Analytics session."
+    },
+    "v1StopSessionResponse": {
+      "type": "object",
+      "description": "StopSessionResponse is the response for stopping Real-Time Analytics session.\n\nEmpty response for now."
+    }
+  }
+}

--- a/api/realtimeanalytics/v1/realtimeanalytics_grpc.pb.go
+++ b/api/realtimeanalytics/v1/realtimeanalytics_grpc.pb.go
@@ -8,7 +8,6 @@ package realtimeanalyticsv1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -132,23 +131,18 @@ type UnimplementedRealtimeAnalyticsServiceServer struct{}
 func (UnimplementedRealtimeAnalyticsServiceServer) ListServices(context.Context, *ListServicesRequest) (*ListServicesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListServices not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListSessions not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) StartSession(context.Context, *StartSessionRequest) (*StartSessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StartSession not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) StopSession(context.Context, *StopSessionRequest) (*StopSessionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method StopSession not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) SearchQueries(context.Context, *SearchQueriesRequest) (*SearchQueriesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SearchQueries not implemented")
 }
-
 func (UnimplementedRealtimeAnalyticsServiceServer) mustEmbedUnimplementedRealtimeAnalyticsServiceServer() {
 }
 func (UnimplementedRealtimeAnalyticsServiceServer) testEmbeddedByValue() {}

--- a/managed/models/agent_helpers.go
+++ b/managed/models/agent_helpers.go
@@ -362,6 +362,7 @@ func FindDBConfigForService(q *reform.Querier, serviceID string) (*DBConfig, err
 			PostgresExporterType,
 			QANPostgreSQLPgStatementsAgentType,
 			QANPostgreSQLPgStatMonitorAgentType,
+			RTAPostgreSQLAgentType,
 		}
 	case MongoDBServiceType:
 		agentTypes = []AgentType{
@@ -875,6 +876,9 @@ func compatibleServiceAndAgent(serviceType ServiceType, agentType AgentType) boo
 		RTAMongoDBAgentType: {
 			MongoDBServiceType,
 		},
+		RTAPostgreSQLAgentType: {
+			PostgreSQLServiceType,
+		},
 		PostgresExporterType: {
 			PostgreSQLServiceType,
 		},
@@ -982,7 +986,7 @@ func CreateAgent(q *reform.Querier, agentType AgentType, params *CreateAgentPara
 
 	switch agentType {
 	// For the time being only RTA MangoDB Agent has RTA options.
-	case RTAMongoDBAgentType:
+	case RTAMongoDBAgentType, RTAPostgreSQLAgentType:
 		row.RTAOptions = RTAOptions{
 			// default value
 			CollectInterval: new(2 * time.Second), //nolint:mnd

--- a/managed/models/agent_model.go
+++ b/managed/models/agent_model.go
@@ -82,13 +82,14 @@ const (
 	NomadAgentType                      AgentType = "nomad-agent"
 	ValkeyExporterType                  AgentType = "valkey_exporter"
 	RTAMongoDBAgentType                 AgentType = "rta-mongodb-agent"
+	RTAPostgreSQLAgentType              AgentType = "rta-postgresql-agent"
 )
 
 // GetRTAAgentTypes returns all Real-Time Analytics Agent types.
 func GetRTAAgentTypes() []AgentType {
 	return []AgentType{
 		RTAMongoDBAgentType,
-		// Add more types here once they are implemented.
+		RTAPostgreSQLAgentType,
 	}
 }
 
@@ -721,7 +722,7 @@ func (a *Agent) DSN(service *Service, dsnParams DSNParams, tdp *DelimiterPair, p
 		dsn = strings.ReplaceAll(dsn, url.QueryEscape(tdp.Right), tdp.Right)
 		return dsn
 
-	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType:
+	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType, RTAPostgreSQLAgentType:
 		q := make(url.Values)
 
 		sslmode := DisableSSLMode
@@ -931,7 +932,7 @@ func (a Agent) Files() map[string]string { //nolint:gocognit
 		}
 
 		return nil
-	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType:
+	case PostgresExporterType, QANPostgreSQLPgStatementsAgentType, QANPostgreSQLPgStatMonitorAgentType, RTAPostgreSQLAgentType:
 		files := make(map[string]string)
 
 		if a.PostgreSQLOptions.SSLCa != "" {

--- a/managed/models/dsn_helpers.go
+++ b/managed/models/dsn_helpers.go
@@ -63,6 +63,7 @@ func FindDSNByServiceIDandPMMAgentID(q *reform.Querier, serviceID, pmmAgentID, d
 			QANPostgreSQLPgStatementsAgentType,
 			QANPostgreSQLPgStatMonitorAgentType,
 			PostgresExporterType,
+			RTAPostgreSQLAgentType,
 		)
 		dsnParams.PostgreSQLSupportsSSLSNI, err = IsPostgreSQLSSLSniSupported(q, pmmAgentID)
 		if err != nil {

--- a/managed/services/agents/postgresql.go
+++ b/managed/services/agents/postgresql.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/AlekSi/pointer"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	agentv1 "github.com/percona/pmm/api/agent/v1"
 	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
@@ -214,6 +215,34 @@ func qanPostgreSQLPgStatMonitorAgentConfig(service *models.Service, agent *model
 		DisableQueryExamples:   agent.QANOptions.QueryExamplesDisabled,
 		MaxQueryLength:         agent.QANOptions.MaxQueryLength,
 		DisableCommentsParsing: agent.QANOptions.CommentsParsingDisabled,
+		TextFiles: &agentv1.TextFiles{
+			Files:              agent.Files(),
+			TemplateLeftDelim:  tdp.Left,
+			TemplateRightDelim: tdp.Right,
+		},
+	}
+}
+
+// rtaPostgreSQLAgentConfig returns desired configuration of rta-postgresql-agent RTA agent.
+func rtaPostgreSQLAgentConfig(service *models.Service, agent *models.Agent, pmmAgentVersion *version.Parsed) *agentv1.SetStateRequest_BuiltinAgent {
+	tdp := agent.TemplateDelimiters(service)
+	dsnParams := models.DSNParams{
+		DialTimeout:              5 * time.Second,
+		Database:                 service.DatabaseName,
+		PostgreSQLSupportsSSLSNI: !pmmAgentVersion.Less(postgresSSLSniVersion),
+	}
+
+	apiRTAOptions := &inventoryv1.RTAOptions{}
+	if agent.RTAOptions.CollectInterval != nil {
+		apiRTAOptions.CollectInterval = durationpb.New(*agent.RTAOptions.CollectInterval)
+	}
+
+	return &agentv1.SetStateRequest_BuiltinAgent{
+		Type:        inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT,
+		Dsn:         agent.DSN(service, dsnParams, nil, pmmAgentVersion),
+		RtaOptions:  apiRTAOptions,
+		ServiceId:   service.ServiceID,
+		ServiceName: service.ServiceName,
 		TextFiles: &agentv1.TextFiles{
 			Files:              agent.Files(),
 			TemplateLeftDelim:  tdp.Left,

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -243,7 +243,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			models.ValkeyExporterType, models.QANMySQLPerfSchemaAgentType, models.QANMySQLSlowlogAgentType,
 			models.QANMongoDBProfilerAgentType, models.QANMongoDBMongologAgentType,
 			models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType,
-			models.RTAMongoDBAgentType:
+			models.RTAMongoDBAgentType, models.RTAPostgreSQLAgentType:
 			service, err := models.FindServiceByID(u.db.Querier, pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
@@ -286,6 +286,8 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 				builtinAgents[row.AgentID] = qanPostgreSQLPgStatMonitorAgentConfig(service, row, pmmAgentVersion)
 			case models.RTAMongoDBAgentType:
 				builtinAgents[row.AgentID] = rtaMongoDBAgentConfig(service, row, pmmAgentVersion)
+			case models.RTAPostgreSQLAgentType:
+				builtinAgents[row.AgentID] = rtaPostgreSQLAgentConfig(service, row, pmmAgentVersion)
 			}
 
 		default:

--- a/managed/services/converters.go
+++ b/managed/services/converters.go
@@ -605,6 +605,20 @@ func ToAPIAgent(q *reform.Querier, agent *models.Agent) (inventoryv1.Agent, erro
 			LogLevel:      inventoryv1.LogLevelAPIValue(agent.LogLevel),
 			RtaOptions:    ToAPIRTAOptions(&agent.RTAOptions),
 		}, nil
+	case models.RTAPostgreSQLAgentType:
+		return &inventoryv1.RTAPostgreSQLAgent{
+			AgentId:       agent.AgentID,
+			PmmAgentId:    pointer.GetString(agent.PMMAgentID),
+			ServiceId:     serviceID,
+			Username:      pointer.GetString(agent.Username),
+			Disabled:      agent.Disabled,
+			Status:        inventoryv1.AgentStatus(inventoryv1.AgentStatus_value[agent.Status]),
+			CustomLabels:  labels,
+			Tls:           agent.TLS,
+			TlsSkipVerify: agent.TLSSkipVerify,
+			LogLevel:      inventoryv1.LogLevelAPIValue(agent.LogLevel),
+			RtaOptions:    ToAPIRTAOptions(&agent.RTAOptions),
+		}, nil
 
 	default:
 		panic(fmt.Errorf("cannot convert unknown agent type %s", agent.AgentType))

--- a/managed/services/inventory/agents.go
+++ b/managed/services/inventory/agents.go
@@ -1914,6 +1914,116 @@ func (as *AgentsService) ChangeRTAMongoDBAgent(
 	return res, nil
 }
 
+// AddRTAPostgreSQLAgent adds PostgreSQL Real-Time Analytics Agent.
+func (as *AgentsService) AddRTAPostgreSQLAgent(ctx context.Context, p *inventoryv1.AddRTAPostgreSQLAgentParams) (*inventoryv1.AddAgentResponse, error) {
+	var agent *inventoryv1.RTAPostgreSQLAgent
+
+	pgOptions := models.PostgreSQLOptions{
+		SSLCa:   p.GetTlsCa(),
+		SSLCert: p.GetTlsCert(),
+		SSLKey:  p.GetTlsKey(),
+	}
+
+	e := as.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		params := &models.CreateAgentParams{
+			PMMAgentID:        p.PmmAgentId,
+			ServiceID:         p.ServiceId,
+			Username:          p.Username,
+			Password:          p.Password,
+			CustomLabels:      p.CustomLabels,
+			TLS:               p.Tls,
+			TLSSkipVerify:     p.TlsSkipVerify,
+			PostgreSQLOptions: pgOptions,
+			LogLevel:          services.SpecifyLogLevel(p.LogLevel, inventoryv1.LogLevel_LOG_LEVEL_FATAL),
+		}
+
+		if p.RtaOptions != nil {
+			params.RTAOptions = *models.RTAOptionsFromRequest(p.RtaOptions)
+		}
+
+		row, err := models.CreateAgent(tx.Querier, models.RTAPostgreSQLAgentType, params)
+		if err != nil {
+			return err
+		}
+
+		if !p.SkipConnectionCheck {
+			service, err := models.FindServiceByID(tx.Querier, p.ServiceId)
+			if err != nil {
+				return err
+			}
+
+			err = as.cc.CheckConnectionToService(ctx, tx.Querier, service, row)
+			if err != nil {
+				return err
+			}
+
+			err = as.sib.GetInfoFromService(ctx, tx.Querier, service, row)
+			if err != nil {
+				return err
+			}
+		}
+
+		aa, err := services.ToAPIAgent(tx.Querier, row)
+		if err != nil {
+			return err
+		}
+
+		agent = aa.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+
+		return nil
+	})
+	if e != nil {
+		return nil, e
+	}
+
+	as.state.RequestStateUpdate(ctx, p.PmmAgentId)
+
+	return &inventoryv1.AddAgentResponse{
+		Agent: &inventoryv1.AddAgentResponse_RtaPostgresqlAgent{
+			RtaPostgresqlAgent: agent,
+		},
+	}, nil
+}
+
+// ChangeRTAPostgreSQLAgent updates PostgreSQL Real-Time Analytics Agent with given parameters.
+func (as *AgentsService) ChangeRTAPostgreSQLAgent(
+	ctx context.Context, agentID string,
+	p *inventoryv1.ChangeRTAPostgreSQLAgentParams,
+) (*inventoryv1.ChangeAgentResponse, error) {
+	changeParams := &models.ChangeAgentParams{
+		Enabled:       p.Enable,
+		Username:      p.Username,
+		Password:      p.Password,
+		TLS:           p.Tls,
+		TLSSkipVerify: p.TlsSkipVerify,
+		LogLevel:      convertLogLevel(p.LogLevel),
+		CustomLabels:  convertCustomLabels(p.CustomLabels),
+		PostgreSQLOptions: &models.ChangePostgreSQLOptions{
+			SSLCa:   p.TlsCa,
+			SSLCert: p.TlsCert,
+			SSLKey:  p.TlsKey,
+		},
+	}
+
+	if p.RtaOptions != nil {
+		changeParams.RTAOptions = models.RTAOptionsFromRequest(p.RtaOptions)
+	}
+
+	ag, err := as.executeAgentChange(ctx, agentID, changeParams)
+	if err != nil {
+		return nil, err
+	}
+
+	agent := ag.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+	as.state.RequestStateUpdate(ctx, agent.PmmAgentId)
+
+	return &inventoryv1.ChangeAgentResponse{
+		Agent: &inventoryv1.ChangeAgentResponse_RtaPostgresqlAgent{
+			RtaPostgresqlAgent: agent,
+		},
+	}, nil
+}
+
 // Remove removes Agent, and sends state update to pmm-agent, or kicks it.
 func (as *AgentsService) Remove(ctx context.Context, id string, force bool) error {
 	var removedAgent *models.Agent

--- a/managed/services/inventory/grpc/agents_server.go
+++ b/managed/services/inventory/grpc/agents_server.go
@@ -58,6 +58,7 @@ var agentTypes = map[inventoryv1.AgentType]models.AgentType{
 	inventoryv1.AgentType_AGENT_TYPE_VM_AGENT:                           models.VMAgentType,
 	inventoryv1.AgentType_AGENT_TYPE_NOMAD_AGENT:                        models.NomadAgentType,
 	inventoryv1.AgentType_AGENT_TYPE_RTA_MONGODB_AGENT:                  models.RTAMongoDBAgentType,
+	inventoryv1.AgentType_AGENT_TYPE_RTA_POSTGRESQL_AGENT:               models.RTAPostgreSQLAgentType,
 }
 
 func agentType(req *inventoryv1.ListAgentsRequest) *models.AgentType {
@@ -121,6 +122,8 @@ func (s *agentsServer) ListAgents(ctx context.Context, req *inventoryv1.ListAgen
 			res.NomadAgent = append(res.NomadAgent, agent)
 		case *inventoryv1.RTAMongoDBAgent:
 			res.RtaMongodbAgent = append(res.RtaMongodbAgent, agent)
+		case *inventoryv1.RTAPostgreSQLAgent:
+			res.RtaPostgresqlAgent = append(res.RtaPostgresqlAgent, agent)
 		default:
 			panic(fmt.Errorf("unhandled inventory Agent type %T", agent))
 		}
@@ -175,6 +178,8 @@ func (s *agentsServer) GetAgent(ctx context.Context, req *inventoryv1.GetAgentRe
 		res.Agent = &inventoryv1.GetAgentResponse_NomadAgent{NomadAgent: agent}
 	case *inventoryv1.RTAMongoDBAgent:
 		res.Agent = &inventoryv1.GetAgentResponse_RtaMongodbAgent{RtaMongodbAgent: agent}
+	case *inventoryv1.RTAPostgreSQLAgent:
+		res.Agent = &inventoryv1.GetAgentResponse_RtaPostgresqlAgent{RtaPostgresqlAgent: agent}
 	default:
 		panic(fmt.Errorf("unhandled inventory Agent type %T", agent))
 	}
@@ -231,6 +236,8 @@ func (s *agentsServer) AddAgent(ctx context.Context, req *inventoryv1.AddAgentRe
 		return s.s.AddQANPostgreSQLPgStatMonitorAgent(ctx, req.GetQanPostgresqlPgstatmonitorAgent())
 	case *inventoryv1.AddAgentRequest_RtaMongodbAgent:
 		return s.s.AddRTAMongoDBAgent(ctx, req.GetRtaMongodbAgent())
+	case *inventoryv1.AddAgentRequest_RtaPostgresqlAgent:
+		return s.s.AddRTAPostgreSQLAgent(ctx, req.GetRtaPostgresqlAgent())
 	default:
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid agent type %T", req.Agent))
 	}
@@ -275,6 +282,8 @@ func (s *agentsServer) ChangeAgent(ctx context.Context, req *inventoryv1.ChangeA
 		return s.s.ChangeNomadAgent(ctx, agentID, req.GetNomadAgent())
 	case *inventoryv1.ChangeAgentRequest_RtaMongodbAgent:
 		return s.s.ChangeRTAMongoDBAgent(ctx, agentID, req.GetRtaMongodbAgent())
+	case *inventoryv1.ChangeAgentRequest_RtaPostgresqlAgent:
+		return s.s.ChangeRTAPostgreSQLAgent(ctx, agentID, req.GetRtaPostgresqlAgent())
 	default:
 		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid agent type %T", req.Agent))
 	}

--- a/managed/services/management/agent.go
+++ b/managed/services/management/agent.go
@@ -219,7 +219,7 @@ func (s *ManagementService) agentToAPI(agent *models.Agent) (*managementv1.Unive
 		if len(agent.MySQLOptions.ExtraDSNParams) != 0 {
 			ua.MysqlOptions.ExtraDsnParams = agent.MySQLOptions.ExtraDSNParams
 		}
-	case models.PostgresExporterType, models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType:
+	case models.PostgresExporterType, models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType, models.RTAPostgreSQLAgentType:
 		ua.PostgresqlOptions = &managementv1.UniversalAgent_PostgreSQLOptions{
 			IsSslKeySet:            agent.PostgreSQLOptions.SSLKey != "",
 			AutoDiscoveryLimit:     pointer.GetInt32(agent.PostgreSQLOptions.AutoDiscoveryLimit),

--- a/managed/services/management/postgresql.go
+++ b/managed/services/management/postgresql.go
@@ -165,6 +165,28 @@ func (s *ManagementService) addPostgreSQL(ctx context.Context, req *managementv1
 			postgres.QanPostgresqlPgstatmonitorAgent = agent.(*inventoryv1.QANPostgreSQLPgStatMonitorAgent) //nolint:forcetypeassert
 		}
 
+		if req.RtaPostgresqlAgent {
+			row, err = models.CreateAgent(tx.Querier, models.RTAPostgreSQLAgentType, &models.CreateAgentParams{
+				PMMAgentID:        req.PmmAgentId,
+				ServiceID:         service.ServiceID,
+				Username:          req.Username,
+				Password:          req.Password,
+				TLS:               req.Tls,
+				TLSSkipVerify:     req.TlsSkipVerify,
+				PostgreSQLOptions: models.PostgreSQLOptionsFromRequest(req),
+				LogLevel:          services.SpecifyLogLevel(req.LogLevel, inventoryv1.LogLevel_LOG_LEVEL_FATAL),
+			})
+			if err != nil {
+				return err
+			}
+
+			agent, err = services.ToAPIAgent(tx.Querier, row)
+			if err != nil {
+				return err
+			}
+			postgres.RtaPostgresqlAgent = agent.(*inventoryv1.RTAPostgreSQLAgent) //nolint:forcetypeassert
+		}
+
 		return nil
 	})
 

--- a/managed/services/realtimeanalytics/service.go
+++ b/managed/services/realtimeanalytics/service.go
@@ -150,13 +150,17 @@ func (s *Service) ListServices(ctx context.Context, req *rtav1.ListServicesReque
 		switch apiSvc := apiSvc.(type) {
 		case *inventoryv1.MongoDBService:
 			res.Mongodb = append(res.Mongodb, apiSvc)
-		// Add other service types once RTA is supported for them
+		case *inventoryv1.PostgreSQLService:
+			res.Postgresql = append(res.Postgresql, apiSvc)
 		default:
 			return nil, fmt.Errorf("unhandled inventory Service type %T", apiSvc)
 		}
 	}
 
 	slices.SortStableFunc(res.Mongodb, func(a, b *inventoryv1.MongoDBService) int {
+		return strings.Compare(a.ServiceName, b.ServiceName)
+	})
+	slices.SortStableFunc(res.Postgresql, func(a, b *inventoryv1.PostgreSQLService) int {
 		return strings.Compare(a.ServiceName, b.ServiceName)
 	})
 
@@ -615,6 +619,8 @@ func getRTAAgentTypeForServiceType(serviceType models.ServiceType) (models.Agent
 	switch serviceType {
 	case models.MongoDBServiceType:
 		return models.RTAMongoDBAgentType, nil
+	case models.PostgreSQLServiceType:
+		return models.RTAPostgreSQLAgentType, nil
 	default:
 		return "", fmt.Errorf("service of type %s does not support Real-Time Analytics", serviceType)
 	}

--- a/managed/services/telemetry/config.default.yml
+++ b/managed/services/telemetry/config.default.yml
@@ -1025,6 +1025,41 @@ telemetry:
       - metric_name: "rta_mongo_agents_disabled"
         column: "agent_count"
 
+  - id: RTAPostgresAgentsRegisteredTotalCount
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent';
+    summary: "Total count of RTA PostgreSQL agents ever registered (including stopped/disabled ones)"
+    data:
+      - metric_name: "rta_postgres_agents_total_count"
+        column: "agent_count"
+
+  - id: RTAPostgresAgentsEnabled
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent'
+        AND disabled = false;
+    summary: "Count of Real-Time Analytics PostgreSQL agents currently enabled (disabled=false)"
+    data:
+      - metric_name: "rta_postgres_agents_enabled"
+        column: "agent_count"
+
+  - id: RTAPostgresAgentsDisabled
+    source: PMMDB_SELECT
+    query: >
+      count(*) AS agent_count
+      FROM agents
+      WHERE agent_type = 'rta-postgresql-agent'
+        AND disabled = true;
+    summary: "Count of Real-Time Analytics PostgreSQL agents currently disabled (disabled=true)"
+    data:
+      - metric_name: "rta_postgres_agents_disabled"
+        column: "agent_count"
+
   # Real-Time Analytics (RTA) agents details
   # Per-agent rows; agent_type is the row marker (consumer assumes 4 lines per agent).
   # COALESCE keeps row alignment when version/collect_interval are NULL (empty values would be dropped by removeEmpty).

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
@@ -1,0 +1,181 @@
+# Design: PostgreSQL Real-Time Query Analytics
+
+## Approach
+
+Extend the existing MongoDB RTA architecture to PostgreSQL by adding a parallel agent type and protobuf payload while reusing server-side session management, in-memory store, and UI shell. The implementation follows established PMM patterns: inventory agent registration → pmm-agent polling loop → gRPC collector stream → `managed/services/realtimeanalytics` store → REST API → React UI.
+
+### Data collection (pmm-agent)
+
+The PostgreSQL RTA agent runs inside pmm-agent and connects using the same DSN/credentials as the PostgreSQL exporter for the monitored service (with optional override via inventory, matching MongoDB RTA behavior).
+
+On each collect interval (default 2s, configurable 1–5s via `RTAOptions.collect_interval`):
+
+1. Query `pg_stat_activity` for non-idle backends (include `idle in transaction` as a distinct state).
+2. Query `pg_locks` joined with `pg_stat_activity` to build blocker → blocked lock chains.
+3. Normalize each active backend into a `QueryData` message with `postgres_payload`.
+4. Send changes over the existing RTA collector gRPC stream (`CollectorService`).
+
+**Primary SQL sources:**
+
+```sql
+-- pg_stat_activity: session identity, state, query text, timings, wait events
+SELECT pid, datname, usename, application_name, client_addr, client_port,
+       backend_type, state, query, query_id, backend_start, xact_start,
+       query_start, state_change, wait_event_type, wait_event, leader_pid
+FROM pg_stat_activity
+WHERE pid <> pg_backend_pid()
+  AND backend_type = 'client backend'
+  AND state <> 'idle';
+
+-- pg_locks: lock mode, relation, granted/blocked
+SELECT ... FROM pg_locks l JOIN pg_stat_activity a ON l.pid = a.pid ...
+```
+
+**PostgreSQL-specific processing:**
+
+| Concern | Handling |
+|---------|----------|
+| `query_id` (PG 14+) | Populate from `pg_stat_activity.query_id`; PG 12–13 use query fingerprint hash |
+| Query text truncation | Set `query_text_truncated=true` when `length(query) >= track_activity_query_size`; include tooltip metadata |
+| `idle in transaction` | Use `xact_start` for duration display (not `query_start`); distinct UI badge |
+| Parallel workers (PG 13+) | Group rows where `leader_pid` is set under leader session; collapsed by default in UI |
+| Lock chains | Build directed graph from `pg_locks` where `granted=false`; attach chain to blocked session payload |
+| Permissions | Require `pg_read_all_stats` (or superuser); return structured agent error if missing |
+
+**Performance target:** <1% additional CPU on PostgreSQL host with ≤200 active backends at 2s polling interval (acceptance criterion).
+
+### Server-side (pmm-managed)
+
+Extend existing components with minimal branching:
+
+| Component | Change |
+|-----------|--------|
+| `models/agent_model.go` | Add `RTAPostgreSQLAgentType` (`rta-postgresql-agent`) |
+| `managed/services/inventory/agents.go` | `AddRTAPostgreSQLAgent`, `ChangeRTAPostgreSQLAgent` |
+| `managed/services/management/postgresql.go` | Auto-register RTA agent when adding PostgreSQL service (optional flag, mirror MongoDB) |
+| `managed/services/realtimeanalytics/service.go` | Map `PostgreSQLServiceType` → `RTAPostgreSQLAgentType` in `getRTAAgentTypeForServiceType`; extend `ListServicesResponse` |
+| `managed/services/realtimeanalytics/store.go` | Store PostgreSQL `QueryData` in existing TTL map (no schema change beyond proto) |
+| `managed/services/telemetry/config.default.yml` | Add PostgreSQL RTA telemetry queries |
+
+MongoDB code paths remain unchanged; service-type dispatch selects agent implementation.
+
+### API (protobuf)
+
+**`api/realtimeanalytics/v1/query.proto`:**
+
+```protobuf
+message QueryPostgreSQLData {
+  string db_instance_address = 1;
+  string database_name = 2;
+  string username = 3;
+  string application_name = 4;
+  string session_state = 5;           // active, idle in transaction, ...
+  google.protobuf.Timestamp transaction_start_time = 6;
+  google.protobuf.Timestamp query_start_time = 7;
+  string wait_event_type = 8;
+  string wait_event = 9;
+  int32 backend_pid = 10;
+  int32 leader_pid = 11;                // 0 if not a parallel worker
+  bool query_text_truncated = 12;
+  int32 track_activity_query_size = 13;
+  repeated LockChainLink lock_chain = 14;
+}
+
+message LockChainLink {
+  int32 blocker_pid = 1;
+  int32 blocked_pid = 2;
+  string lock_mode = 3;
+  string relation_name = 4;
+  string blocker_query_text = 5;
+  google.protobuf.Duration blocker_duration = 6;
+}
+```
+
+**`api/realtimeanalytics/v1/realtimeanalytics.proto`:**
+
+- Extend `ListServicesResponse` with `repeated inventory.v1.PostgreSQLService postgresql = 2;`
+
+**`api/inventory/v1/agents.proto`:**
+
+- Add `RTAPostgreSQLAgent`, `AddRTAPostgreSQLAgentParams`, `ChangeRTAPostgreSQLAgentParams` (mirror MongoDB RTA agent fields minus MongoDB-specific auth; reuse PostgreSQL TLS/ssl fields from existing PostgreSQL agents).
+
+### UI (ui/apps/pmm)
+
+Extend existing RTA pages without new navigation:
+
+| Area | Change |
+|------|--------|
+| `types/rta.types.ts` | Add `QueryPostgreSQLData`, extend `RawQueryData` with `postgresPayload` |
+| `api/rta.ts` | Handle PostgreSQL in `listServices` response |
+| `hooks/api/useRealtime.ts` | Include PostgreSQL services in available-services filter |
+| `pages/rta/overview/table/` | PostgreSQL column set: state, wait event, DB, duration, query |
+| `pages/rta/overview/details-pane/` | Lock chain panel, idle-in-transaction section, raw JSON tab |
+| `pages/rta/components/selection-form/` | Show PostgreSQL services in autocomplete |
+
+Reuse MongoDB patterns for pause/resume, auto-refresh (1–5s), session management, and share links.
+
+### QAN coexistence
+
+RTA polling reads `pg_stat_activity` and `pg_locks` only. QAN agents continue using `pg_stat_statements` / `pg_stat_monitor` independently. No shared state, no ClickHouse writes from RTA. Verify no lock contention or duplicate query collection on the same extensions.
+
+### Cloud provider notes
+
+| Provider | Considerations |
+|----------|----------------|
+| RDS / Aurora | Standard `pg_stat_activity`; grant `pg_read_all_stats` via parameter group / role |
+| Cloud SQL | May require `cloudsqlsuperuser`; document IAM/database user setup |
+| Azure | Flexible Server supports `pg_stat_activity`; document required roles |
+
+Aurora `aurora_stat_activity` is out of scope for v1.
+
+## Files / areas touched
+
+**Agent**
+- `agent/agents/postgres/realtimeanalytics/` (new package)
+- `agent/agents/agents.go` — register RTA PostgreSQL agent
+- `agent/client/client.go` — agent state handling
+
+**API**
+- `api/realtimeanalytics/v1/query.proto`
+- `api/realtimeanalytics/v1/realtimeanalytics.proto`
+- `api/inventory/v1/agents.proto`
+- Regenerated `.pb.go`, swagger, json clients
+
+**Managed**
+- `managed/models/agent_model.go`, `agent_helpers.go`
+- `managed/services/inventory/agents.go`, `grpc/agents_server.go`
+- `managed/services/management/postgresql.go`
+- `managed/services/realtimeanalytics/service.go`, `store.go`
+- `managed/services/converters.go`
+- `managed/services/telemetry/config.default.yml`
+
+**UI**
+- `ui/apps/pmm/src/types/rta.types.ts`
+- `ui/apps/pmm/src/api/rta.ts`
+- `ui/apps/pmm/src/hooks/api/useRealtime.ts`
+- `ui/apps/pmm/src/pages/rta/**`
+
+**Docs**
+- `documentation/docs/use/qan/QAN-realtime-analytics.md` — add PostgreSQL section, remove "MongoDB only" warning
+- New or updated PostgreSQL RTA permissions doc
+
+**Version**
+- `version/features.go` — feature gate constant for PostgreSQL RTA agent support
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| High poll frequency increases DB load | Default 2s interval; configurable 1–5s; benchmark ≤200 backends |
+| `pg_read_all_stats` missing on cloud | Structured error in agent + UI; document per-provider setup |
+| Query text truncated by `track_activity_query_size` | Visual indicator + tooltip; document server restart requirement to increase |
+| Lock chain query cost on busy systems | Limit chain depth; single round-trip join; benchmark under load |
+| Proto/API breaking changes | Additive only; MongoDB payload unchanged |
+| Parallel worker UI complexity | Collapse under leader by default; expand on click |
+
+## Testing strategy
+
+- **Unit:** Agent SQL parsing, lock chain builder, proto converters, store TTL
+- **Integration (pmm-managed):** Start/stop session for PostgreSQL service; SearchQueries returns PG payload
+- **Integration (pmm-qa):** Playwright RTA flow for PostgreSQL service selection, live table refresh, lock chain panel
+- **Manual matrix:** PG 12, 14, 15, 16; Percona Distribution; RDS; verify QAN still works on same instance

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
@@ -1,0 +1,39 @@
+# PMM-15167 [RTA] Real-Time Query Analytics for PostgreSQL
+
+## Why
+
+PMM already provides Query Analytics (QAN) for PostgreSQL using `pg_stat_statements` and `pg_stat_monitor`, but QAN aggregates completed queries into one-minute buckets in ClickHouse with 1–2 minutes of end-to-end lag. During live incidents—lock pile-ups, long-running transactions blocking writes, or idle-in-transaction sessions holding locks—DBAs must leave PMM and run manual queries against `pg_stat_activity` and `pg_locks`.
+
+Real-Time Analytics (RTA) for MongoDB shipped in PMM 3.7.0 with a proven architecture: dedicated agent type, `RealtimeAnalyticsService` (gRPC + REST), in-memory TTL store, and a UI under **Query Analytics → Real-time**. PostgreSQL users need the same live visibility inside PMM, extended with PostgreSQL-specific diagnostics (lock chains, wait events, idle-in-transaction detection, parallel worker grouping).
+
+## What changes
+
+- Add **RTA PostgreSQL agent** (`rta-postgresql-agent`) in pmm-agent that polls `pg_stat_activity` and `pg_locks` every 1–5 seconds and streams session records to PMM Server.
+- Extend **Inventory API** with `RTAPostgreSQLAgent` (add/change/list/get) mirroring the MongoDB RTA agent pattern; reuse existing PostgreSQL exporter credentials where possible.
+- Extend **RealtimeAnalyticsService** and `QueryData` protobuf with a PostgreSQL payload (`QueryPostgreSQLData`) including session state, wait events, lock chains, transaction duration, and parallel-worker metadata.
+- Update **UI Real-time tab** to list PostgreSQL services alongside MongoDB, render PostgreSQL-specific columns and panels (lock chain, idle-in-transaction badge, parallel worker collapse), and surface permission/truncation errors clearly.
+- Add **telemetry** counters for PostgreSQL RTA agents (registered, enabled, disabled).
+- Document PostgreSQL RTA in official PMM docs with version matrix (`query_id`, cloud permissions) and known limitations.
+
+## Out of scope
+
+- `EXPLAIN` / execution plan capture in the real-time view (future; may leverage `pg_stat_monitor` separately).
+- `pg_wait_sampling` and `pgsentinel` integration.
+- Cancel / terminate query action from RTA UI.
+- ASH-style persistence for PostgreSQL RTA data.
+- Aurora-specific `aurora_stat_activity` extended view integration.
+- PostgreSQL logical replication lag monitoring in RTA.
+
+## Related work
+
+- Epic: PMM-14550 (MongoDB RTA MVP — reference architecture).
+- Jira: [PMM-15167](https://perconadev.atlassian.net/browse/PMM-15167)
+
+## Phases (delivery)
+
+| Phase | Scope | Done when |
+|-------|-------|-----------|
+| 1 — Agent | Collect from `pg_stat_activity` + `pg_locks` | Agent produces session records with lock chains and idle-in-transaction info; verified on PG 12, 14, 15, 16, and Percona Distribution for PostgreSQL |
+| 2 — Server & API | Extend RealtimeAnalyticsService + Inventory | Server routes PostgreSQL RTA data via existing REST/gRPC API; MongoDB behavior unchanged |
+| 3 — UI | Real-time tab integration | User selects PostgreSQL service and sees live sessions at 1–5s refresh with PG-specific visuals |
+| 4 — Hardening & GA | Tests, docs, cloud variants | Feature enabled for registered PostgreSQL services; integration tests pass; docs published |

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-agent.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-agent.md
@@ -1,0 +1,80 @@
+# PostgreSQL RTA Agent
+
+Capability: pmm-agent collects live PostgreSQL session data and streams it to PMM Server.
+
+## Requirements
+
+### REQ-PG-AGENT-001: Poll active sessions
+
+The RTA PostgreSQL agent SHALL poll `pg_stat_activity` at a configurable interval between 1 and 5 seconds (default 2 seconds) when its session is running.
+
+### REQ-PG-AGENT-002: Exclude idle backends
+
+The agent SHALL include backends in states `active`, `idle in transaction`, and other non-`idle` client backend states. Pure `idle` backends SHALL be excluded unless they are `idle in transaction`.
+
+### REQ-PG-AGENT-003: Collect lock information
+
+The agent SHALL query `pg_locks` (joined with `pg_stat_activity`) on each collection cycle to determine lock contention and build blocker → blocked relationships.
+
+### REQ-PG-AGENT-004: Reuse PostgreSQL credentials
+
+The agent SHALL connect using credentials from the PostgreSQL exporter for the same PMM service unless explicitly overridden in inventory agent configuration.
+
+### REQ-PG-AGENT-005: Permission error handling
+
+When the monitoring user lacks `pg_read_all_stats` (and is not a superuser), the agent SHALL report a structured error with an actionable message rather than returning empty data silently.
+
+### REQ-PG-AGENT-006: Query identification
+
+- On PostgreSQL 14+, the agent SHALL populate `query_id` from `pg_stat_activity.query_id`.
+- On PostgreSQL 12–13, the agent SHALL fall back to a stable query fingerprint hash.
+
+### REQ-PG-AGENT-007: Query text truncation
+
+When query text length equals or exceeds `track_activity_query_size`, the agent SHALL set a truncation flag and include the configured `track_activity_query_size` value in the payload.
+
+### REQ-PG-AGENT-008: Parallel worker metadata
+
+On PostgreSQL 13+, the agent SHALL include `leader_pid` for parallel worker backends.
+
+### REQ-PG-AGENT-009: Performance budget
+
+At a 2-second collect interval with ≤200 active backends, the agent SHALL add less than 1% additional CPU utilization on the PostgreSQL host.
+
+## Scenarios
+
+### Scenario: Active query appears in stream
+
+**GIVEN** a running RTA session for a PostgreSQL service with an active `SELECT` query  
+**WHEN** the agent completes a collection cycle  
+**THEN** a `QueryData` message is emitted with `session_state=active`, non-empty `query_text`, and `query_execution_duration` reflecting elapsed query time
+
+### Scenario: Idle in transaction session
+
+**GIVEN** a backend in state `idle in transaction` with `xact_start` 30 seconds ago  
+**WHEN** the agent collects session data  
+**THEN** the payload includes `session_state=idle in transaction` and duration is computed from `xact_start`, not `query_start`
+
+### Scenario: Lock chain detected
+
+**GIVEN** session A holds a lock and session B is blocked waiting on A  
+**WHEN** the agent collects lock data  
+**THEN** session B's payload includes a lock chain with A as blocker, including A's query text and duration
+
+### Scenario: Missing pg_read_all_stats
+
+**GIVEN** the monitoring user cannot read all rows in `pg_stat_activity`  
+**WHEN** the agent attempts collection  
+**THEN** the agent status reports an error containing guidance to grant `pg_read_all_stats` or use a superuser role
+
+### Scenario: Truncated query text
+
+**GIVEN** `track_activity_query_size=1024` and a query longer than 1024 characters  
+**WHEN** the agent collects the session  
+**THEN** `query_text_truncated=true` and `track_activity_query_size=1024` are set in the payload
+
+### Scenario: Parallel worker grouping metadata
+
+**GIVEN** PostgreSQL 15 with a parallel query where worker PID 12345 has `leader_pid=12340`  
+**WHEN** the agent collects sessions  
+**THEN** the worker record includes `leader_pid=12340` and `backend_pid=12345`

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-server-api.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-server-api.md
@@ -1,0 +1,79 @@
+# PostgreSQL RTA Server & API
+
+Capability: PMM Server registers PostgreSQL RTA agents, accepts streamed session data, and exposes it via RealtimeAnalyticsService.
+
+## Requirements
+
+### REQ-PG-SRV-001: Inventory agent type
+
+PMM SHALL support `rta-postgresql-agent` in the Inventory API with add, change, list, and get operations mirroring `rta-mongodb-agent` (PostgreSQL-appropriate connection fields).
+
+### REQ-PG-SRV-002: Service type mapping
+
+`RealtimeAnalyticsService.ListServices` with `service_type=POSTGRESQL` SHALL return PostgreSQL services eligible for RTA (registered, with running pmm-agent, not already in an active session unless listed as running).
+
+### REQ-PG-SRV-003: Session lifecycle
+
+Starting and stopping RTA sessions for PostgreSQL services SHALL use the same REST/gRPC endpoints as MongoDB (`/v1/realtimeanalytics/sessions:start`, `sessions:stop`, `sessions`, `queries:search`).
+
+### REQ-PG-SRV-004: PostgreSQL query payload
+
+`SearchQueries` responses for PostgreSQL services SHALL include `QueryData.postgres_payload` with session state, wait events, lock chain, and PostgreSQL-specific timestamps.
+
+### REQ-PG-SRV-005: In-memory store
+
+PostgreSQL RTA data SHALL be stored in the existing in-memory TTL store with the same retention semantics as MongoDB RTA (no persistence to ClickHouse).
+
+### REQ-PG-SRV-006: MongoDB compatibility
+
+Existing MongoDB RTA behavior, API contracts, and stored MongoDB payloads SHALL remain unchanged.
+
+### REQ-PG-SRV-007: QAN independence
+
+PostgreSQL RTA SHALL NOT write to ClickHouse or interfere with QAN agents (`pg_stat_statements`, `pg_stat_monitor`) on the same service.
+
+### REQ-PG-SRV-008: Telemetry
+
+PMM SHALL emit telemetry metrics for PostgreSQL RTA agents: total registered, currently enabled (running session), and disabled counts.
+
+### REQ-PG-SRV-009: Access control
+
+Starting and stopping PostgreSQL RTA sessions SHALL require Admin role; viewing live data from running sessions SHALL follow the same role rules as MongoDB RTA.
+
+## Scenarios
+
+### Scenario: List PostgreSQL RTA services
+
+**GIVEN** two registered PostgreSQL services and one without pmm-agent  
+**WHEN** a user calls `ListServices` with `service_type=POSTGRESQL`  
+**THEN** only services with a eligible pmm-agent and no conflicting active session are returned
+
+### Scenario: Start PostgreSQL session
+
+**GIVEN** an Admin user and a registered PostgreSQL service with RTA agent configured  
+**WHEN** the user calls `StartSession` with the service ID  
+**THEN** the RTA agent is enabled, session status is `RUNNING`, and collect interval is applied from agent RTAOptions
+
+### Scenario: Search queries returns PostgreSQL payload
+
+**GIVEN** a running PostgreSQL RTA session with active queries  
+**WHEN** the user calls `SearchQueries` with the service ID  
+**THEN** the response contains `QueryData` entries with populated `postgres_payload` including lock chain when contention exists
+
+### Scenario: Stop session disables agent
+
+**GIVEN** a running PostgreSQL RTA session  
+**WHEN** an Admin calls `StopSession`  
+**THEN** the session status becomes `DOWN`, the agent is disabled, and in-memory queries for that service are evicted per existing TTL rules
+
+### Scenario: MongoDB session unaffected
+
+**GIVEN** an active MongoDB RTA session  
+**WHEN** a PostgreSQL RTA session is started on a different service  
+**THEN** MongoDB `SearchQueries` responses continue to return `mongo_db_payload` without schema or behavior changes
+
+### Scenario: Concurrent QAN collection
+
+**GIVEN** a PostgreSQL service with both QAN (pg_stat_monitor) and RTA agents enabled  
+**WHEN** both agents run for 10 minutes  
+**THEN** QAN continues to receive completed query metrics in ClickHouse and RTA streams live sessions without duplicate or corrupted data

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-ui.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgres-rta-ui.md
@@ -1,0 +1,99 @@
+# PostgreSQL RTA UI
+
+Capability: Query Analytics → Real-time tab displays live PostgreSQL sessions with PostgreSQL-specific diagnostics.
+
+## Requirements
+
+### REQ-PG-UI-001: Service selection
+
+The Real-time tab service selector SHALL list registered PostgreSQL services alongside MongoDB services. Users SHALL start RTA sessions for PostgreSQL without navigating to a new page.
+
+### REQ-PG-UI-002: Live refresh
+
+The overview table SHALL refresh at the user-selected auto-refresh interval (1–5 seconds, default 2 seconds) with end-to-end latency ≤5 seconds.
+
+### REQ-PG-UI-003: Overview columns
+
+For PostgreSQL sessions, the overview table SHALL display at minimum: session state, database, username/application, wait event (type + name), elapsed duration, and query text.
+
+### REQ-PG-UI-004: Lock chain panel
+
+The Details pane SHALL include a lock chain visualization showing blocker → blocked relationships with query text and duration for each link in the chain.
+
+### REQ-PG-UI-005: Idle in transaction
+
+Sessions in state `idle in transaction` SHALL be visually distinguished (badge or row styling) and SHALL display transaction duration derived from `xact_start`, not query duration.
+
+### REQ-PG-UI-006: Parallel workers
+
+On PostgreSQL 13+, parallel worker sessions (where `leader_pid` is set) SHALL be collapsed under their leader row by default with an expand control to show workers.
+
+### REQ-PG-UI-007: Truncated query indicator
+
+When `query_text_truncated` is true, the UI SHALL indicate truncation (icon or label) and show a tooltip explaining `track_activity_query_size` and that increasing it requires a PostgreSQL server restart.
+
+### REQ-PG-UI-008: Permission error
+
+When the agent reports missing `pg_read_all_stats`, the UI SHALL display a specific actionable error message instead of an empty table or generic failure.
+
+### REQ-PG-UI-009: Raw data tab
+
+The Raw data tab SHALL show the full JSON snapshot from the agent (pg_stat_activity and lock fields) for troubleshooting.
+
+### REQ-PG-UI-010: MongoDB parity features
+
+PostgreSQL RTA SHALL support the same pause/resume, share link, multi-session, and session management flows as MongoDB RTA.
+
+### REQ-PG-UI-011: No regression
+
+Existing MongoDB RTA UI behavior and styling SHALL remain unchanged when no PostgreSQL services are present.
+
+## Scenarios
+
+### Scenario: Start PostgreSQL RTA from Real-time tab
+
+**GIVEN** an Admin on Query Analytics → Real-time with no active sessions  
+**WHEN** they select a PostgreSQL service and click Start session  
+**THEN** the live operations table appears and begins auto-refreshing with PostgreSQL session rows
+
+### Scenario: View lock chain in Details
+
+**GIVEN** a PostgreSQL session blocked by another backend  
+**WHEN** the user clicks the blocked session row and opens Details  
+**THEN** the lock chain panel shows the blocker PID, blocker query text, blocker duration, and lock mode
+
+### Scenario: Idle in transaction badge
+
+**GIVEN** a session in state `idle in transaction` running for 45 seconds  
+**WHEN** displayed in the overview table  
+**THEN** the row shows an idle-in-transaction indicator and duration of 45s based on transaction start time
+
+### Scenario: Expand parallel workers
+
+**GIVEN** a parallel query leader with two worker backends  
+**WHEN** the overview table renders  
+**THEN** workers are hidden under the collapsed leader row; clicking expand reveals worker rows with their PIDs and wait events
+
+### Scenario: Truncated query tooltip
+
+**GIVEN** a query with `query_text_truncated=true` and `track_activity_query_size=1024`  
+**WHEN** the user hovers the truncation indicator  
+**THEN** a tooltip explains the query was truncated at 1024 bytes and increasing `track_activity_query_size` requires a server restart
+
+### Scenario: Permission error displayed
+
+**GIVEN** the RTA agent reports insufficient privileges for pg_stat_activity  
+**WHEN** the Real-time page loads  
+**THEN** an error banner explains that `pg_read_all_stats` (or superuser) is required with a link to documentation
+
+### Scenario: Pause preserves PostgreSQL view
+
+**GIVEN** an active PostgreSQL RTA session with auto-refresh enabled  
+**WHEN** the user clicks Pause  
+**THEN** the table freezes on the current snapshot while the agent continues collecting in the background
+
+### Scenario: Share link with PostgreSQL filter
+
+**GIVEN** a user viewing PostgreSQL service X in RTA overview  
+**WHEN** they click Share  
+**THEN** the copied URL includes the service filter and opens Real-time with PostgreSQL service X selected

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
@@ -4,39 +4,39 @@ Check off items as implemented. Phases align with Jira epic delivery order.
 
 ## Phase 1 — PostgreSQL RTA Agent
 
-- [ ] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
-- [ ] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
-- [ ] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
-- [ ] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
-- [ ] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
-- [ ] 1.6 Detect query text truncation vs track_activity_query_size
-- [ ] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
-- [ ] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
-- [ ] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
+- [x] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
+- [x] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
+- [x] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
+- [x] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
+- [x] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
+- [x] 1.6 Detect query text truncation vs track_activity_query_size
+- [x] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
+- [x] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
+- [x] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
 
 ## Phase 2 — Server-Side & API Extension
 
-- [ ] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
-- [ ] 2.2 Extend ListServicesResponse with postgresql services
-- [ ] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
-- [ ] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
-- [ ] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
-- [ ] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
-- [ ] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
+- [x] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
+- [x] 2.2 Extend ListServicesResponse with postgresql services
+- [x] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
+- [x] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
+- [x] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
+- [x] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
+- [x] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
 - [ ] 2.8 Integration tests: start session, collect queries, stop session for PostgreSQL
 - [ ] 2.9 Verify MongoDB RTA regression tests still pass
 
 ## Phase 3 — UI Integration
 
-- [ ] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
-- [ ] 3.2 Include PostgreSQL services in Real-time service selector and session modal
-- [ ] 3.3 Overview table: PostgreSQL columns (state, wait event, DB, duration, query)
-- [ ] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
-- [ ] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
-- [ ] 3.6 Collapse parallel workers under leader by default (PG 13+)
-- [ ] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
-- [ ] 3.8 Permission error banner when pg_read_all_stats missing
-- [ ] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
+- [x] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
+- [x] 3.2 Include PostgreSQL services in Real-time service selector and session modal
+- [x] 3.3 Overview table: PostgreSQL columns (state, wait event, DB, duration, query)
+- [x] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
+- [x] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
+- [x] 3.6 Collapse parallel workers under leader by default (PG 13+)
+- [x] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
+- [x] 3.8 Permission error banner when pg_read_all_stats missing
+- [x] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
 - [ ] 3.10 Component tests for PostgreSQL-specific rendering
 
 ## Phase 4 — Testing, Hardening & GA

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
@@ -1,0 +1,65 @@
+# Tasks
+
+Check off items as implemented. Phases align with Jira epic delivery order.
+
+## Phase 1 — PostgreSQL RTA Agent
+
+- [ ] 1.1 Add `RTAPostgreSQLAgentType` to inventory protobuf and `managed/models`
+- [ ] 1.2 Implement `agent/agents/postgres/realtimeanalytics` collector (pg_stat_activity + pg_locks)
+- [ ] 1.3 Build lock chain graph from pg_locks (blocker → blocked with query text and duration)
+- [ ] 1.4 Map session fields: state, wait events, xact_start vs query_start, leader_pid
+- [ ] 1.5 Populate query_id on PG 14+; fingerprint fallback on PG 12–13
+- [ ] 1.6 Detect query text truncation vs track_activity_query_size
+- [ ] 1.7 Return actionable error when monitoring user lacks pg_read_all_stats
+- [ ] 1.8 Wire agent into pmm-agent SetState / QANCollect-equivalent RTA stream
+- [ ] 1.9 Unit tests: lock chain builder, state mapping, truncation detection, permission error
+
+## Phase 2 — Server-Side & API Extension
+
+- [ ] 2.1 Add QueryPostgreSQLData and LockChainLink to query.proto; regenerate stubs
+- [ ] 2.2 Extend ListServicesResponse with postgresql services
+- [ ] 2.3 Implement AddRTAPostgreSQLAgent / ChangeRTAPostgreSQLAgent in inventory service
+- [ ] 2.4 Extend realtimeanalytics service dispatch for PostgreSQLServiceType
+- [ ] 2.5 Store and serve PostgreSQL QueryData via existing in-memory TTL store
+- [ ] 2.6 Add PostgreSQL RTA telemetry metrics (registered, enabled, disabled counts)
+- [ ] 2.7 Optional: auto-register RTA agent when adding PostgreSQL service (mirror MongoDB flag)
+- [ ] 2.8 Integration tests: start session, collect queries, stop session for PostgreSQL
+- [ ] 2.9 Verify MongoDB RTA regression tests still pass
+
+## Phase 3 — UI Integration
+
+- [ ] 3.1 Extend rta.types.ts and API client for PostgreSQL payload and services list
+- [ ] 3.2 Include PostgreSQL services in Real-time service selector and session modal
+- [ ] 3.3 Overview table: PostgreSQL columns (state, wait event, DB, duration, query)
+- [ ] 3.4 Details pane: lock chain panel (blocker → blocked with query + duration)
+- [ ] 3.5 Visual distinction for idle in transaction (transaction duration, badge)
+- [ ] 3.6 Collapse parallel workers under leader by default (PG 13+)
+- [ ] 3.7 Truncated query tooltip (track_activity_query_size + restart note)
+- [ ] 3.8 Permission error banner when pg_read_all_stats missing
+- [ ] 3.9 Raw data tab shows full pg_stat_activity / lock JSON snapshot
+- [ ] 3.10 Component tests for PostgreSQL-specific rendering
+
+## Phase 4 — Testing, Hardening & GA
+
+- [ ] 4.1 Benchmark agent CPU overhead at 2s interval (≤200 backends, <1% target)
+- [ ] 4.2 Verify QAN (pg_stat_statements + pg_stat_monitor) unaffected on same instance
+- [ ] 4.3 Test matrix: PG 12, 14, 15, 16; Percona Distribution; RDS; Aurora; Cloud SQL; Azure
+- [ ] 4.4 Update QAN-realtime-analytics.md (PostgreSQL section, remove MongoDB-only warning)
+- [ ] 4.5 Document cloud permission setup and query_id version matrix
+- [ ] 4.6 pmm-qa Playwright scenarios for PostgreSQL RTA happy path and error states
+- [ ] 4.7 Enable feature by default for registered PostgreSQL services (or document opt-in if required)
+
+## Verification checklist (acceptance criteria mapping)
+
+- [ ] AC-1: PostgreSQL service selectable; sessions refresh ≤5s
+- [ ] AC-2: RTA + QAN coexist without conflict on same instance
+- [ ] AC-3: Works on PG 12+, Percona Distribution, RDS, Aurora, Cloud SQL, Azure
+- [ ] AC-4: Lock chain panel shows blocker → blocked with query text and duration
+- [ ] AC-5: idle in transaction visually distinct; shows transaction duration
+- [ ] AC-6: Parallel workers collapsed under leader (PG 13+)
+- [ ] AC-7: query_id on PG 14+; fingerprint fallback on 12–13
+- [ ] AC-8: Truncated query text indicated with tooltip
+- [ ] AC-9: Missing pg_read_all_stats shows actionable error
+- [ ] AC-10: No regressions in MongoDB RTA or PostgreSQL QAN
+- [ ] AC-11: <1% CPU overhead at 2s polling (≤200 backends)
+- [ ] AC-12: Official docs updated with version matrix and cloud permissions

--- a/ui/apps/pmm/src/pages/rta/messages.ts
+++ b/ui/apps/pmm/src/pages/rta/messages.ts
@@ -1,4 +1,4 @@
 export const Messages = {
   disclaimer:
-    'Currently available for MongoDB only connected through PMM Client 3.7.0 or newer. More databases coming soon.',
+    'Available for MongoDB and PostgreSQL services connected through PMM Client 3.7.0 or newer.',
 };

--- a/ui/apps/pmm/src/pages/rta/overview/RealtimeOverview.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/RealtimeOverview.tsx
@@ -1,4 +1,4 @@
-import { FC, useRef, useState } from 'react';
+import { FC, useMemo, useRef, useState } from 'react';
 import {
   Navigate,
   Link as RouterLink,
@@ -8,11 +8,13 @@ import { RealtimePage } from '../components/rta-page';
 import { useRealtimeQueries, useRealtimeSessions } from 'hooks/api/useRealtime';
 import OverviewTable from './table/OverviewTable';
 import { DetailsPane } from './details-pane';
-import { QueryData } from 'types/rta.types';
+import { QueryData, RealtimeSessionStatus } from 'types/rta.types';
 import { Icon } from 'components/icon';
 import { Messages } from './RealtimeOverview.messages';
+import { PG_READ_ALL_STATS_ERROR } from './table/OverviewTable.utils';
 import { createRealtimeSessionsUrl } from 'utils/link.utils';
 import Stack from '@mui/material/Stack';
+import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 import { ServicesAutocompleteInput } from '../components/services-autocomplete-input';
 import { AutoRefreshSelect } from './auto-refresh-select';
@@ -38,6 +40,16 @@ const RealtimeOverviewPage: FC = () => {
   // We need to store the previous fetching state to restore it when the details pane is closed
   const previousFetchingState = useRef<boolean>(fetching);
   const { data: sessions = [], isLoading } = useRealtimeSessions();
+
+  const errorSessions = useMemo(
+    () =>
+      sessions.filter(
+        (session) =>
+          serviceIds.includes(session.serviceId) &&
+          session.status === RealtimeSessionStatus.error
+      ),
+    [serviceIds, sessions]
+  );
 
   const selectedQueryIndex = selectedQuery
     ? navigableQueries.findIndex(
@@ -95,6 +107,11 @@ const RealtimeOverviewPage: FC = () => {
 
   return (
     <RealtimePage>
+      {errorSessions.length > 0 && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {PG_READ_ALL_STATS_ERROR}
+        </Alert>
+      )}
       <OverviewTable
         queries={tableQueries}
         onQuerySelected={handleQuerySelected}

--- a/ui/apps/pmm/src/pages/rta/overview/details-pane/QueryAndDetails.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/details-pane/QueryAndDetails.tsx
@@ -1,9 +1,13 @@
 import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import Tooltip from '@mui/material/Tooltip';
 import { FC } from 'react';
 import { format, formatDuration } from 'date-fns';
 import { tz } from '@date-fns/tz';
 import { SyntaxHighlighter } from 'components/syntax-highlighter';
-import { QueryData } from 'types/rta.types';
+import { isPostgresQuery, QueryData } from 'types/rta.types';
 import DetailsMetric from './DetailsMetric';
 import BigNumberMetric from './BigNumberMetric';
 import { Messages } from './QueryAndDetails.messages';
@@ -20,43 +24,160 @@ const GridItem = ({ children }: { children: React.ReactNode }) => (
   </Grid>
 );
 
-const QueryAndDetails: FC<Props> = ({
-  queryData: {
+const formatElapsed = (queryExecutionDurationMs?: number | null) => {
+  if (!queryExecutionDurationMs) {
+    return { mainText: undefined, subText: undefined };
+  }
+
+  const formatted = formatDuration(
+    { seconds: queryExecutionDurationMs },
+    { format: ['seconds'] }
+  );
+  const parts = formatted.split(' ');
+
+  return {
+    mainText: parts.length > 1 ? parts[0] : undefined,
+    subText: parts.length > 1 ? parts[1] : undefined,
+  };
+};
+
+const PostgresDetails: FC<Props> = ({ queryData }) => {
+  const { user } = useUser();
+  const timezone = user?.preferences?.timezone || 'UTC';
+  const payload = queryData.postgresPayload!;
+  const elapsed = formatElapsed(queryData.queryExecutionDurationMs);
+  const isIdleInTransaction = payload.sessionState === 'idle in transaction';
+
+  return (
+    <Grid container spacing={3}>
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Grid container spacing={3}>
+          <GridItem>
+            <DetailsMetric title="Session state" tooltip="PostgreSQL backend state">
+              <Stack direction="row" spacing={1} alignItems="center">
+                <BigNumberMetric mainText={payload.sessionState} dataTestId="session-state-value" />
+                {isIdleInTransaction && (
+                  <Chip label="idle in transaction" color="warning" size="small" />
+                )}
+              </Stack>
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.operationId} tooltip={Messages.tooltips.operationId}>
+              <BigNumberMetric mainText={queryData.queryId} dataTestId="operation-id-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.elapsedExecTime} tooltip={Messages.tooltips.elapsedExecTime}>
+              <BigNumberMetric {...elapsed} dataTestId="elapsed-time-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title="Wait event" tooltip="PostgreSQL wait event type and name">
+              <BigNumberMetric
+                mainText={[payload.waitEventType, payload.waitEvent].filter(Boolean).join(' / ') || undefined}
+                dataTestId="wait-event-value"
+              />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.databaseName} tooltip={Messages.tooltips.databaseName}>
+              <BigNumberMetric mainText={payload.databaseName} size="small" dataTestId="database-name-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.username} tooltip={Messages.tooltips.username}>
+              <BigNumberMetric mainText={payload.username} size="small" dataTestId="username-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.clientAppName} tooltip={Messages.tooltips.clientAppName}>
+              <BigNumberMetric mainText={payload.applicationName} size="small" dataTestId="client-app-name-value" />
+            </DetailsMetric>
+          </GridItem>
+          <GridItem>
+            <DetailsMetric title={Messages.titles.clientAddress} tooltip={Messages.tooltips.clientAddress}>
+              <BigNumberMetric mainText={queryData.clientAddress} size="small" dataTestId="client-address-value" />
+            </DetailsMetric>
+          </GridItem>
+          {payload.lockChain && payload.lockChain.length > 0 && (
+            <Grid size={{ xs: 12 }}>
+              <DetailsMetric title="Lock chain" tooltip="Blocker to blocked lock relationships">
+                <Stack spacing={1}>
+                  {payload.lockChain.map((link, index) => (
+                    <Typography key={`${link.blockerPid}-${index}`} variant="body2">
+                      PID {link.blockerPid} blocks {link.blockedPid} ({link.lockMode}
+                      {link.relationName ? ` on ${link.relationName}` : ''})
+                      {link.blockerQueryText ? `: ${link.blockerQueryText}` : ''}
+                    </Typography>
+                  ))}
+                </Stack>
+              </DetailsMetric>
+            </Grid>
+          )}
+          <GridItem>
+            <DetailsMetric title={Messages.titles.dataCaptureTime} tooltip={Messages.tooltips.dataCaptureTime}>
+              <BigNumberMetric
+                mainText={format(new Date(queryData.queryCollectTime), TIME_FORMAT, { in: tz(timezone) })}
+                size="small"
+                dataTestId="data-capture-time-value"
+              />
+            </DetailsMetric>
+          </GridItem>
+        </Grid>
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }} sx={{ maxHeight: '70vh', overflow: 'auto' }}>
+        {payload.queryTextTruncated && (
+          <Tooltip
+            title={`Query text truncated at ${payload.trackActivityQuerySize} bytes. Increase track_activity_query_size and restart PostgreSQL to capture longer queries.`}
+          >
+            <Chip label="Truncated query" color="warning" size="small" sx={{ mb: 1 }} />
+          </Tooltip>
+        )}
+        <SyntaxHighlighter language="sql" showLineNumbers showCopyButton content={queryData.queryText} />
+      </Grid>
+    </Grid>
+  );
+};
+
+const QueryAndDetails: FC<Props> = ({ queryData }) => {
+  if (isPostgresQuery(queryData)) {
+    return <PostgresDetails queryData={queryData} />;
+  }
+
+  const {
     queryText,
     queryId,
     queryExecutionDurationMs,
     queryCollectTime,
     serviceName,
     clientAddress,
-    mongoDbPayload: {
-      planSummary,
-      databaseName,
-      collection,
-      operation,
-      username,
-      dbInstanceAddress,
-      clientAppName,
-      operationStartTime,
+    mongoDbPayload = {
+      planSummary: '',
+      databaseName: '',
+      collection: '',
+      operation: '',
+      username: '',
+      dbInstanceAddress: '',
+      clientAppName: '',
+      operationStartTime: '',
     },
-  },
-}) => {
+  } = queryData;
+
+  const {
+    planSummary,
+    databaseName,
+    collection,
+    operation,
+    username,
+    dbInstanceAddress,
+    clientAppName,
+    operationStartTime,
+  } = mongoDbPayload;
+
   const { user } = useUser();
   const timezone = user?.preferences?.timezone || 'UTC';
-
-  const formattedQueryExecutionDuration = queryExecutionDurationMs
-    ? formatDuration(
-        {
-          seconds: queryExecutionDurationMs,
-        },
-        {
-          format: ['seconds'],
-        }
-      )
-    : '';
-
-  const formattedQueryExecutionDurationParts = formattedQueryExecutionDuration
-    ? formattedQueryExecutionDuration.split(' ')
-    : [];
+  const elapsed = formatElapsed(queryExecutionDurationMs);
 
   return (
     <Grid container spacing={3}>
@@ -67,10 +188,7 @@ const QueryAndDetails: FC<Props> = ({
               title={Messages.titles.operationId}
               tooltip={Messages.tooltips.operationId}
             >
-              <BigNumberMetric
-                mainText={queryId}
-                dataTestId="operation-id-value"
-              />
+              <BigNumberMetric mainText={queryId} dataTestId="operation-id-value" />
             </DetailsMetric>
           </GridItem>
           <GridItem>
@@ -78,19 +196,7 @@ const QueryAndDetails: FC<Props> = ({
               title={Messages.titles.elapsedExecTime}
               tooltip={Messages.tooltips.elapsedExecTime}
             >
-              <BigNumberMetric
-                mainText={
-                  formattedQueryExecutionDurationParts.length > 1
-                    ? formattedQueryExecutionDurationParts[0]
-                    : undefined
-                }
-                subText={
-                  formattedQueryExecutionDurationParts.length > 1
-                    ? formattedQueryExecutionDurationParts[1]
-                    : undefined
-                }
-                dataTestId="elapsed-time-value"
-              />
+              <BigNumberMetric {...elapsed} dataTestId="elapsed-time-value" />
             </DetailsMetric>
           </GridItem>
           <GridItem>

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.constants.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.constants.tsx
@@ -1,12 +1,29 @@
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import Tooltip from '@mui/material/Tooltip';
 import { type MRT_ColumnDef } from 'material-react-table';
+import { formatDuration } from 'date-fns';
 
-import { QueryData } from 'types/rta.types';
+import UnavailableText from 'components/unavailable-text';
+import { isPostgresQuery, QueryData } from 'types/rta.types';
 import { Messages } from './OverviewTable.messages';
 import { QueryCell } from './query-cell';
-import { formatDuration } from 'date-fns';
-import UnavailableText from 'components/unavailable-text';
 
-export const OVERVIEW_TABLE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
+const elapsedCell = ({ cell }: { cell: { getValue: () => unknown } }) =>
+  cell.getValue() ? (
+    `${formatDuration(
+      {
+        seconds: cell.getValue<number>(),
+      },
+      {
+        format: ['seconds'],
+      }
+    )}`
+  ) : (
+    <UnavailableText />
+  );
+
+const BASE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
   {
     size: 500,
     header: Messages.columns.queryText,
@@ -44,22 +61,73 @@ export const OVERVIEW_TABLE_COLUMNS: MRT_ColumnDef<QueryData>[] = [
     muiTableHeadCellFilterTextFieldProps: {
       inputProps: { step: 0.25, type: 'number' },
     },
-    Cell: ({ cell }) =>
-      cell.getValue() ? (
-        `${formatDuration(
-          {
-            seconds: cell.getValue<number>(),
-          },
-          {
-            format: ['seconds'],
-          }
-        )}`
-      ) : (
-        <UnavailableText />
-      ),
+    Cell: elapsedCell,
     // @ts-expect-error - muiTableBodyCellProps is not typed correctly
     muiTableBodyCellProps: ({ row }) => ({
       'data-testid': `query-${row.original.queryId}-elapsed-time-cell`,
     }),
   },
 ];
+
+const POSTGRES_COLUMNS: MRT_ColumnDef<QueryData>[] = [
+  {
+    header: Messages.columns.sessionState,
+    id: 'sessionState',
+    accessorFn: (row) => row.postgresPayload?.sessionState ?? '',
+    Cell: ({ row }) => {
+      const payload = row.original.postgresPayload;
+      if (!payload) {
+        return <UnavailableText />;
+      }
+
+      const isIdleInTransaction = payload.sessionState === 'idle in transaction';
+
+      return (
+        <Stack direction="row" spacing={0.5} alignItems="center">
+          <span>{payload.sessionState}</span>
+          {isIdleInTransaction && (
+            <Chip label="idle in tx" color="warning" size="small" variant="outlined" />
+          )}
+          {(payload.parallelWorkerCount ?? 0) > 0 && (
+            <Tooltip title={`${payload.parallelWorkerCount} parallel worker(s) hidden`}>
+              <Chip
+                label={`+${payload.parallelWorkerCount} workers`}
+                size="small"
+                variant="outlined"
+              />
+            </Tooltip>
+          )}
+        </Stack>
+      );
+    },
+  },
+  {
+    header: Messages.columns.database,
+    id: 'databaseName',
+    accessorFn: (row) => row.postgresPayload?.databaseName ?? '',
+  },
+  {
+    header: Messages.columns.waitEvent,
+    id: 'waitEvent',
+    accessorFn: (row) => {
+      const payload = row.postgresPayload;
+      if (!payload) {
+        return '';
+      }
+
+      return [payload.waitEventType, payload.waitEvent].filter(Boolean).join(' / ');
+    },
+  },
+];
+
+export const getOverviewTableColumns = (
+  queries: QueryData[]
+): MRT_ColumnDef<QueryData>[] => {
+  if (!queries.some(isPostgresQuery)) {
+    return BASE_COLUMNS;
+  }
+
+  const [queryText, host, operationId, elapsedTime] = BASE_COLUMNS;
+
+  return [queryText, host, ...POSTGRES_COLUMNS, operationId, elapsedTime];
+};

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.messages.ts
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.messages.ts
@@ -4,6 +4,9 @@ export const Messages = {
     host: 'Host',
     operationId: 'Operation ID',
     elapsedTime: 'Elapsed time',
+    sessionState: 'State',
+    database: 'Database',
+    waitEvent: 'Wait event',
   },
   actions: {
     openDetails: 'Open query details',

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.tsx
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.tsx
@@ -8,11 +8,11 @@ import {
 import { Table } from '@percona/percona-ui';
 import { FC, useCallback, useEffect, useRef, useState } from 'react';
 import { QueryData } from 'types/rta.types';
-import { OVERVIEW_TABLE_COLUMNS } from './OverviewTable.constants';
+import { getOverviewTableColumns } from './OverviewTable.constants';
 import { RealtimeTableWrapper } from 'pages/rta/components/rta-table-wrapper';
 import { boxClasses } from '@mui/material/Box';
 import { Messages } from './OverviewTable.messages';
-import { filterElapsedTime } from './OverviewTable.utils';
+import { filterElapsedTime, prepareOverviewQueries } from './OverviewTable.utils';
 
 interface Props {
   queries: QueryData[];
@@ -29,6 +29,8 @@ const OverviewTable: FC<Props> = ({
   actions,
   onRowHover,
 }) => {
+  const tableQueries = prepareOverviewQueries(queries);
+  const columns = getOverviewTableColumns(tableQueries);
   const tableRef = useRef<MRT_TableInstance<QueryData> | null>(null);
   // Controlled table state is required to read the filtered/sorted row model via tableInstanceRef.
   const [columnFilters, setColumnFilters] = useState<MRT_ColumnFiltersState>([]);
@@ -38,8 +40,8 @@ const OverviewTable: FC<Props> = ({
   const getNavigableQueries = useCallback(
     () =>
       tableRef.current?.getPrePaginationRowModel().rows.map((row) => row.original) ??
-      queries,
-    [queries]
+      tableQueries,
+    [tableQueries]
   );
 
   const syncNavigableQueries = useCallback(() => {
@@ -60,8 +62,8 @@ const OverviewTable: FC<Props> = ({
             pageIndex: 0,
           },
         }}
-        columns={OVERVIEW_TABLE_COLUMNS}
-        data={queries}
+        columns={columns}
+        data={tableQueries}
         noDataMessage={Messages.noData}
         muiTopToolbarProps={{
           sx: {

--- a/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.utils.ts
+++ b/ui/apps/pmm/src/pages/rta/overview/table/OverviewTable.utils.ts
@@ -1,5 +1,5 @@
 import { type MRT_Row } from 'material-react-table';
-import { QueryData } from 'types/rta.types';
+import { isPostgresQuery, QueryData } from 'types/rta.types';
 
 export const filterElapsedTime = (
   row: MRT_Row<QueryData>,
@@ -20,3 +20,40 @@ export const filterElapsedTime = (
 
   return valueSeconds >= parseFloat(min) && valueSeconds <= parseFloat(max);
 };
+
+export const hasPostgresQueries = (queries: QueryData[]): boolean =>
+  queries.some(isPostgresQuery);
+
+/** Hide parallel workers; attach worker count to leader rows for PG 13+. */
+export const prepareOverviewQueries = (queries: QueryData[]): QueryData[] => {
+  const workersByLeader = new Map<number, number>();
+
+  for (const query of queries) {
+    const leaderPid = query.postgresPayload?.leaderPid ?? 0;
+    if (leaderPid > 0) {
+      workersByLeader.set(leaderPid, (workersByLeader.get(leaderPid) ?? 0) + 1);
+    }
+  }
+
+  return queries
+    .filter((query) => (query.postgresPayload?.leaderPid ?? 0) === 0)
+    .map((query) => {
+      const backendPid = query.postgresPayload?.backendPid ?? 0;
+      const workerCount = backendPid > 0 ? workersByLeader.get(backendPid) : undefined;
+
+      if (!workerCount) {
+        return query;
+      }
+
+      return {
+        ...query,
+        postgresPayload: {
+          ...query.postgresPayload!,
+          parallelWorkerCount: workerCount,
+        },
+      };
+    });
+};
+
+export const PG_READ_ALL_STATS_ERROR =
+  'Monitoring user lacks pg_read_all_stats role. Grant pg_read_all_stats or use a superuser account for full pg_stat_activity visibility.';

--- a/ui/apps/pmm/src/pages/rta/selection/RealtimeSelection.tsx
+++ b/ui/apps/pmm/src/pages/rta/selection/RealtimeSelection.tsx
@@ -23,7 +23,10 @@ export const RealtimeSelection: FC = () => {
   const { user } = useUser();
   const navigate = useNavigate();
   // TODO: Add other service types when available
-  const { isLoading } = useAvailableServices([ServiceType.mongodb]);
+  const { isLoading } = useAvailableServices([
+    ServiceType.mongodb,
+    ServiceType.postgresql,
+  ]);
   const { data: sessions, isLoading: isLoadingSessions } =
     useRealtimeSessions();
 

--- a/ui/apps/pmm/src/types/rta.types.ts
+++ b/ui/apps/pmm/src/types/rta.types.ts
@@ -40,21 +40,14 @@ export interface SearchQueriesResponse {
   queries: RawQueryData[];
 }
 
-export interface RawQueryData {
-  serviceId: string;
-  serviceName: string;
-  queryId: string;
-  queryText: string;
-  queryExecutionDuration?: string | null;
-  queryCollectTime: string;
-  clientAddress: string;
-  queryRawJson: string;
-  mongoDbPayload: QueryMongoDBData;
+export interface LockChainLink {
+  blockerPid: number;
+  blockedPid: number;
+  lockMode: string;
+  relationName: string;
+  blockerQueryText: string;
+  blockerDuration?: string | null;
 }
-
-export type QueryData = Exclude<RawQueryData, 'queryExecutionDuration'> & {
-  queryExecutionDurationMs?: number | null;
-};
 
 export interface QueryMongoDBData {
   dbInstanceAddress: string;
@@ -67,7 +60,49 @@ export interface QueryMongoDBData {
   collection?: string;
 }
 
-// TODO: Add other service types when available
+export interface QueryPostgreSQLData {
+  dbInstanceAddress: string;
+  databaseName: string;
+  username: string;
+  applicationName: string;
+  sessionState: string;
+  transactionStartTime?: string;
+  queryStartTime?: string;
+  waitEventType: string;
+  waitEvent: string;
+  backendPid: number;
+  leaderPid: number;
+  queryTextTruncated: boolean;
+  trackActivityQuerySize: number;
+  lockChain?: LockChainLink[];
+  /** UI-only: number of parallel workers collapsed under this leader row. */
+  parallelWorkerCount?: number;
+}
+
+export interface RawQueryData {
+  serviceId: string;
+  serviceName: string;
+  queryId: string;
+  queryText: string;
+  queryExecutionDuration?: string | null;
+  queryCollectTime: string;
+  clientAddress: string;
+  queryRawJson: string;
+  mongoDbPayload?: QueryMongoDBData;
+  postgresPayload?: QueryPostgreSQLData;
+}
+
+export type QueryData = Exclude<RawQueryData, 'queryExecutionDuration'> & {
+  queryExecutionDurationMs?: number | null;
+};
+
 export interface AvailableServicesResponse {
   mongodb: VersionedService[];
+  postgresql: VersionedService[];
 }
+
+export const isPostgresQuery = (query: QueryData): boolean =>
+  !!query.postgresPayload && Object.keys(query.postgresPayload).length > 0;
+
+export const isMongoQuery = (query: QueryData): boolean =>
+  !!query.mongoDbPayload && Object.keys(query.mongoDbPayload).length > 0;

--- a/version/features.go
+++ b/version/features.go
@@ -33,6 +33,7 @@ var (
 	MysqlExporterPluginCollector  FeatureVersion = V2_36_0
 	NomadAgentSupportVersion      FeatureVersion = V3_2_0
 	MongoDBRtaAgentSupportVersion FeatureVersion = V3_7_0
+	PostgreSQLRtaAgentSupportVersion FeatureVersion = V3_7_0
 )
 
 // IsFeatureSupported checks if the feature is supported by the version.


### PR DESCRIPTION
## Summary

OpenSpec proposal for **PMM-15167: [RTA] Real-Time Query Analytics for PostgreSQL**.

Extends the existing MongoDB RTA architecture to PostgreSQL with a dedicated `rta-postgresql-agent`, server/API protobuf extensions, and UI integration under Query Analytics → Real-time.

## OpenSpec

- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/` (agent, server-api, ui)

## Test plan

- [ ] Review proposal, design, and capability specs against Jira acceptance criteria
- [ ] Confirm scope boundaries (out of scope: EXPLAIN, pg_wait_sampling, cancel/terminate, ASH persistence)
- [ ] Approve spec before `/opsx:apply` implementation phase


Made with [Cursor](https://cursor.com)