### PR TITLE
PMM-15335 Bump Go version to 1.26.6

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -10,7 +10,6 @@ on:
       - "documentation/**"
       - "managed/**"
       - "qan-api2/**"
-      - "update/**"
       - "vmproxy/**"
       - "ui/**"
 

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -11,7 +11,6 @@ on:
       - "documentation/**"
       - "managed/**"
       - "qan-api2/**"
-      - "update/**"
       - "vmproxy/**"
       - "ui/**"
 

--- a/.github/workflows/managed.yml
+++ b/.github/workflows/managed.yml
@@ -10,7 +10,6 @@ on:
       - "documentation/**"
       - "dashboards/**"
       - 'qan-api2/**'
-      - 'update/**'
       - 'vmproxy/**'
       - "ui/**"
 

--- a/.github/workflows/qan-api2.yml
+++ b/.github/workflows/qan-api2.yml
@@ -11,7 +11,6 @@ on:
       - "documentation/**"
       - "dashboards/**"
       - "managed/**"
-      - "update/**"
       - "vmproxy/**"
       - "ui/**"
 

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -13,7 +13,6 @@ on:
       - "managed/**"
       - "qan-api2/**"
       - "vmproxy/**"
-      - "update/**"
 
 permissions:
   contents: read

--- a/.github/workflows/vmproxy.yml
+++ b/.github/workflows/vmproxy.yml
@@ -12,7 +12,6 @@ on:
       - "dashboards/**"
       - "managed/**"
       - "qan-api2/**"
-      - "update/**"
       - "ui/**"
 
 permissions:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona/pmm
 
-go 1.26.5
+go 1.26.6
 
 replace github.com/go-openapi/spec => github.com/Percona-Lab/spec v0.22.9-percona
 


### PR DESCRIPTION
Ticket number: PMM-15335

This pull request updates the Go version used in the `go.mod` file from 1.26.5 to 1.26.6. This is a patch version bump, to include the latest bug fixes and improvements.