### PR TITLE
PMM-7 Fix expected status code in basic auth API test

### DIFF
--- a/api-tests/server/auth_test.go
+++ b/api-tests/server/auth_test.go
@@ -223,7 +223,7 @@ func TestBasicAuthPermissions(t *testing.T) {
 			{userType: "admin", login: admin, statusCode: 200},
 		}},
 		{name: "grafana serviceaccounts search", url: "/graph/api/serviceaccounts/search?query=pmm-install", method: "GET", userCase: []userCase{
-			{userType: "default", login: none, statusCode: 401},
+			{userType: "default", login: none, statusCode: 403},
 			{userType: "viewer", login: viewer, statusCode: 403},
 			{userType: "editor", login: editor, statusCode: 403},
 			{userType: "admin", login: admin, statusCode: 200},


### PR DESCRIPTION
The `grafana serviceaccounts search / Basic auth default` case added in #5250 expects 401 for a user created without an explicit role, but CI gets 403.

The 401 expectation was never valid: Grafana auto-assigns the Viewer org role to new users (`auto_assign_org = true`, `auto_assign_org_role = Viewer` in Grafana defaults), so the "default" user authenticates successfully and is denied by RBAC with 403 ("Permissions needed: serviceaccounts:read") - exactly like the explicit viewer case. PMM's auth server is not involved in the status code: `/graph` paths require role `none`, so the request is passed through to Grafana.

Verified against a running PMM Server (Grafana 12.4.4, full nginx stack): `TestBasicAuthPermissions` passes with this change; 12.4.4 also returns 403, so this is not a Grafana 12.4.5 regression - the new test case simply hadn't been exercised by CI before.