### PR TITLE
Fix CodeRabbit review findings on pnpm setup PR

### DIFF
--- a/.devcontainer/Makefile
+++ b/.devcontainer/Makefile
@@ -62,7 +62,7 @@ run: run-all                         ## Aliased to "run-all"
 	echo "run is aliased to run-all"
 
 ui-setup:                            ## Install UI dependencies
-	cd ui && pnpm install --yes
+	cd ui && pnpm install
 
 run-ui: ui-setup setup-livereload    ## Start vite dev server for UI with HMR
 	mv /srv/grafana/plugins/pmm-compat-app /srv/grafana/plugins/pmm-compat-app.bak; \

--- a/ui/README.md
+++ b/ui/README.md
@@ -73,7 +73,11 @@ The devcontainer ships a prebuilt Grafana baked into the `perconalab/pmm-server`
 - ../grafana/public:/usr/share/grafana/public
 ```
 
-The first mount provides the Grafana source for the backend build; the second serves the fork's built frontend (`public/`). 3. Recreate the container so the new mounts take effect — volume mappings are read at container create time (`make env-down` then `make env-up`, or recreate via your container tooling). 4. Rebuild the Grafana backend **inside the container**:
+The first mount provides the Grafana source for the backend build; the second serves the fork's built frontend (`public/`).
+
+3. Recreate the container so the new mounts take effect — volume mappings are read at container create time (`make env-down` then `make env-up`, or recreate via your container tooling).
+
+4. Rebuild the Grafana backend **inside the container**:
 
 ```bash
  make grafana-be-build
@@ -123,7 +127,7 @@ pnpm implements workspace linking via a workspace-wide override: this adds an en
  pnpm unlink @percona/peak-ui
 ```
 
-`unlink` only reverses the override in `pnpm-workspace.yaml` and `apps/pmm`'s own specifier — it leaves the anchor entry behind in the root `ui/package.json`/`ui/pnpm-lock.yaml`. Check `git diff ui/package.json ui/pnpm-lock.yaml` afterwards and discard any leftover `@percona/peak-ui": "link:../../peak-ui"` entry with `git checkout -- ui/package.json ui/pnpm-lock.yaml`.
+`unlink` only reverses the override in `pnpm-workspace.yaml` and `apps/pmm`'s own specifier — it leaves the anchor entry behind in the root `ui/package.json`/`ui/pnpm-lock.yaml`. Check `git diff ui/package.json ui/pnpm-lock.yaml` afterward and manually remove any leftover `@percona/peak-ui": "link:../../peak-ui"` entry — don't `git checkout` those files, since that discards any other uncommitted changes they may have.
 
 ## Run locally on the host
 


### PR DESCRIPTION
## What

Addresses CodeRabbit findings left on #5805:

- `.devcontainer/Makefile`: remove the unsupported `--yes` flag from `pnpm install` — pnpm has no such option, so `make ui-setup` (and anything depending on it, e.g. `run-ui`) would fail in the devcontainer.
- `ui/README.md`: split numbered steps 3 and 4 (under "Update Grafana in the devcontainer") into their own paragraphs — they were merged into the preceding sentence and wouldn't render as separate list items.
- `ui/README.md`: reword the `peak-ui` unlink cleanup instructions to have users manually remove the leftover `@percona/peak-ui": "link:../../peak-ui"` entry instead of running `git checkout -- ui/package.json ui/pnpm-lock.yaml`, which would discard any other uncommitted changes in those files. Also fixed an "afterwards" → "afterward" (US English) nit in the same sentence.

## Why

Each finding was verified against the current diff on #5805 before fixing; all three were real issues (not false positives).

## Test plan

- [x] Docs/Makefile only change — no build or test suite applies.
- [x] Manually re-read the affected Markdown to confirm the numbered list renders correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvueJRoLDq6zw7H8uQ6DG3)_