### PR TITLE
PMM-15242 Fix pmm-admin panic when run without a subcommand

### DIFF
--- a/admin/cli/cli.go
+++ b/admin/cli/cli.go
@@ -85,9 +85,21 @@ type CmdWithContextRunner interface {
 	RunCmdWithContext(ctx context.Context, globals *flags.GlobalFlags) (commands.Result, error)
 }
 
+// usageErrorExitCode mirrors Kong's internal exitUsageError, used when the
+// binary is invoked without a subcommand.
+const usageErrorExitCode = 80
+
 func run(ctx *kong.Context, globals *flags.GlobalFlags) error {
 	var res commands.Result
 	var err error
+
+	// Since Kong 1.16.0 the root command is treated as runnable, so invoking
+	// pmm-admin without a subcommand no longer produces a parse error and
+	// ctx.Selected() is nil. Print usage and exit as previous versions did.
+	if ctx.Selected() == nil {
+		_ = ctx.PrintUsage(false)
+		os.Exit(usageErrorExitCode)
+	}
 
 	i := ctx.Selected().Target.Addr().Interface()
 

--- a/admin/cmd/pmm-admin/main_test.go
+++ b/admin/cmd/pmm-admin/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os/exec"
 	"testing"
@@ -24,7 +25,7 @@ import (
 )
 
 func TestPackages(t *testing.T) {
-	cmd := exec.Command("pmm-admin", "-h")
+	cmd := exec.CommandContext(t.Context(), "pmm-admin", "-h")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
 
@@ -34,7 +35,7 @@ func TestPackages(t *testing.T) {
 }
 
 func TestVersionPlain(t *testing.T) {
-	cmd := exec.Command("pmm-admin", "--version")
+	cmd := exec.CommandContext(t.Context(), "pmm-admin", "--version")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
 
@@ -42,8 +43,26 @@ func TestVersionPlain(t *testing.T) {
 	assert.Contains(t, out, `Version:`, `--version output is incorrect`)
 }
 
+func TestNoCommandPrintsUsage(t *testing.T) {
+	// --server-url avoids the local pmm-agent lookup so the test does not depend
+	// on a running agent; with no subcommand pmm-admin must print usage instead
+	// of panicking (PMM-15242).
+	cmd := exec.CommandContext(t.Context(), "pmm-admin", "--server-url=http://localhost/")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr, "stdout=%q stderr=%q", stdout.String(), stderr.String())
+	assert.Equal(t, 80, exitErr.ExitCode())
+	assert.Contains(t, stdout.String(), "Usage: pmm-admin <command>")
+	assert.NotContains(t, stderr.String(), "panic")
+	assert.NotContains(t, stderr.String(), "SIGSEGV")
+}
+
 func TestVersionJson(t *testing.T) {
-	cmd := exec.Command("pmm-admin", "--version", "--json")
+	cmd := exec.CommandContext(t.Context(), "pmm-admin", "--version", "--json")
 	b, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s", b)
 


### PR DESCRIPTION
PMM-15242

SUBMODULES-4491

## Problem

Running `pmm-admin` with no arguments crashes with a nil-pointer `SIGSEGV` (exit 2) on 3.9.0 when pmm-agent is running, instead of printing usage to stdout as it did on 3.8.1 (exit 80). This broke the nightly PMM Integration Tests (`cli/tests/generic.spec.ts:62`).

## Root cause

The `github.com/alecthomas/kong` 1.15.0 → 1.16.0 bump introduced a "runnable root" rule: when `pmm-admin` is invoked with no subcommand, Kong no longer returns a usage error during parse. Instead it treats the root `PMMAdminCommands` as runnable and calls its `Run` method with `ctx.Selected() == nil`. `run()` in `admin/cli/cli.go` then dereferenced that nil node (`ctx.Selected().Target.Addr()`), causing the SIGSEGV.

This only surfaces when pmm-agent is reachable (the CI scenario); otherwise `base.SetupClients` in `admin/commands/base/setup.go` exits 1 before `Run` is reached — matching the ticket's exit 1 vs exit 2 observations.

## Fix

Guard `ctx.Selected() == nil` in `run()` (`admin/cli/cli.go`): print usage to stdout via `ctx.PrintUsage(false)` and exit with Kong's usage-error code (80), restoring the pre-1.16.0 behavior.

## Testing

- Added regression test `TestNoCommandPrintsUsage` in `admin/cmd/pmm-admin/main_test.go`; verified it fails with the exact SIGSEGV panic on the unpatched binary and passes with the fix.
- Existing `exec.Command` calls in the test file converted to `exec.CommandContext(t.Context(), ...)` to satisfy `noctx`.
- `go vet`, `go test -race`, and `golangci-lint` clean on the touched packages.
