### PR TITLE
PMM-15167: Real-Time Query Analytics for PostgreSQL

### DIFF
--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md
@@ -1,0 +1,86 @@
+# Design
+
+## Approach
+
+Extend the proven MongoDB RTA architecture to PostgreSQL. The data path mirrors the existing pipeline:
+
+```
+pmm-agent (RTAPostgreSQLAgent)
+  → polls pg_stat_activity + pg_locks every collect_interval (1–5s)
+  → builds rtav1.QueryData with QueryPostgreSQLData payload
+  → RTAChannel (gRPC client stream)
+    → pmm-managed RealtimeAnalyticsService (CollectorService.Collect)
+      → in-memory TTL Store
+        → REST/gRPC SearchQueries, ListServices, session management
+          → PMM UI Real-Time tab
+```
+
+### Phase 1 — PostgreSQL RTA Agent (`agent/`)
+
+- New package: `agent/agents/postgresql/realtimeanalytics/` following the MongoDB agent pattern (`mongodb/realtimeanalytics/mongodb.go`).
+- Poll query joins `pg_stat_activity` with `pg_locks` to produce session records including:
+  - Session state, wait event type/class, query text, backend type
+  - Lock chain (blocker → blocked) with query text and duration per link
+  - Idle-in-transaction detection with transaction duration (distinct from query duration)
+  - Parallel worker grouping under leader (PostgreSQL 13+)
+  - `query_id` on PG 14+; fingerprint fallback on PG 12–13
+- Reuse existing PostgreSQL connection helpers from QAN agents where applicable.
+- Register agent in supervisor (`agent/agents/supervisor/supervisor.go`) and wire through `agent/client`.
+- Required PostgreSQL privileges: `pg_read_all_stats` (or superuser). Surface actionable error when missing.
+
+### Phase 2 — Server-Side & API (`managed/`, `api/`)
+
+- **Protobuf** (`api/realtimeanalytics/v1/`):
+  - Add `QueryPostgreSQLData` message with PostgreSQL-specific fields (state, wait_event, lock_chain, backend_type, database, user, transaction_duration, is_idle_in_transaction, leader_pid, query_truncated).
+  - Extend `QueryData.payload` oneof with `postgresql_payload`.
+  - Extend `ListServicesResponse` with `repeated inventory.v1.PostgreSQLService postgresql`.
+- **Inventory API** (`api/inventory/v1/agents.proto`):
+  - Add `RTAPostgreSQLAgent` agent type, add/change/get/list handlers mirroring `RTAMongoDBAgent`.
+- **Models** (`managed/models/`):
+  - Add `RTAPostgreSQLAgentType` constant; extend agent model helpers and DSN resolution.
+- **RealtimeAnalyticsService** (`managed/services/realtimeanalytics/service.go`):
+  - Extend `getRTAAgentTypeForServiceType` for `PostgreSQLServiceType`.
+  - Extend `ListServices`, session lifecycle, and query search for PostgreSQL payloads.
+  - Add feature flag / version gate (`version.PostgreSQLRtaAgentSupportVersion`).
+- **Inventory & agent state** (`managed/services/inventory/`, `managed/services/agents/`):
+  - `AddRTAPostgreSQLAgent`, `ChangeRTAPostgreSQLAgent`, state conversion, auto-provisioning on PostgreSQL service add (Phase 4).
+
+### Phase 3 — UI Integration (`ui/`)
+
+- Extend `rta.types.ts` with `QueryPostgreSQLData` and `postgresql` in `AvailableServicesResponse`.
+- Update Real-Time overview table columns for PostgreSQL: state, wait event, database, lock indicator.
+- Details pane: lock chain panel, idle-in-transaction badge with transaction duration, parallel worker collapse.
+- Query text truncation tooltip explaining `track_activity_query_size` and restart requirement.
+- Service selector: include PostgreSQL services alongside MongoDB.
+- MongoDB RTA behavior unchanged.
+
+### Phase 4 — Testing, Hardening & GA
+
+- Integration tests across PostgreSQL 12, 14, 15, 16, Percona Distribution for PostgreSQL.
+- Cloud variant validation (RDS, Aurora, Cloud SQL, Azure) with documented permission setups.
+- Performance validation: <1% additional CPU at 2s polling with ≤200 active backends.
+- Update user docs (`documentation/docs/use/qan/QAN-realtime-analytics.md`).
+- Enable by default for all registered PostgreSQL services.
+
+## Files / areas touched
+
+| Area | Key paths |
+|------|-----------|
+| Agent collector | `agent/agents/postgresql/realtimeanalytics/`, `agent/agents/supervisor/supervisor.go`, `agent/client/` |
+| Protobuf / API | `api/realtimeanalytics/v1/query.proto`, `api/realtimeanalytics/v1/realtimeanalytics.proto`, `api/inventory/v1/agents.proto` |
+| Server backend | `managed/services/realtimeanalytics/`, `managed/services/inventory/`, `managed/services/agents/`, `managed/models/` |
+| UI | `ui/apps/pmm/src/pages/rta/`, `ui/apps/pmm/src/types/rta.types.ts`, `ui/apps/pmm/src/hooks/api/useRealtime.ts` |
+| Version / feature flags | `version/features.go` |
+| Documentation | `documentation/docs/use/qan/QAN-realtime-analytics.md` |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `pg_stat_activity` polling overhead on busy instances | Configurable 1–5s interval (default 2s); validate <1% CPU target; reuse connection pool |
+| Missing `pg_read_all_stats` on cloud RDS/Azure | Detect at agent start; return specific actionable error in session status |
+| Query text truncation (`track_activity_query_size`) | Visual indicator + tooltip; document server-restart requirement |
+| `query_id` unavailable on PG 12–13 | Fingerprint fallback; document in version matrix |
+| RTA/QAN conflict on same instance | Independent agents; RTA reads `pg_stat_activity`, QAN reads `pg_stat_statements`/`pg_stat_monitor` — no shared state |
+| MongoDB RTA regression | Existing MongoDB code paths unchanged; shared service layer extended via type switch |
+| Protobuf regeneration scope | Run `make -C api gen` only for edited `.proto` files — never `make gen` at repo root |

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md
@@ -1,0 +1,28 @@
+# PMM-15167 Real-Time Query Analytics for PostgreSQL
+
+## Why
+
+PMM provides two query analysis modes for PostgreSQL:
+
+- **Query Analytics (QAN)** aggregates completed queries into one-minute buckets stored in ClickHouse (`pg_stat_statements` or `pg_stat_monitor`). End-to-end visibility lag is 1–2 minutes — too slow for live incident triage.
+- **Real-Time Analytics (RTA)** polls actively executing operations every 1–5 seconds and streams them to the UI without aggregation or persistence. RTA launched for MongoDB in PMM v3.7.0; the production architecture (`RTAMongoDBAgentType`, `RealtimeAnalyticsService`, in-memory TTL store, UI with service selector, pause/resume, raw diagnostics panel) is proven.
+
+PostgreSQL users currently have no visibility into actively executing queries inside PMM. During lock pile-ups, long-running transactions, or idle-in-transaction sessions holding locks, they must leave PMM and run manual queries against `pg_stat_activity` and `pg_locks`.
+
+## What changes
+
+- Add a **PostgreSQL RTA agent** (`RTAPostgreSQLAgentType`) in pmm-agent that polls `pg_stat_activity` and `pg_locks` every 1–5 seconds and forwards session records to PMM Server via the existing RTA gRPC collector channel.
+- Extend **RealtimeAnalyticsService** and the Inventory API to register, route, and expose PostgreSQL RTA data through the same REST/gRPC endpoints consumed by the UI.
+- Extend **Query Analytics → Real-Time tab** to list PostgreSQL services, display live sessions, and surface PostgreSQL-specific diagnostics: lock chains, idle-in-transaction detection, wait event breakdown, and parallel worker grouping (PG 13+).
+- Add `QueryPostgreSQLData` payload to the RTA protobuf schema alongside the existing MongoDB payload.
+- Enable RTA by default for registered PostgreSQL services (Phase 4 / GA).
+- Document version matrix, permission requirements (`pg_read_all_stats`), and known limitations.
+
+## Out of scope
+
+- PostgreSQL `EXPLAIN` / execution plan capture in the real-time view.
+- `pg_wait_sampling` and `pgsentinel` integration.
+- Cancel / terminate query action from RTA UI.
+- Active Session History (ASH) style persistence for PostgreSQL RTA data.
+- Aurora-specific `aurora_stat_activity` extended view integration.
+- PostgreSQL logical replication lag monitoring in RTA.

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/README.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/README.md
@@ -1,0 +1,11 @@
+# PostgreSQL RTA specs
+
+Delta specs for PMM-15167 — Real-Time Query Analytics for PostgreSQL.
+
+| Spec | Capability |
+|------|------------|
+| [postgresql-rta-agent.md](postgresql-rta-agent.md) | pmm-agent collector: polling, lock chains, permissions |
+| [postgresql-rta-server-api.md](postgresql-rta-server-api.md) | Server API, inventory, session lifecycle |
+| [postgresql-rta-ui.md](postgresql-rta-ui.md) | Real-Time tab UI for PostgreSQL sessions |
+
+Each spec uses **Requirement** statements and **Scenario** blocks (GIVEN/WHEN/THEN) for QA verification.

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-agent.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-agent.md
@@ -1,0 +1,103 @@
+# PostgreSQL RTA Agent
+
+## Requirement: Poll active sessions from pg_stat_activity
+
+The PostgreSQL RTA agent MUST poll `pg_stat_activity` (joined with `pg_locks` where applicable) at the configured collect interval (1–5 seconds, default 2 seconds) and produce `QueryData` messages with a `QueryPostgreSQLData` payload for each active backend session.
+
+### Scenario: Active query appears in next poll cycle
+
+- **GIVEN** a PostgreSQL service with RTA session running and collect interval set to 2 seconds
+- **WHEN** a long-running `SELECT` query is executing on the monitored instance
+- **THEN** the agent sends a `QueryData` record within the next poll cycle containing the query text, session state, and query execution duration
+
+### Scenario: Collect interval is configurable
+
+- **GIVEN** an RTA session with collect interval set to 5 seconds
+- **WHEN** the agent runs its collection loop
+- **THEN** polls occur at approximately 5-second intervals (±500ms tolerance)
+
+## Requirement: Lock chain resolution
+
+The agent MUST resolve lock contention by joining `pg_stat_activity` with `pg_locks` to identify blocker → blocked chains, including query text and duration for each link in the chain.
+
+### Scenario: Blocked session shows lock chain
+
+- **GIVEN** session A holds a row lock and session B is waiting on that lock
+- **WHEN** the agent polls during the contention
+- **THEN** session B's record includes a lock chain with session A as blocker, showing A's query text and duration
+
+## Requirement: Idle-in-transaction detection
+
+The agent MUST detect sessions in `idle in transaction` state and report transaction duration separately from query execution duration.
+
+### Scenario: Idle-in-transaction session is flagged
+
+- **GIVEN** a session that started a transaction, ran a query, and is now idle within the open transaction
+- **WHEN** the agent polls
+- **THEN** the record has state `idle in transaction`, `is_idle_in_transaction=true`, and transaction duration greater than query execution duration
+
+## Requirement: Parallel worker grouping
+
+On PostgreSQL 13+, the agent MUST identify parallel worker sessions and associate them with their leader PID for UI collapse.
+
+### Scenario: Parallel workers linked to leader
+
+- **GIVEN** a parallel query running with a leader and two workers on PostgreSQL 14
+- **WHEN** the agent polls
+- **THEN** worker records include `leader_pid` pointing to the leader session's PID
+
+## Requirement: query_id with fingerprint fallback
+
+On PostgreSQL 14+, the agent MUST populate `query_id` from `pg_stat_activity.query_id`. On PostgreSQL 12–13, it MUST fall back to a query fingerprint.
+
+### Scenario: query_id on PostgreSQL 14+
+
+- **GIVEN** a monitored PostgreSQL 14 instance with an active query
+- **WHEN** the agent collects the session
+- **THEN** `query_id` is populated from `pg_stat_activity.query_id`
+
+### Scenario: Fingerprint fallback on PostgreSQL 12
+
+- **GIVEN** a monitored PostgreSQL 12 instance with an active query
+- **WHEN** the agent collects the session
+- **THEN** `query_id` contains a deterministic fingerprint of the query text
+
+## Requirement: Permission error handling
+
+When the monitoring user lacks `pg_read_all_stats`, the agent MUST report a specific actionable error (not an empty result set).
+
+### Scenario: Missing pg_read_all_stats
+
+- **GIVEN** a PostgreSQL service where the monitoring user does not have `pg_read_all_stats`
+- **WHEN** the RTA agent starts
+- **THEN** the agent status is `AGENT_STATUS_INITIALIZATION_ERROR` with a message explaining the required grant
+
+## Requirement: RTA and QAN independence
+
+RTA and QAN agents MUST operate independently on the same PostgreSQL instance without conflict or data duplication.
+
+### Scenario: Both QAN and RTA active
+
+- **GIVEN** a PostgreSQL service with both QAN (pg_stat_statements) and RTA agents running
+- **WHEN** queries execute on the instance
+- **THEN** QAN continues collecting to ClickHouse and RTA continues streaming live sessions with no interference
+
+## Requirement: Supported PostgreSQL versions
+
+The agent MUST work on PostgreSQL 12+, Percona Distribution for PostgreSQL, and major cloud variants (RDS, Aurora, Cloud SQL, Azure).
+
+### Scenario: Percona Distribution for PostgreSQL
+
+- **GIVEN** a Percona Distribution for PostgreSQL 16 instance registered in PMM
+- **WHEN** RTA session is started
+- **THEN** live session data is collected and forwarded successfully
+
+## Requirement: Performance overhead
+
+At a 2-second polling interval, the agent MUST add less than 1% additional CPU on a host with ≤200 active backends.
+
+### Scenario: CPU overhead within budget
+
+- **GIVEN** a PostgreSQL instance with 200 active backends and RTA polling at 2 seconds
+- **WHEN** baseline and RTA-enabled CPU usage are measured over 5 minutes
+- **THEN** additional CPU consumption is less than 1% of baseline

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-server-api.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-server-api.md
@@ -1,0 +1,87 @@
+# PostgreSQL RTA Server & API
+
+## Requirement: Inventory agent type for PostgreSQL RTA
+
+The Inventory API MUST support `RTAPostgreSQLAgent` with add, change, get, and list operations mirroring the existing `RTAMongoDBAgent` lifecycle.
+
+### Scenario: Add PostgreSQL RTA agent via inventory API
+
+- **GIVEN** a registered PostgreSQL service and connected pmm-agent
+- **WHEN** an Admin calls `AddAgent` with type `RTAPostgreSQLAgent` for that service
+- **THEN** the agent is created in inventory and pmm-agent receives configuration to start the collector
+
+## Requirement: ListServices includes PostgreSQL
+
+`RealtimeAnalyticsService.ListServices` MUST return PostgreSQL services when filtered by `SERVICE_TYPE_POSTGRESQL`.
+
+### Scenario: List PostgreSQL RTA-capable services
+
+- **GIVEN** two PostgreSQL services and one MongoDB service registered in PMM
+- **WHEN** `GET /v1/realtimeanalytics/services?service_type=SERVICE_TYPE_POSTGRESQL` is called
+- **THEN** the response contains both PostgreSQL services and no MongoDB services
+
+## Requirement: Session lifecycle for PostgreSQL
+
+Start and stop session endpoints MUST work for PostgreSQL services using the same REST/gRPC API as MongoDB.
+
+### Scenario: Start RTA session for PostgreSQL
+
+- **GIVEN** a registered PostgreSQL service with no active RTA session
+- **WHEN** an Admin calls `POST /v1/realtimeanalytics/sessions:start` with the service ID
+- **THEN** a session is created with status `SESSION_STATUS_RUNNING` and the RTA agent begins collecting
+
+### Scenario: Stop RTA session for PostgreSQL
+
+- **GIVEN** an active RTA session for a PostgreSQL service
+- **WHEN** an Admin calls `POST /v1/realtimeanalytics/sessions:stop` with the service ID
+- **THEN** the session stops and the agent status becomes `AGENT_STATUS_DONE`
+
+## Requirement: SearchQueries returns PostgreSQL payloads
+
+`SearchQueries` MUST return `QueryData` records with `postgresql_payload` populated for active PostgreSQL sessions.
+
+### Scenario: Search live PostgreSQL sessions
+
+- **GIVEN** an active RTA session with executing queries on a PostgreSQL service
+- **WHEN** `POST /v1/realtimeanalytics/queries:search` is called with the service ID
+- **THEN** the response contains queries with `postgresql_payload` including state, wait event, database, and lock chain data
+
+## Requirement: In-memory TTL store for PostgreSQL queries
+
+The server MUST store PostgreSQL RTA query data in the existing in-memory TTL store with the same retention semantics as MongoDB RTA (no persistence to ClickHouse).
+
+### Scenario: Stale queries expire from store
+
+- **GIVEN** a query that was active in the previous poll but has since completed
+- **WHEN** the next `SearchQueries` call occurs after TTL expiry
+- **THEN** the completed query no longer appears in the response
+
+## Requirement: MongoDB RTA unchanged
+
+All existing MongoDB RTA server behavior MUST remain unchanged after PostgreSQL support is added.
+
+### Scenario: MongoDB RTA regression check
+
+- **GIVEN** an active MongoDB RTA session before and after PostgreSQL RTA deployment
+- **WHEN** `SearchQueries` is called for the MongoDB service
+- **THEN** responses contain `mongo_db_payload` with the same fields and refresh behavior as before
+
+## Requirement: Actionable permission errors in session status
+
+When the PostgreSQL RTA agent reports a permission error, the session status MUST reflect `SESSION_STATUS_ERROR` with a human-readable message.
+
+### Scenario: Session shows permission error
+
+- **GIVEN** a PostgreSQL RTA agent that failed to start due to missing `pg_read_all_stats`
+- **WHEN** `GET /v1/realtimeanalytics/sessions` is called
+- **THEN** the session status is `SESSION_STATUS_ERROR` and the error message mentions `pg_read_all_stats`
+
+## Requirement: Feature version gate
+
+The server MUST reject RTA session start for PostgreSQL when the connected pmm-agent version does not support PostgreSQL RTA.
+
+### Scenario: Old pmm-agent version
+
+- **GIVEN** a pmm-agent version older than the PostgreSQL RTA support version
+- **WHEN** an Admin attempts to start an RTA session for a PostgreSQL service
+- **THEN** the request fails with an error indicating the agent must be upgraded

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-ui.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-ui.md
@@ -1,0 +1,111 @@
+# PostgreSQL RTA UI
+
+## Requirement: PostgreSQL services in Real-Time tab
+
+The Query Analytics → Real-Time tab MUST allow selecting any registered PostgreSQL service to start an RTA session, with no new navigation required.
+
+### Scenario: Start session for PostgreSQL service
+
+- **GIVEN** a registered PostgreSQL service and an Admin user
+- **WHEN** the user navigates to Query Analytics → Real-Time, selects the PostgreSQL service, and clicks Start session
+- **THEN** the live operations table appears and begins auto-refreshing
+
+## Requirement: Live session refresh latency
+
+The Real-Time view MUST display executing PostgreSQL sessions with ≤5 second refresh latency.
+
+### Scenario: Session data refreshes within 5 seconds
+
+- **GIVEN** an active RTA session for a PostgreSQL service with auto-refresh set to 2 seconds
+- **WHEN** a new long-running query starts on the database
+- **THEN** the query appears in the table within 5 seconds
+
+## Requirement: PostgreSQL-specific table columns
+
+The overview table MUST display PostgreSQL-relevant columns including session state, wait event, and database name.
+
+### Scenario: Wait event visible for waiting session
+
+- **GIVEN** a PostgreSQL session waiting on a lock
+- **WHEN** the Real-Time table refreshes
+- **THEN** the row shows the wait event type/class in the table
+
+## Requirement: Lock chain panel in details pane
+
+The details pane MUST show a lock chain panel with blocker → blocked relationships, query text, and duration for each link.
+
+### Scenario: Lock chain displayed in details
+
+- **GIVEN** a blocked PostgreSQL session visible in the Real-Time table
+- **WHEN** the user clicks the row to open the details pane
+- **THEN** the lock chain panel shows the blocker session with its query text and duration
+
+## Requirement: Idle-in-transaction visual distinction
+
+Sessions in `idle in transaction` state MUST be visually distinguished and show transaction duration (not query duration).
+
+### Scenario: Idle-in-transaction badge
+
+- **GIVEN** a session in `idle in transaction` state
+- **WHEN** displayed in the Real-Time table or details pane
+- **THEN** an idle-in-transaction indicator is shown with transaction duration
+
+## Requirement: Parallel worker collapse
+
+On PostgreSQL 13+, parallel worker sessions MUST be collapsed under their leader by default.
+
+### Scenario: Workers grouped under leader
+
+- **GIVEN** a parallel query with a leader and two workers on PostgreSQL 14
+- **WHEN** the Real-Time table displays the sessions
+- **THEN** workers appear collapsed under the leader row and can be expanded
+
+## Requirement: Query text truncation indicator
+
+When query text is truncated due to `track_activity_query_size`, the UI MUST indicate truncation with a tooltip explaining the setting and server-restart requirement.
+
+### Scenario: Truncated query shows tooltip
+
+- **GIVEN** a query whose text exceeds `track_activity_query_size`
+- **WHEN** displayed in the Real-Time table
+- **THEN** a truncation indicator is shown and hovering reveals a tooltip mentioning `track_activity_query_size`
+
+## Requirement: Permission error display
+
+When the monitoring user lacks required privileges, the UI MUST show a specific actionable error instead of a blank screen.
+
+### Scenario: Missing pg_read_all_stats error in UI
+
+- **GIVEN** a PostgreSQL RTA session that failed due to missing `pg_read_all_stats`
+- **WHEN** the user views the Real-Time tab for that service
+- **THEN** an error message explains that `pg_read_all_stats` must be granted to the monitoring user
+
+## Requirement: Pause and resume
+
+The existing pause/resume controls MUST work for PostgreSQL RTA sessions identically to MongoDB.
+
+### Scenario: Pause freezes PostgreSQL view
+
+- **GIVEN** an active PostgreSQL RTA session with live data refreshing
+- **WHEN** the user clicks Pause
+- **THEN** the table stops updating while the agent continues collecting in the background
+
+## Requirement: MongoDB RTA UI unchanged
+
+The MongoDB Real-Time experience MUST remain unchanged after PostgreSQL support is added.
+
+### Scenario: MongoDB session still works
+
+- **GIVEN** an active MongoDB RTA session
+- **WHEN** the user views the Real-Time tab with a MongoDB service selected
+- **THEN** MongoDB-specific columns (operation, collection, plan summary) display as before
+
+## Requirement: Raw diagnostics panel
+
+The Raw data tab in the details pane MUST show the full JSON payload from the PostgreSQL RTA agent for diagnostic purposes.
+
+### Scenario: Raw JSON available for PostgreSQL session
+
+- **GIVEN** an active PostgreSQL session in the Real-Time table
+- **WHEN** the user opens the details pane and selects the Raw data tab
+- **THEN** the full `queryRawJson` payload is displayed

--- a/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
+++ b/openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md
@@ -1,0 +1,38 @@
+# Tasks
+
+## Phase 1 — PostgreSQL RTA Agent
+
+- [ ] 1.1 Add `QueryPostgreSQLData` message to `api/realtimeanalytics/v1/query.proto`; extend `QueryData.payload` oneof; run `make -C api gen`
+- [ ] 1.2 Add `RTAPostgreSQLAgent` to `api/inventory/v1/agents.proto`; run `make -C api gen`
+- [ ] 1.3 Add `RTAPostgreSQLAgentType` to `managed/models/agent_model.go` and related helpers
+- [ ] 1.4 Implement `agent/agents/postgresql/realtimeanalytics/` collector (pg_stat_activity + pg_locks polling, lock chains, idle-in-transaction, parallel workers)
+- [ ] 1.5 Wire PostgreSQL RTA agent into supervisor and pmm-agent client channel
+- [ ] 1.6 Unit tests for parser/collector (lock chain resolution, query_id vs fingerprint, idle-in-transaction)
+
+## Phase 2 — Server-Side & API
+
+- [ ] 2.1 Extend `RealtimeAnalyticsService.ListServices` to return PostgreSQL services
+- [ ] 2.2 Extend `getRTAAgentTypeForServiceType` and session/query handlers for PostgreSQL
+- [ ] 2.3 Implement `AddRTAPostgreSQLAgent` / `ChangeRTAPostgreSQLAgent` in inventory service
+- [ ] 2.4 Wire agent state provisioning in `managed/services/agents/state.go`
+- [ ] 2.5 Add `version.PostgreSQLRtaAgentSupportVersion` feature gate
+- [ ] 2.6 Handle missing-permission errors with actionable session status messages
+
+## Phase 3 — UI Integration
+
+- [ ] 3.1 Extend `rta.types.ts` and `useRealtime.ts` for PostgreSQL payload and service list
+- [ ] 3.2 Update Real-Time overview table with PostgreSQL-specific columns and indicators
+- [ ] 3.3 Add lock chain panel and idle-in-transaction badge in details pane
+- [ ] 3.4 Collapse parallel workers under leader (PG 13+); query truncation tooltip
+- [ ] 3.5 Include PostgreSQL services in service selector; verify MongoDB unchanged
+- [ ] 3.6 Run `make -C ui lint`
+
+## Phase 4 — Testing, Hardening & GA
+
+- [ ] 4.1 Dev smoke test: provision PostgreSQL, start RTA session, verify live sessions via API and UI
+- [ ] 4.2 Validate on PostgreSQL 12, 14, 15, 16 and Percona Distribution for PostgreSQL
+- [ ] 4.3 Validate cloud variants (RDS, Aurora, Cloud SQL, Azure) with documented permissions
+- [ ] 4.4 Performance check: <1% CPU overhead at 2s interval with ≤200 backends
+- [ ] 4.5 Update `documentation/docs/use/qan/QAN-realtime-analytics.md` with PostgreSQL section and version matrix
+- [ ] 4.6 Enable RTA by default for registered PostgreSQL services
+- [ ] 4.7 Open `Percona-Lab/pmm-submodules` FB PR after percona/pmm PR is ready


### PR DESCRIPTION
## Summary

Extend Real-Time Query Analytics (RTA) to PostgreSQL so PMM users can see actively executing queries with 1–5 second refresh directly in Query Analytics → Real-Time — without leaving PMM during live incidents.

PostgreSQL RTA builds on the proven MongoDB RTA architecture (`RTAMongoDBAgentType`, `RealtimeAnalyticsService`, in-memory TTL store, Real-Time UI tab). The PostgreSQL agent polls `pg_stat_activity` and `pg_locks` to surface session states, lock chains, idle-in-transaction sessions, wait events, and parallel workers. QAN stored metrics (`pg_stat_statements` / `pg_stat_monitor`) continue operating independently.

**Phases:** (1) PostgreSQL RTA agent, (2) server/API extension, (3) UI integration, (4) testing/hardening/GA.

## OpenSpec (draft)

- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/proposal.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/design.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/tasks.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-agent.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-server-api.md`
- `openspec/changes/PMM-15167-rta-real-time-query-analytics-for-postgr/specs/postgresql-rta-ui.md`

## Test plan

- [ ] Review proposal scope and out-of-scope items against PMM-15167 Jira epic
- [ ] Confirm design aligns with existing MongoDB RTA architecture
- [ ] Validate acceptance criteria coverage in delta specs (lock chains, idle-in-transaction, parallel workers, query_id, permissions)
- [ ] Approve task breakdown for `/opsx:apply` implementation phase


Made with [Cursor](https://cursor.com)