### PR TITLE
PMM-7 Use ubuntu-latest in GH actions

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -1,3 +1,4 @@
+---
 name: 'Client: pmm-admin'
 
 on:
@@ -34,7 +35,7 @@ env:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,3 +1,4 @@
+---
 name: 'Client: pmm-agent'
 
 on:
@@ -35,7 +36,7 @@ env:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         images:
@@ -138,7 +139,7 @@ jobs:
 
   build-gssapi:
     name: Build PMM Agent with GSSAPI support
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: false
     defaults:
       run:

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,3 +1,4 @@
+---
 name: 'API Tests'
 
 on:
@@ -36,7 +37,7 @@ permissions:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PMM_URL: https://admin:admin@127.0.0.1
       BRANCH: ${{ github.event.inputs.BRANCH || 'main' }}

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,3 +1,4 @@
+---
 name: Sync API Docs
 on:
   push:

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,3 +1,4 @@
+---
 name: Cleanup
 on:
   schedule:
@@ -13,7 +14,7 @@ jobs:
     timeout-minutes: 5
 
     continue-on-error: false
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     env:
       GOFLAGS: -v -mod=readonly

--- a/.github/workflows/dashboards.yml
+++ b/.github/workflows/dashboards.yml
@@ -1,3 +1,4 @@
+---
 name: Dashboards
 on: 
   pull_request:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,3 +1,4 @@
+---
 name: Dependabot
 on: pull_request
 
@@ -7,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     name: Enable auto-merge
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
       contents: write

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,3 +1,4 @@
+---
 name: Devcontainer
 on:
   workflow_dispatch:
@@ -21,7 +22,7 @@ permissions:
 jobs:
   devcontainer:
     name: Devcontainer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       packages: write

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -1,3 +1,4 @@
+---
 name: Update Docker Hub Readme
 on:
   push:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,3 +1,4 @@
+---
 name: PMM Docs 3.x
 
 on:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,3 +1,4 @@
+---
 name: Auto label PRs
 
 on:

--- a/.github/workflows/linkspector.yml
+++ b/.github/workflows/linkspector.yml
@@ -1,3 +1,4 @@
+---
 name: Linkspector
 on:
   pull_request:
@@ -17,7 +18,7 @@ permissions:
 jobs:
   check-links:
     name: linkspector
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Check out code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+---
 name: Main
 
 on:
@@ -27,7 +28,7 @@ env:
 jobs:
   check:
     name: Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read
@@ -140,7 +141,7 @@ jobs:
   workflow_success:
     needs: [ check ]
     name: Slack Notification success
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_TOKEN_PMM_CI }}
       SLACK_CHANNEL: "pmm-ci"
@@ -158,7 +159,7 @@ jobs:
     if: ${{ failure() }}
     needs: [ check ]
     name: Slack Notification failure
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_TOKEN_PMM_CI }}
       SLACK_CHANNEL: "pmm-ci"

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -1,3 +1,4 @@
+---
 name: Managed
 on:
   push:
@@ -28,7 +29,7 @@ permissions: read-all
 jobs:
   test:
     name: Unit tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     env:

--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,3 +1,4 @@
+---
 name: Merge Gatekeeper
 
 on:

--- a/.github/workflows/percona-intelligence.yml
+++ b/.github/workflows/percona-intelligence.yml
@@ -1,3 +1,4 @@
+---
 name: 'Percona Intelligence'
 on:
   push:
@@ -26,7 +27,7 @@ env:
 jobs:
   validate:
     name: Validate PI files
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out code

--- a/.github/workflows/qan-api2.yml
+++ b/.github/workflows/qan-api2.yml
@@ -1,3 +1,4 @@
+---
 name: QAN
 
 on:
@@ -35,7 +36,7 @@ env:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/release-doc.yml
+++ b/.github/workflows/release-doc.yml
@@ -1,3 +1,4 @@
+---
 name: Publish release changelog
 on:
   push:
@@ -30,7 +31,7 @@ jobs:
       contents: write  # for softprops/action-gh-release to create GitHub release
 
     if: (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') && github.repository == 'percona/pmm'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set version for testing
         id: set_version

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,3 +1,4 @@
+---
 name: SBOM
 
 on:
@@ -10,7 +11,7 @@ permissions:
 
 jobs:
   sbom:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -27,7 +28,7 @@ jobs:
           sbom-artifact-match: ".*\\.spdx\\.json$"
 
   vmproxy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,3 +1,4 @@
+---
 name: Scorecard
 on:
   # To guarantee Maintained check is occasionally updated. See

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,3 +1,4 @@
+---
 name: UI
 
 on:
@@ -30,7 +31,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/.github/workflows/vmproxy.yml
+++ b/.github/workflows/vmproxy.yml
@@ -1,3 +1,4 @@
+---
 name: VMProxy
 
 on:
@@ -35,7 +36,7 @@ env:
 jobs:
   test:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:


### PR DESCRIPTION
Ticket number: PMM-7

This pull request updates all GitHub Actions workflow files to use the latest available Ubuntu runner (`ubuntu-latest`) instead of a specific version (`ubuntu-22.04`). This ensures that workflows always run on the most up-to-date and supported environment, improving compatibility and reducing maintenance overhead.

**CI/CD Environment Updates:**

* Updated the `runs-on` parameter from `ubuntu-22.04` to `ubuntu-latest` in all workflow files, including but not limited to `admin.yml`, `agent.yml`, `api-tests.yml`, `clean.yml`, `dependabot.yml`, `devcontainer.yml`, `linkspector.yml`, `main.yml`, `managed.yml`, `percona-intelligence.yml`, `qan-api2.yml`, `release-doc.yml`, `sbom.yml`, `ui.yml`, and `vmproxy.yml`. 

**No logic or functional changes were made to workflow steps or jobs.**
