### PR TITLE
PMM-15279 Productize the SEP nginx reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,9 +49,14 @@ PMM_PORT_HTTPS=443
 # Expose the built-in PostgreSQL to SEP running in a side container on the same bridge
 # network. PMM creates a dedicated `sep` database owned by a non-superuser `sep` role and
 # accepts connections for it from the container's Docker subnets only; nothing is
-# published on the host. Both variables are required to enable it.
+# published on the host. The first two variables are required to enable it.
+#
+# The same flag makes nginx reverse-proxy /sep/ to the side-car. PMM_SEP_ADDRESS
+# overrides where it is reached and defaults to sep:9000, so it only needs setting
+# when the side-car's service name or port differs.
 # PMM_ENABLE_SEP=1
 # PMM_SEP_POSTGRES_PASSWORD=<password>
+# PMM_SEP_ADDRESS=sep:9000
 
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full

--- a/build/ansible/roles/nginx/files/conf.d/pmm.conf
+++ b/build/ansible/roles/nginx/files/conf.d/pmm.conf
@@ -143,6 +143,10 @@
       return 403 '{"code":7,"error":"Access denied","message":"Access denied"}';
     }
 
+    # SEP side-car locations, installed by the entrypoint when PMM_ENABLE_SEP is
+    # enabled. The glob is a no-op when the directory is empty or absent.
+    include /etc/nginx/sep.d/*.conf;
+
     # PMM UI
     location /pmm-ui {
       # Will redirect on FE to login page if user is not authenticated

--- a/build/ansible/roles/nginx/files/sep/sep.conf.template
+++ b/build/ansible/roles/nginx/files/sep/sep.conf.template
@@ -1,0 +1,55 @@
+# Reverse-proxy locations for the SEP side-car. Installed into
+# /etc/nginx/sep.d/ by build/docker/server/entrypoint.sh when PMM_ENABLE_SEP is
+# enabled; removed on the next start when it is not.
+
+location @sep_unavailable {
+  auth_request off;
+  default_type application/json;
+
+  # An explicit body bypasses the server-level error_page 503 @maintenance,
+  # which would otherwise turn this into PMM's maintenance page.
+  return 503 '{"code":14,"error":"SEP unavailable","message":"SEP unavailable"}';
+}
+
+location /sep/ {
+  # SEP authenticates its own bearer; pmm-managed knows nothing about it.
+  auth_request off;
+
+  # The http-level resolver is public and cannot answer for a container name.
+  # The address is read from /etc/resolv.conf at start so this works under both
+  # Docker and Podman. It stays inside this location on purpose: this file is
+  # included in the server block, so at file scope it would also redirect DNS
+  # for every other request-time lookup, /percona-blog/feed among them.
+  # valid= caps how long a restarted side-car stays unreachable.
+  resolver __SEP_RESOLVER__ valid=10s ipv6=off;
+  resolver_timeout 5s;
+
+  # A variable defers resolution to request time, so this config loads with the
+  # side-car absent. It must carry no URI component: a trailing / would replace
+  # the request URI rather than strip the prefix.
+  set $sep_upstream "__SEP_ADDRESS__";
+  proxy_pass http://$sep_upstream;
+
+  # Covers nginx-generated DNS and connect failures only; proxy_intercept_errors
+  # is off, so a 502 returned by SEP itself passes through unchanged. Like
+  # proxy_set_header below, this is not additive -- it drops the inherited
+  # 401/403/503 handlers, which is only safe while auth_request is off.
+  error_page 502 504 = @sep_unavailable;
+
+  # proxy_set_header is not additive: declaring any header here discards the
+  # server-level X-Forwarded-For, so it is re-declared.
+  # Host drives SEP's url_for output; without it SEP emits upstream-addressed URLs.
+  proxy_set_header Host $http_host;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+
+  # Buffering stays on. SEP marks its own streaming responses with
+  # X-Accel-Buffering: no, which nginx honours per response -- keeping stream
+  # knowledge in SEP instead of encoding routes here.
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $connection_upgrade;
+  proxy_read_timeout 3600;
+
+  client_max_body_size 100m;
+}

--- a/build/ansible/roles/nginx/files/sep/sep.conf.template
+++ b/build/ansible/roles/nginx/files/sep/sep.conf.template
@@ -21,7 +21,7 @@ location /sep/ {
   # included in the server block, so at file scope it would also redirect DNS
   # for every other request-time lookup, /percona-blog/feed among them.
   # valid= caps how long a restarted side-car stays unreachable.
-  resolver __SEP_RESOLVER__ valid=10s ipv6=off;
+  resolver __SEP_RESOLVER__ valid=10s;
   resolver_timeout 5s;
 
   # A variable defers resolution to request time, so this config loads with the
@@ -45,7 +45,9 @@ location /sep/ {
 
   # Buffering stays on. SEP marks its own streaming responses with
   # X-Accel-Buffering: no, which nginx honours per response -- keeping stream
-  # knowledge in SEP instead of encoding routes here.
+  # knowledge in SEP instead of encoding routes here. SEP applies that header
+  # from one frozen constant shared by every streaming route, so a new stream
+  # cannot reach this proxy without it.
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $connection_upgrade;

--- a/build/ansible/roles/nginx/tasks/main.yml
+++ b/build/ansible/roles/nginx/tasks/main.yml
@@ -14,6 +14,7 @@
     - /srv/nginx/tmp/uwsgi/
     - /srv/nginx/tmp/scgi/
     - /etc/nginx/conf.d/
+    - /etc/nginx/sep.d/
     - /etc/nginx/ssl/
 
 - name: Enable nginx 1.26 module stream

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -166,16 +166,27 @@ if is_enabled "$PMM_ENABLE_SEP"; then
     fi
 
     # Container DNS: 127.0.0.11 under Docker, an aardvark address under Podman.
-    # IPv4 is preferred because nginx needs IPv6 resolver addresses bracketed,
-    # and a bare one fails nginx -t and so blocks the whole server from starting.
+    # IPv4 first, then an unscoped IPv6 in brackets -- nginx requires the brackets
+    # and rejects a bare address, which fails nginx -t and so blocks the whole
+    # server from starting.
     declare SEP_RESOLVER
     SEP_RESOLVER=$(awk '/^nameserver/ && $2 !~ /:/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)
     if [ -z "$SEP_RESOLVER" ]; then
-        SEP_RESOLVER=$(awk '/^nameserver/ { sub(/%.*/, "", $2); print "[" $2 "]"; exit }' /etc/resolv.conf 2>/dev/null || true)
+        # Scoped addresses are skipped rather than stripped of their zone: nginx has
+        # no syntax for the interface scope, so a stripped fe80:: address yields a
+        # config that passes nginx -t and can never route DNS -- trading a startup
+        # failure for every /sep/ request timing out into the 503.
+        SEP_RESOLVER=$(awk '/^nameserver/ && $2 !~ /%/ { print "[" $2 "]"; exit }' /etc/resolv.conf 2>/dev/null || true)
     fi
     if [ -z "$SEP_RESOLVER" ]; then
-        echo "FATAL: PMM_ENABLE_SEP is set but no nameserver found in /etc/resolv.conf." >&2
-        echo "Please attach the container to a network with working DNS, or unset PMM_ENABLE_SEP." >&2
+        if awk '/^nameserver/ && $2 ~ /%/ { found = 1 } END { exit !found }' /etc/resolv.conf 2>/dev/null; then
+            echo "FATAL: /etc/resolv.conf lists only scoped IPv6 nameservers, such as fe80::1%eth0." >&2
+            echo "nginx cannot express the interface scope, so such an address cannot be used." >&2
+            echo "Please attach the container to a network with an IPv4 or unscoped IPv6 nameserver, or unset PMM_ENABLE_SEP." >&2
+        else
+            echo "FATAL: PMM_ENABLE_SEP is set but no nameserver found in /etc/resolv.conf." >&2
+            echo "Please attach the container to a network with working DNS, or unset PMM_ENABLE_SEP." >&2
+        fi
         exit 1
     fi
 

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -141,7 +141,58 @@ else
 fi
 
 if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; }; then
-    echo "WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use." >&2
+    echo "WARNING: not exposing a database to SEP, the embedded PostgreSQL is not in use." >&2
+fi
+
+# The reverse proxy is independent of which database SEP uses, so it is not nested
+# in the embedded-PostgreSQL branch above.
+declare SEP_NGINX_DIR=/etc/nginx/sep.d
+declare SEP_NGINX_TEMPLATE=/opt/ansible/roles/nginx/files/sep/sep.conf.template
+if is_enabled "$PMM_ENABLE_SEP"; then
+    declare SEP_ADDRESS="${PMM_SEP_ADDRESS:-sep:9000}"
+    # The address is interpolated into an nginx config, so an unvalidated value
+    # is a config-injection vector. The digit count is capped so the range test
+    # below cannot be handed a value that overflows the shell's integer parsing
+    # and fails open.
+    if ! [[ "$SEP_ADDRESS" =~ ^[A-Za-z0-9._-]+:[0-9]{1,5}$ ]]; then
+        echo "FATAL: PMM_SEP_ADDRESS must be <host>:<port>, got '${SEP_ADDRESS}'." >&2
+        exit 1
+    fi
+    # A variable proxy_pass resolves per request, so an out-of-range port would
+    # pass nginx -t and only surface as a 502 at runtime.
+    if [ "${SEP_ADDRESS##*:}" -lt 1 ] || [ "${SEP_ADDRESS##*:}" -gt 65535 ]; then
+        echo "FATAL: PMM_SEP_ADDRESS port must be 1-65535, got '${SEP_ADDRESS##*:}'." >&2
+        exit 1
+    fi
+
+    # Container DNS: 127.0.0.11 under Docker, an aardvark address under Podman.
+    # IPv4 is preferred because nginx needs IPv6 resolver addresses bracketed,
+    # and a bare one fails nginx -t and so blocks the whole server from starting.
+    declare SEP_RESOLVER
+    SEP_RESOLVER=$(awk '/^nameserver/ && $2 !~ /:/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)
+    if [ -z "$SEP_RESOLVER" ]; then
+        SEP_RESOLVER=$(awk '/^nameserver/ { sub(/%.*/, "", $2); print "[" $2 "]"; exit }' /etc/resolv.conf 2>/dev/null || true)
+    fi
+    if [ -z "$SEP_RESOLVER" ]; then
+        echo "FATAL: PMM_ENABLE_SEP is set but no nameserver found in /etc/resolv.conf." >&2
+        echo "Please attach the container to a network with working DNS, or unset PMM_ENABLE_SEP." >&2
+        exit 1
+    fi
+
+    if [ ! -f "$SEP_NGINX_TEMPLATE" ]; then
+        echo "FATAL: missing ${SEP_NGINX_TEMPLATE}, cannot configure the SEP reverse proxy." >&2
+        exit 1
+    fi
+
+    echo "Installing nginx reverse-proxy configuration for SEP at ${SEP_ADDRESS}..."
+    mkdir -p "$SEP_NGINX_DIR"
+    sed -e "s|__SEP_ADDRESS__|${SEP_ADDRESS}|" \
+        -e "s|__SEP_RESOLVER__|${SEP_RESOLVER}|" \
+        "$SEP_NGINX_TEMPLATE" > "$SEP_NGINX_DIR/sep.conf"
+else
+    # Clears the whole directory, not just the file this version writes: an older
+    # build or an operator may have left others behind in the writable layer.
+    rm -f "$SEP_NGINX_DIR"/*.conf
 fi
 
 echo "Generating self-signed certificates for nginx..."

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -170,13 +170,13 @@ if is_enabled "$PMM_ENABLE_SEP"; then
     # and rejects a bare address, which fails nginx -t and so blocks the whole
     # server from starting.
     declare SEP_RESOLVER
-    SEP_RESOLVER=$(awk '/^nameserver/ && $2 !~ /:/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)
+    SEP_RESOLVER=$(awk '/^nameserver/ && $2 != "" && $2 !~ /:/ { print $2; exit }' /etc/resolv.conf 2>/dev/null || true)
     if [ -z "$SEP_RESOLVER" ]; then
         # Scoped addresses are skipped rather than stripped of their zone: nginx has
         # no syntax for the interface scope, so a stripped fe80:: address yields a
         # config that passes nginx -t and can never route DNS -- trading a startup
         # failure for every /sep/ request timing out into the 503.
-        SEP_RESOLVER=$(awk '/^nameserver/ && $2 !~ /%/ { print "[" $2 "]"; exit }' /etc/resolv.conf 2>/dev/null || true)
+        SEP_RESOLVER=$(awk '/^nameserver/ && $2 != "" && $2 !~ /%/ { print "[" $2 "]"; exit }' /etc/resolv.conf 2>/dev/null || true)
     fi
     if [ -z "$SEP_RESOLVER" ]; then
         if awk '/^nameserver/ && $2 ~ /%/ { found = 1 } END { exit !found }' /etc/resolv.conf 2>/dev/null; then
@@ -187,6 +187,14 @@ if is_enabled "$PMM_ENABLE_SEP"; then
             echo "FATAL: PMM_ENABLE_SEP is set but no nameserver found in /etc/resolv.conf." >&2
             echo "Please attach the container to a network with working DNS, or unset PMM_ENABLE_SEP." >&2
         fi
+        exit 1
+    fi
+    # Interpolated into the same config as SEP_ADDRESS, so it needs the same
+    # guard: awk yields a whitespace-delimited field, and a nameserver line
+    # carrying anything else would close the /sep/ block and open its own.
+    if ! [[ "$SEP_RESOLVER" =~ ^([0-9.]+|\[[0-9a-fA-F:]+\])$ ]]; then
+        echo "FATAL: /etc/resolv.conf nameserver '${SEP_RESOLVER}' is not a usable address." >&2
+        echo "Please attach the container to a network with working DNS, or unset PMM_ENABLE_SEP." >&2
         exit 1
     fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,10 @@ services:
       - PMM_POSTGRES_DBPASSWORD
       - PMM_DISABLE_BUILTIN_POSTGRES
       # To expose the built-in PostgreSQL to SEP running on the same bridge network
+      # and reverse-proxy the SEP side-car under /sep/
       - PMM_ENABLE_SEP
       - PMM_SEP_POSTGRES_PASSWORD
+      - PMM_SEP_ADDRESS
       # To discover RDS databases via UI
       - AWS_ACCESS_KEY
       - AWS_SECRET_KEY

--- a/managed/services/server/logs.go
+++ b/managed/services/server/logs.go
@@ -52,12 +52,11 @@ const (
 
 // sepConfigFiles returns the SEP nginx drop-ins under dir, and nothing when dir is
 // absent. They are globbed rather than listed because their presence depends on
-// PMM_ENABLE_SEP: absent must not mean an error in the archive.
-func sepConfigFiles(ctx context.Context, dir string) []string {
-	configs, err := filepath.Glob(filepath.Join(dir, "*.conf"))
-	if err != nil {
-		logger.Get(ctx).WithField("component", "logs").Error(err)
-	}
+// PMM_ENABLE_SEP: absent must not mean an error in the archive. Glob's only error
+// is ErrBadPattern, which a caller-supplied directory joined with a literal
+// suffix cannot produce, so it is discarded rather than reported.
+func sepConfigFiles(dir string) []string {
+	configs, _ := filepath.Glob(filepath.Join(dir, "*.conf"))
 
 	return configs
 }
@@ -199,7 +198,7 @@ func (l *Logs) files(ctx context.Context, pprofConfig *PprofConfig, logReadLines
 		"/etc/supervisord.d/vmproxy.ini",
 
 		models.AgentConfigFilePath,
-	}, sepConfigFiles(ctx, sepNginxConfigDir))
+	}, sepConfigFiles(sepNginxConfigDir))
 
 	for _, f := range configs {
 		b, m, err := readFile(f)

--- a/managed/services/server/logs.go
+++ b/managed/services/server/logs.go
@@ -44,7 +44,23 @@ import (
 
 const (
 	maxLogReadLines = 50000
+
+	// sepNginxConfigDir holds the nginx drop-ins the entrypoint renders when
+	// PMM_ENABLE_SEP is set. It is absent on a default installation.
+	sepNginxConfigDir = "/etc/nginx/sep.d"
 )
+
+// sepConfigFiles returns the SEP nginx drop-ins under dir, and nothing when dir is
+// absent. They are globbed rather than listed because their presence depends on
+// PMM_ENABLE_SEP: absent must not mean an error in the archive.
+func sepConfigFiles(ctx context.Context, dir string) []string {
+	configs, err := filepath.Glob(filepath.Join(dir, "*.conf"))
+	if err != nil {
+		logger.Get(ctx).WithField("component", "logs").Error(err)
+	}
+
+	return configs
+}
 
 // fileContent represents logs.zip item.
 type fileContent struct {
@@ -165,13 +181,6 @@ func (l *Logs) files(ctx context.Context, pprofConfig *PprofConfig, logReadLines
 			Err:      err,
 		})
 	}
-	// The SEP nginx drop-ins exist only when PMM_ENABLE_SEP was set at container start,
-	// so they are globbed rather than listed: absent must not mean an error in the archive.
-	sepConfigs, err := filepath.Glob("/etc/nginx/sep.d/*.conf")
-	if err != nil {
-		logger.Get(ctx).WithField("component", "logs").Error(err)
-	}
-
 	// add configs
 	configs := slices.Concat([]string{
 		"/etc/nginx/nginx.conf",
@@ -190,7 +199,7 @@ func (l *Logs) files(ctx context.Context, pprofConfig *PprofConfig, logReadLines
 		"/etc/supervisord.d/vmproxy.ini",
 
 		models.AgentConfigFilePath,
-	}, sepConfigs)
+	}, sepConfigFiles(ctx, sepNginxConfigDir))
 
 	for _, f := range configs {
 		b, m, err := readFile(f)

--- a/managed/services/server/logs.go
+++ b/managed/services/server/logs.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -164,8 +165,15 @@ func (l *Logs) files(ctx context.Context, pprofConfig *PprofConfig, logReadLines
 			Err:      err,
 		})
 	}
+	// The SEP nginx drop-ins exist only when PMM_ENABLE_SEP was set at container start,
+	// so they are globbed rather than listed: absent must not mean an error in the archive.
+	sepConfigs, err := filepath.Glob("/etc/nginx/sep.d/*.conf")
+	if err != nil {
+		logger.Get(ctx).WithField("component", "logs").Error(err)
+	}
+
 	// add configs
-	for _, f := range []string{
+	configs := slices.Concat([]string{
 		"/etc/nginx/nginx.conf",
 		"/etc/nginx/conf.d/pmm.conf",
 		"/etc/nginx/conf.d/pmm-ssl.conf",
@@ -182,7 +190,9 @@ func (l *Logs) files(ctx context.Context, pprofConfig *PprofConfig, logReadLines
 		"/etc/supervisord.d/vmproxy.ini",
 
 		models.AgentConfigFilePath,
-	} {
+	}, sepConfigs)
+
+	for _, f := range configs {
 		b, m, err := readFile(f)
 		files = append(files, fileContent{
 			Name:     filepath.Base(f),

--- a/managed/services/server/logs.go
+++ b/managed/services/server/logs.go
@@ -45,8 +45,8 @@ import (
 const (
 	maxLogReadLines = 50000
 
-	// sepNginxConfigDir holds the nginx drop-ins the entrypoint renders when
-	// PMM_ENABLE_SEP is set. It is absent on a default installation.
+	// The entrypoint renders the SEP nginx drop-ins here when PMM_ENABLE_SEP is
+	// set. The directory is absent on a default installation.
 	sepNginxConfigDir = "/etc/nginx/sep.d"
 )
 

--- a/managed/services/server/logs_test.go
+++ b/managed/services/server/logs_test.go
@@ -204,6 +204,38 @@ func TestFiles(t *testing.T) {
 	assert.Equal(t, commonExpectedFiles, actual)
 }
 
+func TestSepConfigFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects the drop-ins and ignores everything else", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		sep := filepath.Join(dir, "sep.conf")
+		extra := filepath.Join(dir, "extra.conf")
+		require.NoError(t, os.WriteFile(sep, []byte("location /sep/ {}\n"), 0o600))
+		require.NoError(t, os.WriteFile(extra, []byte("# left by an older build\n"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "sep.conf.template"), []byte("# not a drop-in\n"), 0o600))
+
+		ctx := logger.Set(t.Context(), t.Name())
+		assert.ElementsMatch(t, []string{sep, extra}, sepConfigFiles(ctx, dir))
+	})
+
+	t.Run("absent directory is not an error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := logger.Set(t.Context(), t.Name())
+		assert.Empty(t, sepConfigFiles(ctx, filepath.Join(t.TempDir(), "sep.d")))
+	})
+
+	t.Run("empty directory is not an error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := logger.Set(t.Context(), t.Name())
+		assert.Empty(t, sepConfigFiles(ctx, t.TempDir()))
+	})
+}
+
 func TestZip(t *testing.T) {
 	t.Skip("FIXME")
 

--- a/managed/services/server/logs_test.go
+++ b/managed/services/server/logs_test.go
@@ -217,22 +217,19 @@ func TestSepConfigFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(extra, []byte("# left by an older build\n"), 0o600))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "sep.conf.template"), []byte("# not a drop-in\n"), 0o600))
 
-		ctx := logger.Set(t.Context(), t.Name())
-		assert.ElementsMatch(t, []string{sep, extra}, sepConfigFiles(ctx, dir))
+		assert.ElementsMatch(t, []string{sep, extra}, sepConfigFiles(dir))
 	})
 
 	t.Run("absent directory is not an error", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := logger.Set(t.Context(), t.Name())
-		assert.Empty(t, sepConfigFiles(ctx, filepath.Join(t.TempDir(), "sep.d")))
+		assert.Empty(t, sepConfigFiles(filepath.Join(t.TempDir(), "sep.d")))
 	})
 
 	t.Run("empty directory is not an error", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := logger.Set(t.Context(), t.Name())
-		assert.Empty(t, sepConfigFiles(ctx, t.TempDir()))
+		assert.Empty(t, sepConfigFiles(t.TempDir()))
 	})
 }
 

--- a/managed/services/server/logs_test.go
+++ b/managed/services/server/logs_test.go
@@ -181,6 +181,13 @@ func TestFiles(t *testing.T) {
 			continue
 		}
 
+		// Present only when the container was started with PMM_ENABLE_SEP,
+		// so it cannot belong to a fixed expectation either way.
+		if f.Name == "sep.conf" {
+			require.NoError(t, f.Err, "name = %q", f.Name)
+			continue
+		}
+
 		if f.Name == "supervisorctl_status.log" {
 			require.EqualError(t, f.Err, "exit status 3")
 			// NOTE: this fails in supervisorctl v4+ if there are stopped services; it is not critical because the call succeeds

--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -121,8 +121,8 @@ func ParseEnvVars(envs []string) (*models.ChangeSettingsParams, []error, []strin
 			"PMM_DISABLE_BUILTIN_POSTGRES":
 			// skip env variables for external postgres
 			continue
-		case "PMM_ENABLE_SEP", "PMM_SEP_POSTGRES_PASSWORD":
-			// skip env variables consumed by the entrypoint to expose postgres to SEP
+		case "PMM_ENABLE_SEP", "PMM_SEP_POSTGRES_PASSWORD", "PMM_SEP_ADDRESS":
+			// skip env variables consumed by the entrypoint to wire up SEP
 			continue
 		case "PERCONA_TELEMETRY_DISABLE":
 			// skip the Pillars telemetry environment variable

--- a/managed/utils/envvars/parser_test.go
+++ b/managed/utils/envvars/parser_test.go
@@ -76,7 +76,7 @@ func TestEnvVarValidator(t *testing.T) {
 	t.Run("SEP env variables", func(t *testing.T) {
 		t.Parallel()
 
-		envs := []string{"PMM_ENABLE_SEP=1", "PMM_SEP_POSTGRES_PASSWORD=s3cr3t"}
+		envs := []string{"PMM_ENABLE_SEP=1", "PMM_SEP_POSTGRES_PASSWORD=s3cr3t", "PMM_SEP_ADDRESS=sep:9000"}
 		expectedEnvVars := &models.ChangeSettingsParams{}
 
 		gotEnvVars, gotErrs, gotWarns := ParseEnvVars(envs)


### PR DESCRIPTION
Ticket number: PMM-15279

Feature build: pending — this branch cannot be exercised end-to-end alone; see **Dependencies** below.

Ships the nginx reverse-proxy configuration that routes `/sep/` to the SEP side-car as first-class shipped configuration. Today this exists only as a hand-maintained overlay in SEP's feature-build harness, which mounts a rendered `pmm.conf` over the stock one and reaches the side-car at a fixed Compose IP — neither of which can ship.

Targets `PMM-15205-sep-fb`, the PMM-15205 epic's integration branch, where every child of that epic lands before the epic goes to `main`. It extends the same `PMM_ENABLE_SEP` gate and the same `parser.go` case as #5700 (PMM-15238), which is already merged to `main`. Entirely opt-in: with the flag unset the only shipped delta is one inert glob `include`.

## How it works

`pmm.conf` gains a single line inside its `server` block:

```nginx
include /etc/nginx/sep.d/*.conf;
```

A glob include whose directory is empty *or absent* is a no-op, so the shipped config is behaviourally inert with the flag off. The drop-in deliberately does **not** live in `conf.d/`: `nginx.conf` includes that directory at `http` context, where `location` is not allowed, and nginx would refuse to start.

The entrypoint renders `build/ansible/roles/nginx/files/sep/sep.conf.template` into `/etc/nginx/sep.d/sep.conf` when `PMM_ENABLE_SEP` is enabled, and clears the directory when it is not — idempotent in both directions. The template reaches the image via the existing `COPY ansible /opt/ansible`, the same mechanism #5700 relies on for `postgres-sep`. The existing `nginx -t` gate already runs before supervisord starts, so it validates the rendered drop-in for free.

Two values are substituted at start:

- **Upstream** — `set $sep_upstream "<host>:<port>";` + `proxy_pass http://$sep_upstream;`. Because the upstream is a *variable*, nginx defers resolution to request time: the config loads with SEP absent, and a side-car that restarts on a new address is picked up within the resolver TTL without restarting pmm-server. The variable must carry no URI component — a trailing `/` replaces the request URI rather than stripping a prefix.
- **Resolver** — read from `/etc/resolv.conf` at container start rather than hardcoded to Docker's `127.0.0.11`. The AMI and OVF images run this same entrypoint: their systemd unit is `podman run … --net pmm_default … ${PMM_IMAGE}` with no command override, and the image's `CMD` is the entrypoint. Under Podman that network is served by aardvark-dns at a different address — measured `10.89.0.1` there versus `127.0.0.11` under Docker — so a hardcoded resolver would have silently broken those distributions.

Two details about the resolver that are easy to get wrong, and are the reason it looks the way it does:

- It is declared **inside `location /sep/`**, not at the drop-in's top level. The drop-in is included in the `server` block, so a top-level `resolver` would override the http-level `resolver 8.8.8.8 8.8.4.4` for every other location that resolves a name at request time — `location = /percona-blog/feed` does exactly that via `proxy_pass $feed`. Scoping it keeps the flag from changing DNS for anything but `/sep/`.
- An **IPv4** nameserver is preferred, with a bracketed fallback when only an unscoped IPv6 one is available. nginx requires IPv6 resolver addresses in brackets; a bare one is `[emerg] invalid port in resolver`, which fails `nginx -t` and therefore stops the whole server from booting — on a network the operator never configured for SEP. A **scoped** address (`fe80::1%eth0`) is skipped rather than stripped of its zone, and a resolv.conf offering nothing else is a named fatal: nginx rejects `[fe80::1%eth0]` as an invalid IPv6 address and has no other syntax for the interface scope, so dropping the zone would yield a config that passes `nginx -t` and can never route DNS — every `/sep/` request timing out into the 503 instead of the server refusing to start.

`PMM_SEP_ADDRESS` is new, optional, and defaults to `sep:9000`. It is validated as `<host>:<port>` with the port bounded to 1–65535 before interpolation, because the value is written into an nginx config: an unvalidated one is a config-injection vector, and because a variable `proxy_pass` is parsed per request, an out-of-range port would otherwise pass `nginx -t` and surface only as a runtime 502.

## One `/sep/` prefix, not five top-level names

The issue left the namespace question open, and this settles it on a single `/sep/` prefix. The alternative — proxying `/api`, `/sep_app`, `/stream-logs`, `/execution-events`, `/files` — claims five generic top-level names at pmm-server's document root for a side-car. PMM's own API lives at `/v1/`, so a top-level `/api` owned by SEP forecloses the most obvious future name for PMM's own API surface. `/sep/` reserves exactly one name and is self-describing.

Stripping the prefix in nginx was considered and rejected: with SEP's `root_path` unset, its `url_for`-generated URLs in API payloads come back unprefixed, so stripping converts a one-line SEP change into an audit of every generated URL.

The cost is that SEP must serve itself under the prefix — and it now does: SEP's app is constructed with `root_path=sep_settings.ROOT_PATH`, and its shipped side-car profile sets `ROOT_PATH: /sep`, which matches the `location /sep/` hardcoded here. PMM deliberately does **not** add a `PMM_SEP_PREFIX` variable; the prefix is fixed topology on both sides, and a knob would create a second source of truth.

One consequence worth stating: forwarding one prefix proxies SEP's whole surface, where the five-prefix design incidentally firewalled off everything it did not name. That is bounded by SEP's own auth (below) and shrinks further when SEP's legacy SSR layer is removed.

This made three of the issue's original acceptance criteria stale; they were realigned on the ticket before implementation, and the sibling FE tickets were updated to target `/sep/*`.

## What changed

| File | Change |
| --- | --- |
| `build/ansible/roles/nginx/files/conf.d/pmm.conf` | one `include` line inside `server` |
| `build/ansible/roles/nginx/files/sep/sep.conf.template` | new — the `/sep/` location, its resolver, and the unavailable-fallback |
| `build/ansible/roles/nginx/tasks/main.yml` | create `/etc/nginx/sep.d/` at build time (`pmm:root`, `0775`) |
| `build/docker/server/entrypoint.sh` | render the drop-in when the flag is on, clear it when off |
| `managed/utils/envvars/parser.go` (+ test) | recognise `PMM_SEP_ADDRESS` |
| `managed/services/server/logs.go` (+ test) | collect the drop-in into the support bundle |
| `docker-compose.yml`, the Compose sample environment file | pass through and document `PMM_SEP_ADDRESS` |

Creating `sep.d/` at build time rather than only in the entrypoint is what makes the arbitrary-UID-with-GID-0 (OpenShift) case work.

The support bundle globs `/etc/nginx/sep.d/*.conf` rather than naming the file: the collector records a read error as a zip entry and logs it at error level, so a statically listed path that is absent by design would put a spurious error in every bundle on the default configuration. `TestFiles` skips the drop-in for the same reason — it asserts an exact filename list, which cannot hold for a file whose presence depends on the flag.

One line from #5700 is reworded: its warning read `ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use`. That was accurate when the flag only drove the database exposure; now the flag also drives the reverse proxy, which is independent of which database SEP uses, so the message would over-claim.

## Trust boundary

`/sep/` sets `auth_request off`, so **PMM contributes no authentication or authorization to anything under that prefix** — all of it is SEP's. This is not incidental: pmm-managed's `/auth_request` forwards the client's `Authorization` header to Grafana, so leaving it on would reject the SEP bearer the embedded UI is meant to send, even for a valid PMM session. AC-7 also forbids synthesizing headers here.

The practical surface is narrow — SEP requires a bearer on its API and streaming routes, including GETs — but the enforcement lives entirely on SEP's side, and nothing in PMM would notice a SEP route added without it. Worth carrying into the Tech-Preview risk notes rather than leaving implicit.

## Testing

`shellcheck build/docker/server/entrypoint.sh` is clean (also at `-S style`), and `go test ./managed/utils/envvars/...` passes with the new `PMM_SEP_ADDRESS` assertion added to the existing SEP subtest. `make check` is clean.

The rest was exercised in a container rig built from the **real shipped configs** — this branch's `nginx.conf`, `pmm.conf` and `sep.conf.template`, with the drop-in rendered by this branch's actual entrypoint block, on `nginx:1.26-alpine` (the version `tasks/main.yml` pins) — against an echo/stream stub standing in for the side-car, under Docker and Podman.

| AC | Scenario | Result |
| --- | --- | --- |
| 1 | `nginx -t`, flag off, `sep.d` empty **and** absent | passes both ways; config delta is the include line alone |
| 2 | `GET /sep/api/things?x=1&y=2` | SEP saw path `/sep/api/things`, query `x=1&y=2` |
| 3 | Flag on → restart with it unset | drop-in written, then directory emptied — including a planted stale `.conf` |
| 4 | Flag on, side-car **absent** | nginx starts, no `host not found in upstream`; `/sep/` returns the 503 JSON |
| 5 | Side-car moved `172.18.0.3` → `172.18.0.4`, pmm-server **not** restarted | next request 200 (restart count still 0) |
| 6 | SSE stream; 75 s idle; WebSocket upgrade | 5 chunks ~1 s apart; 200 after 75 s idle (the 60 s default would 504); `101 Switching Protocols` with a bidirectional frame |
| 7 | Without / with `Authorization` | absent stays absent; `Bearer …` arrives byte-identical; server-level `X-Forwarded-For` still reaches SEP |
| 8 | All 26 stock locations, plus `/september` and `/sep-report`, flag on | zero reached the side-car |
| 9 | 25 MB `POST /sep/files/upload` | 200, all 26,214,400 bytes received (location raises the server's 10m) |
| 10 | Side-car down, maintenance off | 503 + `{"code":14,…}` in 9 ms, not the maintenance page |

Both resolver behaviours were checked against a positive control rather than asserted:

- **Scoping.** A probe location mirroring `/percona-blog/feed` (`set $probe http://sep:9000/health; proxy_pass $probe;`) returns 502 with the shipped drop-in — public DNS cannot resolve a container name — and 200 when the same `resolver` is moved to the drop-in's top level, i.e. the leak is real and the location scoping closes it, with `/sep/` still 200 either way.
- **IPv6.** Six `/etc/resolv.conf` shapes. IPv4-only, IPv6-then-IPv4 and IPv6-only yield a resolver that passes `nginx -t` (`10.0.0.53`, `10.0.0.53`, `[fd00::1]`); scoped-then-unscoped now prefers the later usable nameserver (`[fd00::1]`); scoped-only and empty each exit 1 with their own message. Controls confirm the three forms nginx rejects: unbracketed `fe80::1%eth0` is `[emerg] invalid port in resolver`, bracketed-with-zone `[fe80::1%eth0]` is `[emerg] invalid IPv6 address in resolver`, and a bare `fd00::1` is `invalid port`. The scoped-only and scoped-then-unscoped rows were added after review — the first revision stripped the zone, which passed `nginx -t` and produced a resolver that could not route.

Also covered: percent-encoding survives un-decoded (`a%20b.txt`); a 502 *returned by SEP itself* passes through unchanged rather than becoming the JSON body (`proxy_intercept_errors` is off); bare `/sep` 301s to `/sep/`; malformed `PMM_SEP_ADDRESS`, an out-of-range port, an empty `/etc/resolv.conf` and a missing template each exit 1 with a named message and leave no partial drop-in; and the UID matrix — `1000:0` and `4001:0` succeed, `2000:2000` fails loudly. Under Podman on a `pmm_default` network the resolver was derived as `10.89.0.1` and requests proxied end-to-end, confirming the AMI/OVF path.

**Where this evidence stops.** The rig is not a built PMM server image, so two claims are only partly discharged: AC-4's "the rest of PMM stays fully usable" and AC-8's "unaffected" were verified as *non-shadowing* (no stock path is captured by `/sep/`, none leaks to the side-car) — the rig's stock upstreams are absent, so those locations return errors there by construction and their functional behaviour needs the feature build. AC-6's incremental delivery reproduced both with and without `X-Accel-Buffering: no`, so the rig confirms streaming works but does not isolate that header as the mechanism; real behaviour depends on SEP marking its own streams, which the no-`proxy_buffering off` design rests on. That dependency was subsequently checked against SEP's source rather than left as an assumption: the side-car runs `sep_app`, and every streaming route that app serves — two in `app/sep/routes/stream_logs.py`, one in `app/sep/routes/download_files.py` — sets `X-Accel-Buffering: no`. The `StreamingResponse`s that do not are served by a different program on a different port and are unreachable through `/sep/`. `TestFiles` fails identically with and without this change (it needs a live PostgreSQL and container paths), so it neither covers nor is broken by the `logs.go` edit; the glob extracted out of it is covered by `TestSepConfigFiles`, which needs neither.

## Known limitations

- **Writes fail until the SPA sends a bearer.** SEP requires a Bearer on mutating methods, and the embedded SPA currently sends none; the harness overlay hid this by injecting a static internal token, which is deliberately dropped here. Reads succeed; every POST/PUT/PATCH/DELETE gets 401/403 from SEP until the FE token-exchange ticket lands. Do not "fix" this by reintroducing injection.
- **`X-Forwarded-Proto` reports the hop into nginx, not the client's original scheme.** Behind an external TLS terminator forwarding to `:8080`, SEP sees `http` and may generate `http://` absolute URLs. `map` cannot fix this from the drop-in, since `map` is http-context only and the drop-in is included inside `server`. No other PMM location sends this header at all, so nothing regresses — but nothing tracks it either.
  <!-- followup -->
- **No upstream keepalive.** A variable `proxy_pass` cannot reference an `upstream` block, and `Connection $connection_upgrade` is `close` for non-WebSocket requests, so every `/sep/` request opens a fresh connection to the side-car. Acceptable at Tech-Preview scale, worth knowing before anyone benchmarks it.
  <!-- followup -->
- **`client_max_body_size 100m` is a bound, not a measurement.** It clears the server-level 10m for SEP uploads; real SEP payload sizes have not been measured.
- **`proxy_read_timeout` is a blanket 3600s** for the whole prefix; there is no per-route knowledge available to scope it, and the streams need it. A hung request holds a connection for an hour rather than 60s.
- **The flag is read only at container start.** Changing it on a running container does nothing — supervisord has no reload hook for nginx and the repo contains no `nginx -s reload`. This matches every other entrypoint-consumed `PMM_*` flag.
- **Maintenance mode still wins.** While `maintenance.html` exists, the server-level check runs in the rewrite phase, before location selection, so `/sep/` requests get the maintenance page too. Correct behaviour, but it bounds AC-10.
- **`PMM_SEP_ADDRESS` accepts no IPv6 literal.** The validation regex admits a host of `[A-Za-z0-9._-]` plus a port, so `[::1]:9000` is rejected and the container exits 1 — before nginx, which would accept a bracketed literal in a variable `proxy_pass`, is ever consulted. A side-car reachable only over IPv6 cannot be addressed. Widening the regex is small, but it adds a branch to a container-start hard gate, so it belongs in the rig rather than in a late edit.
  <!-- followup -->
- **The flag cannot select the proxy alone while the builtin PostgreSQL is in use.** `postgres-sep` exits 1 when `PMM_ENABLE_SEP` is set and `PMM_SEP_POSTGRES_PASSWORD` is empty, and it runs earlier in the entrypoint under `set -o errexit`. So an operator who wants only the reverse proxy — SEP on its own database, PMM still on its builtin one — must supply a password nothing will use, or set `PMM_DISABLE_BUILTIN_POSTGRES` and accept its wider consequences. The reworded warning above covers the HA and disabled-builtin cases, not this one.
  <!-- followup -->
- **Nothing in PMM enforces the `X-Accel-Buffering` contract.** Leaving `proxy_buffering` on rests on SEP marking its own streams. That holds for every streaming route the side-car serves today (verified above), but a route added later without the header is silently buffered, and the failure is invisible from PMM — no log, no warning, no test. Forwarding one prefix instead of five is what makes the set of routes this has to hold for open-ended.
  <!-- followup -->
- **The support-bundle archive entry is covered by review only.** The glob itself is now unit-tested (`TestSepConfigFiles`, over a temporary directory: drop-ins collected, non-`.conf` ignored, absent and empty each yielding nothing). What is still uncovered is that the collected path is read into the zip — that runs through the shared append loop in `files()`, whose dozen-plus config paths are all hardcoded, so reaching it needs an injectable config root.
- #5700's own notes say "Docker only — the AMI and OVF distributions do not run this entrypoint." That is not accurate, as measured above; the issue's out-of-scope note has been corrected, and no code change to #5700 is required — its gate is env-based and its subnet derivation works under Podman too.

## Dependencies

Nothing is blocking merge into the epic branch any more: #5700 (PMM-15238) is on `main`, and the FE re-pathing onto `/sep/*` reached this PR's base with #5653 (PMM-15216). The SEP-side prefix support is **no longer blocking** — SEP's app now takes `root_path` from settings and its side-car profile ships `ROOT_PATH: /sep`.

A working feature build additionally needs the FE token exchange, the Grafana service account, and the ticket delivering SEP's secret key and database credentials — the side-car will not start without a secret key. Ordering inside the FB matters even though merge order does not: retiring the harness overlay must not land ahead of the FE token exchange, or the stack reports as working while silently failing every write. The harness also names its service differently from the `sep:9000` default, so `PMM_SEP_ADDRESS` must be set there; the failure looks like a proxy fault rather than a missing variable.

The feature build is where the rig's blind spots get covered: SSE incrementality against real SEP, AC-5 recovery against a real restarted side-car, resolver derivation on an actual AMI, and the arbitrary-UID write path into `sep.d/` in the built image.

- [ ] API Docs updated — not applicable, no API endpoints added, removed or altered.



