### PR TITLE
PMM-7 Fix flaky Codecov project status checks, fix panic in telemetry

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,18 +2,26 @@ coverage:
   range: "60...80"
   status:
     default_rules:
-      flag_coverage_not_uploaded_behavior: exclude
+      # Independent workflows upload their flags at different times. Pass a
+      # component's status while its flag is still pending instead of scoring
+      # it on a partial merge; carryforward fills the gap until the upload lands.
+      flag_coverage_not_uploaded_behavior: pass
 
     # disabled for now until we agree on the thresholds
     patch: off
 
     project:
       default:
-        flag_coverage_not_uploaded_behavior: pass
+        # Whole-repo aggregate spans every flag across independent workflows,
+        # so it can't be gated on a single upload and is inherently racy.
+        # Report it, but never let it block the merge.
+        informational: true
         threshold: 1%
 
       admin:
         threshold: 1%
+        flags:
+          - admin
         paths:
           - admin/
 
@@ -26,6 +34,8 @@ coverage:
 
       managed:
         threshold: 1%
+        flags:
+          - managed
         paths:
           - managed/
 
@@ -36,6 +46,8 @@ coverage:
 
       vmproxy:
         threshold: 1%
+        flags:
+          - vmproxy
         paths:
           - vmproxy/
 

--- a/managed/services/telemetry/telemetry.go
+++ b/managed/services/telemetry/telemetry.go
@@ -146,6 +146,9 @@ func (s *Service) Run(ctx context.Context) {
 		}
 
 		report := s.prepareReport(ctx)
+		if report == nil {
+			return
+		}
 
 		if s.l.Logger.IsLevelEnabled(logrus.DebugLevel) {
 			s.l.Debugf("\nTelemetry captured:\n%s\n", s.Format(report))
@@ -235,7 +238,11 @@ func (s *Service) processSendCh(ctx context.Context) {
 
 func (s *Service) prepareReport(ctx context.Context) *telemetryv1.GenericReport { //nolint:gocognit
 	initializedDataSources := make(map[DataSourceName]DataSource)
-	telemetryMetric, _ := s.makeMetric(ctx)
+	telemetryMetric, err := s.makeMetric(ctx)
+	if err != nil {
+		s.l.Errorf("Failed to prepare telemetry report: %s", err)
+		return nil
+	}
 	var totalTime time.Duration
 
 	// initialize datasources

--- a/managed/services/telemetry/telemetry_test.go
+++ b/managed/services/telemetry/telemetry_test.go
@@ -264,7 +264,7 @@ func TestRunHandlesMakeMetricError(t *testing.T) {
 
 	sqlDB, dbMock, err := sqlmock.New()
 	require.NoError(t, err)
-	t.Cleanup(func() { sqlDB.Close() })
+	t.Cleanup(func() { sqlDB.Close() }) //nolint:gosec
 	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
 
 	// doSend's initial GetSettings succeeds and telemetry is enabled...

--- a/managed/services/telemetry/telemetry_test.go
+++ b/managed/services/telemetry/telemetry_test.go
@@ -17,6 +17,7 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"testing"
@@ -244,6 +245,55 @@ func TestRunSkipsNonReleaseVersion(t *testing.T) {
 			require.NoError(t, dbMock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestRunHandlesMakeMetricError(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.StandardLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	logEntry := logrus.NewEntry(logger)
+
+	settingsJSON := []byte(`{"telemetry":{"uuid":"00000000-0000-0000-0000-000000000001"}}`)
+
+	var mockSender mockSender
+	mockSender.Test(t)
+	t.Cleanup(func() {
+		mockSender.AssertNotCalled(t, "SendTelemetry")
+	})
+
+	sqlDB, dbMock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { sqlDB.Close() })
+	db := reform.NewDB(sqlDB, postgresql.Dialect, nil)
+
+	// doSend's initial GetSettings succeeds and telemetry is enabled...
+	dbMock.ExpectQuery("SELECT settings FROM settings").
+		WillReturnRows(sqlmock.NewRows([]string{"settings"}).AddRow(settingsJSON))
+	// ...but makeMetric's transaction fails, so prepareReport must return nil
+	// and Run must skip sending rather than dereference the nil report.
+	dbMock.ExpectBegin()
+	dbMock.ExpectQuery("SELECT settings FROM settings").
+		WillReturnError(errors.New("boom"))
+	dbMock.ExpectRollback()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	s := Service{
+		db:     db,
+		l:      logEntry,
+		config: getTestConfig(true, 10*time.Second),
+		// Release version: the send path is reachable, so not sending proves
+		// we bailed on the makeMetric error rather than on a version check.
+		pmmVersion:   "3.7.1",
+		dus:          getDistributionUtilService(t, logEntry),
+		portalClient: &mockSender,
+		sendCh:       make(chan *telemetryv1.GenericReport, sendChSize),
+	}
+	s.Run(ctx)
+
+	require.NoError(t, dbMock.ExpectationsWereMet())
 }
 
 func getServiceConfig(pgPortHost string, qanDSN string, vmDSN string) ServiceConfig {

--- a/managed/services/telemetry/telemetry_test.go
+++ b/managed/services/telemetry/telemetry_test.go
@@ -227,7 +227,7 @@ func TestRunSkipsNonReleaseVersion(t *testing.T) {
 				WillReturnRows(sqlmock.NewRows([]string{"settings"}).AddRow(settingsJSON))
 			dbMock.ExpectCommit()
 
-			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 			defer cancel()
 
 			s := Service{


### PR DESCRIPTION
Ticket number: PMM-7

## Problem

The `codecov/project` and `codecov/project/managed` status checks flake and block **Merge Gatekeeper** (which requires every non-`linkspector` status to be green). The failing deltas appear even on changes that touch no production code, so they are reporting artifacts, not real regressions.

<img width="863" height="168" alt="Screenshot 2026-07-30 at 19 44 05" src="https://github.com/user-attachments/assets/4dfe1c2f-758f-47be-a073-48a056fd7ad9" />

**Root cause:** PMM uploads coverage from several independent workflows (`agent`, `managed`, `admin`, `vmproxy`), each finishing at a different time. Codecov evaluates and posts the commit statuses before every flag has been uploaded and merged, so it scores components on a partial merge. The whole-repo aggregate has no single flag to gate on, so it is inherently racy.

## Changes to `codecov.yml`

- **Flag-scope the `admin`, `managed` and `vmproxy` components** (`agent` already was) so each is scored from its own flag instead of a partial cross-workflow merge — this removes the phantom drops such as the `-2.35%` seen on `managed`.
- **`flag_coverage_not_uploaded_behavior: exclude → pass`** so a component status passes while its flag upload is still pending; carryforward fills the gap until it lands.
- **Mark the whole-repo `default` aggregate `informational: true`.** It spans every flag across independent workflows and cannot be gated on a single upload, so it now reports coverage without blocking the merge. Per-component statuses remain the enforced coverage gates.

`qan-api2` is left path-only — no workflow uploads a `qan-api2` flag, so it always carries forward and passes.

## Relationship to #5599

Complementary. #5599 fixes the `agent` flag's own 11-uploads race (11 matrix legs → one atomic upload). This PR fixes the cross-workflow aggregate/component races that surface as the failing `project` / `project/managed` checks. Neither depends on the other; both are needed for the complete fix.

## Validation

`codecov.yml` passes `codecov.io/validate`. Runtime timing behaviour can only be confirmed against real CI on this PR.

## Additional fix: telemetry nil-pointer panic

While validating this PR, the managed `Unit tests` job (which runs here because `codecov.yml` is not in its `paths-ignore`) hit a pre-existing flaky failure, `TestRunSkipsNonReleaseVersion`, unrelated to the codecov change. Folded the fix in:

- `prepareReport` discarded the error from `makeMetric` and then dereferenced the nil report (`telemetry.go:311`), so any failure of the telemetry DB transaction would crash pmm-managed with a SIGSEGV. It now logs the error, returns nil, and `doSend` skips a nil report.
- The test's 100ms context deadline could expire before `makeMetric` under CI load and trigger that nil path; widened to 2s.

Reproduced deterministically (forcing the deadline reproduces the exact `telemetry.go:311` panic) and verified the target test passes 20x under `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry reliability by preventing invalid reports from being submitted when metric preparation fails.
  * Added clearer handling for telemetry preparation errors.

* **Tests**
  * Added coverage for telemetry database failures.
  * Increased telemetry test timing tolerance to reduce intermittent failures.

* **Chores**
  * Updated code coverage reporting behavior for more consistent status results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->