### PR TITLE
PMM-7 Disable gosec G101 (hardcoded credentials) linter for _test.go files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -114,6 +114,10 @@ linters:
           - unusedwrite      # not critical for tests
         path: _test\.go
       - linters:
+          - gosec
+        text: G101 # Potential hardcoded credentials - acceptable in tests
+        path: _test\.go
+      - linters:
           - recvcheck
         path: managed/models/
       - linters:


### PR DESCRIPTION
## What changed

Adds a targeted exclusion to `.golangci.yml` so that gosec rule **G101 (Potential hardcoded credentials)** is no longer reported for `*_test.go` files.

Test files frequently contain literal secret-like strings — fake tokens, sample passwords, dummy connection strings — that trigger G101 but are not real credentials. The exclusion matches only the `G101` rule text under the `gosec` linter for the `_test\.go` path, so all other gosec checks (and G101 in non-test code) remain active.

```yaml
- linters:
    - gosec
  text: G101 # Potential hardcoded credentials - acceptable in tests
  path: _test\.go
```
