### PR TITLE
PMM-15099 Bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.0.0-20260107142235-15cbcf569b9f
 


### PR DESCRIPTION
Ticket number: PMM-15099

This pull request updates the Go version used in the `go.mod` file from 1.26.4 to 1.26.5. This is a minor version bump, to include the latest bug fixes and improvements.
