### PR TITLE
PMM-7 Restore SELinux permissive mode in AMI build to fix pmm-server SELinux Enforcing crash on fresh volumes

### DIFF
--- a/build/packer/ansible/roles/podman-setup/tasks/main.yml
+++ b/build/packer/ansible/roles/podman-setup/tasks/main.yml
@@ -14,6 +14,11 @@
   set_fact:
     pmm_distribution_method: ami
 
+- name: Set SELinux in permissive mode
+  selinux:
+    policy: targeted
+    state: permissive
+
 - name: Update podman.conf
   lineinfile:
     path: /usr/lib/tmpfiles.d/podman.conf


### PR DESCRIPTION
Ticket number: PMM-7 Restore SELinux permissive mode in AMI build to fix pmm-server SELinux Enforcing crash on fresh volumes