### PR TITLE
PMM-7 Fix GH Actions cache cleanup

### DIFF
--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -21,6 +21,9 @@ jobs:
       contents: read
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Delete caches for the PR branch
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -21,9 +21,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Check out code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
       - name: Delete caches for the PR branch
         env:
           GH_TOKEN: ${{ github.token }}
@@ -31,6 +28,6 @@ jobs:
           echo "[INFO] Deleting caches for PR #${{ github.event.pull_request.number }}"
 
           # Delete caches associated with the PR merge ref
-          gh cache delete --all --succeed-on-no-caches --ref "refs/pull/${{ github.event.pull_request.number }}/merge"
+          gh cache delete --all --succeed-on-no-caches --repo "${{ github.repository }}" --ref "refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "[INFO] Cache cleanup complete"


### PR DESCRIPTION
Ticket number: PMM-7

From GH Action run:
```
failed to determine base repo: failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This pull request makes a small improvement to the cache cleanup workflow by ensuring cache deletion commands explicitly specify the repository. This increases reliability, especially in cases where the workflow might run in a different context.

* [`.github/workflows/pr-cache-cleanup.yml`](diffhunk://#diff-1295857e03bc77b9036228830ab556ad436693e3cfa35e56172491c16546bd36L31-R31): Added the `--repo "${{ github.repository }}"` flag to the `gh cache delete` command to ensure the correct repository is targeted during cache cleanup.