### PR TITLE
PMM-15179 - Fix 2 broken advisor "read more" doc links

### DIFF
--- a/managed/data/checks/mongodb_maxsessions.yml
+++ b/managed/data/checks/mongodb_maxsessions.yml
@@ -31,7 +31,7 @@ checks:
                           results.append({
                               "summary": "MongoDB is using maxSessionn - {}, which is more than the default value - 1000000".format(maxSV),
                               "description": "To avoid performance issues, see the following blog to check & set the right value for your environment",
-                              "read_more_url": read_url.format("mongodb-maxsession"),
+                              "read_more_url": read_url.format("mongodb-maxSessions"),
                               "severity": "warning",
                           })
               return results

--- a/managed/data/checks/mongodb_maxsessions.yml
+++ b/managed/data/checks/mongodb_maxsessions.yml
@@ -29,7 +29,7 @@ checks:
                       maxSV = int(setParameter.get("maxSessions", fail))
                       if maxSV > 1000000:
                           results.append({
-                              "summary": "MongoDB is using maxSessionn - {}, which is more than the default value - 1000000".format(maxSV),
+                              "summary": "MongoDB is using maxSessions - {}, which is more than the default value - 1000000".format(maxSV),
                               "description": "To avoid performance issues, see the following blog to check & set the right value for your environment",
                               "read_more_url": read_url.format("mongodb-maxSessions"),
                               "severity": "warning",

--- a/managed/data/checks/mongodb_xfs_ftype.yml
+++ b/managed/data/checks/mongodb_xfs_ftype.yml
@@ -41,7 +41,7 @@ checks:
                   results.append({
                       "summary": "The DBPATH mount point is not currently using XFS as its filesystem type.",
                       "description": "The dbPath for this instance is not currently using XFS as its filesystem type. It is strongly recommended to use XFS to provide better performance for data bearing nodes and to avoid performance issues that have been observed when using EXT4 with the wiredTiger engine. DBPATH - {}, MOUNT - {}, FTYPE - {}".format(dbpath, mount, ftype),
-                      "read_more_url": read_url.format("Mongodb-XFS"),
+                      "read_more_url": read_url.format("mongodb-xfs"),
                       "severity": "warning",
                   })
 


### PR DESCRIPTION
Follow-up to the advisor doc-link domain migration (PMM-15179 / [#5655](https://github.com/percona/pmm/pull/5655)). That change swapped the doc domain to percona-monitoring-and-management/3/... but left two check slugs pointing at non-existent pages (they redirect to 404.html). This corrects the slugs to match the actual published pages, validated against the docs sitemap.

Changes
- https://docs.percona.com/percona-monitoring-and-management/3/advisors/checks/mongodb-maxsession.html   <-- ⚠ BROKEN: redirects to 404 (pre-existing bad slug)
-- fix: mongodb_maxsessions.yml: mongodb-maxsession → mongodb-maxSessions

- https://docs.percona.com/percona-monitoring-and-management/3/advisors/checks/Mongodb-XFS.html   <-- ⚠ BROKEN: redirects to 404 (case-sensitive; lowercase mongodb-xfs below works)
-- fix: mongodb_xfs_ftype.yml: Mongodb-XFS → mongodb-xfs (aligns with the sibling branch in the same file, which already uses the correct slug)

Both corrected URLs verified to return live 200s.

Known issue (not addressed here)
- The AHI check (mysql_ahi_efficiency_performance_basic_check.yml) links to mysql-ahi-efficiency-performance-basic-check.html, which does not exist in the docs at all. This needs a docs page to be authored — tracked separately. The code reference is intentionally left unchanged so it resolves automatically once the page is published.