### PR TITLE
PMM-15316 Publish SEP's secrets and generate its database password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,8 +58,12 @@ PMM_PORT_HTTPS=443
 # PMM_SEP_POSTGRES_PASSWORD=<password>
 # PMM_SEP_ADDRESS=sep:9000
 
-# PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
-# and group, one file per canonical SEP settings name:
+# With PMM_ENABLE_SEP set, PMM writes SEP's deployment secrets to /srv/sep - the pmm-sep
+# volume, which the SEP container mounts read-only with SECRETS_DIR pointing at it.
+# The directory is setgid mode 2770 and the files 0640, so every file belongs to group 0
+# whichever uid PMM runs as. PMM cannot chgrp to SEP's own group, so the SEP container
+# has to join group 0 - `group_add: ["0"]`, or `user: "1001:0"` - or it cannot read them.
+# One file per canonical SEP settings name:
 #   SECRET_KEY                      generated once on first start and persisted on the
 #                                   /srv volume, so restarting PMM keeps every SEP
 #                                   session valid
@@ -70,14 +74,15 @@ PMM_PORT_HTTPS=443
 # and copied from there on every start. A fresh /srv volume mints a new one; an existing one
 # is never overwritten, so back /srv up to keep SEP's sessions across a redeployment.
 # Do not pass SECRET_KEY to the SEP container — an environment value outranks the file, and
-# a PMM that later mints its own key then diverges from it silently. As with the token names
-# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than empty.
+# a PMM that later mints its own key then diverges from it silently. Leave the three canonical
+# *__DATABASE__PASSWORD names unset on the SEP container rather than empty: an empty value
+# counts as supplied there and outranks the file, which then goes unused.
 # Give PMM_SEP_POSTGRES_PASSWORD no leading or trailing whitespace: PostgreSQL keeps it, SEP
 # strips it when reading the file, and the two then disagree.
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
 # Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: an empty
-# PMM_SEP_POSTGRES_PASSWORD, or a /srv/sep-secrets it cannot write to, is fatal. Neither
+# PMM_SEP_POSTGRES_PASSWORD, or a /srv/sep it cannot write to, is fatal. Neither
 # check applies under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore
 # PMM_ENABLE_SEP outright and leave no SEP database to hold a password for.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted

--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,9 @@ PMM_PORT_HTTPS=443
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
 # Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: a /srv/sep
-# it cannot write to is fatal, and so is one that is not setgid group 0, since the files
-# would otherwise be published in a group SEP cannot read. Neither check applies under
+# it cannot write to is fatal, and so is one that is not setgid group 0 with group r-x,
+# since the files would otherwise be published in a group SEP cannot read, or behind a
+# directory SEP cannot search. Neither check applies under
 # PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore PMM_ENABLE_SEP outright and
 # leave no SEP database to hold a password for - so nothing is generated or written at all.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted

--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,23 @@ PMM_PORT_HTTPS=443
 # PMM_SEP_POSTGRES_PASSWORD=<password>
 # PMM_SEP_ADDRESS=sep:9000
 
+# PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
+# and group, one file per canonical SEP settings name:
+#   SECRET_KEY                      generated once on first start and persisted on the
+#                                   /srv volume, so restarting PMM keeps every SEP
+#                                   session valid
+#   SEP__DATABASE__PASSWORD         PMM_SEP_POSTGRES_PASSWORD verbatim, rewritten on
+#   INVENTORY__DATABASE__PASSWORD   every start so rotating it takes effect on the next
+#   TASKS__DATABASE__PASSWORD       restart
+# A fresh /srv volume mints a new SECRET_KEY; an existing one is never overwritten. Do not
+# pass SECRET_KEY or SEP_DB_PASSWORD to the SEP container — and, as with the token names
+# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than
+# empty. Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the
+# database and rewrite the files, then restart the SEP container, which reads them only at
+# process start.
+# Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
+# SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
+
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full
 # GF_DATABASE_CA_CERT_PATH=/tmp/certs/root.crt

--- a/.env.example
+++ b/.env.example
@@ -86,9 +86,10 @@ PMM_PORT_HTTPS=443
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
 # Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: a /srv/sep
-# it cannot write to is fatal. That check does not apply under PMM_HA_ENABLE or
-# PMM_DISABLE_BUILTIN_POSTGRES, which ignore PMM_ENABLE_SEP outright and leave no SEP
-# database to hold a password for.
+# it cannot write to is fatal, and so is one that is not setgid group 0, since the files
+# would otherwise be published in a group SEP cannot read. Neither check applies under
+# PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore PMM_ENABLE_SEP outright and
+# leave no SEP database to hold a password for - so nothing is generated or written at all.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/.env.example
+++ b/.env.example
@@ -49,7 +49,11 @@ PMM_PORT_HTTPS=443
 # Expose the built-in PostgreSQL to SEP running in a side container on the same bridge
 # network. PMM creates a dedicated `sep` database owned by a non-superuser `sep` role and
 # accepts connections for it from the container's Docker subnets only; nothing is
-# published on the host. The first two variables are required to enable it.
+# published on the host. PMM_ENABLE_SEP alone is enough: PMM generates the role's password
+# on first start and persists it at /srv/.sep_postgres_password mode 0600, so a plain
+# `docker compose up` needs no secret chosen in advance. Set PMM_SEP_POSTGRES_PASSWORD to
+# supply your own instead; it is used verbatim and is not persisted, so clearing it later
+# returns to the generated one.
 #
 # The same flag makes nginx reverse-proxy /sep/ to the side-car. PMM_SEP_ADDRESS
 # overrides where it is reached and defaults to sep:9000, so it only needs setting
@@ -67,8 +71,8 @@ PMM_PORT_HTTPS=443
 #   SECRET_KEY                      generated once on first start and persisted on the
 #                                   /srv volume, so restarting PMM keeps every SEP
 #                                   session valid
-#   SEP__DATABASE__PASSWORD         PMM_SEP_POSTGRES_PASSWORD verbatim, rewritten on
-#   INVENTORY__DATABASE__PASSWORD   every start so rotating it takes effect on the next
+#   SEP__DATABASE__PASSWORD         the role's password, generated or supplied, rewritten
+#   INVENTORY__DATABASE__PASSWORD   on every start so rotating it takes effect on the next
 #   TASKS__DATABASE__PASSWORD       restart
 # SECRET_KEY is persisted outside the secrets directory, at /srv/.sep_secret_key mode 0600,
 # and copied from there on every start. A fresh /srv volume mints a new one; an existing one
@@ -81,10 +85,10 @@ PMM_PORT_HTTPS=443
 # strips it when reading the file, and the two then disagree.
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
-# Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: an empty
-# PMM_SEP_POSTGRES_PASSWORD, or a /srv/sep it cannot write to, is fatal. Neither
-# check applies under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore
-# PMM_ENABLE_SEP outright and leave no SEP database to hold a password for.
+# Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: a /srv/sep
+# it cannot write to is fatal. That check does not apply under PMM_HA_ENABLE or
+# PMM_DISABLE_BUILTIN_POSTGRES, which ignore PMM_ENABLE_SEP outright and leave no SEP
+# database to hold a password for.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,10 @@ PMM_PORT_HTTPS=443
 # strips it when reading the file, and the two then disagree.
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
-# With PMM_ENABLE_SEP set, an empty PMM_SEP_POSTGRES_PASSWORD or a /srv/sep-secrets PMM
-# cannot write stops PMM Server from starting rather than degrading SEP alone.
+# Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: an empty
+# PMM_SEP_POSTGRES_PASSWORD, or a /srv/sep-secrets it cannot write to, is fatal. Neither
+# check applies under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore
+# PMM_ENABLE_SEP outright and leave no SEP database to hold a password for.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/.env.example
+++ b/.env.example
@@ -66,12 +66,18 @@ PMM_PORT_HTTPS=443
 #   SEP__DATABASE__PASSWORD         PMM_SEP_POSTGRES_PASSWORD verbatim, rewritten on
 #   INVENTORY__DATABASE__PASSWORD   every start so rotating it takes effect on the next
 #   TASKS__DATABASE__PASSWORD       restart
-# A fresh /srv volume mints a new SECRET_KEY; an existing one is never overwritten. Do not
-# pass SECRET_KEY or SEP_DB_PASSWORD to the SEP container — and, as with the token names
-# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than
-# empty. Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the
-# database and rewrite the files, then restart the SEP container, which reads them only at
-# process start.
+# SECRET_KEY is persisted outside the secrets directory, at /srv/.sep_secret_key mode 0600,
+# and copied from there on every start. A fresh /srv volume mints a new one; an existing one
+# is never overwritten, so back /srv up to keep SEP's sessions across a redeployment.
+# Do not pass SECRET_KEY to the SEP container — an environment value outranks the file, and
+# a PMM that later mints its own key then diverges from it silently. As with the token names
+# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than empty.
+# Give PMM_SEP_POSTGRES_PASSWORD no leading or trailing whitespace: PostgreSQL keeps it, SEP
+# strips it when reading the file, and the two then disagree.
+# Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
+# rewrite the files, then restart the SEP container, which reads them only at process start.
+# With PMM_ENABLE_SEP set, an empty PMM_SEP_POSTGRES_PASSWORD or a /srv/sep-secrets PMM
+# cannot write stops PMM Server from starting rather than degrading SEP alone.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -37,7 +37,7 @@ Source code (Go, TypeScript)
 | `grafana` | Install Grafana, provision datasources and dashboards |
 | `nginx` | Configure Nginx as reverse proxy (SSL termination, routing) |
 | `postgres` | Install and configure PostgreSQL for pmm-managed |
-| `sep` | SEP side-car integration helpers (secrets published when `PMM_ENABLE_SEP` is set) |
+| `sep` | SEP side-car integration helpers copied into the image and invoked from the entrypoint (no `tasks/`); publishes SEP's secrets when `PMM_ENABLE_SEP` is set |
 | `supervisord` | Configure Supervisord for process management |
 | `dashboards` | Provision PMM Grafana dashboards |
 | `initialization` | PMM Server first-run setup |

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -37,6 +37,7 @@ Source code (Go, TypeScript)
 | `grafana` | Install Grafana, provision datasources and dashboards |
 | `nginx` | Configure Nginx as reverse proxy (SSL termination, routing) |
 | `postgres` | Install and configure PostgreSQL for pmm-managed |
+| `sep` | SEP side-car integration helpers (secrets published when `PMM_ENABLE_SEP` is set) |
 | `supervisord` | Configure Supervisord for process management |
 | `dashboards` | Provision PMM Grafana dashboards |
 | `initialization` | PMM Server first-run setup |

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -82,3 +82,17 @@
         owner: pmm
         group: root
         mode: 0664
+
+    # Must exist in the image: a named volume mounted at a path the image lacks is
+    # created root:root, which pmm-server cannot write to. Group-writable like the
+    # other /srv directories, so an arbitrary runtime uid in group 0 can still write.
+    # Setgid so the files written here belong to group 0 whatever that uid's primary
+    # group is - the SEP container joins group 0 to read them. Docker carries the bit
+    # into a fresh named volume mounted at this path.
+    - name: Create the SEP directory
+      file:
+        path: /srv/sep
+        state: directory
+        owner: pmm
+        group: root
+        mode: 02770

--- a/build/ansible/roles/postgres/files/postgres-sep
+++ b/build/ansible/roles/postgres/files/postgres-sep
@@ -97,7 +97,7 @@ fi
 
 if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
     echo "FATAL: PMM_ENABLE_SEP is set but PMM_SEP_POSTGRES_PASSWORD is empty." >&2
-    echo "Please set PMM_SEP_POSTGRES_PASSWORD to the password SEP will connect with and try again." >&2
+    echo "The entrypoint generates one when it is unset, so reaching here means /srv could not be written; check its ownership and try again." >&2
     exit 1
 fi
 

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -137,7 +137,7 @@ fi
 
 if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
     echo "FATAL: PMM_ENABLE_SEP is set but PMM_SEP_POSTGRES_PASSWORD is empty." >&2
-    echo "Please set PMM_SEP_POSTGRES_PASSWORD to the password SEP will connect with and try again." >&2
+    echo "The entrypoint generates one when it is unset, so reaching here means /srv could not be written; check its ownership and try again." >&2
     exit 1
 fi
 

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -16,12 +16,12 @@
 # the flag.
 #
 # Runs from the entrypoint rather than under supervisord because neither value depends on
-# a running service - unlike grafana-sep, which cannot provision until Grafana is up.
+# a running service: the key is generated here and the password comes from the environment.
 
 set -o errexit
 set -o pipefail
 
-declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
+declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep}"
 declare SECRET_KEY_FILE="/srv/.sep_secret_key"
 declare -a DB_PASSWORD_FILES=(
     SEP__DATABASE__PASSWORD
@@ -124,9 +124,9 @@ if ! is_enabled "$PMM_ENABLE_SEP"; then
     exit 0
 fi
 
-# Deliberately not bailing on GF_DATABASE_URL/GF_DATABASE_HOST the way grafana-sep does:
-# nothing here touches Grafana, and postgres-sep still provisions the sep role and
-# database with an external Grafana, so SEP still needs its password files.
+# Deliberately not bailing on GF_DATABASE_URL/GF_DATABASE_HOST: nothing here touches
+# Grafana, and postgres-sep still provisions the sep role and database with an external
+# Grafana, so SEP still needs its password files.
 #
 # The entrypoint has already warned about the combination below; bail quietly rather than
 # print a second copy of the same line.

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -21,7 +21,7 @@
 set -o errexit
 set -o pipefail
 
-declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep}"
+declare SECRETS_DIR="${PMM_DEV_SEP_SECRETS_DIR:-/srv/sep}"
 declare SECRET_KEY_FILE="/srv/.sep_secret_key"
 declare -a DB_PASSWORD_FILES=(
     SEP__DATABASE__PASSWORD
@@ -87,7 +87,10 @@ remove_managed_files() {
 
     for name in "${MANAGED_FILES[@]}"; do
         path="${SECRETS_DIR:?}/$name"
-        rm -f "$path" 2> /dev/null || true
+        # The staging temporaries go too. cleanup removes them on any exit bash runs a trap
+        # for, so what survives to reach here is the SIGKILL and grace-period-expiry
+        # residue - a readable .$name.XXXXXX the canonical names alone never collect.
+        rm -f "$path" "${SECRETS_DIR:?}/.$name".?????? 2> /dev/null || true
         if [ -e "$path" ]; then
             echo "WARNING: could not remove $path, SEP can still read this secret." >&2
         fi
@@ -103,6 +106,8 @@ remove_managed_files() {
 # would then accept and republish forever. errexit aborts before the rename, so an
 # interrupted generation leaves the previous key - or no key - untouched.
 ensure_secret_key() {
+    local mode
+
     if [ ! -s "$SECRET_KEY_FILE" ]; then
         echo "Generating SEP's SECRET_KEY..."
         TMP_FILE=$(mktemp "$SECRET_KEY_FILE.XXXXXX")
@@ -111,12 +116,19 @@ ensure_secret_key() {
         TMP_FILE=""
     fi
     # Unconditional so a key whose mode was widened by hand is narrowed back without being
-    # replaced, but never fatal: chmod needs ownership, not write permission, and the
-    # arbitrary-uid path lets a later start run as a uid that does not own what an earlier
-    # one persisted. Failing to harden a key this start can still read and publish is not
-    # worth stopping pmm-server for - entrypoint.sh guards its own /srv chmod the same way.
-    chmod 600 "$SECRET_KEY_FILE" 2> /dev/null ||
-        echo "WARNING: could not narrow $SECRET_KEY_FILE to mode 600." >&2
+    # replaced. A failed chmod is not by itself fatal: it needs ownership rather than write
+    # permission, and the arbitrary-uid path lets a later start run as a uid that does not
+    # own what an earlier one persisted. A mode that still leaves the key readable beyond
+    # its owner is fatal, because this is the value that signs every SEP session - the same
+    # rule entrypoint.sh applies to the password it persists next to it.
+    if ! chmod 600 "$SECRET_KEY_FILE" 2> /dev/null; then
+        mode=$(stat -c '%a' "$SECRET_KEY_FILE")
+        if [ $((8#$mode & 8#077)) -ne 0 ]; then
+            echo "FATAL: $SECRET_KEY_FILE is mode $mode and could not be narrowed to 600." >&2
+            echo "Please make sure it is owned by uid $(id -u), or narrow it by hand, and try again." >&2
+            exit 1
+        fi
+    fi
 }
 
 if ! is_enabled "$PMM_ENABLE_SEP"; then
@@ -142,14 +154,31 @@ if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
 fi
 
 # Created only when absent: install -d on an existing directory also chmods it, which a
-# uid that does not own the mountpoint cannot do.
+# uid that does not own the mountpoint cannot do. -g 0 rather than the creator's egid,
+# because the group is what SEP reads these files through; the fallback covers a uid that
+# is not a member of group 0, which the inheritance check below then rejects.
 if [ ! -d "$SECRETS_DIR" ]; then
-    install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
+    install -d -m 2770 -g 0 "$SECRETS_DIR" 2> /dev/null ||
+        install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
 fi
 
 if [ ! -w "$SECRETS_DIR" ]; then
     echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
     echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
+    exit 1
+fi
+
+# -w answers whether this uid can create files here, which is not the question SEP cares
+# about: it reads the 0640 files through group 0, and nothing below sets a group, so the
+# files take whatever the directory hands them. A directory that is not setgid group 0
+# therefore publishes a complete, correct set of secrets SEP cannot open - and the failure
+# surfaces on the SEP side as a missing setting rather than here.
+declare SECRETS_DIR_GID SECRETS_DIR_MODE
+SECRETS_DIR_GID=$(stat -c '%g' "$SECRETS_DIR")
+SECRETS_DIR_MODE=$(stat -c '%a' "$SECRETS_DIR")
+if [ "$SECRETS_DIR_GID" -ne 0 ] || [ $((8#$SECRETS_DIR_MODE & 8#2000)) -eq 0 ]; then
+    echo "FATAL: $SECRETS_DIR is gid $SECRETS_DIR_GID mode $SECRETS_DIR_MODE, not setgid group 0." >&2
+    echo "Please run 'chgrp 0 $SECRETS_DIR && chmod g+rwxs $SECRETS_DIR' on the volume mounted there and try again." >&2
     exit 1
 fi
 

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Publishes SEP's SECRET_KEY and database credentials to a secrets directory the SEP
+# container mounts, one file per canonical SEP settings name. The files are 0640 and
+# take group 0 from the setgid directory post-build.yml ships - nothing here sets their
+# group, so that bit must stay.
+#
+# The two lifecycles differ deliberately. SECRET_KEY is generated once and persisted on
+# /srv: re-minting it signs out every SEP session and changes the SEP_INTERNAL_TOKEN
+# derived from it by HMAC. The database credential is rewritten on every start so
+# rotating PMM_SEP_POSTGRES_PASSWORD takes effect on the next restart.
+#
+# Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again, the
+# files this script wrote are removed on the next start; the persisted key is left in
+# place so re-enabling SEP does not invalidate the sessions of a deployment that toggled
+# the flag.
+#
+# Runs from the entrypoint rather than under supervisord because neither value depends on
+# a running service - unlike grafana-sep, which cannot provision until Grafana is up.
+
+set -o errexit
+set -o pipefail
+
+declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
+declare SECRET_KEY_FILE="/srv/.sep_secret_key"
+declare -a DB_PASSWORD_FILES=(
+    SEP__DATABASE__PASSWORD
+    INVENTORY__DATABASE__PASSWORD
+    TASKS__DATABASE__PASSWORD
+)
+declare -a MANAGED_FILES=(SECRET_KEY "${DB_PASSWORD_FILES[@]}")
+declare TMP_FILE=""
+
+cleanup() {
+    [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    return 0
+}
+trap cleanup EXIT
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+# Written through a temporary file so SEP never reads a half-written secret, and with
+# printf '%s' so no trailing newline reaches a reader that strips rather than chomps.
+publish() {
+    local name="$1" value="$2"
+
+    TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+    printf '%s' "$value" > "$TMP_FILE"
+    chmod 0640 "$TMP_FILE"
+    mv "$TMP_FILE" "$SECRETS_DIR/$name"
+    TMP_FILE=""
+}
+
+# Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
+# write - but a secret left behind is still readable by SEP, so it is reported.
+remove_managed_files() {
+    local name path
+
+    for name in "${MANAGED_FILES[@]}"; do
+        path="${SECRETS_DIR:?}/$name"
+        rm -f "$path" 2> /dev/null || true
+        if [ -e "$path" ]; then
+            echo "WARNING: could not remove $path, SEP can still read this secret." >&2
+        fi
+    done
+}
+
+# Non-empty rather than merely present: SEP's settings classes reject a blank SECRET_KEY,
+# and the side-car's own gate treats a mounted-but-empty key file as a failure rather than
+# as a supplied value.
+#
+# Generated into a temporary file and renamed, never written at the final path: a direct
+# redirect that dies mid-write leaves a short but non-empty key there, which the -s test
+# would then accept and republish forever. errexit aborts before the rename, so an
+# interrupted generation leaves the previous key - or no key - untouched.
+ensure_secret_key() {
+    if [ ! -s "$SECRET_KEY_FILE" ]; then
+        echo "Generating SEP's SECRET_KEY..."
+        TMP_FILE=$(mktemp "$SECRET_KEY_FILE.XXXXXX")
+        openssl rand -hex 32 > "$TMP_FILE"
+        mv "$TMP_FILE" "$SECRET_KEY_FILE"
+        TMP_FILE=""
+    fi
+    # Unconditional: a key persisted by an earlier start whose mode was widened by hand is
+    # narrowed back without being replaced.
+    chmod 600 "$SECRET_KEY_FILE"
+}
+
+if ! is_enabled "$PMM_ENABLE_SEP"; then
+    remove_managed_files
+    exit 0
+fi
+
+# Deliberately not bailing on GF_DATABASE_URL/GF_DATABASE_HOST the way grafana-sep does:
+# nothing here touches Grafana, and postgres-sep still provisions the sep role and
+# database with an external Grafana, so SEP still needs its password files.
+#
+# The entrypoint has already warned about the combination below; bail quietly rather than
+# print a second copy of the same line.
+if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
+    remove_managed_files
+    exit 0
+fi
+
+if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
+    echo "FATAL: PMM_ENABLE_SEP is set but PMM_SEP_POSTGRES_PASSWORD is empty." >&2
+    echo "Please set PMM_SEP_POSTGRES_PASSWORD to the password SEP will connect with and try again." >&2
+    exit 1
+fi
+
+# Created only when absent: install -d on an existing directory also chmods it, which a
+# uid that does not own the mountpoint cannot do.
+if [ ! -d "$SECRETS_DIR" ]; then
+    install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
+fi
+
+if [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
+    echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
+    exit 1
+fi
+
+ensure_secret_key
+# Republished on every start, not only on generation, so a wiped or newly attached secrets
+# volume is refilled from the persisted key rather than left short a file.
+publish SECRET_KEY "$(< "$SECRET_KEY_FILE")"
+
+for name in "${DB_PASSWORD_FILES[@]}"; do
+    publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"
+done
+
+echo "Published SEP's SECRET_KEY and database credentials to $SECRETS_DIR."

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -81,9 +81,13 @@ ensure_secret_key() {
         mv "$TMP_FILE" "$SECRET_KEY_FILE"
         TMP_FILE=""
     fi
-    # Unconditional: a key persisted by an earlier start whose mode was widened by hand is
-    # narrowed back without being replaced.
-    chmod 600 "$SECRET_KEY_FILE"
+    # Unconditional so a key whose mode was widened by hand is narrowed back without being
+    # replaced, but never fatal: chmod needs ownership, not write permission, and the
+    # arbitrary-uid path lets a later start run as a uid that does not own what an earlier
+    # one persisted. Failing to harden a key this start can still read and publish is not
+    # worth stopping pmm-server for - entrypoint.sh guards its own /srv chmod the same way.
+    chmod 600 "$SECRET_KEY_FILE" 2> /dev/null ||
+        echo "WARNING: could not narrow $SECRET_KEY_FILE to mode 600." >&2
 }
 
 if ! is_enabled "$PMM_ENABLE_SEP"; then
@@ -121,9 +125,25 @@ if [ ! -w "$SECRETS_DIR" ]; then
 fi
 
 ensure_secret_key
+
+# Read into a variable rather than inline at the call below: a command substitution that
+# fails in argument position does not trip errexit, so an unreadable key would publish an
+# empty SECRET_KEY over a good one and fail SEP's own gate instead of stopping here.
+# Regenerating instead would be worse - the file is non-empty, so something is using it.
+declare SECRET_KEY_VALUE=""
+if [ -r "$SECRET_KEY_FILE" ]; then
+    SECRET_KEY_VALUE=$(< "$SECRET_KEY_FILE")
+fi
+
+if [ -z "$SECRET_KEY_VALUE" ]; then
+    echo "FATAL: SEP's SECRET_KEY persisted at $SECRET_KEY_FILE is unreadable or blank." >&2
+    echo "Please make sure it is readable for uid $(id -u), or remove it to generate a new one - which signs every SEP session out." >&2
+    exit 1
+fi
+
 # Republished on every start, not only on generation, so a wiped or newly attached secrets
 # volume is refilled from the persisted key rather than left short a file.
-publish SECRET_KEY "$(< "$SECRET_KEY_FILE")"
+publish SECRET_KEY "$SECRET_KEY_VALUE"
 
 for name in "${DB_PASSWORD_FILES[@]}"; do
     publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -170,14 +170,17 @@ fi
 
 # -w answers whether this uid can create files here, which is not the question SEP cares
 # about: it reads the 0640 files through group 0, and nothing below sets a group, so the
-# files take whatever the directory hands them. A directory that is not setgid group 0
-# therefore publishes a complete, correct set of secrets SEP cannot open - and the failure
-# surfaces on the SEP side as a missing setting rather than here.
+# files take whatever the directory hands them. Handing them the group is half of it -
+# group 0 needs r-x on the directory too, since a 0640 file behind a directory group 0
+# cannot search is as unreachable as one in the wrong group. A directory failing either
+# half publishes a complete, correct set of secrets SEP cannot open - and the failure
+# surfaces on the SEP side as a missing setting rather than here. Group write is not in
+# the mask: only this uid writes here, which -w already answered.
 declare SECRETS_DIR_GID SECRETS_DIR_MODE
 SECRETS_DIR_GID=$(stat -c '%g' "$SECRETS_DIR")
 SECRETS_DIR_MODE=$(stat -c '%a' "$SECRETS_DIR")
-if [ "$SECRETS_DIR_GID" -ne 0 ] || [ $((8#$SECRETS_DIR_MODE & 8#2000)) -eq 0 ]; then
-    echo "FATAL: $SECRETS_DIR is gid $SECRETS_DIR_GID mode $SECRETS_DIR_MODE, not setgid group 0." >&2
+if [ "$SECRETS_DIR_GID" -ne 0 ] || [ $((8#$SECRETS_DIR_MODE & 8#2050)) -ne $((8#2050)) ]; then
+    echo "FATAL: $SECRETS_DIR is gid $SECRETS_DIR_GID mode $SECRETS_DIR_MODE, not setgid group 0 with group r-x." >&2
     echo "Please run 'chgrp 0 $SECRETS_DIR && chmod g+rwxs $SECRETS_DIR' on the volume mounted there and try again." >&2
     exit 1
 fi

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -29,26 +29,55 @@ declare -a DB_PASSWORD_FILES=(
     TASKS__DATABASE__PASSWORD
 )
 declare -a MANAGED_FILES=(SECRET_KEY "${DB_PASSWORD_FILES[@]}")
+declare -a STAGED_TMP=() STAGED_DEST=()
 declare TMP_FILE=""
 
 cleanup() {
+    local tmp
+
     [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    for tmp in "${STAGED_TMP[@]}"; do
+        rm -f "$tmp"
+    done
     return 0
 }
 trap cleanup EXIT
 
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
-# Written through a temporary file so SEP never reads a half-written secret, and with
+# Every fallible step - mktemp, the write, the chmod - runs here, before commit_staged
+# renames anything, so the failure that actually happens to this operation (a write dying
+# on a full volume) leaves SEP the previous complete set rather than a mix of new and
+# stale credentials. Interleaving write and rename per file is what makes that mix
+# reachable; the rename itself, within one filesystem and after a complete write, is not
+# the fallible part.
+#
 # printf '%s' so no trailing newline reaches a reader that strips rather than chomps.
-publish() {
-    local name="$1" value="$2"
+stage() {
+    local name="$1" value="$2" tmp
 
-    TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
-    printf '%s' "$value" > "$TMP_FILE"
-    chmod 0640 "$TMP_FILE"
-    mv "$TMP_FILE" "$SECRETS_DIR/$name"
-    TMP_FILE=""
+    tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+    # Recorded before the write, not after: errexit abandons the rest of this function on
+    # a failed write, and a temporary created but not yet recorded is one cleanup cannot
+    # find.
+    STAGED_TMP+=("$tmp")
+    STAGED_DEST+=("$SECRETS_DIR/$name")
+    printf '%s' "$value" > "$tmp"
+    chmod 0640 "$tmp"
+}
+
+# Each rename replaces a whole file with one already written in full, so SEP never reads a
+# half-written secret. The set is still four renames rather than one operation: a failure
+# between them leaves the earlier files updated, which is the residue this cannot remove
+# without a directory swap the mountpoint contract rules out.
+commit_staged() {
+    local i
+
+    for i in "${!STAGED_TMP[@]}"; do
+        mv "${STAGED_TMP[$i]}" "${STAGED_DEST[$i]}"
+    done
+    STAGED_TMP=()
+    STAGED_DEST=()
 }
 
 # Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
@@ -143,10 +172,12 @@ fi
 
 # Republished on every start, not only on generation, so a wiped or newly attached secrets
 # volume is refilled from the persisted key rather than left short a file.
-publish SECRET_KEY "$SECRET_KEY_VALUE"
+stage SECRET_KEY "$SECRET_KEY_VALUE"
 
 for name in "${DB_PASSWORD_FILES[@]}"; do
-    publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"
+    stage "$name" "$PMM_SEP_POSTGRES_PASSWORD"
 done
+
+commit_staged
 
 echo "Published SEP's SECRET_KEY and database credentials to $SECRETS_DIR."

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -218,6 +218,11 @@ fi
 # removed on the start after PMM_ENABLE_SEP is cleared.
 bash /opt/ansible/roles/sep/files/sep-secrets
 
+# The last consumer has run, so drop the password before exec'ing supervisord: otherwise
+# every child inherits it, and pmm-managed-init logs each variable it is handed - name and
+# value - once PMM_TRACE is set.
+unset PMM_SEP_POSTGRES_PASSWORD
+
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1
 

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -112,6 +112,29 @@ if [ ! -d "/srv/pmm-agent/tmp" ]; then
     install -d -m 770 /srv/pmm-agent/tmp
 fi
 
+# Resolved before postgres-sep, which sets the sep role's password, and sep-secrets,
+# which publishes it - both read it from the environment and neither can generate it for
+# the other. An operator value wins and is not persisted, so unsetting it returns to the
+# generated one rather than pinning whatever was passed once.
+if is_enabled "$PMM_ENABLE_SEP" && [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
+    declare SEP_PG_PASSWORD_FILE="/srv/.sep_postgres_password"
+
+    if [ ! -s "$SEP_PG_PASSWORD_FILE" ]; then
+        echo "Generating the PostgreSQL password for SEP..."
+        SEP_PG_TMP=$(mktemp "$SEP_PG_PASSWORD_FILE.XXXXXX")
+        openssl rand -hex 24 > "$SEP_PG_TMP"
+        mv "$SEP_PG_TMP" "$SEP_PG_PASSWORD_FILE"
+        unset SEP_PG_TMP
+    fi
+
+    chmod 600 "$SEP_PG_PASSWORD_FILE" 2> /dev/null ||
+        echo "WARNING: could not narrow $SEP_PG_PASSWORD_FILE to mode 600." >&2
+
+    PMM_SEP_POSTGRES_PASSWORD=$(< "$SEP_PG_PASSWORD_FILE")
+    export PMM_SEP_POSTGRES_PASSWORD
+    unset SEP_PG_PASSWORD_FILE
+fi
+
 # The script owns the embedded cluster: it upgrades a PostgreSQL 14 data directory,
 # creates the cluster on a fresh installation, and repairs older ones.
 if is_enabled "$PMM_HA_ENABLE"; then

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -116,23 +116,46 @@ fi
 # which publishes it - both read it from the environment and neither can generate it for
 # the other. An operator value wins and is not persisted, so unsetting it returns to the
 # generated one rather than pinning whatever was passed once.
-if is_enabled "$PMM_ENABLE_SEP" && [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
+#
+# Gated on the same two flags as the migration branch below, which is what decides whether
+# postgres-sep runs at all: under either of them sep-secrets bails too, so generating here
+# would persist a credential on /srv that nothing ever reads.
+if is_enabled "$PMM_ENABLE_SEP" && [ -z "$PMM_SEP_POSTGRES_PASSWORD" ] &&
+    ! is_enabled "$PMM_HA_ENABLE" && ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
     declare SEP_PG_PASSWORD_FILE="/srv/.sep_postgres_password"
+    declare SEP_PG_MODE
 
     if [ ! -s "$SEP_PG_PASSWORD_FILE" ]; then
         echo "Generating the PostgreSQL password for SEP..."
         SEP_PG_TMP=$(mktemp "$SEP_PG_PASSWORD_FILE.XXXXXX")
-        openssl rand -hex 24 > "$SEP_PG_TMP"
+        # Removed here rather than from an EXIT trap: the only trap this file installs is
+        # the NSS wrapper's, and a second one would replace it rather than chain onto it.
+        if ! openssl rand -hex 24 > "$SEP_PG_TMP"; then
+            rm -f "$SEP_PG_TMP"
+            echo "FATAL: could not generate the PostgreSQL password for SEP." >&2
+            exit 1
+        fi
         mv "$SEP_PG_TMP" "$SEP_PG_PASSWORD_FILE"
         unset SEP_PG_TMP
     fi
 
-    chmod 600 "$SEP_PG_PASSWORD_FILE" 2> /dev/null ||
-        echo "WARNING: could not narrow $SEP_PG_PASSWORD_FILE to mode 600." >&2
+    # chmod needs ownership rather than write permission, and the arbitrary-uid path lets a
+    # later start run as a uid that does not own what an earlier one persisted - so a failed
+    # chmod is not by itself a reason to stop. A mode that still leaves the credential
+    # readable beyond its owner is, because the value is about to be exported: refusing to
+    # start beats publishing a password this uid cannot narrow.
+    if ! chmod 600 "$SEP_PG_PASSWORD_FILE" 2> /dev/null; then
+        SEP_PG_MODE=$(stat -c '%a' "$SEP_PG_PASSWORD_FILE")
+        if [ $((8#$SEP_PG_MODE & 8#077)) -ne 0 ]; then
+            echo "FATAL: $SEP_PG_PASSWORD_FILE is mode $SEP_PG_MODE and could not be narrowed to 600." >&2
+            echo "Please make sure it is owned by uid $(id -u), or narrow it by hand, and try again." >&2
+            exit 1
+        fi
+    fi
 
     PMM_SEP_POSTGRES_PASSWORD=$(< "$SEP_PG_PASSWORD_FILE")
     export PMM_SEP_POSTGRES_PASSWORD
-    unset SEP_PG_PASSWORD_FILE
+    unset SEP_PG_PASSWORD_FILE SEP_PG_MODE
 fi
 
 # The script owns the embedded cluster: it upgrades a PostgreSQL 14 data directory,
@@ -242,8 +265,8 @@ fi
 bash /opt/ansible/roles/sep/files/sep-secrets
 
 # The last consumer has run, so drop the password before exec'ing supervisord: otherwise
-# every child inherits it, and pmm-managed-init logs each variable it is handed - name and
-# value - once PMM_TRACE is set.
+# every supervisord child inherits it, and anything sharing the container's PID namespace
+# can then read it out of /proc/<pid>/environ.
 unset PMM_SEP_POSTGRES_PASSWORD
 
 echo "Generating self-signed certificates for nginx..."

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -214,6 +214,10 @@ else
     rm -f "$SEP_NGINX_DIR"/*.conf
 fi
 
+# Unconditional: the script owns its own gates, so the files it published are still
+# removed on the start after PMM_ENABLE_SEP is cleared.
+bash /opt/ansible/roles/sep/files/sep-secrets
+
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,9 @@ services:
       - ${PMM_PORT_HTTPS:-443}:8443
     volumes:
       - pmm-data:/srv
+      # Credentials PMM provisions for SEP. Mount this same volume read-only in the SEP
+      # container and point SECRETS_DIR at it; never share pmm-data itself with SEP.
+      - pmm-sep:/srv/sep
 
   pmm-client:
     profiles:
@@ -164,3 +167,5 @@ services:
 volumes:
   pmm-data:
     name: pmm-data
+  pmm-sep:
+    name: pmm-sep


### PR DESCRIPTION
## Summary

With `PMM_ENABLE_SEP` set, pmm-server now writes SEP's deployment secrets into `/srv/sep` as regular files named after the canonical SEP settings name each supplies:

| File | Value | Lifecycle |
|---|---|---|
| `SECRET_KEY` | `openssl rand -hex 32` | generated once, persisted at `/srv/.sep_secret_key`, republished every start |
| `SEP__DATABASE__PASSWORD` | the `sep` role's password — generated by PMM, or `PMM_SEP_POSTGRES_PASSWORD` verbatim when set | rewritten every start |
| `INVENTORY__DATABASE__PASSWORD` | same value | rewritten every start |
| `TASKS__DATABASE__PASSWORD` | same value | rewritten every start |

This removes the manual `openssl rand -hex 32` step SEP's documentation instructs operators to perform, and takes the database credential out of the SEP container's environment, where `docker inspect` and every process in its PID namespace can read it.

Everything here is a no-op unless `PMM_ENABLE_SEP` is set. Docker only, matching #5700.

**This targets `PMM-15205-sep-fb`,** the PMM-15205 epic's integration branch, rebased on top of #5759's landing there. #5755 is closed — the Grafana service account moves to the SEP side — so the `/srv/sep` mountpoint, the `pmm-sep` volume and the 2770/0640 permission contract are carried here instead of inherited. The directory is `/srv/sep` rather than `/srv/sep-secrets` per review on the closed PR, so a second thing PMM hands SEP lands beside the first; the volume follows the path it is mounted at. Needs #5700, already merged.

### PMM generates the database password when it is unset

`PMM_ENABLE_SEP=1` is now sufficient on its own. With `PMM_SEP_POSTGRES_PASSWORD` unset the entrypoint generates `openssl rand -hex 24`, persists it at `/srv/.sep_postgres_password` mode `0600` and exports it, so a bare `docker compose up` brings the pair up with no secret chosen in advance. Compose cannot generate a value and hand it to two services, which is the whole reason the feature-build harness carries a bootstrap script; this leaves that script with nothing to seed but its test-MySQL passwords.

It is resolved in the entrypoint rather than in either consumer because `postgres-sep` sets the role's password and `sep-secrets` publishes it, both read it from the environment, and `postgres-sep` runs first — so neither can generate it for the other.

An operator value still wins and is deliberately **not** persisted: clearing it later returns to the generated password rather than pinning whatever was passed once. `postgres-sep`'s and `sep-secrets`' FATAL on an empty value stays as an invariant check, with its message corrected — reaching it now means `/srv` could not be written, not that the operator forgot something.

### The two lifecycles are deliberately different

This is the one thing the change must not get wrong, and the reason both values ship together rather than separately.

**`SECRET_KEY` is generated once and persisted**, following `/srv/.postgres_password`. It signs SEP's session cookies and CSRF tokens, and derives `SEP_INTERNAL_TOKEN` by HMAC when that is unset, so re-minting it per start signs every session out and changes the inter-service token. `-s`, not `-f`, decides whether to generate: SEP's settings classes reject a blank key outright, so an empty file would otherwise be republished forever. Generation goes through `mktemp` + rename, never a direct redirect at the final path, so an interrupted write cannot leave a short-but-non-empty key that `-s` would then accept.

**The database credential is rewritten on every start**, so rotating the operator-supplied `PMM_SEP_POSTGRES_PASSWORD` takes effect on the next restart.

### Two design points

**It runs from the entrypoint, not as a supervisord one-shot.** Neither value depends on a running service — no Grafana, no PostgreSQL, no migrated schema — so the entrypoint puts them on disk before `exec supervisord`, which is the earliest pmm-server can deliver them. Folding them into `sep-provision` would make SEP's database credentials hostage to Grafana's health and to that one-shot's 600-second readiness wait, a coupling neither credential has.

**It deliberately does not bail on `GF_DATABASE_URL`/`GF_DATABASE_HOST`.** Nothing here touches Grafana, and `postgres-sep` still provisions the `sep` role and database with an external Grafana database, so SEP still needs its password files. Guarding on those would silently strip them on a configuration that otherwise works.

The helper lives in a new `build/ansible/roles/sep/`, which has no `tasks/` — `Dockerfile.el9` copies `build/ansible` wholesale to `/opt/ansible`, the same way `postgres-sep` and `postgres-migration` reach the image.

### `CELERY__BEAT_DBURI` is not written

The ticket lists a fifth file, required only while SEP-1797 was unlanded, and pre-authorizes both branches. SEP-1797 has landed: `sidecar/settings.yaml` now leaves the key unset so the beat store defaults to the resolved SEP database, and `DatabaseOptions.URL` percent-encodes both username and password itself. Writing the file anyway would persist as an explicit override of a URI SEP resolves for itself. Three password files complete the set — only `PASSWORD` is absent from the three baked `DATABASE` blocks.

### Contract for the SEP side

| Element | Value |
|---|---|
| Directory | `/srv/sep` (the `pmm-sep` volume); SEP mounts it read-only with `SECRETS_DIR` pointing at it |
| Filenames | `SECRET_KEY`, `SEP__DATABASE__PASSWORD`, `INVENTORY__DATABASE__PASSWORD`, `TASKS__DATABASE__PASSWORD` |
| Modes | directory setgid `2770`, files `0640`, group inherited from the directory, so group 0 whatever uid PMM runs as |
| Encoding | value verbatim, no trailing newline. Give `PMM_SEP_POSTGRES_PASSWORD` no leading or trailing whitespace: PostgreSQL keeps it, SEP strips it on read, and the two then disagree |
| SEP-side requirement | join group 0 (`group_add: ["0"]`, or `user: "1001:0"`). Do not pass `SECRET_KEY` on the SEP container — a non-empty environment value outranks the file. Leave the three `*__DATABASE__PASSWORD` names unset rather than empty |
| Rotation | two restarts: restart PMM to move the database and rewrite the files, then restart the SEP container, which resolves settings only at process start |
| Disabled | with `PMM_ENABLE_SEP` unset all four files are removed; `/srv/.sep_secret_key` is kept, so re-enabling does not sign existing sessions out |
| Hard failures | with SEP enabled, an unwritable `/srv/sep` stops PMM Server from starting rather than degrading SEP alone — same class as `postgres-sep`'s existing FATAL. An empty password is no longer an operator-reachable failure |

## Tested

There is no unit-test layer for the container's shell/ansible surface and this change touches no Go, TypeScript, proto or dashboard code, so verification is a behavioural matrix rather than a test suite.

- [x] **53-assertion behavioural matrix**, run against a scratch `/srv` bind-mounted inside a user+mount namespace so the real paths and modes are exercised: fresh start; modes `0640` / `0600` / directory `2770` with nothing world-readable; key byte-identical over three restarts with no regeneration message; regeneration after a `/srv` wipe with the stale published file overwritten; refill from the persisted key after a secrets-volume wipe; zero-byte key regenerated and short key reused (the documented `-s` limitation); passwords written verbatim including `p@ss:w/rd#1`, leading/trailing whitespace and an embedded newline, each with no trailing newline; rotation updating all three files while `SECRET_KEY` is untouched; neither value ever printed; the disable path removing all four files, keeping the persisted key and leaving an unrelated file in the directory alone; re-enabling republishing the same key; `PMM_HA_ENABLE` and `PMM_DISABLE_BUILTIN_POSTGRES` each removing the files and exiting 0 silently; all four files still written with `GF_DATABASE_HOST`/`GF_DATABASE_URL` set; both FATAL branches; directory auto-creation at `2770`; no stray temp files in either directory.
- [x] **Arbitrary-UID paths against the real image** (`percona/pmm-server` via a feature-build image), which the namespace harness structurally cannot cover because it runs as namespace-root: a `0640` key owned by uid 1000 is read, published and group-0-owned when the container is restarted as uid 1002; a `0600` key owned by uid 1000 stops with an actionable FATAL naming the file and the uid instead of a bare `chmod: Operation not permitted`.
- [x] **Password generation across its four states**, exercised against a scratch `/srv`: SEP disabled writes no file; SEP enabled with no password generates one at mode `0600`; a second start reuses the same value rather than regenerating; an operator-supplied value is used verbatim and leaves the persisted file untouched.
- [x] `shellcheck -s bash` clean on the new helper, both modified helpers and the entrypoint; `bash -n` clean.

### Known limitations, recorded rather than fixed

- **The three password files are replaced atomically one at a time, but not as a set.** `settings-env.sh` inventories the directory once and each supervisord child then resolves its own settings at its own start, so a SEP start interleaved with a rotation could give two services different passwords. PMM cannot order SEP's process starts, the loop is three renames wide, and the recovery is a SEP restart — which rotation already requires.
- **The first-boot race is not closed from this side.** `depends_on: [pmm-server]` is start-order only, and a side-car started before pmm-server reaches this line exits non-zero for want of a `SECRET_KEY`. Writing from the entrypoint narrows the window; only a restart policy or a health-gated dependency closes it, which is SEP-1810's.
- **A `/srv` volume restarted under a different arbitrary UID is not recoverable here**, and deliberately so: `postgres-sep` reads `/srv/.postgres_password` at mode `0600` ten lines earlier in the entrypoint and hard-fails first for the identical reason, so widening this key would move the failure rather than fix it. The failure is now reported with an actionable message instead of a bare `chmod` error.
- **`AGENTS.md`'s Linting decision tree has no row for the container's shell surface** — no `shellcheck`/`shfmt` step exists in any workflow. Flagging rather than adding one in this PR.
- **The paired harness needs percona/SEP#1382 to land in step.** It still mounted the old `pmm-sep-secrets` name when this was written; that PR has since merged, so the pair is consistent again.

### Not run here, and needing a Feature Build or the SEP side

- [ ] **The shipped image path.** The `/srv/sep` mountpoint surviving into the image is now this PR's own, and only a real build exercises it, since `VOLUME ["/srv"]` prevents baking it into a derived image. **A Feature Build is required before merge.**
- [ ] **End to end with SEP.** This ships only the PMM half. The currently pinned side-car predates SEP-1775 and has no `SECRETS_DIR` handling at all, so the paired stack cannot consume these files until SEP-1810 repins the harness. Note that a mounted `*__DATABASE__PASSWORD` file already outranks the harness's `SEP_DB_PASSWORD`, since `export_canonical` tests the canonical name and falls through to the secrets source — so only the `SECRET_KEY` half waits on the environment passthroughs being retired.

`SEP_DB_PASSWORD` itself appears nowhere in this repository — it lives only in SEP's feature-build harness, and SEP-1810 owns retiring it along with the other passthroughs these files replace.



