### PR TITLE
PMM-15280 Provision a Grafana service account for SEP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,11 +60,13 @@ PMM_PORT_HTTPS=443
 # settings name:
 #   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
 #   PMM__API_KEY
-# The directory is mode 0750 and the files 0640, owned by PMM's runtime user and group
-# (uid 1000, gid 0). PMM cannot chgrp to SEP's own group, so the SEP container has to
-# join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
-# The token is revalidated against Grafana on every PMM start and replaced only when
-# Grafana rejects it, so restarting PMM does not revoke the token a running SEP holds.
+# The directory is mode 0770 and the files 0640, owned by PMM's runtime user and its
+# primary group (uid 1000, gid 0 in the stock image). PMM cannot chgrp to SEP's own
+# group, so the SEP container has to join group 0 — `group_add: ["0"]`, or
+# `user: "1001:0"` — or it cannot read them.
+# The token is revalidated against Grafana on every PMM start, and replaced when the
+# file is missing or empty or Grafana rejects it, so restarting PMM does not revoke the
+# token a running SEP holds.
 # Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
 # account is left in place.
 

--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,21 @@ PMM_PORT_HTTPS=443
 # PMM_ENABLE_SEP=1
 # PMM_SEP_POSTGRES_PASSWORD=<password>
 
+# With PMM_ENABLE_SEP set, PMM also provisions the Grafana service account SEP
+# authenticates users against, and writes its token to /srv/sep-secrets — the
+# `pmm-sep-secrets` volume, which the SEP container mounts read-only with SECRETS_DIR
+# pointing at it. The same token value is written to two files, one per canonical SEP
+# settings name:
+#   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
+#   PMM__API_KEY
+# The directory is mode 0750 and the files 0640, owned by PMM's runtime user and group
+# (uid 1000, gid 0). PMM cannot chgrp to SEP's own group, so the SEP container has to
+# join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
+# The token is revalidated against Grafana on every PMM start and replaced only when
+# Grafana rejects it, so restarting PMM does not revoke the token a running SEP holds.
+# Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
+# account is left in place.
+
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full
 # GF_DATABASE_CA_CERT_PATH=/tmp/certs/root.crt

--- a/.env.example
+++ b/.env.example
@@ -60,10 +60,11 @@ PMM_PORT_HTTPS=443
 # settings name:
 #   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
 #   PMM__API_KEY
-# The directory is mode 0770 and the files 0640, owned by PMM's runtime user and its
-# primary group (uid 1000, gid 0 in the stock image). PMM cannot chgrp to SEP's own
-# group, so the SEP container has to join group 0 — `group_add: ["0"]`, or
-# `user: "1001:0"` — or it cannot read them.
+# The directory is setgid mode 2770 and the files 0640, so both files belong to group 0
+# whichever uid PMM runs as. PMM cannot chgrp to SEP's own group, so the SEP container
+# has to join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
+# Leave both settings names above unset on the SEP container rather than empty: an empty
+# value counts as supplied there and outranks the file, which then goes unused.
 # The token is revalidated against Grafana on every PMM start, and replaced when the
 # file is missing or empty or Grafana rejects it, so restarting PMM does not revoke the
 # token a running SEP holds.

--- a/api-tests/server/logs_test.go
+++ b/api-tests/server/logs_test.go
@@ -68,6 +68,7 @@ func TestDownloadLogs(t *testing.T) {
 		"prometheus.base.yml",
 		"qan-api2.ini",
 		"qan-api2.log",
+		"sep-provision.log",
 		"supervisorctl_status.log",
 		"supervisord.conf",
 		"supervisord.log",

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -70,13 +70,16 @@
     # Must exist in the image: a named volume mounted at a path the image lacks is
     # created root:root, which pmm-server cannot write to. Group-writable like the
     # other /srv directories, so an arbitrary runtime uid in group 0 can still write.
+    # Setgid so the token files written here belong to group 0 whatever that uid's
+    # primary group is - the SEP container joins group 0 to read them. Docker carries
+    # the bit into a fresh named volume mounted at this path.
     - name: Create the SEP secrets mountpoint
       file:
         path: /srv/sep-secrets
         state: directory
         owner: pmm
         group: root
-        mode: 0770
+        mode: 02770
 
     - name: Create empty log directory for nginx
       file:

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -67,6 +67,16 @@
         - directory
       no_log: true
 
+    # Must exist in the image: a named volume mounted at a path the image lacks is
+    # created root:root, which pmm-server cannot write to.
+    - name: Create the SEP secrets mountpoint
+      file:
+        path: /srv/sep-secrets
+        state: directory
+        owner: pmm
+        group: root
+        mode: 0750
+
     - name: Create empty log directory for nginx
       file:
         path: /var/log/nginx

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -68,14 +68,15 @@
       no_log: true
 
     # Must exist in the image: a named volume mounted at a path the image lacks is
-    # created root:root, which pmm-server cannot write to.
+    # created root:root, which pmm-server cannot write to. Group-writable like the
+    # other /srv directories, so an arbitrary runtime uid in group 0 can still write.
     - name: Create the SEP secrets mountpoint
       file:
         path: /srv/sep-secrets
         state: directory
         owner: pmm
         group: root
-        mode: 0750
+        mode: 0770
 
     - name: Create empty log directory for nginx
       file:

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# Provisions the Grafana service account SEP authenticates with, and publishes its
+# token to a secrets directory the SEP container mounts. One file per canonical SEP
+# settings name, mode 0640, owned by pmm's primary group, so SEP must join group 0.
+#
+# Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
+# the token files this script wrote are removed on the next start; the Grafana
+# service account itself is left in place.
+#
+# Runs under supervisord rather than from the entrypoint because Grafana is neither
+# running nor migrated - on a first boot its schema does not exist at all - until
+# long after the entrypoint has exec'd supervisord.
+#
+# The token is validated against Grafana on every start and replaced only when
+# Grafana rejects it, because SEP reads the secrets directory once at its own start:
+# re-minting unconditionally would revoke the token a running SEP is still holding.
+
+set -o errexit
+set -o pipefail
+
+declare SECRETS_DIR="${SECRETS_DIR:-/srv/sep-secrets}"
+declare GRAFANA_URL="http://127.0.0.1:3000"
+declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
+declare SA_NAME="pmm-sep"
+declare TOKEN_NAME="pmm-sep"
+declare READY_TIMEOUT=300
+declare READY_INTERVAL=5
+declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+psql_grafana() {
+    "$POSTGRES_BIN_DIR/psql" -X -q -v ON_ERROR_STOP=1 -U postgres -h /run/postgresql -d grafana "$@"
+}
+
+# Same readiness signal pmm-managed waits on: /api/health reporting the database as ok.
+wait_for_grafana() {
+    local waited=0
+
+    while [ "$waited" -lt "$READY_TIMEOUT" ]; do
+        if curl -sS --max-time 5 "$GRAFANA_URL/api/health" 2> /dev/null |
+            grep -q '"database": *"ok"'; then
+            return 0
+        fi
+        sleep "$READY_INTERVAL"
+        waited=$((waited + READY_INTERVAL))
+    done
+
+    return 1
+}
+
+# Proves the token by an authenticated call to the access-control endpoint SEP's
+# org-role lookups go through. The header is fed on stdin rather than passed with
+# -H so the token never appears in any process's argv.
+grafana_authenticates() {
+    local code
+
+    code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
+        curl -sS -K - -o /dev/null -w '%{http_code}' \
+            "$GRAFANA_URL/api/access-control/user/permissions") || return 1
+
+    [ "$code" = "200" ]
+}
+
+# Prints the token value, its api_key.key hash, and the user row's salt, rands and
+# uid, one per line. The encoding reproduces Grafana's own: the checksum is
+# crc32("glsa_" + secret) serialised little-endian, and the stored hash is
+# util.EncodePassword(secret, checksum).
+generate_token_material() {
+    python3 - <<'PY'
+import binascii
+import hashlib
+import secrets
+import string
+import zlib
+
+alnum = string.ascii_letters + string.digits
+secret = "".join(secrets.choice(alnum) for _ in range(32))
+checksum = binascii.hexlify(
+    zlib.crc32(("glsa_" + secret).encode()).to_bytes(4, "little")
+).decode()
+
+print(f"glsa_{secret}_{checksum}")
+print(hashlib.pbkdf2_hmac("sha256", secret.encode(), checksum.encode(), 10000, 50).hex())
+print("".join(secrets.choice(alnum) for _ in range(10)))
+print("".join(secrets.choice(alnum) for _ in range(10)))
+print("".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(14)))
+PY
+}
+
+# Administers Grafana through the database it owns, the way postgres-sep provisions
+# the sep role as the local superuser: Grafana exposes no credential-free path to
+# create a service account, and pmm-server holds no Grafana admin credential once an
+# operator has changed the admin password.
+#
+# psql only interpolates :'var' when reading a script, hence stdin rather than -c.
+# \gset is what carries the org and service-account ids between statements; the
+# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and
+# DO UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
+provision_service_account() {
+    local hashed="$1" salt="$2" rands="$3" uid="$4"
+
+    psql_grafana -v sa_name="$SA_NAME" -v token_name="$TOKEN_NAME" -v hashed="$hashed" \
+        -v salt="$salt" -v rands="$rands" -v uid="$uid" <<'SQL'
+BEGIN;
+
+SELECT id AS org_id FROM org ORDER BY id LIMIT 1
+\gset
+
+INSERT INTO "user" (version, login, email, name, password, salt, rands, company, org_id,
+                    is_admin, email_verified, theme, created, updated, help_flags1,
+                    is_disabled, is_service_account, uid, is_provisioned)
+VALUES (0, 'sa-' || :'org_id' || '-' || :'sa_name', 'sa-' || :'org_id' || '-' || :'sa_name',
+        :'sa_name', '', :'salt', :'rands', '', :'org_id',
+        false, false, '', now(), now(), 0, false, true, :'uid', false)
+ON CONFLICT (login) DO UPDATE SET updated = now(), is_disabled = false
+RETURNING id AS sa_id
+\gset
+
+INSERT INTO org_user (org_id, user_id, role, created, updated)
+VALUES (:'org_id', :'sa_id', 'Admin', now(), now())
+ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'Admin', updated = now();
+
+-- Also matched on (org_id, name) so a token orphaned from an earlier account cannot
+-- collide with UQE_api_key_org_id_name and abort the insert below.
+DELETE FROM api_key
+WHERE service_account_id = :'sa_id' OR (org_id = :'org_id' AND name = :'token_name');
+
+-- Grafana stores Viewer in api_key.role for every service-account token whatever role
+-- the request asked for; the effective authority is org_user.role above.
+INSERT INTO api_key (org_id, name, key, role, created, updated, service_account_id, is_revoked)
+VALUES (:'org_id', :'token_name', :'hashed', 'Viewer', now(), now(), :'sa_id', false);
+
+COMMIT;
+SQL
+}
+
+# Written through a temporary file so SEP never reads a half-written secret.
+publish_token() {
+    local token="$1" name tmp
+
+    for name in "${TOKEN_FILES[@]}"; do
+        tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+        printf '%s' "$token" > "$tmp"
+        chmod 0640 "$tmp"
+        mv "$tmp" "$SECRETS_DIR/$name"
+    done
+}
+
+remove_token_files() {
+    local name
+
+    for name in "${TOKEN_FILES[@]}"; do
+        rm -f "${SECRETS_DIR:?}/$name"
+    done
+}
+
+if ! is_enabled "$PMM_ENABLE_SEP"; then
+    remove_token_files
+    exit 0
+fi
+
+if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
+    [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
+    echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
+    exit 0
+fi
+
+if ! install -d -m 0750 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for $(id -un)." >&2
+    echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
+    exit 1
+fi
+
+if ! wait_for_grafana; then
+    echo "FATAL: Grafana did not become ready within ${READY_TIMEOUT}s, cannot provision the SEP service account." >&2
+    exit 1
+fi
+
+declare TOKEN=""
+if [ -s "$SECRETS_DIR/${TOKEN_FILES[0]}" ]; then
+    TOKEN=$(< "$SECRETS_DIR/${TOKEN_FILES[0]}")
+fi
+
+if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
+    echo "The Grafana service account token for SEP is still valid, keeping it."
+    publish_token "$TOKEN"
+    exit 0
+fi
+
+echo "Provisioning the Grafana service account for SEP..."
+
+declare MATERIAL
+MATERIAL=$(generate_token_material)
+
+declare -a PARTS
+mapfile -t PARTS <<< "$MATERIAL"
+if [ ${#PARTS[@]} -ne 5 ]; then
+    echo "FATAL: could not generate the Grafana service account token." >&2
+    exit 1
+fi
+
+TOKEN="${PARTS[0]}"
+provision_service_account "${PARTS[1]}" "${PARTS[2]}" "${PARTS[3]}" "${PARTS[4]}"
+
+# Validated before publishing so a half-working credential never reaches SEP, and so a
+# future change to Grafana's schema or token encoding fails loudly here instead of
+# silently breaking SEP's authentication.
+if ! grafana_authenticates "$TOKEN"; then
+    echo "FATAL: Grafana rejected the service account token just provisioned for SEP." >&2
+    exit 1
+fi
+
+publish_token "$TOKEN"
+echo "Published the Grafana service account token for SEP to $SECRETS_DIR."

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -25,7 +25,9 @@ declare GRAFANA_URL="http://127.0.0.1:3000"
 declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
-declare READY_TIMEOUT=300
+# Generous because a failed run is not retried: the one-shot cannot bound its own
+# restarts under supervisord, so waiting longer here is what absorbs a slow first boot.
+declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
 declare TMP_FILE=""
@@ -171,13 +173,18 @@ publish_token() {
     done
 }
 
-# Kept unconditionally inert: rm fails on an existing file in a directory this uid
-# cannot write, and the disabled path must never turn that into a non-zero exit.
+# Inert by design - the disabled path must not fail a start over a directory this uid
+# cannot write - but a token left behind is still readable by SEP, so say so rather
+# than swallowing the failure.
 remove_token_files() {
-    local name
+    local name path
 
     for name in "${TOKEN_FILES[@]}"; do
-        rm -f "${SECRETS_DIR:?}/$name" || true
+        path="${SECRETS_DIR:?}/$name"
+        rm -f "$path" 2> /dev/null || true
+        if [ -e "$path" ]; then
+            echo "WARNING: could not remove $path, SEP can still read this token." >&2
+        fi
     done
 }
 

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -19,6 +19,7 @@ set -o pipefail
 declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
 declare GRAFANA_URL="http://127.0.0.1:3000"
 declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
+declare TOKEN_BIN="/usr/sbin/pmm-sep-token"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
 # Generous because a failed run is not retried: the one-shot cannot bound its own
@@ -91,32 +92,6 @@ WHERE u.id = ou.user_id
   AND u.login = 'sa-' || ou.org_id || '-' || :'sa_name'
   AND ou.role <> 'Admin';
 SQL
-}
-
-# Prints, one per line and in the order the caller unpacks them: the token value, its
-# api_key.key hash, and the user row's salt, rands and uid. The encoding reproduces
-# Grafana's own - crc32("glsa_" + secret) little-endian as the checksum,
-# util.EncodePassword(secret, checksum) as the stored hash.
-generate_token_material() {
-    python3 - <<'PY'
-import binascii
-import hashlib
-import secrets
-import string
-import zlib
-
-alnum = string.ascii_letters + string.digits
-secret = "".join(secrets.choice(alnum) for _ in range(32))
-checksum = binascii.hexlify(
-    zlib.crc32(("glsa_" + secret).encode()).to_bytes(4, "little")
-).decode()
-
-print(f"glsa_{secret}_{checksum}")
-print(hashlib.pbkdf2_hmac("sha256", secret.encode(), checksum.encode(), 10000, 50).hex())
-print("".join(secrets.choice(alnum) for _ in range(10)))
-print("".join(secrets.choice(alnum) for _ in range(10)))
-print("".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(14)))
-PY
 }
 
 # Administers Grafana through the database it owns, the way postgres-sep provisions the
@@ -251,8 +226,10 @@ esac
 
 echo "Provisioning the Grafana service account for SEP..."
 
+# Five lines, in the order unpacked below: the token value, its api_key.key hash, and
+# the user row's salt, rands and uid.
 declare MATERIAL
-MATERIAL=$(generate_token_material)
+MATERIAL=$("$TOKEN_BIN")
 
 declare -a PARTS
 mapfile -t PARTS <<< "$MATERIAL"

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,8 +2,10 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a 0770 directory, owned by pmm's primary group, so the
-# SEP container must join group 0 to read them.
+# settings name, mode 0640 in a setgid 2770 directory, so each file's group is
+# inherited from the directory - group 0 - whatever uid pmm-server runs as, and the
+# SEP container must join group 0 to read them. Without setgid a file takes the
+# publishing process's primary group, which is 0 only in the stock image.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
@@ -20,7 +22,7 @@
 set -o errexit
 set -o pipefail
 
-declare SECRETS_DIR="${SECRETS_DIR:-/srv/sep-secrets}"
+declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
 declare GRAFANA_URL="http://127.0.0.1:3000"
 declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
@@ -60,17 +62,30 @@ wait_for_grafana() {
     return 1
 }
 
-# Proves the token by an authenticated call to the access-control endpoint SEP's
-# org-role lookups go through. The header is fed on stdin rather than passed with
-# -H so the token never appears in any process's argv.
-grafana_authenticates() {
-    local code
+# Prints the status of an authenticated call to the access-control endpoint SEP's
+# org-role lookups go through, or 000 when the call could not be made at all. The
+# header is fed on stdin rather than passed with -H so the token never appears in any
+# process's argv.
+#
+# Retried, and unreachable kept distinct from rejected, because a transient failure is
+# not a revoked token: reading one as the other on the reuse path would re-mint and so
+# revoke the token a running SEP holds - the very thing this script avoids.
+grafana_auth_status() {
+    local code attempt=0
 
-    code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
-        curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
-            "$GRAFANA_URL/api/access-control/user/permissions") || return 1
+    while :; do
+        code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
+            curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
+                "$GRAFANA_URL/api/access-control/user/permissions") || code="000"
 
-    [ "$code" = "200" ]
+        attempt=$((attempt + 1))
+        if [ "$code" != "000" ] || [ "$attempt" -ge 3 ]; then
+            break
+        fi
+        sleep "$READY_INTERVAL"
+    done
+
+    printf '%s' "$code"
 }
 
 # The validator endpoint answers 200 for any role, so a service account demoted in the
@@ -196,10 +211,21 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
+    # Same cleanup as the disabled path: a token this script can no longer revalidate or
+    # replace must not be left behind for SEP to keep reading.
+    remove_token_files
     exit 0
 fi
 
-if ! install -d -m 0770 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+# Created only when absent, because install -d on an existing directory also chmods it,
+# which a uid that does not own the mountpoint cannot do. The mountpoint ships in the
+# image already setgid (post-build.yml), so this create path is only for setups that
+# mount nothing here.
+if [ ! -d "$SECRETS_DIR" ]; then
+    install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
+fi
+
+if [ ! -w "$SECRETS_DIR" ]; then
     echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
     echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
     exit 1
@@ -215,12 +241,29 @@ if [ -s "$SECRETS_DIR/${TOKEN_FILES[0]}" ]; then
     TOKEN=$(< "$SECRETS_DIR/${TOKEN_FILES[0]}")
 fi
 
-if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
-    echo "The Grafana service account token for SEP is still valid, keeping it."
-    ensure_admin_role
-    publish_token "$TOKEN"
-    exit 0
+declare STATUS=""
+if [ -n "$TOKEN" ]; then
+    STATUS=$(grafana_auth_status "$TOKEN")
 fi
+
+case "$STATUS" in
+    200)
+        echo "The Grafana service account token for SEP is still valid, keeping it."
+        # Published before the role repair so a token already proven valid still reaches
+        # SEP if that secondary step fails under errexit.
+        publish_token "$TOKEN"
+        ensure_admin_role
+        exit 0
+        ;;
+    "" | 401 | 403)
+        # No token yet, or Grafana genuinely rejected it: fall through and mint.
+        ;;
+    *)
+        echo "FATAL: could not verify the existing Grafana token for SEP, the check answered $STATUS." >&2
+        echo "Please retry once Grafana answers again; replacing the token now would revoke the one SEP is using." >&2
+        exit 1
+        ;;
+esac
 
 echo "Provisioning the Grafana service account for SEP..."
 
@@ -240,7 +283,7 @@ provision_service_account "${PARTS[1]}" "${PARTS[2]}" "${PARTS[3]}" "${PARTS[4]}
 # Validated before publishing so a half-working credential never reaches SEP, and so a
 # future change to Grafana's schema or token encoding fails loudly here instead of
 # silently breaking SEP's authentication.
-if ! grafana_authenticates "$TOKEN"; then
+if [ "$(grafana_auth_status "$TOKEN")" != "200" ]; then
     echo "FATAL: Grafana rejected the service account token just provisioned for SEP." >&2
     exit 1
 fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,7 +2,8 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640, owned by pmm's primary group, so SEP must join group 0.
+# settings name, mode 0640 in a 0770 directory, owned by pmm's primary group, so the
+# SEP container must join group 0 to read them.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
@@ -12,9 +13,9 @@
 # running nor migrated - on a first boot its schema does not exist at all - until
 # long after the entrypoint has exec'd supervisord.
 #
-# The token is validated against Grafana on every start and replaced only when
-# Grafana rejects it, because SEP reads the secrets directory once at its own start:
-# re-minting unconditionally would revoke the token a running SEP is still holding.
+# The token is validated against Grafana on every start, and replaced when the file is
+# missing or empty or Grafana rejects it, because SEP reads the secrets directory once
+# at its own start: re-minting unconditionally would revoke a running SEP's token.
 
 set -o errexit
 set -o pipefail
@@ -27,6 +28,13 @@ declare TOKEN_NAME="pmm-sep"
 declare READY_TIMEOUT=300
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
+declare TMP_FILE=""
+
+cleanup() {
+    [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    return 0
+}
+trap cleanup EXIT
 
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
@@ -57,10 +65,24 @@ grafana_authenticates() {
     local code
 
     code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
-        curl -sS -K - -o /dev/null -w '%{http_code}' \
+        curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
             "$GRAFANA_URL/api/access-control/user/permissions") || return 1
 
     [ "$code" = "200" ]
+}
+
+# The validator endpoint answers 200 for any role, so a service account demoted in the
+# Grafana UI would keep authenticating while SEP's org-role lookups silently degrade.
+# Idempotent, and writes only when the role has actually drifted.
+ensure_admin_role() {
+    psql_grafana -v sa_name="$SA_NAME" <<'SQL'
+UPDATE org_user ou
+SET role = 'Admin', updated = now()
+FROM "user" u
+WHERE u.id = ou.user_id
+  AND u.login = 'sa-' || ou.org_id || '-' || :'sa_name'
+  AND ou.role <> 'Admin';
+SQL
 }
 
 # Prints the token value, its api_key.key hash, and the user row's salt, rands and
@@ -138,21 +160,24 @@ SQL
 
 # Written through a temporary file so SEP never reads a half-written secret.
 publish_token() {
-    local token="$1" name tmp
+    local token="$1" name
 
     for name in "${TOKEN_FILES[@]}"; do
-        tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
-        printf '%s' "$token" > "$tmp"
-        chmod 0640 "$tmp"
-        mv "$tmp" "$SECRETS_DIR/$name"
+        TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+        printf '%s' "$token" > "$TMP_FILE"
+        chmod 0640 "$TMP_FILE"
+        mv "$TMP_FILE" "$SECRETS_DIR/$name"
+        TMP_FILE=""
     done
 }
 
+# Kept unconditionally inert: rm fails on an existing file in a directory this uid
+# cannot write, and the disabled path must never turn that into a non-zero exit.
 remove_token_files() {
     local name
 
     for name in "${TOKEN_FILES[@]}"; do
-        rm -f "${SECRETS_DIR:?}/$name"
+        rm -f "${SECRETS_DIR:?}/$name" || true
     done
 }
 
@@ -167,8 +192,8 @@ if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     exit 0
 fi
 
-if ! install -d -m 0750 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
-    echo "FATAL: $SECRETS_DIR is not writable for $(id -un)." >&2
+if ! install -d -m 0770 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
     echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
     exit 1
 fi
@@ -185,6 +210,7 @@ fi
 
 if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
     echo "The Grafana service account token for SEP is still valid, keeping it."
+    ensure_admin_role
     publish_token "$TOKEN"
     exit 0
 fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,9 +2,8 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a setgid 2770 directory, so each file's group is
-# inherited from the directory - group 0 - whatever uid pmm-server runs as, and the
-# SEP container must join group 0 to read them. Without setgid a file takes the
+# settings name, mode 0640 in a setgid 2770 directory, so the SEP container must join
+# group 0 to read them. The setgid bit is load-bearing: without it a file takes the
 # publishing process's primary group, which is 0 only in the stock image.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
@@ -67,9 +66,8 @@ wait_for_grafana() {
 # header is fed on stdin rather than passed with -H so the token never appears in any
 # process's argv.
 #
-# Retried, and unreachable kept distinct from rejected, because a transient failure is
-# not a revoked token: reading one as the other on the reuse path would re-mint and so
-# revoke the token a running SEP holds - the very thing this script avoids.
+# Unreachable is kept distinct from rejected, and retried, because a transient failure
+# is not a revoked token: reading one as the other re-mints on the reuse path below.
 grafana_auth_status() {
     local code attempt=0
 
@@ -211,16 +209,12 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
-    # Same cleanup as the disabled path: a token this script can no longer revalidate or
-    # replace must not be left behind for SEP to keep reading.
     remove_token_files
     exit 0
 fi
 
-# Created only when absent, because install -d on an existing directory also chmods it,
-# which a uid that does not own the mountpoint cannot do. The mountpoint ships in the
-# image already setgid (post-build.yml), so this create path is only for setups that
-# mount nothing here.
+# Created only when absent: install -d on an existing directory also chmods it, which a
+# uid that does not own the mountpoint cannot do.
 if [ ! -d "$SECRETS_DIR" ]; then
     install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
 fi
@@ -249,8 +243,8 @@ fi
 case "$STATUS" in
     200)
         echo "The Grafana service account token for SEP is still valid, keeping it."
-        # Published before the role repair so a token already proven valid still reaches
-        # SEP if that secondary step fails under errexit.
+        # Ordered so a token already proven valid reaches SEP even if the role repair
+        # below fails under errexit.
         publish_token "$TOKEN"
         ensure_admin_role
         exit 0

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -1,22 +1,17 @@
 #!/bin/bash
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
-# token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a setgid 2770 directory, so the SEP container must join
-# group 0 to read them. The setgid bit is load-bearing: without it a file takes the
-# publishing process's primary group, which is 0 only in the stock image.
+# token to a secrets directory the SEP container mounts, one file per canonical SEP
+# settings name. The files are 0640 and take group 0 from the setgid directory
+# post-build.yml ships - nothing here sets their group, so that bit must stay.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
 # service account itself is left in place.
 #
 # Runs under supervisord rather than from the entrypoint because Grafana is neither
-# running nor migrated - on a first boot its schema does not exist at all - until
-# long after the entrypoint has exec'd supervisord.
-#
-# The token is validated against Grafana on every start, and replaced when the file is
-# missing or empty or Grafana rejects it, because SEP reads the secrets directory once
-# at its own start: re-minting unconditionally would revoke a running SEP's token.
+# running nor migrated - on a first boot its schema does not exist - until long after
+# the entrypoint has exec'd supervisord.
 
 set -o errexit
 set -o pipefail
@@ -27,7 +22,7 @@ declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
 # Generous because a failed run is not retried: the one-shot cannot bound its own
-# restarts under supervisord, so waiting longer here is what absorbs a slow first boot.
+# restarts under supervisord.
 declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
@@ -62,9 +57,8 @@ wait_for_grafana() {
 }
 
 # Prints the status of an authenticated call to the access-control endpoint SEP's
-# org-role lookups go through, or 000 when the call could not be made at all. The
-# header is fed on stdin rather than passed with -H so the token never appears in any
-# process's argv.
+# org-role lookups go through, or 000 when the call could not be made at all. Fed on
+# stdin rather than -H so the token never appears in any process's argv.
 #
 # Unreachable is kept distinct from rejected, and retried, because a transient failure
 # is not a revoked token: reading one as the other re-mints on the reuse path below.
@@ -88,7 +82,6 @@ grafana_auth_status() {
 
 # The validator endpoint answers 200 for any role, so a service account demoted in the
 # Grafana UI would keep authenticating while SEP's org-role lookups silently degrade.
-# Idempotent, and writes only when the role has actually drifted.
 ensure_admin_role() {
     psql_grafana -v sa_name="$SA_NAME" <<'SQL'
 UPDATE org_user ou
@@ -100,10 +93,10 @@ WHERE u.id = ou.user_id
 SQL
 }
 
-# Prints the token value, its api_key.key hash, and the user row's salt, rands and
-# uid, one per line. The encoding reproduces Grafana's own: the checksum is
-# crc32("glsa_" + secret) serialised little-endian, and the stored hash is
-# util.EncodePassword(secret, checksum).
+# Prints, one per line and in the order the caller unpacks them: the token value, its
+# api_key.key hash, and the user row's salt, rands and uid. The encoding reproduces
+# Grafana's own - crc32("glsa_" + secret) little-endian as the checksum,
+# util.EncodePassword(secret, checksum) as the stored hash.
 generate_token_material() {
     python3 - <<'PY'
 import binascii
@@ -126,15 +119,13 @@ print("".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in ra
 PY
 }
 
-# Administers Grafana through the database it owns, the way postgres-sep provisions
-# the sep role as the local superuser: Grafana exposes no credential-free path to
-# create a service account, and pmm-server holds no Grafana admin credential once an
-# operator has changed the admin password.
+# Administers Grafana through the database it owns, the way postgres-sep provisions the
+# sep role as the local superuser: Grafana exposes no credential-free path to create a
+# service account, and once an operator changes the admin password pmm-server holds none.
 #
-# psql only interpolates :'var' when reading a script, hence stdin rather than -c.
-# \gset is what carries the org and service-account ids between statements; the
-# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and
-# DO UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
+# psql only interpolates :'var' when reading a script, hence stdin rather than -c. The
+# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and DO
+# UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
 provision_service_account() {
     local hashed="$1" salt="$2" rands="$3" uid="$4"
 
@@ -159,8 +150,8 @@ INSERT INTO org_user (org_id, user_id, role, created, updated)
 VALUES (:'org_id', :'sa_id', 'Admin', now(), now())
 ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'Admin', updated = now();
 
--- Also matched on (org_id, name) so a token orphaned from an earlier account cannot
--- collide with UQE_api_key_org_id_name and abort the insert below.
+-- Every token on the account, plus any token elsewhere in the org already holding the
+-- name, which would otherwise collide with UQE_api_key_org_id_name below.
 DELETE FROM api_key
 WHERE service_account_id = :'sa_id' OR (org_id = :'org_id' AND name = :'token_name');
 
@@ -186,9 +177,8 @@ publish_token() {
     done
 }
 
-# Inert by design - the disabled path must not fail a start over a directory this uid
-# cannot write - but a token left behind is still readable by SEP, so say so rather
-# than swallowing the failure.
+# Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
+# write - but a token left behind is still readable by SEP, so it is reported.
 remove_token_files() {
     local name path
 

--- a/build/ansible/roles/grafana/tasks/main.yml
+++ b/build/ansible/roles/grafana/tasks/main.yml
@@ -53,3 +53,9 @@
     src: change-admin-password
     dest: /usr/local/sbin/change-admin-password
     mode: 0755
+
+- name: Copy grafana-sep command
+  copy:
+    src: grafana-sep
+    dest: /usr/local/sbin/grafana-sep
+    mode: 0755

--- a/build/ansible/roles/supervisord/files/sep.ini
+++ b/build/ansible/roles/supervisord/files/sep.ini
@@ -1,16 +1,21 @@
 ; Provisions the Grafana service account SEP authenticates with, once Grafana is up.
-; A no-op unless PMM_ENABLE_SEP is set. startsecs is 0 because this is a one-shot:
-; a non-zero value makes the immediate exit of the disabled path look like a failed start.
+; A no-op unless PMM_ENABLE_SEP is set.
+;
+; A one-shot, hence startsecs = 0: a non-zero value makes the immediate exit of the
+; disabled path look like a failed start. That in turn rules out autorestart, since
+; startretries only bounds restarts from BACKOFF, a state startsecs = 0 never reaches -
+; leaving every failure to respawn immediately and forever. A failed provisioning run
+; is meant to be read, not retried: it lands as EXITED with a non-zero status in
+; supervisorctl and a FATAL line in the log below.
 
 [program:sep-provision]
 priority = 20
 command = /usr/local/sbin/grafana-sep
 directory = /
-autorestart = unexpected
+autorestart = false
 exitcodes = 0
 autostart = true
 startsecs = 0
-startretries = 3
 stdout_logfile = /srv/logs/sep-provision.log
 stdout_logfile_maxbytes = 10MB
 stdout_logfile_backups = 3

--- a/build/ansible/roles/supervisord/files/sep.ini
+++ b/build/ansible/roles/supervisord/files/sep.ini
@@ -1,0 +1,17 @@
+; Provisions the Grafana service account SEP authenticates with, once Grafana is up.
+; A no-op unless PMM_ENABLE_SEP is set. startsecs is 0 because this is a one-shot:
+; a non-zero value makes the immediate exit of the disabled path look like a failed start.
+
+[program:sep-provision]
+priority = 20
+command = /usr/local/sbin/grafana-sep
+directory = /
+autorestart = unexpected
+exitcodes = 0
+autostart = true
+startsecs = 0
+startretries = 3
+stdout_logfile = /srv/logs/sep-provision.log
+stdout_logfile_maxbytes = 10MB
+stdout_logfile_backups = 3
+redirect_stderr = true

--- a/build/ansible/roles/supervisord/tasks/main.yml
+++ b/build/ansible/roles/supervisord/tasks/main.yml
@@ -81,6 +81,7 @@
     - supervisord.ini
     - grafana.ini
     - pmm.ini
+    - sep.ini
 
 - name: Fix credentials
   ini_file:

--- a/build/packages/rpm/server/SPECS/pmm-managed.spec
+++ b/build/packages/rpm/server/SPECS/pmm-managed.spec
@@ -51,6 +51,7 @@ install -p -m 0755 bin/pmm-managed %{buildroot}%{_sbindir}/pmm-managed
 install -p -m 0755 bin/pmm-encryption-rotation %{buildroot}%{_sbindir}/pmm-encryption-rotation
 install -p -m 0755 bin/pmm-managed-init %{buildroot}%{_sbindir}/pmm-managed-init
 install -p -m 0755 bin/pmm-managed-starlark %{buildroot}%{_sbindir}/pmm-managed-starlark
+install -p -m 0755 bin/pmm-sep-token %{buildroot}%{_sbindir}/pmm-sep-token
 
 cd src/github.com/percona/pmm
 cp -pa ./api/swagger %{buildroot}%{_datadir}/%{name}
@@ -65,6 +66,7 @@ cp -pa ./managed/data/alerting-templates/*.yml %{buildroot}/usr/local/percona/al
 %{_sbindir}/pmm-encryption-rotation
 %{_sbindir}/pmm-managed-init
 %{_sbindir}/pmm-managed-starlark
+%{_sbindir}/pmm-sep-token
 %{_datadir}/%{name}
 %attr(0644, pmm, root) /usr/local/percona/advisors/*.yml
 %attr(0644, pmm, root) /usr/local/percona/checks/*.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       - ${PMM_PORT_HTTPS:-443}:8443
     volumes:
       - pmm-data:/srv
+      # Credentials PMM provisions for SEP. Mount this same volume in the SEP container
+      # and point SECRETS_DIR at it; never share pmm-data itself with SEP.
+      - pmm-sep-secrets:/srv/sep-secrets
 
   pmm-client:
     profiles:
@@ -162,3 +165,5 @@ services:
 volumes:
   pmm-data:
     name: pmm-data
+  pmm-sep-secrets:
+    name: pmm-sep-secrets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
       - ${PMM_PORT_HTTPS:-443}:8443
     volumes:
       - pmm-data:/srv
-      # Credentials PMM provisions for SEP. Mount this same volume in the SEP container
-      # and point SECRETS_DIR at it; never share pmm-data itself with SEP.
+      # Credentials PMM provisions for SEP. Mount this same volume read-only in the SEP
+      # container and point SECRETS_DIR at it; never share pmm-data itself with SEP.
       - pmm-sep-secrets:/srv/sep-secrets
 
   pmm-client:

--- a/managed/cmd/pmm-sep-token/main.go
+++ b/managed/cmd/pmm-sep-token/main.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package main generates the material for a Grafana service account token.
+//
+// It prints five lines on stdout, in the order the caller unpacks them: the
+// token value, its api_key.key hash, and the user row's salt, rands and uid.
+// The encoding reproduces Grafana's own - crc32("glsa_" + secret) little-endian
+// as the checksum, util.EncodePassword(secret, checksum) as the stored hash.
+//
+// The secret is generated and hashed in-process so it never reaches any
+// command line, which is also why this is a program rather than a shell
+// pipeline over openssl.
+package main
+
+import (
+	"crypto/pbkdf2"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+	"os"
+)
+
+const (
+	tokenPrefix    = "glsa_"
+	secretLength   = 32
+	saltLength     = 10
+	randsLength    = 10
+	uidLength      = 14
+	hashIterations = 10000
+	hashLength     = 50
+
+	alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	lowerAlnum   = "abcdefghijklmnopqrstuvwxyz0123456789"
+)
+
+// randomString returns n characters drawn uniformly from alphabet.
+//
+// Bytes at or above limit are discarded rather than folded in, because a plain
+// modulo would over-represent the first 256%len(alphabet) characters.
+func randomString(n int, alphabet string) (string, error) {
+	limit := 256 - 256%len(alphabet)
+	buf := make([]byte, n)
+	out := make([]byte, 0, n)
+
+	for len(out) < n {
+		if _, err := rand.Read(buf); err != nil {
+			return "", fmt.Errorf("cannot read random bytes: %w", err)
+		}
+		for _, b := range buf {
+			if int(b) >= limit {
+				continue
+			}
+			out = append(out, alphabet[int(b)%len(alphabet)])
+			if len(out) == n {
+				break
+			}
+		}
+	}
+
+	return string(out), nil
+}
+
+// checksumFor reproduces Grafana's apikeygenprefix checksum: the CRC32 of the
+// prefixed secret, little-endian, hex-encoded.
+func checksumFor(secret string) string {
+	sum := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sum, crc32.ChecksumIEEE([]byte(tokenPrefix+secret)))
+	return hex.EncodeToString(sum)
+}
+
+func generate() ([]string, error) {
+	secret, err := randomString(secretLength, alphanumeric)
+	if err != nil {
+		return nil, err
+	}
+	salt, err := randomString(saltLength, alphanumeric)
+	if err != nil {
+		return nil, err
+	}
+	rands, err := randomString(randsLength, alphanumeric)
+	if err != nil {
+		return nil, err
+	}
+	uid, err := randomString(uidLength, lowerAlnum)
+	if err != nil {
+		return nil, err
+	}
+
+	checksum := checksumFor(secret)
+	hashed, err := pbkdf2.Key(sha256.New, secret, []byte(checksum), hashIterations, hashLength)
+	if err != nil {
+		return nil, fmt.Errorf("cannot derive the token hash: %w", err)
+	}
+
+	return []string{
+		tokenPrefix + secret + "_" + checksum,
+		hex.EncodeToString(hashed),
+		salt,
+		rands,
+		uid,
+	}, nil
+}
+
+func main() {
+	lines, err := generate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pmm-sep-token: %s\n", err)
+		os.Exit(1)
+	}
+
+	for _, line := range lines {
+		fmt.Println(line)
+	}
+}

--- a/managed/cmd/pmm-sep-token/main.go
+++ b/managed/cmd/pmm-sep-token/main.go
@@ -88,6 +88,18 @@ func checksumFor(secret string) string {
 	return hex.EncodeToString(sum)
 }
 
+// hashSecret reproduces Grafana's util.EncodePassword for a service account
+// token: PBKDF2-HMAC-SHA256 over the secret, salted with the token's own
+// checksum, hex-encoded.
+func hashSecret(secret, checksum string) (string, error) {
+	hashed, err := pbkdf2.Key(sha256.New, secret, []byte(checksum), hashIterations, hashLength)
+	if err != nil {
+		return "", fmt.Errorf("cannot derive the token hash: %w", err)
+	}
+
+	return hex.EncodeToString(hashed), nil
+}
+
 func generate() ([]string, error) {
 	secret, err := randomString(secretLength, alphanumeric)
 	if err != nil {
@@ -107,14 +119,14 @@ func generate() ([]string, error) {
 	}
 
 	checksum := checksumFor(secret)
-	hashed, err := pbkdf2.Key(sha256.New, secret, []byte(checksum), hashIterations, hashLength)
+	hashed, err := hashSecret(secret, checksum)
 	if err != nil {
-		return nil, fmt.Errorf("cannot derive the token hash: %w", err)
+		return nil, err
 	}
 
 	return []string{
 		tokenPrefix + secret + "_" + checksum,
-		hex.EncodeToString(hashed),
+		hashed,
 		salt,
 		rands,
 		uid,

--- a/managed/cmd/pmm-sep-token/main.go
+++ b/managed/cmd/pmm-sep-token/main.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"os"
+	"strings"
 )
 
 const (
@@ -45,6 +46,8 @@ const (
 	hashIterations = 10000
 	hashLength     = 50
 
+	byteValues = 256
+
 	alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	lowerAlnum   = "abcdefghijklmnopqrstuvwxyz0123456789"
 )
@@ -52,14 +55,15 @@ const (
 // randomString returns n characters drawn uniformly from alphabet.
 //
 // Bytes at or above limit are discarded rather than folded in, because a plain
-// modulo would over-represent the first 256%len(alphabet) characters.
+// modulo would over-represent the first byteValues%len(alphabet) characters.
 func randomString(n int, alphabet string) (string, error) {
-	limit := 256 - 256%len(alphabet)
+	limit := byteValues - byteValues%len(alphabet)
 	buf := make([]byte, n)
 	out := make([]byte, 0, n)
 
 	for len(out) < n {
-		if _, err := rand.Read(buf); err != nil {
+		_, err := rand.Read(buf)
+		if err != nil {
 			return "", fmt.Errorf("cannot read random bytes: %w", err)
 		}
 		for _, b := range buf {
@@ -79,7 +83,7 @@ func randomString(n int, alphabet string) (string, error) {
 // checksumFor reproduces Grafana's apikeygenprefix checksum: the CRC32 of the
 // prefixed secret, little-endian, hex-encoded.
 func checksumFor(secret string) string {
-	sum := make([]byte, 4)
+	sum := make([]byte, crc32.Size)
 	binary.LittleEndian.PutUint32(sum, crc32.ChecksumIEEE([]byte(tokenPrefix+secret)))
 	return hex.EncodeToString(sum)
 }
@@ -124,7 +128,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	for _, line := range lines {
-		fmt.Println(line)
+	_, err = os.Stdout.WriteString(strings.Join(lines, "\n") + "\n")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pmm-sep-token: cannot write the token material: %s\n", err)
+		os.Exit(1)
 	}
 }

--- a/managed/cmd/pmm-sep-token/main_test.go
+++ b/managed/cmd/pmm-sep-token/main_test.go
@@ -1,0 +1,124 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Captured from Grafana's own encoding for this secret. The point of this
+// program is to agree with it, so a change here means the tokens it mints stop
+// authenticating - not that the expectation needs updating.
+const (
+	goldenSecret   = "AbC123xyzAbC123xyzAbC123xyzAbC12"
+	goldenChecksum = "1de4e29c"
+	goldenHash     = "04b88d1cf73811f69ad14ec35d15e2c1c80a06f9aa8cbf5b1266ad979635e21b" +
+		"c377f2b1c507fd839f756482ac30e05c4fff"
+)
+
+var (
+	tokenRE = regexp.MustCompile(`^glsa_[A-Za-z0-9]{32}_[0-9a-f]{8}$`)
+	hashRE  = regexp.MustCompile(`^[0-9a-f]{100}$`)
+	saltRE  = regexp.MustCompile(`^[A-Za-z0-9]{10}$`)
+	uidRE   = regexp.MustCompile(`^[a-z0-9]{14}$`)
+)
+
+func TestEncodingMatchesGrafana(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, goldenChecksum, checksumFor(goldenSecret))
+
+	hashed, err := hashSecret(goldenSecret, goldenChecksum)
+	require.NoError(t, err)
+	assert.Equal(t, goldenHash, hashed)
+}
+
+func TestGenerateShape(t *testing.T) {
+	t.Parallel()
+
+	parts, err := generate()
+	require.NoError(t, err)
+	require.Len(t, parts, 5)
+
+	assert.Regexp(t, tokenRE, parts[0])
+	assert.Regexp(t, hashRE, parts[1])
+	assert.Regexp(t, saltRE, parts[2])
+	assert.Regexp(t, saltRE, parts[3])
+	assert.Regexp(t, uidRE, parts[4])
+}
+
+// The token Grafana hands out and the hash Grafana stores have to describe the
+// same secret, so the emitted pair is re-derived from the token itself.
+func TestGeneratedPairAgrees(t *testing.T) {
+	t.Parallel()
+
+	parts, err := generate()
+	require.NoError(t, err)
+	require.Len(t, parts, 5)
+
+	trimmed := strings.TrimPrefix(parts[0], tokenPrefix)
+	secret, checksum, found := strings.Cut(trimmed, "_")
+	require.True(t, found)
+
+	assert.Equal(t, checksumFor(secret), checksum)
+
+	hashed, err := hashSecret(secret, checksum)
+	require.NoError(t, err)
+	assert.Equal(t, parts[1], hashed)
+}
+
+func TestGenerateDoesNotRepeat(t *testing.T) {
+	t.Parallel()
+
+	first, err := generate()
+	require.NoError(t, err)
+	second, err := generate()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second)
+}
+
+func TestRandomString(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		length   int
+		alphabet string
+	}{
+		{"secret", secretLength, alphanumeric},
+		{"uid", uidLength, lowerAlnum},
+		{"single character alphabet", 8, "a"},
+		{"zero length", 0, alphanumeric},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := randomString(tc.length, tc.alphabet)
+			require.NoError(t, err)
+			assert.Len(t, out, tc.length)
+
+			for _, r := range out {
+				assert.Contains(t, tc.alphabet, string(r))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

With `PMM_ENABLE_SEP` set, pmm-server now provisions the Grafana service account SEP authenticates users against, and publishes its token to `/srv/sep-secrets` as two files named after the canonical SEP settings names (`AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN` and `PMM__API_KEY`, same value in both).

This replaces the manual minting step SEP's feature-build harness performs today, which calls `POST /graph/api/serviceaccounts` with `admin:admin` basic auth from outside the container — it breaks as soon as the Grafana admin password changes, and it requires whoever provisions SEP to hold a Grafana admin credential.

Everything here is a no-op unless `PMM_ENABLE_SEP` is set. Docker only, matching #5700.

**Base branch is `PMM-15238-expose-pg-to-sep` (#5700), not `main`** — that branch adds the `PMM_ENABLE_SEP` passthrough this one extends. Please merge #5700 first.

### How the account is created

Directly in Grafana's own PostgreSQL database over the local socket, the same way `postgres-sep` provisions the `sep` role as the local superuser. Grafana exposes no credential-free path to create a service account — checked on 12.4.5: `grafana cli admin` offers only `reset-admin-password`, `data-migration`, `secrets-migration`, `secrets-consolidation` and `flush-rbac-seed-assignment`, and `conf/provisioning/` covers only `access-control`, `alerting`, `dashboards`, `datasources`, `plugins` and `sample`. `POST /api/serviceaccounts` therefore needs an Admin credential, which pmm-server does not reliably have once an operator has changed the admin password.

### Two deliberate design points

**It runs as a supervisord one-shot, not from the entrypoint.** Grafana is not a running process at any point during the entrypoint, and on a first boot its schema does not exist at all — the `grafana` database is created by the `pmm-init` playbook and migrated by Grafana itself, both strictly after the entrypoint has exec'd supervisord. The helper waits for `/api/health` to report `"database": "ok"`, the same readiness signal pmm-managed uses.

**The token is validated every start and replaced only when it is missing, empty, or rejected** — not re-minted unconditionally. SEP reads the secrets directory once, at its own container start, so re-minting on every pmm-server start would revoke the token a still-running SEP is holding, and a plain `docker restart pmm-server` would leave SEP 401-ing until it too was restarted.

A freshly minted token that Grafana rejects is fatal and is **never published**, so a future change to Grafana's schema or token encoding surfaces as a failed `sep-provision` rather than as silent SEP auth failure.

### Contract for the SEP side

| Element | Value |
|---|---|
| Directory | `/srv/sep-secrets` (the `pmm-sep-secrets` volume); SEP mounts it read-only with `SECRETS_DIR` pointing at it |
| Filenames | `AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN`, `PMM__API_KEY` — same value |
| Modes | directory setgid `2770`, files `0640`; each file's group is inherited from the directory, so it is group 0 whatever uid PMM runs as |
| SEP-side requirement | the SEP container must join group 0 (`group_add: ["0"]`, or `user: "1001:0"`) — PMM cannot `chgrp` to SEP's own group. Leave both settings names unset there rather than empty: an empty value counts as supplied and outranks the mounted file |
| Service account | name `pmm-sep`, login `sa-<orgId>-pmm-sep`, org role Admin, one token named `pmm-sep` |
| Disabled | with `PMM_ENABLE_SEP` unset both files are removed; the Grafana service account is left in place |

## Tested

There is no unit-test layer for the container's shell/ansible surface and this change touches no Go code, so verification is a matrix run against a built image. Because the server image needs the full RPM pipeline, I ran everything against `perconalab/pmm-server-fb:PR-4500-0357c3b` — which ships **percona-grafana 12.4.5 on the embedded PostgreSQL** and already carries this PR's base branch — with the helper and `sep.ini` layered in. Commands were run verbatim; every result below was observed.

- [x] **Mechanism gate on the real target.** The token encoding reproduces an API-minted token exactly on percona-grafana 12.4.5: value `glsa_<secret>_<checksum>`, checksum = `crc32("glsa_"+secret)` little-endian, `api_key.key` = `pbkdf2_hmac("sha256", secret, checksum, 10000, 50)`. The `user`/`org_user`/`api_key` column sets and the `UQE_user_login` / `UQE_org_user_org_id_user_id` / `UQE_api_key_org_id_name` indexes all match what the SQL assumes. `api_key.role` is stored as `Viewer` even when the API request asks for Admin — effective authority comes from `org_user.role`.
- [x] **Fresh start under real supervisord.** `sep-provision` reaches `exit status 0; expected`; both files appear `0640 pmm:root` in a `0770` directory; the token returns 200 from `/api/access-control/user/permissions` and `"role":"Admin"` from `/graph/api/serviceaccounts/search` through nginx.
- [x] **Restart idempotency.** `docker restart` with Grafana state intact keeps the same token value, `api_key` rows stay at 1, one `user` row, and the token still authenticates without SEP being restarted.
- [x] **Grafana state reset**, using the real two-volume topology: destroyed the container and its `/srv` volume while keeping the secrets volume, then started fresh. The stale token was rejected, replaced, and the replacement validated by an actual HTTP call.
- [x] **Stale token and deleted account.** Deleting the `api_key` row, and separately deleting the whole service account through the Grafana API, both lead to a re-mint that authenticates; no accumulation.
- [x] **Disabled.** On a fresh volume with `PMM_ENABLE_SEP` unset: no service account, no secrets directory, an empty `sep-provision` log, `readyz` 200 and the container healthy. Disabling after enabling removes both token files and leaves an unrelated file in the directory untouched and the Grafana account in place.
- [x] **Guards.** `PMM_HA_ENABLE`, `PMM_DISABLE_BUILTIN_POSTGRES`, `GF_DATABASE_HOST` and `GF_DATABASE_URL` each produce the warning and exit 0 without writing anything.
- [x] **Secrecy.** The token secret appears in no process's `argv`, the container environment, `docker logs`, `docker inspect`, or `sep-provision.log` — checked with the needle staged in a file so the probe itself could not create a match, and with a control confirming the probe detects a real hit.
- [x] **Permissions contract.** uid 1001 in group 0 reads both files; the same uid with gid 1001 gets `Permission denied`; uid 1002 cannot read them at all.
- [x] **Access control.** With `PMM_ENABLE_ACCESS_CONTROL=1` the validator endpoint still returns 200 and the role still reads `Admin`, so no token is revoked for a configuration reason.
- [x] **Failure paths.** A corrupted token encoding (simulating a future Grafana change) is fatal, exits 1, and publishes nothing. Grafana never becoming ready is fatal and exits 1. A failing one-shot exits once and stays `EXITED` — the pre-review configuration respawned it ~82 times in 8 seconds, which the review caught.
- [x] **Volume-ownership trap.** A named volume mounted at a path present in the image owned `1000:0 0770` inherits that ownership and is writable; at a path absent from the image it is created `root:root` and writes are denied. This is what the `post-build.yml` mountpoint task exists for. On a real build the one-line check for it is `docker run --rm --entrypoint /bin/ls <image> -ldn /srv/sep-secrets`, which should print `1000 0` — that belongs to the Feature Build item below, not to this one.
- [x] shellcheck clean; `bash -n` clean; the three changed playbooks parse; `docker compose config` succeeds.

**The matrix above was run against the pre-review revision** (`16c2db83`). Reviewing the helper against the two contracts it documents turned up five defects, fixed in `c5d0c344`: the published files took the group of whichever uid pmm-server runs as rather than the directory's, so `group_add: ["0"]` only worked while that uid's primary group was 0; the reuse check read an unreachable Grafana as a rejected token and re-minted, revoking a live SEP token; `install -d` on an existing directory exited 0 only because the mode it asked for matched the image; a `psql` failure in the secondary role repair aborted before the valid token was republished; and the Grafana-not-on-embedded-Postgres guard left token files it can no longer revalidate. The decision paths were re-verified directly — keep, genuine rejection, inconclusive answer, dropped connection, first boot, disabled, and both guards — and the setgid ownership model was reproduced end to end on `oraclelinux:9-slim`, including that Docker carries the bit into a fresh named volume. **The image rows still need re-running on a Feature Build**, since only a real build produces the setgid mountpoint.

Not run here, and needing a Feature Build or the SEP side:

- [ ] **The shipped image path.** The ansible copy tasks, the supervisord registration and the `/srv/sep-secrets` mountpoint surviving into the image were reviewed and reasoned about but not executed — `VOLUME ["/srv"]` prevents baking the mountpoint into a derived image, so only a real build exercises them. **A Feature Build is required before merge.**
- [ ] **End to end with SEP.** This ships only the PMM half. `sidecar/pmm-fb/compose.yaml` on percona/SEP branch `pmm` still passes `SEP_GRAFANA_TOKEN` and declares no shared volume, `SECRETS_DIR` or `group_add`, so the paired stack cannot consume these files yet. A mounted file already outranks the value SEP derives from `SEP_GRAFANA_TOKEN`, so the two channels can coexist during migration. <!-- followup -->

## Known limitations

- **A failed provisioning run is not retried until the container restarts.** A one-shot cannot bound its own restarts under supervisord — `startretries` only bounds restarts out of `BACKOFF`, which `startsecs = 0` never reaches — so the choice is between no retry and an unbounded respawn loop. Failure is loud (`EXITED` with a non-zero status, plus a `FATAL` line in `/srv/logs/sep-provision.log`) and the readiness budget is 600s to absorb a slow first boot. <!-- followup -->
- **The `pmm-sep` service account name is this feature's namespace.** Re-provisioning adopts an existing `sa-<org>-pmm-sep` account and deletes every token on it, plus any `pmm-sep`-named token elsewhere in the org. That is what makes the state-reset path idempotent, but a manually created account of the same name would be adopted and its tokens replaced.
- **Grafana's schema and token encoding are consumed, not modified**, and are internal to Grafana. The scheme survived 11.6.4 → 12.4.5 with an identical column set and encoding. Treat a change to `%define grafana_version` in `build/packages/rpm/server/SPECS/grafana.spec` as a trigger to re-run the mechanism gate.
- With `PMM_ENABLE_SEP` unset the residue in stock PMM is an empty `/srv/sep-secrets` directory in the image (which must pre-exist for volume ownership to be inherited), a `sep-provision` program that `supervisorctl status` shows as `EXITED` after each boot, an empty `/srv/logs/sep-provision.log`, and — for users of this repo's `docker-compose.yml` — a `pmm-sep-secrets` named volume created unconditionally, because compose has no conditional mounts. None carries data, a service account or any behaviour, but the acceptance criterion's "nothing about stock PMM changes" is these four things wide.
- `docker-compose.dev.yml` is not updated; the dev stack builds from a published dev-container image that does not carry this helper, so the volume would have nothing to deliver.

## Related

- prerequisite: #5700 (PMM-15238)
- Sibling: PMM-15316 delivers SEP's `SECRET_KEY` and database credentials over this same channel


