### PR TITLE
PMM-15326: Authorize the OM routes by role

### DIFF
--- a/managed/services/grafana/auth_server.go
+++ b/managed/services/grafana/auth_server.go
@@ -65,6 +65,22 @@ var rules = map[string]role{
 	"/server.v1.":               admin,
 	"/qan.v1.CollectorService.": viewer,
 	"/qan.v1.QANService.":       viewer,
+	// Reading OM over gRPC is a viewer's business; the writes are named exactly below.
+	//
+	// The HTTP methodRules cannot cover these: that table is keyed "METHOD /path" and a
+	// gRPC method name carries no verb, so /om.v1.OmService/DeleteInventoryHost would walk
+	// past every write rule and land here on viewer. A gRPC method name is unambiguous on
+	// its own, which is why these sit in `rules` rather than being method-qualified, the
+	// same as the agent and RTA endpoints above.
+	//
+	// The gateway reaches pmm-managed over HTTP, so in a normal deployment nothing uses
+	// these. They exist so the gRPC surface is not a way around the HTTP roles.
+	"/om.": viewer,
+	"/om.v1.OmService/TriggerInventoryRefresh":       editor,
+	"/om.v1.OmService/DeleteInventoryHost":           admin,
+	"/om.v1.OmService/DeleteInventoryService":        admin,
+	"/om.v1.OmService/UpdateInventoryConfig":         admin,
+	"/om.v1.OmService/DeleteInventoryConfigOverride": admin,
 
 	"/v1/alerting":                    viewer,
 	"/v1/alerting/rules":              editor,
@@ -102,6 +118,11 @@ var rules = map[string]role{
 	"/v1/qan":  viewer,
 	"/v1/qan:": viewer,
 
+	// Reading OM is a viewer's business. The writes are qualified by method in
+	// methodRules below -- /v1/om/inventory can forget rows, change the app's
+	// configuration and run code on database hosts, none of which a viewer may do.
+	"/v1/om": viewer,
+
 	"/prometheus":      admin,
 	"/victoriametrics": admin,
 	"/nomad":           admin,
@@ -136,6 +157,40 @@ var methodRules = map[string]role{
 	http.MethodPost + " /v1/alerting/templates":    editor,
 	http.MethodPut + " /v1/alerting/templates/":    editor,
 	http.MethodDelete + " /v1/alerting/templates/": editor,
+
+	// OM's inventory surface reads as viewer (see "/v1/om" above) but writes here.
+	//
+	// Refreshing is editor rather than admin. It runs SEP's fixed probe payload on the
+	// hosts it covers -- nothing the caller supplies, no database touched -- and the
+	// per-host refresh is the button beside a row that answers "I just fixed this, is it
+	// healthy now". Requiring admin for that would put the routine question behind the
+	// rarest role.
+	// The custom verb is part of the path, and it is the path that exists: there is no
+	// plain POST /v1/om/inventory/runs to gate. nextPrefix walks back past a colon, so a
+	// rule on the bare collection would match this too -- naming the real route instead
+	// keeps the rule readable as the thing it authorizes.
+	http.MethodPost + " /v1/om/inventory/runs:trigger": editor,
+
+	// Forgetting a row and changing the app's configuration are both admin. A DELETE is
+	// not suppression -- the row returns on the next refresh if PMM still knows the
+	// entity -- but it is destructive to the annotations and history on that row. A
+	// configuration change sets the sweep schedule for the whole deployment, so it is
+	// the kind of thing one person does on everyone's behalf.
+	//
+	// The trailing slash on the id-bearing paths is not load-bearing: nextPrefix strips
+	// one as its own step, so the slash-less spelling would catch the same requests.
+	// It is kept because it reads as "everything under here" rather than as a path.
+	http.MethodDelete + " /v1/om/inventory/hosts/":    admin,
+	http.MethodDelete + " /v1/om/inventory/services/": admin,
+	http.MethodPut + " /v1/om/inventory/config":       admin,
+
+	// Two rules for one route, on purpose. The first names the route that exists; the
+	// second is the backstop, because resolveRule walks longest prefix first and anything
+	// else that ever appears under config/ would otherwise fall through to the viewer rule
+	// at "/v1/om" -- which is the failure this table's test exists to catch. A DELETE
+	// anywhere under an app's configuration should default to admin, not to readable.
+	http.MethodDelete + " /v1/om/inventory/config/overrides/": admin,
+	http.MethodDelete + " /v1/om/inventory/config/":           admin,
 }
 
 var lbacPrefixes = []string{

--- a/managed/services/grafana/auth_server_test.go
+++ b/managed/services/grafana/auth_server_test.go
@@ -76,6 +76,43 @@ func TestResolveRule(t *testing.T) {
 		{http.MethodPut, "/v1/alerting/templates/foo", editor},    // UpdateTemplate
 		{http.MethodDelete, "/v1/alerting/templates/foo", editor}, // DeleteTemplate
 		{http.MethodPost, "/v1/alerting/rules", editor},           // CreateRule
+
+		// OM: reading the estate is a viewer's, changing it is not. Asserted per path
+		// rather than trusted, because whether a write rule applies depends on how
+		// resolveRule walks prefixes, and that is not obvious from the rule table. It
+		// tries methodRules then rules at each prefix, and nextPrefix strips a trailing
+		// "/" as its own step -- so "/v1/om/inventory/hosts/" and
+		// "/v1/om/inventory/hosts" both catch a DELETE of an id under them. What would
+		// silently fall through to the viewer rule at "/v1/om" is a write path with no
+		// rule at all.
+		{http.MethodGet, "/v1/om/topology", viewer},
+		{http.MethodGet, "/v1/om/inventory/hosts", viewer},
+		{http.MethodGet, "/v1/om/inventory/hosts/node-1", viewer},
+		{http.MethodGet, "/v1/om/inventory/services", viewer},
+		{http.MethodGet, "/v1/om/inventory/config", viewer},
+		{http.MethodPost, "/v1/om/inventory/runs:trigger", editor},
+		{http.MethodDelete, "/v1/om/inventory/hosts/node-1", admin},
+		{http.MethodDelete, "/v1/om/inventory/services/svc-1", admin},
+		{http.MethodPut, "/v1/om/inventory/config", admin},
+		{http.MethodDelete, "/v1/om/inventory/config/overrides/SCHEDULE__every", admin},
+		// The backstop: no such route today, but a DELETE under an app's configuration
+		// must not degrade to the viewer rule at "/v1/om" if one is ever added.
+		{http.MethodDelete, "/v1/om/inventory/config/anything-else", admin},
+		// PMM's own collection pass stays viewer: it recomputes a document from data PMM
+		// already holds and never reaches a host.
+		{http.MethodPost, "/v1/om/topology/runs:collect", viewer},
+
+		// The same surface over gRPC. methodRules cannot reach these -- a gRPC method
+		// name carries no HTTP verb -- so without exact entries every one of them walks
+		// past the write rules and lands on the viewer rule at "/om.".
+		{http.MethodPost, "/om.v1.OmService/GetTopology", viewer},
+		{http.MethodPost, "/om.v1.OmService/ListInventoryHosts", viewer},
+		{http.MethodPost, "/om.v1.OmService/TriggerInventoryRefresh", editor},
+		{http.MethodPost, "/om.v1.OmService/DeleteInventoryHost", admin},
+		{http.MethodPost, "/om.v1.OmService/DeleteInventoryService", admin},
+		{http.MethodPost, "/om.v1.OmService/UpdateInventoryConfig", admin},
+		{http.MethodPost, "/om.v1.OmService/DeleteInventoryConfigOverride", admin},
+
 		// No matching rule falls back to grafanaAdmin.
 		{http.MethodGet, "/v1/unknown", grafanaAdmin},
 	} {


### PR DESCRIPTION
Ticket number: PMM-15326

Feature build: N/A - authorization rules only; the routes they cover are added by the API and service PRs in the same stack.

## What

Role rules for OM's routes in `managed/services/grafana/auth_server.go`, plus cases in `TestResolveRule` for each one.

Reading is viewer. The writes are named individually:

| route | role | why |
| --- | --- | --- |
| `GET /v1/om/**` | viewer | reading the estate |
| `POST /v1/om/inventory/runs:trigger` | editor | see below |
| `DELETE /v1/om/inventory/hosts/{id}` | admin | destructive to that row's history |
| `DELETE /v1/om/inventory/services/{id}` | admin | same |
| `PUT /v1/om/inventory/config` | admin | changes the sweep schedule for the whole deployment |
| `DELETE /v1/om/inventory/config/overrides/{key}` | admin | same |

## Please look at this: a viewer can trigger a topology collection

`POST /v1/om/topology/runs:collect` resolves to **viewer**, and the test asserts it.

The reasoning: a topology collection only reads PMM's own inventory and VictoriaMetrics. It runs no code on database hosts, takes nothing from the caller, and writes only OM's own run history. So it is closer to a refresh of a page than to a write.

The counter-argument is that it is still a `POST` that costs work and adds rows, and that "viewer" for anything that mutates state may not be a line you want crossed. **If you would rather it were editor, say so and it changes in one line.** I would rather have that decided here than have it noticed later as an accident.

## Why the refresh is editor and not admin

`POST /v1/om/inventory/runs:trigger` runs SEP's fixed probe payload on hosts SEP already covers. Nothing the caller supplies is executed, and no database is touched. The per-host refresh is the button beside a row that answers "I just fixed this, is it healthy now" - putting that behind admin would put the routine question behind the rarest role.

## Why the five gRPC write methods are named in `rules` rather than `methodRules`

`methodRules` is keyed `"METHOD /path"`, and a gRPC method name carries no verb. So `/om.v1.OmService/DeleteInventoryHost` would walk past every write rule and land on the `"/om."` prefix at viewer. The five write methods are therefore named exactly in `rules`, beside the agent and RTA endpoints that do the same thing.

In a normal deployment the gateway reaches pmm-managed over HTTP, so nothing uses these. They exist so the gRPC surface is not a way around the HTTP roles.

## Two details in the table worth a second look

**The trailing slash on the id-bearing paths is not load-bearing.** `nextPrefix` strips one as its own step, so the slash-less spelling catches the same requests. It is kept because it reads as "everything under here" rather than as a path.

**There are two rules for the config route on purpose.** The first names the route that exists; `DELETE /v1/om/inventory/config/` is a backstop, because `resolveRule` walks longest prefix first and anything else that ever appears under `config/` would otherwise fall through to the viewer rule at `/v1/om`. A DELETE anywhere under an app's configuration should default to admin, not to readable.

## Tests

`TestResolveRule` gains a case per route rather than a sample, because whether a write rule applies depends on how `resolveRule` walks prefixes, and that is not obvious from reading the rule table. The thing that would silently fall through to viewer is a write path with no rule at all, so each is asserted rather than trusted.

## Related work

One of seven stacked PRs splitting #5795 ("OpenManager initial implementation") into area-owned reviews. This one targets `PMM-15299-open-manager` directly, depends on nothing else in the stack, and can be reviewed and merged on its own - the rules are inert until the routes exist.
