### PR TITLE
PMM-14766 Add email to Maintainer field to fix pmm-client Resolute build

### DIFF
--- a/build/packages/deb/control
+++ b/build/packages/deb/control
@@ -1,7 +1,7 @@
 Source: pmm-client
 Section: utils
 Priority: optional
-Maintainer: Percona LLC
+Maintainer: Percona LLC <info@percona.com>
 Version: %{version}
 Homepage: https://percona.com
 Build-Depends: debhelper


### PR DESCRIPTION
Ticket number: PMM-14766

Feature build: SUBMODULES-4437

---

Fix `dpkg-source` Maintainer parse error on `Ubuntu Resolute`. After merging the changes to build `pmm-client` for `Ubuntu Resolute`, the deb build started failing with:
**_[2026-06-26T08:18:05.786Z] dpkg-source: error: cannot parse Maintainer field value "Percona LLC"_**

A Debian `Maintainer:` field must be in the form `Name <email>`. The current value is just `Percona LLC`, with no `<...@...>` part. The newer `dpkg` toolchain on `Ubuntu Resolute` treats this as a hard error.