### PR TITLE
PMM-15331 Gate health on SEP provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ PMM_PORT_HTTPS=443
 # PMM_POSTGRES_SSL_CERT_PATH=/tmp/certs/pmm-managed.crt
 # PMM_DISABLE_BUILTIN_POSTGRES=1
 
+# Expose the built-in PostgreSQL to SEP running in a side container on the same bridge
+# network. PMM creates a dedicated `sep` database owned by a non-superuser `sep` role and
+# accepts connections for it from the container's Docker subnets only; nothing is
+# published on the host. Both variables are required to enable it.
+# PMM_ENABLE_SEP=1
+# PMM_SEP_POSTGRES_PASSWORD=<password>
+
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full
 # GF_DATABASE_CA_CERT_PATH=/tmp/certs/root.crt

--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,13 @@ PMM_PORT_HTTPS=443
 # token a running SEP holds.
 # Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
 # account is left in place.
+# With PMM_ENABLE_SEP set, the container reports healthy only once the current start has
+# published both token files above, so a SEP container gated on
+#   depends_on: {pmm-server: {condition: service_healthy}}
+# never starts before its credentials exist. Without that condition it can, and SEP reads
+# these files only at process start. Under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES,
+# where PMM_ENABLE_SEP is ignored outright and none of the files above are published, the
+# container still reports healthy as it does today.
 
 # PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
 # and group, one file per canonical SEP settings name:

--- a/.env.example
+++ b/.env.example
@@ -57,10 +57,11 @@ PMM_PORT_HTTPS=443
 # settings name:
 #   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
 #   PMM__API_KEY
-# The directory is mode 0770 and the files 0640, owned by PMM's runtime user and its
-# primary group (uid 1000, gid 0 in the stock image). PMM cannot chgrp to SEP's own
-# group, so the SEP container has to join group 0 — `group_add: ["0"]`, or
-# `user: "1001:0"` — or it cannot read them.
+# The directory is setgid mode 2770 and the files 0640, so both files belong to group 0
+# whichever uid PMM runs as. PMM cannot chgrp to SEP's own group, so the SEP container
+# has to join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
+# Leave both settings names above unset on the SEP container rather than empty: an empty
+# value counts as supplied there and outranks the file, which then goes unused.
 # The token is revalidated against Grafana on every PMM start, and replaced when the
 # file is missing or empty or Grafana rejects it, so restarting PMM does not revoke the
 # token a running SEP holds.

--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,23 @@ PMM_PORT_HTTPS=443
 # Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
 # account is left in place.
 
+# PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
+# and group, one file per canonical SEP settings name:
+#   SECRET_KEY                      generated once on first start and persisted on the
+#                                   /srv volume, so restarting PMM keeps every SEP
+#                                   session valid
+#   SEP__DATABASE__PASSWORD         PMM_SEP_POSTGRES_PASSWORD verbatim, rewritten on
+#   INVENTORY__DATABASE__PASSWORD   every start so rotating it takes effect on the next
+#   TASKS__DATABASE__PASSWORD       restart
+# A fresh /srv volume mints a new SECRET_KEY; an existing one is never overwritten. Do not
+# pass SECRET_KEY or SEP_DB_PASSWORD to the SEP container — and, as with the token names
+# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than
+# empty. Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the
+# database and rewrite the files, then restart the SEP container, which reads them only at
+# process start.
+# Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
+# SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
+
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full
 # GF_DATABASE_CA_CERT_PATH=/tmp/certs/root.crt

--- a/.env.example
+++ b/.env.example
@@ -71,15 +71,11 @@ PMM_PORT_HTTPS=443
 # published both files above, so gate the SEP container on
 # `depends_on: {pmm-server: {condition: service_healthy}}` — it reads them only at process
 # start. Under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, where PMM_ENABLE_SEP is
-# ignored outright, the gate does not apply and health is what it was before.
-# With an external Grafana database — GF_DATABASE_URL or GF_DATABASE_HOST, without either
-# flag above — the container never reports healthy: PMM cannot provision the service account
-# in a database it does not own, and a SEP released there would run with Grafana sign-in and
-# the PMM syncer inert. Point SEP at its own Grafana, or do not set PMM_ENABLE_SEP.
-# The healthcheck's start period is 720s for every deployment, SEP or not, because
-# HEALTHCHECK options are image metadata and cannot depend on an environment variable. A
-# server that becomes ready is reported healthy immediately; only the unhealthy verdict for
-# one that never became ready is deferred that long.
+# ignored outright, the gate does not apply.
+# With an external Grafana database — GF_DATABASE_URL or GF_DATABASE_HOST, without either flag
+# above — the container never reports healthy, because PMM cannot provision the service
+# account in a database it does not own. Point SEP at its own Grafana, or leave
+# PMM_ENABLE_SEP unset.
 
 # PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
 # and group, one file per canonical SEP settings name:

--- a/.env.example
+++ b/.env.example
@@ -57,11 +57,13 @@ PMM_PORT_HTTPS=443
 # settings name:
 #   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
 #   PMM__API_KEY
-# The directory is mode 0750 and the files 0640, owned by PMM's runtime user and group
-# (uid 1000, gid 0). PMM cannot chgrp to SEP's own group, so the SEP container has to
-# join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
-# The token is revalidated against Grafana on every PMM start and replaced only when
-# Grafana rejects it, so restarting PMM does not revoke the token a running SEP holds.
+# The directory is mode 0770 and the files 0640, owned by PMM's runtime user and its
+# primary group (uid 1000, gid 0 in the stock image). PMM cannot chgrp to SEP's own
+# group, so the SEP container has to join group 0 — `group_add: ["0"]`, or
+# `user: "1001:0"` — or it cannot read them.
+# The token is revalidated against Grafana on every PMM start, and replaced when the
+# file is missing or empty or Grafana rejects it, so restarting PMM does not revoke the
+# token a running SEP holds.
 # Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
 # account is left in place.
 

--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,15 @@ PMM_PORT_HTTPS=443
 # published both files above, so gate the SEP container on
 # `depends_on: {pmm-server: {condition: service_healthy}}` — it reads them only at process
 # start. Under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, where PMM_ENABLE_SEP is
-# ignored outright, health is unchanged.
+# ignored outright, the gate does not apply and health is what it was before.
+# With an external Grafana database — GF_DATABASE_URL or GF_DATABASE_HOST, without either
+# flag above — the container never reports healthy: PMM cannot provision the service account
+# in a database it does not own, and a SEP released there would run with Grafana sign-in and
+# the PMM syncer inert. Point SEP at its own Grafana, or do not set PMM_ENABLE_SEP.
+# The healthcheck's start period is 720s for every deployment, SEP or not, because
+# HEALTHCHECK options are image metadata and cannot depend on an environment variable. A
+# server that becomes ready is reported healthy immediately; only the unhealthy verdict for
+# one that never became ready is deferred that long.
 
 # PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
 # and group, one file per canonical SEP settings name:

--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,10 @@ PMM_PORT_HTTPS=443
 # strips it when reading the file, and the two then disagree.
 # Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
 # rewrite the files, then restart the SEP container, which reads them only at process start.
-# With PMM_ENABLE_SEP set, an empty PMM_SEP_POSTGRES_PASSWORD or a /srv/sep-secrets PMM
-# cannot write stops PMM Server from starting rather than degrading SEP alone.
+# Once SEP is actually in use, PMM Server stops rather than degrading SEP alone: an empty
+# PMM_SEP_POSTGRES_PASSWORD, or a /srv/sep-secrets it cannot write to, is fatal. Neither
+# check applies under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, which ignore
+# PMM_ENABLE_SEP outright and leave no SEP database to hold a password for.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,21 @@ PMM_PORT_HTTPS=443
 # PMM_ENABLE_SEP=1
 # PMM_SEP_POSTGRES_PASSWORD=<password>
 
+# With PMM_ENABLE_SEP set, PMM also provisions the Grafana service account SEP
+# authenticates users against, and writes its token to /srv/sep-secrets — the
+# `pmm-sep-secrets` volume, which the SEP container mounts read-only with SECRETS_DIR
+# pointing at it. The same token value is written to two files, one per canonical SEP
+# settings name:
+#   AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN
+#   PMM__API_KEY
+# The directory is mode 0750 and the files 0640, owned by PMM's runtime user and group
+# (uid 1000, gid 0). PMM cannot chgrp to SEP's own group, so the SEP container has to
+# join group 0 — `group_add: ["0"]`, or `user: "1001:0"` — or it cannot read them.
+# The token is revalidated against Grafana on every PMM start and replaced only when
+# Grafana rejects it, so restarting PMM does not revoke the token a running SEP holds.
+# Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
+# account is left in place.
+
 # Use SSL certificates for PMM Server's internal database connection (PostgreSQL)
 # GF_DATABASE_SSL_MODE=verify-full
 # GF_DATABASE_CA_CERT_PATH=/tmp/certs/root.crt

--- a/.env.example
+++ b/.env.example
@@ -68,12 +68,10 @@ PMM_PORT_HTTPS=443
 # Unsetting PMM_ENABLE_SEP removes both files on the next start; the Grafana service
 # account is left in place.
 # With PMM_ENABLE_SEP set, the container reports healthy only once the current start has
-# published both token files above, so a SEP container gated on
-#   depends_on: {pmm-server: {condition: service_healthy}}
-# never starts before its credentials exist. Without that condition it can, and SEP reads
-# these files only at process start. Under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES,
-# where PMM_ENABLE_SEP is ignored outright and none of the files above are published, the
-# container still reports healthy as it does today.
+# published both files above, so gate the SEP container on
+# `depends_on: {pmm-server: {condition: service_healthy}}` — it reads them only at process
+# start. Under PMM_HA_ENABLE or PMM_DISABLE_BUILTIN_POSTGRES, where PMM_ENABLE_SEP is
+# ignored outright, health is unchanged.
 
 # PMM writes SEP's remaining deployment secrets to the same directory, with the same mode
 # and group, one file per canonical SEP settings name:

--- a/.env.example
+++ b/.env.example
@@ -76,12 +76,18 @@ PMM_PORT_HTTPS=443
 #   SEP__DATABASE__PASSWORD         PMM_SEP_POSTGRES_PASSWORD verbatim, rewritten on
 #   INVENTORY__DATABASE__PASSWORD   every start so rotating it takes effect on the next
 #   TASKS__DATABASE__PASSWORD       restart
-# A fresh /srv volume mints a new SECRET_KEY; an existing one is never overwritten. Do not
-# pass SECRET_KEY or SEP_DB_PASSWORD to the SEP container — and, as with the token names
-# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than
-# empty. Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the
-# database and rewrite the files, then restart the SEP container, which reads them only at
-# process start.
+# SECRET_KEY is persisted outside the secrets directory, at /srv/.sep_secret_key mode 0600,
+# and copied from there on every start. A fresh /srv volume mints a new one; an existing one
+# is never overwritten, so back /srv up to keep SEP's sessions across a redeployment.
+# Do not pass SECRET_KEY to the SEP container — an environment value outranks the file, and
+# a PMM that later mints its own key then diverges from it silently. As with the token names
+# above, leave the three canonical *__DATABASE__PASSWORD names unset there rather than empty.
+# Give PMM_SEP_POSTGRES_PASSWORD no leading or trailing whitespace: PostgreSQL keeps it, SEP
+# strips it when reading the file, and the two then disagree.
+# Rotating PMM_SEP_POSTGRES_PASSWORD takes two restarts: restart PMM to move the database and
+# rewrite the files, then restart the SEP container, which reads them only at process start.
+# With PMM_ENABLE_SEP set, an empty PMM_SEP_POSTGRES_PASSWORD or a /srv/sep-secrets PMM
+# cannot write stops PMM Server from starting rather than degrading SEP alone.
 # Unsetting PMM_ENABLE_SEP removes all four files on the next start; the persisted
 # SECRET_KEY is left in place, so re-enabling SEP keeps existing sessions valid.
 

--- a/api-tests/server/logs_test.go
+++ b/api-tests/server/logs_test.go
@@ -68,6 +68,7 @@ func TestDownloadLogs(t *testing.T) {
 		"prometheus.base.yml",
 		"qan-api2.ini",
 		"qan-api2.log",
+		"sep-provision.log",
 		"supervisorctl_status.log",
 		"supervisord.conf",
 		"supervisord.log",

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -37,7 +37,7 @@ Source code (Go, TypeScript)
 | `grafana` | Install Grafana, provision datasources and dashboards |
 | `nginx` | Configure Nginx as reverse proxy (SSL termination, routing) |
 | `postgres` | Install and configure PostgreSQL for pmm-managed |
-| `sep` | SEP side-car integration helpers (secrets published when `PMM_ENABLE_SEP` is set) |
+| `sep` | SEP side-car integration helpers copied into the image and invoked from the entrypoint (no `tasks/`); publishes SEP's secrets when `PMM_ENABLE_SEP` is set |
 | `supervisord` | Configure Supervisord for process management |
 | `dashboards` | Provision PMM Grafana dashboards |
 | `initialization` | PMM Server first-run setup |

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -85,6 +85,7 @@ make rpmbuild-el9         # Build RPM build environment image
 
 - `build/docker/server/Dockerfile.el9` — PMM Server Docker image definition
 - `build/docker/server/entrypoint.sh` — Server container entrypoint
+- `build/docker/server/healthcheck.sh` — Server container healthcheck
 - `build/ansible/pmm-docker/main.yml` — Docker provisioning playbook
 - `build/ansible/roles/` — All Ansible roles for server components
 - `build/packages/rpm/server/SPECS/` — RPM spec files for server components

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -37,6 +37,7 @@ Source code (Go, TypeScript)
 | `grafana` | Install Grafana, provision datasources and dashboards |
 | `nginx` | Configure Nginx as reverse proxy (SSL termination, routing) |
 | `postgres` | Install and configure PostgreSQL for pmm-managed |
+| `sep` | SEP side-car integration helpers (secrets published when `PMM_ENABLE_SEP` is set) |
 | `supervisord` | Configure Supervisord for process management |
 | `dashboards` | Provision PMM Grafana dashboards |
 | `initialization` | PMM Server first-run setup |

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -70,13 +70,16 @@
     # Must exist in the image: a named volume mounted at a path the image lacks is
     # created root:root, which pmm-server cannot write to. Group-writable like the
     # other /srv directories, so an arbitrary runtime uid in group 0 can still write.
+    # Setgid so the token files written here belong to group 0 whatever that uid's
+    # primary group is - the SEP container joins group 0 to read them. Docker carries
+    # the bit into a fresh named volume mounted at this path.
     - name: Create the SEP secrets mountpoint
       file:
         path: /srv/sep-secrets
         state: directory
         owner: pmm
         group: root
-        mode: 0770
+        mode: 02770
 
     - name: Create empty log directory for nginx
       file:

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -67,6 +67,16 @@
         - directory
       no_log: true
 
+    # Must exist in the image: a named volume mounted at a path the image lacks is
+    # created root:root, which pmm-server cannot write to.
+    - name: Create the SEP secrets mountpoint
+      file:
+        path: /srv/sep-secrets
+        state: directory
+        owner: pmm
+        group: root
+        mode: 0750
+
     - name: Create empty log directory for nginx
       file:
         path: /var/log/nginx

--- a/build/ansible/pmm-docker/post-build.yml
+++ b/build/ansible/pmm-docker/post-build.yml
@@ -68,14 +68,15 @@
       no_log: true
 
     # Must exist in the image: a named volume mounted at a path the image lacks is
-    # created root:root, which pmm-server cannot write to.
+    # created root:root, which pmm-server cannot write to. Group-writable like the
+    # other /srv directories, so an arbitrary runtime uid in group 0 can still write.
     - name: Create the SEP secrets mountpoint
       file:
         path: /srv/sep-secrets
         state: directory
         owner: pmm
         group: root
-        mode: 0750
+        mode: 0770
 
     - name: Create empty log directory for nginx
       file:

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -1,0 +1,216 @@
+#!/bin/bash
+#
+# Provisions the Grafana service account SEP authenticates with, and publishes its
+# token to a secrets directory the SEP container mounts. One file per canonical SEP
+# settings name, mode 0640, owned by pmm's primary group, so SEP must join group 0.
+#
+# Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
+# the token files this script wrote are removed on the next start; the Grafana
+# service account itself is left in place.
+#
+# Runs under supervisord rather than from the entrypoint because Grafana is neither
+# running nor migrated - on a first boot its schema does not exist at all - until
+# long after the entrypoint has exec'd supervisord.
+#
+# The token is validated against Grafana on every start and replaced only when
+# Grafana rejects it, because SEP reads the secrets directory once at its own start:
+# re-minting unconditionally would revoke the token a running SEP is still holding.
+
+set -o errexit
+set -o pipefail
+
+declare SECRETS_DIR="${SECRETS_DIR:-/srv/sep-secrets}"
+declare GRAFANA_URL="http://127.0.0.1:3000"
+declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
+declare SA_NAME="pmm-sep"
+declare TOKEN_NAME="pmm-sep"
+declare READY_TIMEOUT=300
+declare READY_INTERVAL=5
+declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+psql_grafana() {
+    "$POSTGRES_BIN_DIR/psql" -X -q -v ON_ERROR_STOP=1 -U postgres -h /run/postgresql -d grafana "$@"
+}
+
+# Same readiness signal pmm-managed waits on: /api/health reporting the database as ok.
+wait_for_grafana() {
+    local waited=0
+
+    while [ "$waited" -lt "$READY_TIMEOUT" ]; do
+        if curl -sS --max-time 5 "$GRAFANA_URL/api/health" 2> /dev/null |
+            grep -q '"database": *"ok"'; then
+            return 0
+        fi
+        sleep "$READY_INTERVAL"
+        waited=$((waited + READY_INTERVAL))
+    done
+
+    return 1
+}
+
+# Proves the token by an authenticated call to the access-control endpoint SEP's
+# org-role lookups go through. The header is fed on stdin rather than passed with
+# -H so the token never appears in any process's argv.
+grafana_authenticates() {
+    local code
+
+    code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
+        curl -sS -K - -o /dev/null -w '%{http_code}' \
+            "$GRAFANA_URL/api/access-control/user/permissions") || return 1
+
+    [ "$code" = "200" ]
+}
+
+# Prints the token value, its api_key.key hash, and the user row's salt, rands and
+# uid, one per line. The encoding reproduces Grafana's own: the checksum is
+# crc32("glsa_" + secret) serialised little-endian, and the stored hash is
+# util.EncodePassword(secret, checksum).
+generate_token_material() {
+    python3 - <<'PY'
+import binascii
+import hashlib
+import secrets
+import string
+import zlib
+
+alnum = string.ascii_letters + string.digits
+secret = "".join(secrets.choice(alnum) for _ in range(32))
+checksum = binascii.hexlify(
+    zlib.crc32(("glsa_" + secret).encode()).to_bytes(4, "little")
+).decode()
+
+print(f"glsa_{secret}_{checksum}")
+print(hashlib.pbkdf2_hmac("sha256", secret.encode(), checksum.encode(), 10000, 50).hex())
+print("".join(secrets.choice(alnum) for _ in range(10)))
+print("".join(secrets.choice(alnum) for _ in range(10)))
+print("".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(14)))
+PY
+}
+
+# Administers Grafana through the database it owns, the way postgres-sep provisions
+# the sep role as the local superuser: Grafana exposes no credential-free path to
+# create a service account, and pmm-server holds no Grafana admin credential once an
+# operator has changed the admin password.
+#
+# psql only interpolates :'var' when reading a script, hence stdin rather than -c.
+# \gset is what carries the org and service-account ids between statements; the
+# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and
+# DO UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
+provision_service_account() {
+    local hashed="$1" salt="$2" rands="$3" uid="$4"
+
+    psql_grafana -v sa_name="$SA_NAME" -v token_name="$TOKEN_NAME" -v hashed="$hashed" \
+        -v salt="$salt" -v rands="$rands" -v uid="$uid" <<'SQL'
+BEGIN;
+
+SELECT id AS org_id FROM org ORDER BY id LIMIT 1
+\gset
+
+INSERT INTO "user" (version, login, email, name, password, salt, rands, company, org_id,
+                    is_admin, email_verified, theme, created, updated, help_flags1,
+                    is_disabled, is_service_account, uid, is_provisioned)
+VALUES (0, 'sa-' || :'org_id' || '-' || :'sa_name', 'sa-' || :'org_id' || '-' || :'sa_name',
+        :'sa_name', '', :'salt', :'rands', '', :'org_id',
+        false, false, '', now(), now(), 0, false, true, :'uid', false)
+ON CONFLICT (login) DO UPDATE SET updated = now(), is_disabled = false
+RETURNING id AS sa_id
+\gset
+
+INSERT INTO org_user (org_id, user_id, role, created, updated)
+VALUES (:'org_id', :'sa_id', 'Admin', now(), now())
+ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'Admin', updated = now();
+
+-- Also matched on (org_id, name) so a token orphaned from an earlier account cannot
+-- collide with UQE_api_key_org_id_name and abort the insert below.
+DELETE FROM api_key
+WHERE service_account_id = :'sa_id' OR (org_id = :'org_id' AND name = :'token_name');
+
+-- Grafana stores Viewer in api_key.role for every service-account token whatever role
+-- the request asked for; the effective authority is org_user.role above.
+INSERT INTO api_key (org_id, name, key, role, created, updated, service_account_id, is_revoked)
+VALUES (:'org_id', :'token_name', :'hashed', 'Viewer', now(), now(), :'sa_id', false);
+
+COMMIT;
+SQL
+}
+
+# Written through a temporary file so SEP never reads a half-written secret.
+publish_token() {
+    local token="$1" name tmp
+
+    for name in "${TOKEN_FILES[@]}"; do
+        tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+        printf '%s' "$token" > "$tmp"
+        chmod 0640 "$tmp"
+        mv "$tmp" "$SECRETS_DIR/$name"
+    done
+}
+
+remove_token_files() {
+    local name
+
+    for name in "${TOKEN_FILES[@]}"; do
+        rm -f "${SECRETS_DIR:?}/$name"
+    done
+}
+
+if ! is_enabled "$PMM_ENABLE_SEP"; then
+    remove_token_files
+    exit 0
+fi
+
+if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
+    [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
+    echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
+    exit 0
+fi
+
+if ! install -d -m 0750 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for $(id -un)." >&2
+    echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
+    exit 1
+fi
+
+if ! wait_for_grafana; then
+    echo "FATAL: Grafana did not become ready within ${READY_TIMEOUT}s, cannot provision the SEP service account." >&2
+    exit 1
+fi
+
+declare TOKEN=""
+if [ -s "$SECRETS_DIR/${TOKEN_FILES[0]}" ]; then
+    TOKEN=$(< "$SECRETS_DIR/${TOKEN_FILES[0]}")
+fi
+
+if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
+    echo "The Grafana service account token for SEP is still valid, keeping it."
+    publish_token "$TOKEN"
+    exit 0
+fi
+
+echo "Provisioning the Grafana service account for SEP..."
+
+declare MATERIAL
+MATERIAL=$(generate_token_material)
+
+declare -a PARTS
+mapfile -t PARTS <<< "$MATERIAL"
+if [ ${#PARTS[@]} -ne 5 ]; then
+    echo "FATAL: could not generate the Grafana service account token." >&2
+    exit 1
+fi
+
+TOKEN="${PARTS[0]}"
+provision_service_account "${PARTS[1]}" "${PARTS[2]}" "${PARTS[3]}" "${PARTS[4]}"
+
+# Validated before publishing so a half-working credential never reaches SEP, and so a
+# future change to Grafana's schema or token encoding fails loudly here instead of
+# silently breaking SEP's authentication.
+if ! grafana_authenticates "$TOKEN"; then
+    echo "FATAL: Grafana rejected the service account token just provisioned for SEP." >&2
+    exit 1
+fi
+
+publish_token "$TOKEN"
+echo "Published the Grafana service account token for SEP to $SECRETS_DIR."

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -25,7 +25,9 @@ declare GRAFANA_URL="http://127.0.0.1:3000"
 declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
-declare READY_TIMEOUT=300
+# Generous because a failed run is not retried: the one-shot cannot bound its own
+# restarts under supervisord, so waiting longer here is what absorbs a slow first boot.
+declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
 declare TMP_FILE=""
@@ -171,13 +173,18 @@ publish_token() {
     done
 }
 
-# Kept unconditionally inert: rm fails on an existing file in a directory this uid
-# cannot write, and the disabled path must never turn that into a non-zero exit.
+# Inert by design - the disabled path must not fail a start over a directory this uid
+# cannot write - but a token left behind is still readable by SEP, so say so rather
+# than swallowing the failure.
 remove_token_files() {
-    local name
+    local name path
 
     for name in "${TOKEN_FILES[@]}"; do
-        rm -f "${SECRETS_DIR:?}/$name" || true
+        path="${SECRETS_DIR:?}/$name"
+        rm -f "$path" 2> /dev/null || true
+        if [ -e "$path" ]; then
+            echo "WARNING: could not remove $path, SEP can still read this token." >&2
+        fi
     done
 }
 

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -30,10 +30,7 @@ declare TMP_FILE=""
 declare SEP_MARKER="/srv/.sep_provisioned"
 declare MARK_RUN=1
 
-# The marker follows this script's exit status and MARK_RUN, which every skip path clears: a
-# run that published nothing has not provisioned this start. sep.ini already declares the
-# exitcodes = 0 half of that contract, so no exit path can forget it. status must be captured
-# first: the TMP_FILE test below would overwrite $?.
+# status must be captured first: the TMP_FILE test below would overwrite $?.
 cleanup() {
     local status=$?
 
@@ -246,9 +243,8 @@ fi
 case "$STATUS" in
     200)
         echo "The Grafana service account token for SEP is still valid, keeping it."
-        # Ordered so a token already proven valid is on disk for an already-running SEP even
-        # if the role repair below fails under errexit. That failure still withholds the
-        # marker, so a side-car gated on container health waits for the next start instead.
+        # Ordered so a token already proven valid is on disk even if the role repair below
+        # fails under errexit.
         publish_token "$TOKEN"
         ensure_admin_role
         exit 0

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -30,9 +30,10 @@ declare TMP_FILE=""
 declare SEP_MARKER="/srv/.sep_provisioned"
 declare MARK_RUN=1
 
-# The marker follows this script's exit status, the contract sep.ini already declares with
-# exitcodes = 0, so no exit path can forget it. status must be captured first: the TMP_FILE
-# test below would overwrite $?.
+# The marker follows this script's exit status and MARK_RUN, which every skip path clears: a
+# run that published nothing has not provisioned this start. sep.ini already declares the
+# exitcodes = 0 half of that contract, so no exit path can forget it. status must be captured
+# first: the TMP_FILE test below would overwrite $?.
 cleanup() {
     local status=$?
 
@@ -202,6 +203,7 @@ remove_token_files() {
 }
 
 if ! is_enabled "$PMM_ENABLE_SEP"; then
+    MARK_RUN=0
     remove_token_files
     exit 0
 fi
@@ -209,12 +211,7 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
-    # Same precedence as sep-secrets, which bails on those two whatever GF_DATABASE_* says
-    # but keeps publishing SEP's password files for an external Grafana database alone.
-    # Only that last case leaves SEP able to start with its Grafana auth inert.
-    if ! is_enabled "$PMM_HA_ENABLE" && ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
-        MARK_RUN=0
-    fi
+    MARK_RUN=0
     remove_token_files
     exit 0
 fi
@@ -249,8 +246,9 @@ fi
 case "$STATUS" in
     200)
         echo "The Grafana service account token for SEP is still valid, keeping it."
-        # Ordered so a token already proven valid reaches SEP even if the role repair
-        # below fails under errexit.
+        # Ordered so a token already proven valid is on disk for an already-running SEP even
+        # if the role repair below fails under errexit. That failure still withholds the
+        # marker, so a side-car gated on container health waits for the next start instead.
         publish_token "$TOKEN"
         ensure_admin_role
         exit 0

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -22,7 +22,7 @@ declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
 # Generous because a failed run is not retried: the one-shot cannot bound its own
-# restarts under supervisord.
+# restarts under supervisord. The image's HEALTHCHECK start-period is sized on this.
 declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,8 +2,10 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a 0770 directory, owned by pmm's primary group, so the
-# SEP container must join group 0 to read them.
+# settings name, mode 0640 in a setgid 2770 directory, so each file's group is
+# inherited from the directory - group 0 - whatever uid pmm-server runs as, and the
+# SEP container must join group 0 to read them. Without setgid a file takes the
+# publishing process's primary group, which is 0 only in the stock image.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
@@ -20,7 +22,7 @@
 set -o errexit
 set -o pipefail
 
-declare SECRETS_DIR="${SECRETS_DIR:-/srv/sep-secrets}"
+declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
 declare GRAFANA_URL="http://127.0.0.1:3000"
 declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
@@ -60,17 +62,30 @@ wait_for_grafana() {
     return 1
 }
 
-# Proves the token by an authenticated call to the access-control endpoint SEP's
-# org-role lookups go through. The header is fed on stdin rather than passed with
-# -H so the token never appears in any process's argv.
-grafana_authenticates() {
-    local code
+# Prints the status of an authenticated call to the access-control endpoint SEP's
+# org-role lookups go through, or 000 when the call could not be made at all. The
+# header is fed on stdin rather than passed with -H so the token never appears in any
+# process's argv.
+#
+# Retried, and unreachable kept distinct from rejected, because a transient failure is
+# not a revoked token: reading one as the other on the reuse path would re-mint and so
+# revoke the token a running SEP holds - the very thing this script avoids.
+grafana_auth_status() {
+    local code attempt=0
 
-    code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
-        curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
-            "$GRAFANA_URL/api/access-control/user/permissions") || return 1
+    while :; do
+        code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
+            curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
+                "$GRAFANA_URL/api/access-control/user/permissions") || code="000"
 
-    [ "$code" = "200" ]
+        attempt=$((attempt + 1))
+        if [ "$code" != "000" ] || [ "$attempt" -ge 3 ]; then
+            break
+        fi
+        sleep "$READY_INTERVAL"
+    done
+
+    printf '%s' "$code"
 }
 
 # The validator endpoint answers 200 for any role, so a service account demoted in the
@@ -196,10 +211,21 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
+    # Same cleanup as the disabled path: a token this script can no longer revalidate or
+    # replace must not be left behind for SEP to keep reading.
+    remove_token_files
     exit 0
 fi
 
-if ! install -d -m 0770 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+# Created only when absent, because install -d on an existing directory also chmods it,
+# which a uid that does not own the mountpoint cannot do. The mountpoint ships in the
+# image already setgid (post-build.yml), so this create path is only for setups that
+# mount nothing here.
+if [ ! -d "$SECRETS_DIR" ]; then
+    install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
+fi
+
+if [ ! -w "$SECRETS_DIR" ]; then
     echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
     echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
     exit 1
@@ -215,12 +241,29 @@ if [ -s "$SECRETS_DIR/${TOKEN_FILES[0]}" ]; then
     TOKEN=$(< "$SECRETS_DIR/${TOKEN_FILES[0]}")
 fi
 
-if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
-    echo "The Grafana service account token for SEP is still valid, keeping it."
-    ensure_admin_role
-    publish_token "$TOKEN"
-    exit 0
+declare STATUS=""
+if [ -n "$TOKEN" ]; then
+    STATUS=$(grafana_auth_status "$TOKEN")
 fi
+
+case "$STATUS" in
+    200)
+        echo "The Grafana service account token for SEP is still valid, keeping it."
+        # Published before the role repair so a token already proven valid still reaches
+        # SEP if that secondary step fails under errexit.
+        publish_token "$TOKEN"
+        ensure_admin_role
+        exit 0
+        ;;
+    "" | 401 | 403)
+        # No token yet, or Grafana genuinely rejected it: fall through and mint.
+        ;;
+    *)
+        echo "FATAL: could not verify the existing Grafana token for SEP, the check answered $STATUS." >&2
+        echo "Please retry once Grafana answers again; replacing the token now would revoke the one SEP is using." >&2
+        exit 1
+        ;;
+esac
 
 echo "Provisioning the Grafana service account for SEP..."
 
@@ -240,7 +283,7 @@ provision_service_account "${PARTS[1]}" "${PARTS[2]}" "${PARTS[3]}" "${PARTS[4]}
 # Validated before publishing so a half-working credential never reaches SEP, and so a
 # future change to Grafana's schema or token encoding fails loudly here instead of
 # silently breaking SEP's authentication.
-if ! grafana_authenticates "$TOKEN"; then
+if [ "$(grafana_auth_status "$TOKEN")" != "200" ]; then
     echo "FATAL: Grafana rejected the service account token just provisioned for SEP." >&2
     exit 1
 fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,7 +2,8 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640, owned by pmm's primary group, so SEP must join group 0.
+# settings name, mode 0640 in a 0770 directory, owned by pmm's primary group, so the
+# SEP container must join group 0 to read them.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
@@ -12,9 +13,9 @@
 # running nor migrated - on a first boot its schema does not exist at all - until
 # long after the entrypoint has exec'd supervisord.
 #
-# The token is validated against Grafana on every start and replaced only when
-# Grafana rejects it, because SEP reads the secrets directory once at its own start:
-# re-minting unconditionally would revoke the token a running SEP is still holding.
+# The token is validated against Grafana on every start, and replaced when the file is
+# missing or empty or Grafana rejects it, because SEP reads the secrets directory once
+# at its own start: re-minting unconditionally would revoke a running SEP's token.
 
 set -o errexit
 set -o pipefail
@@ -27,6 +28,13 @@ declare TOKEN_NAME="pmm-sep"
 declare READY_TIMEOUT=300
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
+declare TMP_FILE=""
+
+cleanup() {
+    [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    return 0
+}
+trap cleanup EXIT
 
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
@@ -57,10 +65,24 @@ grafana_authenticates() {
     local code
 
     code=$(printf 'header = "Authorization: Bearer %s"\n' "$1" |
-        curl -sS -K - -o /dev/null -w '%{http_code}' \
+        curl -sS -K - --max-time 10 -o /dev/null -w '%{http_code}' \
             "$GRAFANA_URL/api/access-control/user/permissions") || return 1
 
     [ "$code" = "200" ]
+}
+
+# The validator endpoint answers 200 for any role, so a service account demoted in the
+# Grafana UI would keep authenticating while SEP's org-role lookups silently degrade.
+# Idempotent, and writes only when the role has actually drifted.
+ensure_admin_role() {
+    psql_grafana -v sa_name="$SA_NAME" <<'SQL'
+UPDATE org_user ou
+SET role = 'Admin', updated = now()
+FROM "user" u
+WHERE u.id = ou.user_id
+  AND u.login = 'sa-' || ou.org_id || '-' || :'sa_name'
+  AND ou.role <> 'Admin';
+SQL
 }
 
 # Prints the token value, its api_key.key hash, and the user row's salt, rands and
@@ -138,21 +160,24 @@ SQL
 
 # Written through a temporary file so SEP never reads a half-written secret.
 publish_token() {
-    local token="$1" name tmp
+    local token="$1" name
 
     for name in "${TOKEN_FILES[@]}"; do
-        tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
-        printf '%s' "$token" > "$tmp"
-        chmod 0640 "$tmp"
-        mv "$tmp" "$SECRETS_DIR/$name"
+        TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+        printf '%s' "$token" > "$TMP_FILE"
+        chmod 0640 "$TMP_FILE"
+        mv "$TMP_FILE" "$SECRETS_DIR/$name"
+        TMP_FILE=""
     done
 }
 
+# Kept unconditionally inert: rm fails on an existing file in a directory this uid
+# cannot write, and the disabled path must never turn that into a non-zero exit.
 remove_token_files() {
     local name
 
     for name in "${TOKEN_FILES[@]}"; do
-        rm -f "${SECRETS_DIR:?}/$name"
+        rm -f "${SECRETS_DIR:?}/$name" || true
     done
 }
 
@@ -167,8 +192,8 @@ if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     exit 0
 fi
 
-if ! install -d -m 0750 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
-    echo "FATAL: $SECRETS_DIR is not writable for $(id -un)." >&2
+if ! install -d -m 0770 "$SECRETS_DIR" 2> /dev/null || [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
     echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
     exit 1
 fi
@@ -185,6 +210,7 @@ fi
 
 if [ -n "$TOKEN" ] && grafana_authenticates "$TOKEN"; then
     echo "The Grafana service account token for SEP is still valid, keeping it."
+    ensure_admin_role
     publish_token "$TOKEN"
     exit 0
 fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -28,13 +28,11 @@ declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
 declare TMP_FILE=""
 declare SEP_MARKER="/srv/.sep_provisioned"
-# Cleared by the one exit-0 path that leaves SEP half-provisioned - see the guard below.
 declare MARK_RUN=1
 
-# The marker tracks this script's own exit status, which is the same contract sep.ini
-# declares with exitcodes = 0: every deliberate exit 0 below publishes it, and every FATAL
-# path - including an errexit abort - leaves none. entrypoint.sh removes it before
-# supervisord starts, so it can only ever describe the current start.
+# The marker follows this script's exit status, the contract sep.ini already declares with
+# exitcodes = 0, so no exit path can forget it. status must be captured first: the TMP_FILE
+# test below would overwrite $?.
 cleanup() {
     local status=$?
 
@@ -211,12 +209,9 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
-    # Mirrors sep-secrets' own precedence: it bails on the first two conditions whatever
-    # GF_DATABASE_* says, removing every file SEP has, so a container reporting healthy
-    # there vouches for nothing and holds no deployment that does not use SEP. It
-    # deliberately does not bail on an external Grafana database alone, where it still
-    # publishes SEP's other four files - and a start that leaves SEP holding database
-    # credentials and no Grafana token must not report healthy.
+    # Same precedence as sep-secrets, which bails on those two whatever GF_DATABASE_* says
+    # but keeps publishing SEP's password files for an external Grafana database alone.
+    # Only that last case leaves SEP able to start with its Grafana auth inert.
     if ! is_enabled "$PMM_HA_ENABLE" && ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
         MARK_RUN=0
     fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -27,9 +27,21 @@ declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
 declare TMP_FILE=""
+declare SEP_MARKER="/srv/.sep_provisioned"
+# Cleared by the one exit-0 path that leaves SEP half-provisioned - see the guard below.
+declare MARK_RUN=1
 
+# The marker tracks this script's own exit status, which is the same contract sep.ini
+# declares with exitcodes = 0: every deliberate exit 0 below publishes it, and every FATAL
+# path - including an errexit abort - leaves none. entrypoint.sh removes it before
+# supervisord starts, so it can only ever describe the current start.
 cleanup() {
+    local status=$?
+
     [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    if [ "$status" -eq 0 ] && [ "$MARK_RUN" -eq 1 ] && ! : > "$SEP_MARKER"; then
+        echo "WARNING: could not write $SEP_MARKER, the container will not report healthy." >&2
+    fi
     return 0
 }
 trap cleanup EXIT
@@ -199,6 +211,15 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
+    # Mirrors sep-secrets' own precedence: it bails on the first two conditions whatever
+    # GF_DATABASE_* says, removing every file SEP has, so a container reporting healthy
+    # there vouches for nothing and holds no deployment that does not use SEP. It
+    # deliberately does not bail on an external Grafana database alone, where it still
+    # publishes SEP's other four files - and a start that leaves SEP holding database
+    # credentials and no Grafana token must not report healthy.
+    if ! is_enabled "$PMM_HA_ENABLE" && ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
+        MARK_RUN=0
+    fi
     remove_token_files
     exit 0
 fi

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -2,9 +2,8 @@
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
 # token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a setgid 2770 directory, so each file's group is
-# inherited from the directory - group 0 - whatever uid pmm-server runs as, and the
-# SEP container must join group 0 to read them. Without setgid a file takes the
+# settings name, mode 0640 in a setgid 2770 directory, so the SEP container must join
+# group 0 to read them. The setgid bit is load-bearing: without it a file takes the
 # publishing process's primary group, which is 0 only in the stock image.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
@@ -67,9 +66,8 @@ wait_for_grafana() {
 # header is fed on stdin rather than passed with -H so the token never appears in any
 # process's argv.
 #
-# Retried, and unreachable kept distinct from rejected, because a transient failure is
-# not a revoked token: reading one as the other on the reuse path would re-mint and so
-# revoke the token a running SEP holds - the very thing this script avoids.
+# Unreachable is kept distinct from rejected, and retried, because a transient failure
+# is not a revoked token: reading one as the other re-mints on the reuse path below.
 grafana_auth_status() {
     local code attempt=0
 
@@ -211,16 +209,12 @@ fi
 if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" ||
     [ -n "$GF_DATABASE_URL" ] || [ -n "$GF_DATABASE_HOST" ]; then
     echo "WARNING: ignoring PMM_ENABLE_SEP, Grafana is not using the embedded PostgreSQL." >&2
-    # Same cleanup as the disabled path: a token this script can no longer revalidate or
-    # replace must not be left behind for SEP to keep reading.
     remove_token_files
     exit 0
 fi
 
-# Created only when absent, because install -d on an existing directory also chmods it,
-# which a uid that does not own the mountpoint cannot do. The mountpoint ships in the
-# image already setgid (post-build.yml), so this create path is only for setups that
-# mount nothing here.
+# Created only when absent: install -d on an existing directory also chmods it, which a
+# uid that does not own the mountpoint cannot do.
 if [ ! -d "$SECRETS_DIR" ]; then
     install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
 fi
@@ -249,8 +243,8 @@ fi
 case "$STATUS" in
     200)
         echo "The Grafana service account token for SEP is still valid, keeping it."
-        # Published before the role repair so a token already proven valid still reaches
-        # SEP if that secondary step fails under errexit.
+        # Ordered so a token already proven valid reaches SEP even if the role repair
+        # below fails under errexit.
         publish_token "$TOKEN"
         ensure_admin_role
         exit 0

--- a/build/ansible/roles/grafana/files/grafana-sep
+++ b/build/ansible/roles/grafana/files/grafana-sep
@@ -1,22 +1,17 @@
 #!/bin/bash
 #
 # Provisions the Grafana service account SEP authenticates with, and publishes its
-# token to a secrets directory the SEP container mounts. One file per canonical SEP
-# settings name, mode 0640 in a setgid 2770 directory, so the SEP container must join
-# group 0 to read them. The setgid bit is load-bearing: without it a file takes the
-# publishing process's primary group, which is 0 only in the stock image.
+# token to a secrets directory the SEP container mounts, one file per canonical SEP
+# settings name. The files are 0640 and take group 0 from the setgid directory
+# post-build.yml ships - nothing here sets their group, so that bit must stay.
 #
 # Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
 # the token files this script wrote are removed on the next start; the Grafana
 # service account itself is left in place.
 #
 # Runs under supervisord rather than from the entrypoint because Grafana is neither
-# running nor migrated - on a first boot its schema does not exist at all - until
-# long after the entrypoint has exec'd supervisord.
-#
-# The token is validated against Grafana on every start, and replaced when the file is
-# missing or empty or Grafana rejects it, because SEP reads the secrets directory once
-# at its own start: re-minting unconditionally would revoke a running SEP's token.
+# running nor migrated - on a first boot its schema does not exist - until long after
+# the entrypoint has exec'd supervisord.
 
 set -o errexit
 set -o pipefail
@@ -27,7 +22,7 @@ declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:-/usr/pgsql-14/bin}"
 declare SA_NAME="pmm-sep"
 declare TOKEN_NAME="pmm-sep"
 # Generous because a failed run is not retried: the one-shot cannot bound its own
-# restarts under supervisord, so waiting longer here is what absorbs a slow first boot.
+# restarts under supervisord.
 declare READY_TIMEOUT=600
 declare READY_INTERVAL=5
 declare -a TOKEN_FILES=(AUTH__PROVIDER__GRAFANA__SERVICE_ACCOUNT_TOKEN PMM__API_KEY)
@@ -62,9 +57,8 @@ wait_for_grafana() {
 }
 
 # Prints the status of an authenticated call to the access-control endpoint SEP's
-# org-role lookups go through, or 000 when the call could not be made at all. The
-# header is fed on stdin rather than passed with -H so the token never appears in any
-# process's argv.
+# org-role lookups go through, or 000 when the call could not be made at all. Fed on
+# stdin rather than -H so the token never appears in any process's argv.
 #
 # Unreachable is kept distinct from rejected, and retried, because a transient failure
 # is not a revoked token: reading one as the other re-mints on the reuse path below.
@@ -88,7 +82,6 @@ grafana_auth_status() {
 
 # The validator endpoint answers 200 for any role, so a service account demoted in the
 # Grafana UI would keep authenticating while SEP's org-role lookups silently degrade.
-# Idempotent, and writes only when the role has actually drifted.
 ensure_admin_role() {
     psql_grafana -v sa_name="$SA_NAME" <<'SQL'
 UPDATE org_user ou
@@ -100,10 +93,10 @@ WHERE u.id = ou.user_id
 SQL
 }
 
-# Prints the token value, its api_key.key hash, and the user row's salt, rands and
-# uid, one per line. The encoding reproduces Grafana's own: the checksum is
-# crc32("glsa_" + secret) serialised little-endian, and the stored hash is
-# util.EncodePassword(secret, checksum).
+# Prints, one per line and in the order the caller unpacks them: the token value, its
+# api_key.key hash, and the user row's salt, rands and uid. The encoding reproduces
+# Grafana's own - crc32("glsa_" + secret) little-endian as the checksum,
+# util.EncodePassword(secret, checksum) as the stored hash.
 generate_token_material() {
     python3 - <<'PY'
 import binascii
@@ -126,15 +119,13 @@ print("".join(secrets.choice(string.ascii_lowercase + string.digits) for _ in ra
 PY
 }
 
-# Administers Grafana through the database it owns, the way postgres-sep provisions
-# the sep role as the local superuser: Grafana exposes no credential-free path to
-# create a service account, and pmm-server holds no Grafana admin credential once an
-# operator has changed the admin password.
+# Administers Grafana through the database it owns, the way postgres-sep provisions the
+# sep role as the local superuser: Grafana exposes no credential-free path to create a
+# service account, and once an operator changes the admin password pmm-server holds none.
 #
-# psql only interpolates :'var' when reading a script, hence stdin rather than -c.
-# \gset is what carries the org and service-account ids between statements; the
-# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and
-# DO UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
+# psql only interpolates :'var' when reading a script, hence stdin rather than -c. The
+# ON CONFLICT clauses target UQE_user_login and UQE_org_user_org_id_user_id, and DO
+# UPDATE rather than DO NOTHING is what makes RETURNING fire on re-provisioning.
 provision_service_account() {
     local hashed="$1" salt="$2" rands="$3" uid="$4"
 
@@ -159,8 +150,8 @@ INSERT INTO org_user (org_id, user_id, role, created, updated)
 VALUES (:'org_id', :'sa_id', 'Admin', now(), now())
 ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'Admin', updated = now();
 
--- Also matched on (org_id, name) so a token orphaned from an earlier account cannot
--- collide with UQE_api_key_org_id_name and abort the insert below.
+-- Every token on the account, plus any token elsewhere in the org already holding the
+-- name, which would otherwise collide with UQE_api_key_org_id_name below.
 DELETE FROM api_key
 WHERE service_account_id = :'sa_id' OR (org_id = :'org_id' AND name = :'token_name');
 
@@ -186,9 +177,8 @@ publish_token() {
     done
 }
 
-# Inert by design - the disabled path must not fail a start over a directory this uid
-# cannot write - but a token left behind is still readable by SEP, so say so rather
-# than swallowing the failure.
+# Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
+# write - but a token left behind is still readable by SEP, so it is reported.
 remove_token_files() {
     local name path
 

--- a/build/ansible/roles/grafana/tasks/main.yml
+++ b/build/ansible/roles/grafana/tasks/main.yml
@@ -53,3 +53,9 @@
     src: change-admin-password
     dest: /usr/local/sbin/change-admin-password
     mode: 0755
+
+- name: Copy grafana-sep command
+  copy:
+    src: grafana-sep
+    dest: /usr/local/sbin/grafana-sep
+    mode: 0755

--- a/build/ansible/roles/postgres/files/postgres-migration
+++ b/build/ansible/roles/postgres/files/postgres-migration
@@ -2,8 +2,9 @@
 set -o errexit
 set -o pipefail
 
-declare POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:-/srv/postgres14}"
-declare POSTGRES_PASSWORD_FILE="${POSTGRES_PASSWORD_FILE:-/srv/.postgres_password}"
+declare POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:?must be exported by the entrypoint}"
+declare POSTGRES_PASSWORD_FILE="${POSTGRES_PASSWORD_FILE:?must be exported by the entrypoint}"
+declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:?must be exported by the entrypoint}"
 
 ensure_postgres_password() {
     # This check is to verify if the data directory is empty.
@@ -20,19 +21,19 @@ ensure_postgres_password() {
     echo "Generating postgres superuser password..."
     POSTGRES_PASSWORD=$(openssl rand -hex 16)
 
-    if ! /usr/pgsql-14/bin/pg_ctl status -D "$POSTGRES_DATA_DIR" > /dev/null 2>&1; then
-        /usr/pgsql-14/bin/pg_ctl start -D "$POSTGRES_DATA_DIR" -o "-c logging_collector=off"
+    if ! "$POSTGRES_BIN_DIR/pg_ctl" status -D "$POSTGRES_DATA_DIR" > /dev/null 2>&1; then
+        "$POSTGRES_BIN_DIR/pg_ctl" start -D "$POSTGRES_DATA_DIR" -o "-c logging_collector=off"
         STARTED=1
     fi
 
-    PGPASSWORD="$POSTGRES_PASSWORD" /usr/bin/psql -U postgres -h /run/postgresql -d postgres \
+    PGPASSWORD="$POSTGRES_PASSWORD" "$POSTGRES_BIN_DIR/psql" -U postgres -h /run/postgresql -d postgres \
         -c "ALTER USER postgres WITH PASSWORD '${POSTGRES_PASSWORD}'"
 
     echo -n "$POSTGRES_PASSWORD" > "$POSTGRES_PASSWORD_FILE"
     chmod 600 "$POSTGRES_PASSWORD_FILE"
 
     if [ "$STARTED" -eq 1 ]; then
-        /usr/pgsql-14/bin/pg_ctl stop -D "$POSTGRES_DATA_DIR"
+        "$POSTGRES_BIN_DIR/pg_ctl" stop -D "$POSTGRES_DATA_DIR"
     fi
 }
 
@@ -53,8 +54,8 @@ update_pg_hba_auth() {
     sed -E 's/^([[:space:]]*host[[:space:]].*[[:space:]])trust([[:space:]]*)$/\1scram-sha-256\2/' "$hba" > "$tmp"
     mv "$tmp" "$hba"
 
-    if /usr/pgsql-14/bin/pg_ctl status -D "$POSTGRES_DATA_DIR" > /dev/null 2>&1; then
-        /usr/pgsql-14/bin/pg_ctl reload -D "$POSTGRES_DATA_DIR"
+    if "$POSTGRES_BIN_DIR/pg_ctl" status -D "$POSTGRES_DATA_DIR" > /dev/null 2>&1; then
+        "$POSTGRES_BIN_DIR/pg_ctl" reload -D "$POSTGRES_DATA_DIR"
     fi
 }
 

--- a/build/ansible/roles/postgres/files/postgres-sep
+++ b/build/ansible/roles/postgres/files/postgres-sep
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Makes the embedded PostgreSQL reachable by SEP running in a side container on a
+# shared Docker network, and provisions a dedicated low-privilege role/database for it.
+#
+# Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again,
+# the configuration this script added is reverted on the next start; the sep role and
+# database are left untouched.
+
+set -o errexit
+set -o pipefail
+
+declare POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:?must be exported by the entrypoint}"
+declare POSTGRES_PASSWORD_FILE="${POSTGRES_PASSWORD_FILE:?must be exported by the entrypoint}"
+declare POSTGRES_BIN_DIR="${POSTGRES_BIN_DIR:?must be exported by the entrypoint}"
+declare PG_CONF="$POSTGRES_DATA_DIR/postgresql.conf"
+declare PG_HBA="$POSTGRES_DATA_DIR/pg_hba.conf"
+declare BEGIN_MARKER="# BEGIN PMM SEP"
+declare END_MARKER="# END PMM SEP"
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+# Replaces the marker-delimited block of $1 with $2, appending it at the end of the
+# file so it takes precedence over anything set earlier. An empty $2 drops the block.
+write_block() {
+    local file="$1" body="$2" tmp
+
+    if [ ! -f "$file" ]; then
+        echo "FATAL: $file not found." >&2
+        exit 1
+    fi
+
+    if [ -z "$body" ] && ! grep -q "^${BEGIN_MARKER}$" "$file"; then
+        return
+    fi
+
+    tmp=$(mktemp "$POSTGRES_DATA_DIR/.pmm-sep.XXXXXX")
+    sed "/^${BEGIN_MARKER}$/,/^${END_MARKER}$/d" "$file" > "$tmp"
+    if [ -n "$body" ]; then
+        {
+            echo "$BEGIN_MARKER"
+            echo "$body"
+            echo "$END_MARKER"
+        } >> "$tmp"
+    fi
+    mv "$tmp" "$file"
+}
+
+# Prints the IPv4 CIDR of every Docker network this container is attached to.
+container_subnets() {
+    ip -o -4 route show scope link | awk '$1 ~ /\// && $1 !~ /^127\./ { print $1 }'
+}
+
+psql_postgres() {
+    "$POSTGRES_BIN_DIR/psql" -X -q -v ON_ERROR_STOP=1 -U postgres -h /run/postgresql -d postgres "$@"
+}
+
+provision_sep_role() {
+    local started=0 role_exists db_exists
+
+    if ! "$POSTGRES_BIN_DIR/pg_ctl" status -D "$POSTGRES_DATA_DIR" > /dev/null 2>&1; then
+        "$POSTGRES_BIN_DIR/pg_ctl" start -D "$POSTGRES_DATA_DIR" -o "-c logging_collector=off -c listen_addresses="
+        started=1
+    fi
+
+    PGPASSWORD=$(< "$POSTGRES_PASSWORD_FILE")
+    export PGPASSWORD
+
+    role_exists=$(psql_postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname = 'sep'")
+    if [ -z "$role_exists" ]; then
+        psql_postgres -c "CREATE ROLE sep"
+    fi
+
+    # Re-applied on every start so rotating PMM_SEP_POSTGRES_PASSWORD takes effect.
+    # Fed via stdin, not -c: psql only interpolates :'sep_password' when reading a script.
+    psql_postgres -v sep_password="$PMM_SEP_POSTGRES_PASSWORD" <<'SQL'
+ALTER ROLE sep WITH LOGIN NOSUPERUSER NOCREATEROLE NOCREATEDB PASSWORD :'sep_password';
+SQL
+
+    db_exists=$(psql_postgres -tAc "SELECT 1 FROM pg_database WHERE datname = 'sep'")
+    if [ -z "$db_exists" ]; then
+        psql_postgres -c "CREATE DATABASE sep OWNER sep"
+    fi
+
+    unset PGPASSWORD
+
+    if [ "$started" -eq 1 ]; then
+        "$POSTGRES_BIN_DIR/pg_ctl" stop -D "$POSTGRES_DATA_DIR"
+    fi
+}
+
+if ! is_enabled "$PMM_ENABLE_SEP"; then
+    write_block "$PG_CONF" ""
+    write_block "$PG_HBA" ""
+    exit 0
+fi
+
+if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
+    echo "FATAL: PMM_ENABLE_SEP is set but PMM_SEP_POSTGRES_PASSWORD is empty." >&2
+    echo "Please set PMM_SEP_POSTGRES_PASSWORD to the password SEP will connect with and try again." >&2
+    exit 1
+fi
+
+declare -a SUBNETS
+mapfile -t SUBNETS < <(container_subnets)
+if [ ${#SUBNETS[@]} -eq 0 ]; then
+    echo "FATAL: PMM_ENABLE_SEP is set but this container is not attached to any network." >&2
+    echo "Please attach pmm-server to the bridge network shared with SEP and try again." >&2
+    exit 1
+fi
+
+echo "Exposing PostgreSQL to SEP on ${SUBNETS[*]}..."
+
+write_block "$PG_CONF" "listen_addresses = '*'"
+
+declare HBA_BODY=""
+for subnet in "${SUBNETS[@]}"; do
+    HBA_BODY+="host    sep    sep    ${subnet}    scram-sha-256"$'\n'
+done
+write_block "$PG_HBA" "${HBA_BODY%$'\n'}"
+
+provision_sep_role

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -1,0 +1,132 @@
+#!/bin/bash
+#
+# Publishes SEP's SECRET_KEY and database credentials to a secrets directory the SEP
+# container mounts, one file per canonical SEP settings name. The files are 0640 and
+# take group 0 from the setgid directory post-build.yml ships - nothing here sets their
+# group, so that bit must stay.
+#
+# The two lifecycles differ deliberately. SECRET_KEY is generated once and persisted on
+# /srv: re-minting it signs out every SEP session and changes the SEP_INTERNAL_TOKEN
+# derived from it by HMAC. The database credential is rewritten on every start so
+# rotating PMM_SEP_POSTGRES_PASSWORD takes effect on the next restart.
+#
+# Everything below is a no-op unless PMM_ENABLE_SEP is set. When it is unset again, the
+# files this script wrote are removed on the next start; the persisted key is left in
+# place so re-enabling SEP does not invalidate the sessions of a deployment that toggled
+# the flag.
+#
+# Runs from the entrypoint rather than under supervisord because neither value depends on
+# a running service - unlike grafana-sep, which cannot provision until Grafana is up.
+
+set -o errexit
+set -o pipefail
+
+declare SECRETS_DIR="${PMM_SEP_SECRETS_DIR:-/srv/sep-secrets}"
+declare SECRET_KEY_FILE="/srv/.sep_secret_key"
+declare -a DB_PASSWORD_FILES=(
+    SEP__DATABASE__PASSWORD
+    INVENTORY__DATABASE__PASSWORD
+    TASKS__DATABASE__PASSWORD
+)
+declare -a MANAGED_FILES=(SECRET_KEY "${DB_PASSWORD_FILES[@]}")
+declare TMP_FILE=""
+
+cleanup() {
+    [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    return 0
+}
+trap cleanup EXIT
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+# Written through a temporary file so SEP never reads a half-written secret, and with
+# printf '%s' so no trailing newline reaches a reader that strips rather than chomps.
+publish() {
+    local name="$1" value="$2"
+
+    TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+    printf '%s' "$value" > "$TMP_FILE"
+    chmod 0640 "$TMP_FILE"
+    mv "$TMP_FILE" "$SECRETS_DIR/$name"
+    TMP_FILE=""
+}
+
+# Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
+# write - but a secret left behind is still readable by SEP, so it is reported.
+remove_managed_files() {
+    local name path
+
+    for name in "${MANAGED_FILES[@]}"; do
+        path="${SECRETS_DIR:?}/$name"
+        rm -f "$path" 2> /dev/null || true
+        if [ -e "$path" ]; then
+            echo "WARNING: could not remove $path, SEP can still read this secret." >&2
+        fi
+    done
+}
+
+# Non-empty rather than merely present: SEP's settings classes reject a blank SECRET_KEY,
+# and the side-car's own gate treats a mounted-but-empty key file as a failure rather than
+# as a supplied value.
+#
+# Generated into a temporary file and renamed, never written at the final path: a direct
+# redirect that dies mid-write leaves a short but non-empty key there, which the -s test
+# would then accept and republish forever. errexit aborts before the rename, so an
+# interrupted generation leaves the previous key - or no key - untouched.
+ensure_secret_key() {
+    if [ ! -s "$SECRET_KEY_FILE" ]; then
+        echo "Generating SEP's SECRET_KEY..."
+        TMP_FILE=$(mktemp "$SECRET_KEY_FILE.XXXXXX")
+        openssl rand -hex 32 > "$TMP_FILE"
+        mv "$TMP_FILE" "$SECRET_KEY_FILE"
+        TMP_FILE=""
+    fi
+    # Unconditional: a key persisted by an earlier start whose mode was widened by hand is
+    # narrowed back without being replaced.
+    chmod 600 "$SECRET_KEY_FILE"
+}
+
+if ! is_enabled "$PMM_ENABLE_SEP"; then
+    remove_managed_files
+    exit 0
+fi
+
+# Deliberately not bailing on GF_DATABASE_URL/GF_DATABASE_HOST the way grafana-sep does:
+# nothing here touches Grafana, and postgres-sep still provisions the sep role and
+# database with an external Grafana, so SEP still needs its password files.
+#
+# The entrypoint has already warned about the combination below; bail quietly rather than
+# print a second copy of the same line.
+if is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
+    remove_managed_files
+    exit 0
+fi
+
+if [ -z "$PMM_SEP_POSTGRES_PASSWORD" ]; then
+    echo "FATAL: PMM_ENABLE_SEP is set but PMM_SEP_POSTGRES_PASSWORD is empty." >&2
+    echo "Please set PMM_SEP_POSTGRES_PASSWORD to the password SEP will connect with and try again." >&2
+    exit 1
+fi
+
+# Created only when absent: install -d on an existing directory also chmods it, which a
+# uid that does not own the mountpoint cannot do.
+if [ ! -d "$SECRETS_DIR" ]; then
+    install -d -m 2770 "$SECRETS_DIR" 2> /dev/null || true
+fi
+
+if [ ! -w "$SECRETS_DIR" ]; then
+    echo "FATAL: $SECRETS_DIR is not writable for uid $(id -u)." >&2
+    echo "Please make sure the volume mounted there is owned by uid $(id -u) and gid $(id -g) and try again." >&2
+    exit 1
+fi
+
+ensure_secret_key
+# Republished on every start, not only on generation, so a wiped or newly attached secrets
+# volume is refilled from the persisted key rather than left short a file.
+publish SECRET_KEY "$(< "$SECRET_KEY_FILE")"
+
+for name in "${DB_PASSWORD_FILES[@]}"; do
+    publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"
+done
+
+echo "Published SEP's SECRET_KEY and database credentials to $SECRETS_DIR."

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -81,9 +81,13 @@ ensure_secret_key() {
         mv "$TMP_FILE" "$SECRET_KEY_FILE"
         TMP_FILE=""
     fi
-    # Unconditional: a key persisted by an earlier start whose mode was widened by hand is
-    # narrowed back without being replaced.
-    chmod 600 "$SECRET_KEY_FILE"
+    # Unconditional so a key whose mode was widened by hand is narrowed back without being
+    # replaced, but never fatal: chmod needs ownership, not write permission, and the
+    # arbitrary-uid path lets a later start run as a uid that does not own what an earlier
+    # one persisted. Failing to harden a key this start can still read and publish is not
+    # worth stopping pmm-server for - entrypoint.sh guards its own /srv chmod the same way.
+    chmod 600 "$SECRET_KEY_FILE" 2> /dev/null ||
+        echo "WARNING: could not narrow $SECRET_KEY_FILE to mode 600." >&2
 }
 
 if ! is_enabled "$PMM_ENABLE_SEP"; then
@@ -121,9 +125,25 @@ if [ ! -w "$SECRETS_DIR" ]; then
 fi
 
 ensure_secret_key
+
+# Read into a variable rather than inline at the call below: a command substitution that
+# fails in argument position does not trip errexit, so an unreadable key would publish an
+# empty SECRET_KEY over a good one and fail SEP's own gate instead of stopping here.
+# Regenerating instead would be worse - the file is non-empty, so something is using it.
+declare SECRET_KEY_VALUE=""
+if [ -r "$SECRET_KEY_FILE" ]; then
+    SECRET_KEY_VALUE=$(< "$SECRET_KEY_FILE")
+fi
+
+if [ -z "$SECRET_KEY_VALUE" ]; then
+    echo "FATAL: SEP's SECRET_KEY persisted at $SECRET_KEY_FILE is unreadable or blank." >&2
+    echo "Please make sure it is readable for uid $(id -u), or remove it to generate a new one - which signs every SEP session out." >&2
+    exit 1
+fi
+
 # Republished on every start, not only on generation, so a wiped or newly attached secrets
 # volume is refilled from the persisted key rather than left short a file.
-publish SECRET_KEY "$(< "$SECRET_KEY_FILE")"
+publish SECRET_KEY "$SECRET_KEY_VALUE"
 
 for name in "${DB_PASSWORD_FILES[@]}"; do
     publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"

--- a/build/ansible/roles/sep/files/sep-secrets
+++ b/build/ansible/roles/sep/files/sep-secrets
@@ -29,26 +29,55 @@ declare -a DB_PASSWORD_FILES=(
     TASKS__DATABASE__PASSWORD
 )
 declare -a MANAGED_FILES=(SECRET_KEY "${DB_PASSWORD_FILES[@]}")
+declare -a STAGED_TMP=() STAGED_DEST=()
 declare TMP_FILE=""
 
 cleanup() {
+    local tmp
+
     [ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+    for tmp in "${STAGED_TMP[@]}"; do
+        rm -f "$tmp"
+    done
     return 0
 }
 trap cleanup EXIT
 
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
-# Written through a temporary file so SEP never reads a half-written secret, and with
+# Every fallible step - mktemp, the write, the chmod - runs here, before commit_staged
+# renames anything, so the failure that actually happens to this operation (a write dying
+# on a full volume) leaves SEP the previous complete set rather than a mix of new and
+# stale credentials. Interleaving write and rename per file is what makes that mix
+# reachable; the rename itself, within one filesystem and after a complete write, is not
+# the fallible part.
+#
 # printf '%s' so no trailing newline reaches a reader that strips rather than chomps.
-publish() {
-    local name="$1" value="$2"
+stage() {
+    local name="$1" value="$2" tmp
 
-    TMP_FILE=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
-    printf '%s' "$value" > "$TMP_FILE"
-    chmod 0640 "$TMP_FILE"
-    mv "$TMP_FILE" "$SECRETS_DIR/$name"
-    TMP_FILE=""
+    tmp=$(mktemp "$SECRETS_DIR/.${name}.XXXXXX")
+    # Recorded before the write, not after: errexit abandons the rest of this function on
+    # a failed write, and a temporary created but not yet recorded is one cleanup cannot
+    # find.
+    STAGED_TMP+=("$tmp")
+    STAGED_DEST+=("$SECRETS_DIR/$name")
+    printf '%s' "$value" > "$tmp"
+    chmod 0640 "$tmp"
+}
+
+# Each rename replaces a whole file with one already written in full, so SEP never reads a
+# half-written secret. The set is still four renames rather than one operation: a failure
+# between them leaves the earlier files updated, which is the residue this cannot remove
+# without a directory swap the mountpoint contract rules out.
+commit_staged() {
+    local i
+
+    for i in "${!STAGED_TMP[@]}"; do
+        mv "${STAGED_TMP[$i]}" "${STAGED_DEST[$i]}"
+    done
+    STAGED_TMP=()
+    STAGED_DEST=()
 }
 
 # Never fatal, so the disabled path cannot fail a start over a directory this uid cannot
@@ -143,10 +172,12 @@ fi
 
 # Republished on every start, not only on generation, so a wiped or newly attached secrets
 # volume is refilled from the persisted key rather than left short a file.
-publish SECRET_KEY "$SECRET_KEY_VALUE"
+stage SECRET_KEY "$SECRET_KEY_VALUE"
 
 for name in "${DB_PASSWORD_FILES[@]}"; do
-    publish "$name" "$PMM_SEP_POSTGRES_PASSWORD"
+    stage "$name" "$PMM_SEP_POSTGRES_PASSWORD"
 done
+
+commit_staged
 
 echo "Published SEP's SECRET_KEY and database credentials to $SECRETS_DIR."

--- a/build/ansible/roles/supervisord/files/sep.ini
+++ b/build/ansible/roles/supervisord/files/sep.ini
@@ -1,16 +1,21 @@
 ; Provisions the Grafana service account SEP authenticates with, once Grafana is up.
-; A no-op unless PMM_ENABLE_SEP is set. startsecs is 0 because this is a one-shot:
-; a non-zero value makes the immediate exit of the disabled path look like a failed start.
+; A no-op unless PMM_ENABLE_SEP is set.
+;
+; A one-shot, hence startsecs = 0: a non-zero value makes the immediate exit of the
+; disabled path look like a failed start. That in turn rules out autorestart, since
+; startretries only bounds restarts from BACKOFF, a state startsecs = 0 never reaches -
+; leaving every failure to respawn immediately and forever. A failed provisioning run
+; is meant to be read, not retried: it lands as EXITED with a non-zero status in
+; supervisorctl and a FATAL line in the log below.
 
 [program:sep-provision]
 priority = 20
 command = /usr/local/sbin/grafana-sep
 directory = /
-autorestart = unexpected
+autorestart = false
 exitcodes = 0
 autostart = true
 startsecs = 0
-startretries = 3
 stdout_logfile = /srv/logs/sep-provision.log
 stdout_logfile_maxbytes = 10MB
 stdout_logfile_backups = 3

--- a/build/ansible/roles/supervisord/files/sep.ini
+++ b/build/ansible/roles/supervisord/files/sep.ini
@@ -1,0 +1,17 @@
+; Provisions the Grafana service account SEP authenticates with, once Grafana is up.
+; A no-op unless PMM_ENABLE_SEP is set. startsecs is 0 because this is a one-shot:
+; a non-zero value makes the immediate exit of the disabled path look like a failed start.
+
+[program:sep-provision]
+priority = 20
+command = /usr/local/sbin/grafana-sep
+directory = /
+autorestart = unexpected
+exitcodes = 0
+autostart = true
+startsecs = 0
+startretries = 3
+stdout_logfile = /srv/logs/sep-provision.log
+stdout_logfile_maxbytes = 10MB
+stdout_logfile_backups = 3
+redirect_stderr = true

--- a/build/ansible/roles/supervisord/tasks/main.yml
+++ b/build/ansible/roles/supervisord/tasks/main.yml
@@ -67,6 +67,7 @@
     - supervisord.ini
     - grafana.ini
     - pmm.ini
+    - sep.ini
 
 - name: Fix credentials
   ini_file:

--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -50,8 +50,6 @@ VOLUME [ "/srv" ]
 
 EXPOSE 8080 8443
 
-# start-period covers grafana-sep's READY_TIMEOUT plus its bounded token validation; raise it
-# with that timeout. It delays only the unhealthy verdict for a server that was never ready.
 HEALTHCHECK --interval=4s --timeout=2s --start-period=720s --retries=3 CMD ["/opt/healthcheck.sh"]
 
 CMD ["/opt/entrypoint.sh"]

--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -50,6 +50,8 @@ VOLUME [ "/srv" ]
 
 EXPOSE 8080 8443
 
+# start-period covers grafana-sep's READY_TIMEOUT plus its bounded token validation; raise it
+# with that timeout. It delays only the unhealthy verdict for a server that was never ready.
 HEALTHCHECK --interval=4s --timeout=2s --start-period=720s --retries=3 CMD ["/opt/healthcheck.sh"]
 
 CMD ["/opt/entrypoint.sh"]

--- a/build/docker/server/Dockerfile.el9
+++ b/build/docker/server/Dockerfile.el9
@@ -24,6 +24,7 @@ RUN --mount=type=cache,target=/var/cache \
                         dnf -y remove microdnf
 
 COPY entrypoint.sh /opt/entrypoint.sh
+COPY healthcheck.sh /opt/healthcheck.sh
 COPY ansible /opt/ansible
 COPY gitCommit /tmp/gitCommit
 
@@ -49,6 +50,6 @@ VOLUME [ "/srv" ]
 
 EXPOSE 8080 8443
 
-HEALTHCHECK --interval=4s --timeout=2s --start-period=25s --retries=3 CMD curl -sf http://127.0.0.1:8080/v1/server/readyz
+HEALTHCHECK --interval=4s --timeout=2s --start-period=720s --retries=3 CMD ["/opt/healthcheck.sh"]
 
 CMD ["/opt/entrypoint.sh"]

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -159,9 +159,8 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
     echo "WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use." >&2
 fi
 
-# Cleared here rather than in grafana-sep alone: sep-provision is priority 20, so a probe
-# firing before it starts would otherwise observe the marker the previous run left. Fatal
-# only when SEP is in use - a non-SEP start must never fail over a file it does not read.
+# Not in grafana-sep: sep-provision is priority 20, so a probe firing before it starts would
+# still see the previous run's marker. Fatal only when SEP is in use.
 declare SEP_MARKER="/srv/.sep_provisioned"
 rm -f "$SEP_MARKER" 2> /dev/null || true
 if is_enabled "$PMM_ENABLE_SEP" && [ -e "$SEP_MARKER" ]; then

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -159,6 +159,10 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
     echo "WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use." >&2
 fi
 
+# Unconditional: the script owns its own gates, so the files it published are still
+# removed on the start after PMM_ENABLE_SEP is cleared.
+bash /opt/ansible/roles/sep/files/sep-secrets
+
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1
 

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -159,6 +159,16 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
     echo "WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use." >&2
 fi
 
+# Cleared here rather than in grafana-sep alone: sep-provision is priority 20, so a probe
+# firing before it starts would otherwise observe the marker the previous run left. Fatal
+# only when SEP is in use - a non-SEP start must never fail over a file it does not read.
+declare SEP_MARKER="/srv/.sep_provisioned"
+rm -f "$SEP_MARKER" 2> /dev/null || true
+if is_enabled "$PMM_ENABLE_SEP" && [ -e "$SEP_MARKER" ]; then
+    echo "FATAL: could not remove $SEP_MARKER; the health gate would report the previous provisioning run as this one." >&2
+    exit 1
+fi
+
 # Unconditional: the script owns its own gates, so the files it published are still
 # removed on the start after PMM_ENABLE_SEP is cleared.
 bash /opt/ansible/roles/sep/files/sep-secrets
@@ -166,7 +176,7 @@ bash /opt/ansible/roles/sep/files/sep-secrets
 # The last consumer has run, so drop the password before exec'ing supervisord: otherwise
 # every child inherits it, and pmm-managed-init logs each variable it is handed - name and
 # value - once PMM_TRACE is set.
-unset PMM_SEP_POSTGRES_PASSWORD
+unset PMM_SEP_POSTGRES_PASSWORD SEP_MARKER
 
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -8,6 +8,7 @@ declare CURRENT_GID CURRENT_UID CURRENT_USER
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 declare POSTGRES_DATA_DIR="/srv/postgres14"
 declare POSTGRES_PASSWORD_FILE="/srv/.postgres_password"
+declare POSTGRES_BIN_DIR="/usr/pgsql-14/bin"
 
 # Get current user info - handle cases where user doesn't exist in passwd
 CURRENT_UID=$(id -u)
@@ -97,12 +98,12 @@ if [ ! -f "$DIST_FILE" ]; then
         chmod 600 "$POSTGRES_PASSWORD_FILE"
 
         # Initialize database with password authentication
-        /usr/pgsql-14/bin/initdb -D "$POSTGRES_DATA_DIR" --auth-host=scram-sha-256 --auth-local=trust --username=postgres --pwfile="$POSTGRES_PASSWORD_FILE"
+        "$POSTGRES_BIN_DIR/initdb" -D "$POSTGRES_DATA_DIR" --auth-host=scram-sha-256 --auth-local=trust --username=postgres --pwfile="$POSTGRES_PASSWORD_FILE"
 
         echo "Enabling pg_stat_statements extension for PostgreSQL..."
-        /usr/pgsql-14/bin/pg_ctl start -D "$POSTGRES_DATA_DIR" -o "-c logging_collector=off"
-        PGPASSWORD="$POSTGRES_PASSWORD" /usr/bin/psql -U postgres -h /run/postgresql -d postgres -c 'CREATE EXTENSION pg_stat_statements SCHEMA public'
-        /usr/pgsql-14/bin/pg_ctl stop -D "$POSTGRES_DATA_DIR"
+        "$POSTGRES_BIN_DIR/pg_ctl" start -D "$POSTGRES_DATA_DIR" -o "-c logging_collector=off"
+        PGPASSWORD="$POSTGRES_PASSWORD" "$POSTGRES_BIN_DIR/psql" -U postgres -h /run/postgresql -d postgres -c 'CREATE EXTENSION pg_stat_statements SCHEMA public'
+        "$POSTGRES_BIN_DIR/pg_ctl" stop -D "$POSTGRES_DATA_DIR"
 
         # Clean up password from environment
         unset POSTGRES_PASSWORD
@@ -145,7 +146,17 @@ elif is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; then
 else
     mkdir -p /run/postgresql
     chmod 750 "$POSTGRES_DATA_DIR" || true
-    bash /opt/ansible/roles/postgres/files/postgres-migration
+    # Scoped to this subshell so the helper scripts inherit them without polluting
+    # the environment that supervisord and its children are started with.
+    (
+        export POSTGRES_DATA_DIR POSTGRES_PASSWORD_FILE POSTGRES_BIN_DIR
+        bash /opt/ansible/roles/postgres/files/postgres-migration
+        bash /opt/ansible/roles/postgres/files/postgres-sep
+    )
+fi
+
+if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES"; }; then
+    echo "WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use." >&2
 fi
 
 echo "Generating self-signed certificates for nginx..."

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -160,9 +160,10 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
 fi
 
 # Not in grafana-sep: sep-provision is priority 20, so a probe firing before it starts would
-# still see the previous run's marker. Fatal only where grafana-sep will not rewrite it this
-# start - under the two flags just warned about it marks the run whatever provisioning did, so
-# a marker that cannot be removed there misleads nothing and must not take the container down.
+# still see the previous run's marker. Fatal only where a stale marker could outlive this
+# start's provisioning - under the two flags just warned about grafana-sep marks the run
+# whatever provisioning did, so one it cannot remove there misleads nothing and must not take
+# the container down.
 declare SEP_MARKER="/srv/.sep_provisioned"
 rm -f "$SEP_MARKER" 2> /dev/null || true
 if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&
@@ -170,6 +171,7 @@ if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&
     echo "FATAL: could not remove $SEP_MARKER; the health gate would report the previous provisioning run as this one." >&2
     exit 1
 fi
+unset SEP_MARKER
 
 # Unconditional: the script owns its own gates, so the files it published are still
 # removed on the start after PMM_ENABLE_SEP is cleared.
@@ -178,7 +180,7 @@ bash /opt/ansible/roles/sep/files/sep-secrets
 # The last consumer has run, so drop the password before exec'ing supervisord: otherwise
 # every child inherits it, and pmm-managed-init logs each variable it is handed - name and
 # value - once PMM_TRACE is set.
-unset PMM_SEP_POSTGRES_PASSWORD SEP_MARKER
+unset PMM_SEP_POSTGRES_PASSWORD
 
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -160,10 +160,13 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
 fi
 
 # Not in grafana-sep: sep-provision is priority 20, so a probe firing before it starts would
-# still see the previous run's marker. Fatal only when SEP is in use.
+# still see the previous run's marker. Fatal only where grafana-sep will not rewrite it this
+# start - under the two flags just warned about it marks the run whatever provisioning did, so
+# a marker that cannot be removed there misleads nothing and must not take the container down.
 declare SEP_MARKER="/srv/.sep_provisioned"
 rm -f "$SEP_MARKER" 2> /dev/null || true
-if is_enabled "$PMM_ENABLE_SEP" && [ -e "$SEP_MARKER" ]; then
+if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&
+    ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" && [ -e "$SEP_MARKER" ]; then
     echo "FATAL: could not remove $SEP_MARKER; the health gate would report the previous provisioning run as this one." >&2
     exit 1
 fi

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -160,10 +160,7 @@ if is_enabled "$PMM_ENABLE_SEP" && { is_enabled "$PMM_HA_ENABLE" || is_enabled "
 fi
 
 # Not in grafana-sep: sep-provision is priority 20, so a probe firing before it starts would
-# still see the previous run's marker. Fatal only where a stale marker could outlive this
-# start's provisioning - under the two flags just warned about grafana-sep marks the run
-# whatever provisioning did, so one it cannot remove there misleads nothing and must not take
-# the container down.
+# still see the previous run's marker. Fatal only when SEP is in use.
 declare SEP_MARKER="/srv/.sep_provisioned"
 rm -f "$SEP_MARKER" 2> /dev/null || true
 if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&

--- a/build/docker/server/entrypoint.sh
+++ b/build/docker/server/entrypoint.sh
@@ -163,6 +163,11 @@ fi
 # removed on the start after PMM_ENABLE_SEP is cleared.
 bash /opt/ansible/roles/sep/files/sep-secrets
 
+# The last consumer has run, so drop the password before exec'ing supervisord: otherwise
+# every child inherits it, and pmm-managed-init logs each variable it is handed - name and
+# value - once PMM_TRACE is set.
+unset PMM_SEP_POSTGRES_PASSWORD
+
 echo "Generating self-signed certificates for nginx..."
 bash /var/lib/cloud/scripts/per-boot/generate-ssl-certificate > /dev/null 2>&1
 

--- a/build/docker/server/healthcheck.sh
+++ b/build/docker/server/healthcheck.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# The container's HEALTHCHECK. Runs the readiness probe the inline HEALTHCHECK command used
+# to run and, only when PMM_ENABLE_SEP is set, additionally requires that this start's SEP
+# provisioning run finished. A side-car gated on depends_on: {condition: service_healthy}
+# would otherwise be released while grafana-sep is still minting the Grafana token that
+# side-car reads once, at process start.
+#
+# Deliberately not under errexit: Docker reserves exit code 2, so every failure returns 1
+# rather than letting a command's own status escape.
+
+declare READYZ_URL="http://127.0.0.1:8080/v1/server/readyz"
+# Removed by entrypoint.sh before supervisord starts and written by grafana-sep only on a
+# successful run, so its presence describes this start rather than any file left on /srv.
+declare SEP_MARKER="/srv/.sep_provisioned"
+
+is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
+
+curl -sf "$READYZ_URL" || exit 1
+
+if is_enabled "$PMM_ENABLE_SEP" && [ ! -e "$SEP_MARKER" ]; then
+    # Leading newline because curl's unredirected body lands in the same Health.Log entry.
+    printf '\nSEP provisioning has not completed on this start yet.\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/build/docker/server/healthcheck.sh
+++ b/build/docker/server/healthcheck.sh
@@ -12,7 +12,12 @@ is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
 curl -sf "$READYZ_URL" || exit 1
 
-if is_enabled "$PMM_ENABLE_SEP" && [ ! -e "$SEP_MARKER" ]; then
+# The two flags override PMM_ENABLE_SEP outright, so SEP never provisions under them and
+# nothing would ever satisfy this condition - the same precedence entrypoint.sh warns about
+# and sep-secrets bails on. An external Grafana database alone is not one of them: SEP does
+# start there, with its Grafana auth inert, which is exactly what must not report healthy.
+if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&
+    ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" && [ ! -e "$SEP_MARKER" ]; then
     # Leading newline: curl's unredirected body shares the Health.Log entry.
     printf '\nSEP provisioning has not completed on this start yet.\n' >&2
     exit 1

--- a/build/docker/server/healthcheck.sh
+++ b/build/docker/server/healthcheck.sh
@@ -12,10 +12,6 @@ is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 
 curl -sf "$READYZ_URL" || exit 1
 
-# The two flags override PMM_ENABLE_SEP outright, so SEP never provisions under them and
-# nothing would ever satisfy this condition - the same precedence entrypoint.sh warns about
-# and sep-secrets bails on. An external Grafana database alone is not one of them: SEP does
-# start there, with its Grafana auth inert, which is exactly what must not report healthy.
 if is_enabled "$PMM_ENABLE_SEP" && ! is_enabled "$PMM_HA_ENABLE" &&
     ! is_enabled "$PMM_DISABLE_BUILTIN_POSTGRES" && [ ! -e "$SEP_MARKER" ]; then
     # Leading newline: curl's unredirected body shares the Health.Log entry.

--- a/build/docker/server/healthcheck.sh
+++ b/build/docker/server/healthcheck.sh
@@ -1,17 +1,11 @@
 #!/bin/bash
 #
-# The container's HEALTHCHECK. Runs the readiness probe the inline HEALTHCHECK command used
-# to run and, only when PMM_ENABLE_SEP is set, additionally requires that this start's SEP
-# provisioning run finished. A side-car gated on depends_on: {condition: service_healthy}
-# would otherwise be released while grafana-sep is still minting the Grafana token that
-# side-car reads once, at process start.
+# The container's HEALTHCHECK: the readiness probe the inline command used to run, plus the
+# SEP provisioning marker grafana-sep writes and entrypoint.sh clears each start.
 #
-# Deliberately not under errexit: Docker reserves exit code 2, so every failure returns 1
-# rather than letting a command's own status escape.
+# No errexit, and every failure returns 1 explicitly: Docker reserves exit code 2.
 
 declare READYZ_URL="http://127.0.0.1:8080/v1/server/readyz"
-# Removed by entrypoint.sh before supervisord starts and written by grafana-sep only on a
-# successful run, so its presence describes this start rather than any file left on /srv.
 declare SEP_MARKER="/srv/.sep_provisioned"
 
 is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
@@ -19,7 +13,7 @@ is_enabled() { [ "$1" = "1" ] || [ "$1" = "true" ]; }
 curl -sf "$READYZ_URL" || exit 1
 
 if is_enabled "$PMM_ENABLE_SEP" && [ ! -e "$SEP_MARKER" ]; then
-    # Leading newline because curl's unredirected body lands in the same Health.Log entry.
+    # Leading newline: curl's unredirected body shares the Health.Log entry.
     printf '\nSEP provisioning has not completed on this start yet.\n' >&2
     exit 1
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
       - PMM_POSTGRES_USERNAME
       - PMM_POSTGRES_DBPASSWORD
       - PMM_DISABLE_BUILTIN_POSTGRES
+      # To expose the built-in PostgreSQL to SEP running on the same bridge network
+      - PMM_ENABLE_SEP
+      - PMM_SEP_POSTGRES_PASSWORD
       # To discover RDS databases via UI
       - AWS_ACCESS_KEY
       - AWS_SECRET_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,9 @@ services:
       - ${PMM_PORT_HTTPS:-443}:8443
     volumes:
       - pmm-data:/srv
+      # Credentials PMM provisions for SEP. Mount this same volume in the SEP container
+      # and point SECRETS_DIR at it; never share pmm-data itself with SEP.
+      - pmm-sep-secrets:/srv/sep-secrets
 
   pmm-client:
     profiles:
@@ -159,3 +162,5 @@ services:
 volumes:
   pmm-data:
     name: pmm-data
+  pmm-sep-secrets:
+    name: pmm-sep-secrets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,8 @@ services:
       - ${PMM_PORT_HTTPS:-443}:8443
     volumes:
       - pmm-data:/srv
-      # Credentials PMM provisions for SEP. Mount this same volume in the SEP container
-      # and point SECRETS_DIR at it; never share pmm-data itself with SEP.
+      # Credentials PMM provisions for SEP. Mount this same volume read-only in the SEP
+      # container and point SECRETS_DIR at it; never share pmm-data itself with SEP.
       - pmm-sep-secrets:/srv/sep-secrets
 
   pmm-client:

--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -120,6 +120,9 @@ func ParseEnvVars(envs []string) (*models.ChangeSettingsParams, []error, []strin
 			"PMM_DISABLE_BUILTIN_POSTGRES":
 			// skip env variables for external postgres
 			continue
+		case "PMM_ENABLE_SEP", "PMM_SEP_POSTGRES_PASSWORD":
+			// skip env variables consumed by the entrypoint to expose postgres to SEP
+			continue
 		case "PERCONA_TELEMETRY_DISABLE":
 			// skip the Pillars telemetry environment variable
 			continue

--- a/managed/utils/envvars/parser_test.go
+++ b/managed/utils/envvars/parser_test.go
@@ -73,6 +73,18 @@ func TestEnvVarValidator(t *testing.T) {
 		assert.Equal(t, expectedWarns, gotWarns)
 	})
 
+	t.Run("SEP env variables", func(t *testing.T) {
+		t.Parallel()
+
+		envs := []string{"PMM_ENABLE_SEP=1", "PMM_SEP_POSTGRES_PASSWORD=s3cr3t"}
+		expectedEnvVars := &models.ChangeSettingsParams{}
+
+		gotEnvVars, gotErrs, gotWarns := ParseEnvVars(envs)
+		assert.Equal(t, expectedEnvVars, gotEnvVars)
+		assert.Nil(t, gotErrs)
+		assert.Nil(t, gotWarns)
+	})
+
 	t.Run("Default env vars", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Ticket number: PMM-15331

Feature build: SUBMODULES-0 — **not yet created; required before merge** (see [Not run here](#not-run-here))

## Summary

With `PMM_ENABLE_SEP` set, pmm-server no longer reports its container healthy until the current start's SEP provisioning run has finished. `HEALTHCHECK` tests `/v1/server/readyz`, which covers pmm-managed alone, and supervisord starts `pmm-managed` at priority 14 against `sep-provision`'s 20 — so the container goes healthy well before `grafana-sep` publishes the Grafana token files, and a side-car released by `depends_on: {condition: service_healthy}` comes up with Grafana authentication permanently inert.

`HEALTHCHECK` now runs `/opt/healthcheck.sh`: today's probe verbatim, plus one condition gated on SEP actually being in use — a marker at `/srv/.sep_provisioned` proving *this* start's run finished. `grafana-sep` writes it from its existing `EXIT` trap (keyed on the script's own exit status, so no exit path can forget it); `entrypoint.sh` clears it before `exec supervisord`, so it can only describe the current start. `/v1/server/readyz` is untouched.

A per-run marker rather than a file test, because `publish_token` writes its two files through separate `mktemp`/`mv` pairs and files from a previous run survive a restart — a stale-but-non-empty pair would go green while a replacement is being minted.

**Base branch is `PMM-15316` (#5762), not `main`.** Please merge #5755 and #5762 first. #5759 is a sibling, not a dependency.

### "SEP is in use" is a three-term predicate

`PMM_ENABLE_SEP` alone is not it. `PMM_HA_ENABLE` and `PMM_DISABLE_BUILTIN_POSTGRES` override it outright — `entrypoint.sh` says so in a warning — so all three sites that care test the same thing:

| Site | Behaviour |
|---|---|
| `healthcheck.sh` | requires the marker only when `PMM_ENABLE_SEP` is set **and** neither flag is |
| `entrypoint.sh` | a marker it cannot clear is fatal under the same condition, and only there |
| `grafana-sep` | `MARK_RUN=0` on every path that skips provisioning, so the marker means this start provisioned |

An external Grafana database — `GF_DATABASE_URL` or `GF_DATABASE_HOST` without either flag — is deliberately **not** exempt, and this is the asymmetry worth reviewing. `sep-secrets` treats the two groups differently, and correctly:

| Condition | `sep-secrets` | SEP | Container health |
|---|---|---|---|
| `PMM_HA_ENABLE` / `PMM_DISABLE_BUILTIN_POSTGRES`, whatever `GF_DATABASE_*` says | removes all six files | refuses to start | **unaffected** — the gate does not apply |
| `GF_DATABASE_URL` / `GF_DATABASE_HOST` alone | publishes all four password files | starts, Grafana auth inert | **never healthy** — no marker is ever written |

The precedence is load-bearing: the documented external-PostgreSQL recipe sets `PMM_DISABLE_BUILTIN_POSTGRES=1` **and** `GF_DATABASE_HOST` together (`documentation/docs/reference/third-party/postgresql.md:192-213`), and `sep-secrets` bails on the first pair before it looks at `GF_DATABASE_*`. Exempting on `GF_DATABASE_*` instead would let those deployments through while holding the one case that genuinely breaks SEP.

That verdict is reached by the marker simply never being written, not by the healthcheck testing `GF_DATABASE_*` — the gate does not need to know why provisioning did not happen.

### Timing

`--start-period` 25s → 720s, covering `grafana-sep`'s nominal `READY_TIMEOUT=600` plus ≤80s of bounded token validation. `HEALTHCHECK` options are image metadata and cannot depend on an env var, so this applies to every container. A healthy server is not delayed — a probe that succeeds during the start period marks it healthy immediately. Only the unhealthy verdict for a server that has **never** been ready moves, ≈37s → ≈732s; one that came up and then broke still fails in ~12s. `Config.Healthcheck.Test` becomes `["CMD","/opt/healthcheck.sh"]`; nothing in this repo asserts on that literal.

## Tested

`build/` has no unit tests and no lint job — there is no `shellcheck`/`shfmt` in any workflow or Makefile target, and no workflow triggers on `build/**` — and `api-tests` pulls `perconalab/pmm-server:3-dev-latest` and never sets `PMM_ENABLE_SEP`, so **CI cannot exercise any of this**. Evidence is therefore static gates plus harnesses driving the shipped scripts directly.

- [x] `shellcheck -S style` and `bash -n` clean on all three scripts; `git ls-files -s` confirms `100755` on `healthcheck.sh`, which matters because `COPY` preserves the mode and the image drops to `USER 1000`.
- [x] **The shipped `healthcheck.sh`, 11 scenarios** against a stub `readyz`, one per acceptance criterion it touches. `PMM_ENABLE_SEP` unset: 200 → healthy, 503 → unhealthy, marker ignored either way. Embedded SEP: no marker → unhealthy, marker → healthy. Both ignore flags, and either of them combined with `GF_DATABASE_HOST`: healthy with **no marker present at all**. `GF_DATABASE_HOST` alone and `GF_DATABASE_URL` alone: unhealthy. A failing `readyz` still dominates every combination. `PMM_ENABLE_SEP=true` behaves as `1`; `yes` does not enable.
- [x] **The shipped `grafana-sep`'s exit-0 paths, 6 cases** with a redirected secrets dir: no skip path marks the run — `PMM_ENABLE_SEP` unset, both ignore flags, and both `GF_DATABASE_*` forms all exit 0 with the marker absent and the token files removed. An unwritable secrets directory stays `FATAL` and unmarked.
- [x] **The shipped `entrypoint.sh` marker block, 13 combinations** over both marker shapes — a plain file, and a directory standing in for one `rm -f` cannot clear. Fatal for embedded SEP and for either `GF_DATABASE_*` form alone; clean start under both ignore flags and with `PMM_ENABLE_SEP` unset; the marker is always cleared when it is removable.
- [x] **`grafana-sep` exit paths, 15 cases** against a fake Grafana and a `psql` stub: both skip paths, all three HA/disable-builtin + `GF_DATABASE_*` overlaps, unwritable secrets dir, reuse with a valid token, ambiguous check, malformed material, rejected mint, published mint, and an `errexit` abort. Plus the Grafana-wait timeout at the real unshortened 600s.
- [x] Neither `docker-compose.yml` nor `api-tests/docker-compose.yml` overrides pmm-server's healthcheck, so the image metadata governs both; only `ps` declares its own.

### Not run here

- [ ] **The Feature Build matrix** the ticket requires — first boot, restart with a valid token, restart where Grafana rejects it, permanent failure, `PMM_ENABLE_SEP` unset, and `PMM_ENABLE_SEP=1` with `GF_DATABASE_URL` set. The harnesses exercise neither a real Grafana, nor supervisord ordering, nor real boot timings. **A Feature Build is required before merge.**
- [ ] **Wall clock from start to `healthy` on a real first boot** — the number that would make 720s measured rather than well-sized.
- [ ] **`api-tests`**, which need a live server. `/v1/server/readyz` is untouched, so `readyz_test.go` is unaffected by inspection, not by a run.

### Known limitations

- **A failed provisioning run holds the container unhealthy for the container's life.** `sep-provision` is `autorestart = false`, so a transient Grafana failure that trips a FATAL path never retries — and this change makes that terminal for health rather than merely logged. The ticket scopes retrying out and prefers a loudly unhealthy server to a silently broken side-car, with the reason in `/srv/logs/sep-provision.log`, but nothing tracks adding a bounded retry. <!-- followup -->
- **`api-tests.yml` loses a fast failure**: a server that never becomes ready now burns the full `--wait-timeout=100` instead of failing at ≈37s. CI still fails, less specifically.
- **Two pre-existing residuals in `grafana-sep` are not bounded by 720s**: `wait_for_grafana` counts sleep time rather than wall clock, and the `psql` calls have no timeout. An undersized budget is recoverable — one successful probe restores `healthy` and resets `FailingStreak` — so the risk is a transient window, not a stuck container. Bounding both is deferred work with no issue filed. <!-- followup -->
- **The marker certifies a complete publish via the run's exit status, not by re-reading the two files.** Every path reaching the write ran `publish_token` under `errexit`, and an uncaught signal sets `$?` to 128+signum, so no current path defeats it. A future exit-0 path added without clearing `MARK_RUN` would; a `[ -s ]` check on both token files inside the trap would make it a code invariant instead of a consequence of `errexit` discipline. Not added here — it guards a hypothetical future edit rather than a reachable state.

`.env.example` and `build/AGENTS.md` changes are recorded on the ticket as accepted deltas, since its AC describes only healthcheck behaviour.
