### PR TITLE
docs: add Cursor Cloud dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,3 +248,16 @@ All long-running daemons expose on `127.0.0.1`:
 - `dev/docs/process/tech_stack.md` — technology choices and rationale
 - `dev/docs/process/best_practices.md` — coding best practices
 - `dev/docs/process/GIT_AND_GITHUB.md` — git workflow
+
+## Cursor Cloud specific instructions
+
+The entire PMM Server dev environment runs **inside a single Docker container** (`make env-up`, using `docker-compose.dev.yml` with the default `pmm` profile). Docker is preinstalled in the VM snapshot. The startup update script ensures `.env` exists (`cp .env.dev.example .env`). Key non-obvious caveats:
+
+- **Start the Docker daemon first.** `dockerd` is not managed by systemd here. If `docker info` fails, start it (e.g. in tmux): `sudo dockerd` and then `sudo chmod 666 /var/run/docker.sock` (or use `sudo` for docker commands). Docker 29 is configured with the `fuse-overlayfs` storage driver and `containerd-snapshotter` disabled in `/etc/docker/daemon.json` — do not remove those, the VM kernel needs them.
+- **Bring up the server:** from the repo root run `make env-up` (pulls/starts `pmm-server`). First boot runs the `pmm-init` Ansible provisioning; wait ~30–60s and confirm all services with `docker exec pmm-server supervisorctl status` (postgresql, clickhouse, grafana, pmm-managed, victoriametrics, vmproxy, qan-api2, vmalert, pmm-agent should be RUNNING; `pmm-init` shows EXITED, which is normal).
+- **UI/API:** `https://localhost` (self-signed cert — use `curl -k`), credentials `admin` / `admin`. Readiness: `curl -sk https://localhost/v1/readyz`.
+- **Running Go tooling inside the container:** the default `docker exec pmm-server` user is `pmm` (uid 1000) and **cannot write** the `go-modules` volume at `/root/go/pkg/mod` (owned by root). Run Go builds/tests/lint as root: `docker exec -u root ... pmm-server` (equivalently `make env-root TARGET=...`). Also configure git once for root to avoid "dubious ownership" on the bind-mounted repo: `docker exec -u root pmm-server git config --global --add safe.directory /root/go/src/github.com/percona/pmm`.
+- **Go toolchain download:** `go.mod` pins `toolchain go1.26.4`, so the first `go` invocation in the container downloads it (needs network). This is expected.
+- **Dev component workflow:** rebuild+hot-swap a server component with `make env-root TARGET=run-<managed|agent|vmproxy|qan>-ci` (the non-`-ci` variants tail logs and block). Example verified: `run-vmproxy-ci`.
+- **`pmm-admin add`/`list` return "Unauthorized"** because the server has access control enabled; the in-container `pmm-admin` is not configured with server credentials. To add/inspect inventory, use the REST API with `-u admin:admin` (e.g. `POST https://localhost/v1/management/services`) or configure `pmm-admin` with the server URL + credentials. `pmm-admin status` works without extra config.
+- **Host toolchain:** the host has Go 1.22, Node 22, and Yarn 1.22 for host-local UI/agent dev (`ui/`, `agent/`), but the canonical workflow is the container above.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the PMM development environment for Cursor Cloud agents and documents the non-obvious startup/run caveats discovered during setup.

The canonical dev workflow runs the entire PMM Server inside a single Docker container via `make env-up` (using `docker-compose.dev.yml`). This change adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering:

- Starting the Docker daemon (`dockerd` is not systemd-managed here) and the required `fuse-overlayfs` / disabled `containerd-snapshotter` config for Docker 29.
- Bringing up the server (`make env-up`), waiting for `pmm-init` Ansible provisioning, and verifying services via `supervisorctl status`.
- UI/API access at `https://localhost` (self-signed, `admin`/`admin`).
- Running Go tooling in the container as `root` (the default `pmm` user can't write the `go-modules` volume) and configuring git `safe.directory` for the bind-mounted repo.
- The `go.mod` toolchain auto-download, the rebuild+hot-swap component workflow, and the `pmm-admin` "Unauthorized" caveat (use the REST API instead).

No product code was modified.

## Verification

Verified end-to-end in the cloud VM:
- `make env-up` → PMM Server v3.8.0 healthy; all supervisord services RUNNING.
- Build+hot-swap: `make run-vmproxy-ci` rebuilt `vmproxy` from source and restarted it.
- Tests: `go test ./version/...` passed.
- Lint: `golangci-lint run -c=.golangci.yml ./version/...` runs.
- Hello-world: registered a monitored PostgreSQL service via `POST /v1/management/services`; the `postgres_exporter` reached `AGENT_STATUS_RUNNING` and `pg_up{service_name="hello-world-pg"}=1` metrics landed in VictoriaMetrics.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee65de6d-dfb3-41fc-b5e0-8a7bcf85b7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee65de6d-dfb3-41fc-b5e0-8a7bcf85b7b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

