### PR TITLE
PMM-15326: Implement the OM service in pmm-managed

### DIFF
--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -73,6 +73,7 @@ import (
 	hav1beta1 "github.com/percona/pmm/api/ha/v1beta1"
 	inventoryv1 "github.com/percona/pmm/api/inventory/v1"
 	managementv1 "github.com/percona/pmm/api/management/v1"
+	omv1 "github.com/percona/pmm/api/om/v1"
 	rtav1 "github.com/percona/pmm/api/realtimeanalytics/v1"
 	serverv1 "github.com/percona/pmm/api/server/v1"
 	userv1 "github.com/percona/pmm/api/user/v1"
@@ -95,6 +96,7 @@ import (
 	managementgrpc "github.com/percona/pmm/managed/services/management/grpc"
 	"github.com/percona/pmm/managed/services/minio"
 	"github.com/percona/pmm/managed/services/nomad"
+	"github.com/percona/pmm/managed/services/om"
 	"github.com/percona/pmm/managed/services/qan"
 	"github.com/percona/pmm/managed/services/realtimeanalytics"
 	"github.com/percona/pmm/managed/services/scheduler"
@@ -234,6 +236,10 @@ type gRPCServerDeps struct {
 	versionCache              *versioncache.Service
 	vmdb                      *victoriametrics.Service
 	vmalert                   *vmalert.Service
+
+	// Built in main so its collection timer can be registered as an HA leader service.
+	// runGRPCServer only exposes it.
+	omService *om.Service
 }
 
 // runGRPCServer runs gRPC server until context is canceled, then gracefully stops it.
@@ -323,6 +329,8 @@ func runGRPCServer(ctx context.Context, deps *gRPCServerDeps) {
 	userv1.RegisterUserServiceServer(gRPCServer, user.NewUserService(deps.db, deps.grafanaClient))
 
 	hav1beta1.RegisterHAServiceServer(gRPCServer, ha.NewHAServer(deps.ha))
+
+	omv1.RegisterOmServiceServer(gRPCServer, deps.omService)
 
 	// Register RTA service with in-memory store
 	rtaStore := realtimeanalytics.NewStore()
@@ -430,6 +438,8 @@ func runHTTP1Server(ctx context.Context, deps *http1ServerDeps) {
 		backupv1.RegisterRestoreServiceHandler,
 
 		dumpv1beta1.RegisterDumpServiceHandler,
+
+		omv1.RegisterOmServiceHandler,
 
 		rtav1.RegisterRealtimeAnalyticsServiceHandler,
 
@@ -677,6 +687,16 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	kingpin.Version(version.FullInfo())
 	kingpin.HelpFlag.Short('h')
+
+	// Where SEP is, not where any one of its apps is: OM's on-host facts come from
+	// the om_inventory app today and the actions apps will come from the same SEP, so
+	// each consumer appends its own /api/apps/<module> path. Optional -- with no URL
+	// the probe source reports itself disabled and the document is built from PMM's own
+	// inventory and metrics alone.
+	sepURLF := kingpin.Flag("sep-url", "Base URL of SEP, e.g. http://127.0.0.1:8000").
+		Envar("PMM_SEP_URL").String()
+	sepTokenF := kingpin.Flag("sep-token", "Bearer token for SEP's API").
+		Envar("PMM_SEP_TOKEN").String()
 
 	victoriaMetricsURLF := kingpin.Flag("victoriametrics-url", "VictoriaMetrics base URL").Envar("PMM_VM_URL").
 		Default(models.VMBaseURL).String()
@@ -1177,6 +1197,20 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		return nil
 	}))
 
+	// Where SEP is, optional. Empty means OM builds its document from PMM's own inventory
+	// and metrics alone and records the probe source as disabled.
+	omService := om.New(db, v1.NewAPI(vmClient), logrus.WithField("component", "om"))
+	omService.WithProbeSource(*sepURLF, *sepTokenF)
+
+	// Leader-only, like every other periodic writer here. A collection persists a run and
+	// its snapshot and then prunes the shared history, so running it on every node of an
+	// HA cluster would have each node writing runs and pruning the others' -- and the
+	// pruning is what makes that destructive rather than merely wasteful.
+	haService.AddLeaderService(ha.NewContextService("om", func(ctx context.Context) error {
+		omService.Run(ctx)
+		return nil
+	}))
+
 	wg.Go(func() {
 		runGRPCServer(ctx,
 			&gRPCServerDeps{
@@ -1208,6 +1242,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 				templatesService:          alertingService,
 				versionCache:              versionCache,
 				vmalert:                   vmalert,
+				omService:                 omService,
 				vmClient:                  &vmClient,
 				vmdb:                      vmdb,
 			})

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -1199,7 +1199,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	// Where SEP is, optional. Empty means OM builds its document from PMM's own inventory
 	// and metrics alone and records the probe source as disabled.
-	omService := om.New(db, v1.NewAPI(vmClient), logrus.WithField("component", "om"))
+	omService := om.New(db, v1.NewAPI(vmClient), haService, logrus.WithField("component", "om"))
 	omService.WithProbeSource(*sepURLF, *sepTokenF)
 
 	// Leader-only, like every other periodic writer here. A collection persists a run and

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -1201,6 +1201,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	// and metrics alone and records the probe source as disabled.
 	omService := om.New(db, v1.NewAPI(vmClient), haService, logrus.WithField("component", "om"))
 	omService.WithProbeSource(*sepURLF, *sepTokenF)
+	prom.MustRegister(om.NewMetricsCollector(omService))
 
 	// Leader-only, like every other periodic writer here. A collection persists a run and
 	// its snapshot and then prunes the shared history, so running it on every node of an

--- a/managed/services/ha/haservice.go
+++ b/managed/services/ha/haservice.go
@@ -600,6 +600,18 @@ func (s *Service) IsLeader() bool {
 	return !s.params.Enabled || (s.raftNode != nil && s.raftNode.State() == raft.Leader)
 }
 
+// LeaderID returns the current Raft leader's node ID, or "" when HA is disabled or no
+// leader is known yet.
+func (s *Service) LeaderID() string {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+	if !s.params.Enabled || s.raftNode == nil {
+		return ""
+	}
+	_, leaderID := s.raftNode.LeaderWithID()
+	return string(leaderID)
+}
+
 // Params returns HA parameters.
 func (s *Service) Params() *models.HAParams {
 	return s.params

--- a/managed/services/om/catalog.go
+++ b/managed/services/om/catalog.go
@@ -75,21 +75,21 @@ const (
 const metricsLookback = "24h"
 
 // highResolutionJob narrows every query to the high-resolution scrape job, which is what
-// makes "one series per service per metric" true and volatileMaxAge meaningful.
+// makes volatileMaxAge meaningful.
 //
 // Each exporter is scraped once per resolution, so a metric it emits on every scrape
-// regardless of collector flags arrives once per job. That is what mongodb_up is: two
-// series per service, hr and lr. Reduced across both, exporter_up is dated by the lr
-// series -- ages() takes the oldest, deliberately -- whose age swings up to its own 60s
-// interval, so the fact reads stale for most of every minute and the service reports DOWN
-// while its hr sample is seconds old. Measured against a 14-service sandbox: half of them
-// DOWN per collection, a different half each time.
+// regardless of collector flags arrives once per job. That is what mongodb_up is: an hr and
+// an lr series per service. The lr series' age swings up to its own 60s interval, so a
+// volatile fact read from it is stale for most of every minute while the hr sample is
+// seconds old -- and sizing volatileMaxAge off lr instead would blunt every volatile field
+// to minutes to accommodate one metric. The management package selects its own "up" metrics
+// the same way.
 //
-// Narrowing rather than resizing volatileMaxAge, because the ages() reduction is right for
-// the case it was written for -- one series per peer of
-// mongodb_mongod_replset_member_replication_lag, all from the hr job -- and sizing the
-// window off lr would blunt every volatile field to minutes to accommodate one metric. The
-// management package selects its own "up" metrics the same way.
+// What this does not make true is "one series per service per metric", which nothing does:
+// an exporter's label set changes over its own lifetime -- cluster_role appears once it can
+// determine the role -- so it abandons a series and begins another under the same
+// service_id. Pairing each sample with its own series' age is what handles that, not this
+// matcher; see seriesSample.supersedes.
 const highResolutionJob = `job=~".*_hr$"`
 
 // How old a volatile observation may be and still count as current.

--- a/managed/services/om/catalog.go
+++ b/managed/services/om/catalog.go
@@ -1,0 +1,189 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"time"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+)
+
+// The signal catalog: exactly the queries the topology document needs, and nothing
+// speculative. Every query aggregates or is keyed by service_id, which is the only safe
+// join key -- a service name is reused across re-registrations while the superseded
+// series live on until retention expires, so a name-keyed join silently mixes
+// generations.
+const (
+	// The exporter's info metric: identity, running version, vendor and edition.
+	metricVersionInfo = "mongodb_version_info"
+	// The replSetGetStatus view as seen from the member itself -- its own member_state.
+	// The sibling mongodb_rs_members_state carries one series per peer; this one is a
+	// single series describing the node being asked.
+	metricMembersSelf = "mongodb_members_self"
+	// The exporter's own reachability flag. A service that is down produces no series at
+	// all rather than a 0, so absence is what the document reads as DOWN.
+	metricUp = "mongodb_up"
+	// Emitted only by a mongos, so its presence is the router test -- more reliable than
+	// the port convention, which only ever guessed.
+	metricMongosShards = "mongodb_mongos_sharding_shards_total"
+	// Seconds a peer trails the primary's optime. Several series per service, one per
+	// (reporting node, secondary peer), so it needs a reducer. The primary appears in no
+	// series by construction, and a single-member set emits nothing at all -- which is
+	// "not applicable" rather than "not collected".
+	metricReplicationLag = "mongodb_mongod_replset_member_replication_lag"
+	// Oplog bounds as epoch seconds; their difference is the window. One series per
+	// service each. A standalone emits neither -- no replica set, no oplog.
+	metricOplogHead = "mongodb_mongod_replset_oplog_head_timestamp"
+	metricOplogTail = "mongodb_mongod_replset_oplog_tail_timestamp"
+)
+
+// Derived percentages. Neither exists as a series, so both are expressions. %[1]s is the
+// series matcher -- the service_id set and highResolutionJob -- and %[2]s the freshness
+// window; both aggregate by (service_id) so the result still joins back to a service.
+//
+// The CPU expression needs no last_over_time: irate over a 30s range already requires
+// two raw samples inside it, so a service that stopped reporting drops out on its own.
+const (
+	queryCPUUsage = `100 * (1 - sum by (service_id) (irate(mongodb_sys_cpu_idle_ms{%[1]s}[30s]))` +
+		` / (1000 * max by (service_id) (last_over_time(mongodb_sys_cpu_num_logical_cores{%[1]s}[%[2]s]))))`
+	queryConnectionsFree = `100 * max by (service_id) (last_over_time(mongodb_connections{%[1]s,state="available"}[%[2]s]))` +
+		` / (max by (service_id) (last_over_time(mongodb_connections{%[1]s,state="current"}[%[2]s]))` +
+		` + max by (service_id) (last_over_time(mongodb_connections{%[1]s,state="available"}[%[2]s])))`
+)
+
+// metricsLookback is the window every query is read over.
+//
+// Deliberately long, and deliberately not the freshness rule. Without an explicit window
+// this would be VictoriaMetrics' instant-query lookbehind of five minutes, so a query
+// returns nothing whenever scraping paused -- indistinguishable from "no such service".
+// Reading over a day instead means a since-unreachable node still contributes what it
+// last reported, carrying the age that says so. Whether that age is too old to act on is
+// a separate decision, made per field by volatileFields and volatileMaxAge.
+const metricsLookback = "24h"
+
+// highResolutionJob narrows every query to the high-resolution scrape job, which is what
+// makes "one series per service per metric" true and volatileMaxAge meaningful.
+//
+// Each exporter is scraped once per resolution, so a metric it emits on every scrape
+// regardless of collector flags arrives once per job. That is what mongodb_up is: two
+// series per service, hr and lr. Reduced across both, exporter_up is dated by the lr
+// series -- ages() takes the oldest, deliberately -- whose age swings up to its own 60s
+// interval, so the fact reads stale for most of every minute and the service reports DOWN
+// while its hr sample is seconds old. Measured against a 14-service sandbox: half of them
+// DOWN per collection, a different half each time.
+//
+// Narrowing rather than resizing volatileMaxAge, because the ages() reduction is right for
+// the case it was written for -- one series per peer of
+// mongodb_mongod_replset_member_replication_lag, all from the hr job -- and sizing the
+// window off lr would blunt every volatile field to minutes to accommodate one metric. The
+// management package selects its own "up" metrics the same way.
+const highResolutionJob = `job=~".*_hr$"`
+
+// How old a volatile observation may be and still count as current.
+//
+// Sized against the scrape interval rather than picked: every query carries
+// highResolutionJob, so the window is volatileMaxAgeFactor of PMM's configured high
+// resolution, floored by minVolatileMaxAge. Four intervals tolerates several missed
+// scrapes while still noticing a stopped database in well under a minute.
+const (
+	volatileMaxAgeFactor = 4
+	minVolatileMaxAge    = 30 * time.Second
+)
+
+// sourceQueries names what the document was derived from, and is carried in the document
+// so a reader can see that without reading this file. Ordered as the collector issues
+// them.
+var sourceQueries = []string{
+	metricVersionInfo,
+	metricMembersSelf,
+	metricUp,
+	metricMongosShards,
+	"mongodb_sys_cpu_idle_ms",
+	"mongodb_connections",
+	metricReplicationLag,
+	metricOplogHead,
+	metricOplogTail,
+}
+
+// The document fields sources set. Names match SEP's om_inventory app so a fact
+// produced there needs no translation on the way in.
+const (
+	fieldHost             = "host"
+	fieldServiceType      = "service_type"
+	fieldCluster          = "cluster"
+	fieldReplicationSet   = "replication_set"
+	fieldEnvironment      = "environment"
+	fieldVersion          = "version"
+	fieldVendor           = "vendor"
+	fieldEdition          = "edition"
+	fieldState            = "state"
+	fieldEndpoint         = "endpoint"
+	fieldClusterRole      = "cluster_role"
+	fieldExporterUp       = "exporter_up"
+	fieldCPUUsage         = "cpu_usage_percent"
+	fieldConnectionsFree  = "connections_free_percent"
+	fieldIsMongos         = "is_mongos"
+	fieldReplicationLag   = "replication_lag_seconds"
+	fieldOplogHead        = "oplog_head_timestamp"
+	fieldOplogTail        = "oplog_tail_timestamp"
+	fieldInstalledVersion = "installed_version"
+	fieldConfigPath       = "config_path"
+	fieldArgv             = "argv"
+)
+
+// volatileFields are the fields that describe now rather than describe the service.
+//
+// Everything is collected over metricsLookback and kept with its age, so the document can
+// still say what a since-unreachable node last reported. But these fields are only
+// meaningful while fresh: a replica-set state or an up flag from an hour ago is not a
+// fact about the present, whereas an edition is. Reading one past volatileMaxAge yields
+// nothing, which is what turns a stopped database into status DOWN instead of a
+// confident, day-old UP.
+var volatileFields = map[string]bool{
+	fieldState:           true,
+	fieldClusterRole:     true,
+	fieldExporterUp:      true,
+	fieldCPUUsage:        true,
+	fieldConnectionsFree: true,
+	fieldIsMongos:        true,
+	fieldReplicationLag:  true,
+	fieldOplogHead:       true,
+	fieldOplogTail:       true,
+}
+
+// clusterRoles maps the exporter's cl_role label onto the document's process_role.
+//
+// The label is the exporter's vocabulary and the enum is ours, so this is the only place
+// the two meet. A label we do not recognise falls through to PROCESS_ROLE_MONGOD rather
+// than UNSPECIFIED: an unlabelled mongod is the ordinary case, not a gap.
+var clusterRoles = map[string]omv1.ProcessRole{
+	"configsvr": omv1.ProcessRole_PROCESS_ROLE_CONFIGSVR,
+	"shardsvr":  omv1.ProcessRole_PROCESS_ROLE_SHARDSVR,
+}
+
+// unmeasured is the gauge sentinel: -1 rather than null so the field stays a number for
+// every service, and rather than 0 because zero CPU is a legitimate reading.
+const unmeasured = -1
+
+// unspecified is the grouping key for a service whose environment or cluster is unset.
+// Internal only -- the document emits null for it, because inventing the string
+// "UNSPECIFIED" as a name would make it indistinguishable from a real environment
+// called that.
+const unspecified = "UNSPECIFIED"
+
+// schemaVersion is the version of the emitted document. Versioned so that a stored
+// snapshot stays readable across changes.
+const schemaVersion = 3

--- a/managed/services/om/catalog.go
+++ b/managed/services/om/catalog.go
@@ -186,4 +186,9 @@ const unspecified = "UNSPECIFIED"
 
 // schemaVersion is the version of the emitted document. Versioned so that a stored
 // snapshot stays readable across changes.
-const schemaVersion = 3
+//
+// Starts at 1: nothing has shipped yet, so there is no prior version's snapshot a reader
+// needs to keep distinguishing from this one. A dev database is one `./om reset data`
+// away, which is what makes 1 the honest number rather than leftover numbering from
+// development.
+const schemaVersion = 1

--- a/managed/services/om/deps.go
+++ b/managed/services/om/deps.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+// victoriaMetricsClient is a subset of methods of prometheus' API used by this package.
+type victoriaMetricsClient interface {
+	Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error)
+}

--- a/managed/services/om/deps.go
+++ b/managed/services/om/deps.go
@@ -27,3 +27,13 @@ import (
 type victoriaMetricsClient interface {
 	Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error)
 }
+
+// haChecker reports HA leadership, so a write-triggering RPC can refuse on a follower
+// rather than race the leader for the same collection.
+//
+// Optional like probe: a Service built without one (every test in this package but the
+// ones that care) treats every node as the leader, which is the single-node default too.
+type haChecker interface {
+	IsLeader() bool
+	LeaderID() string
+}

--- a/managed/services/om/facts.go
+++ b/managed/services/om/facts.go
@@ -62,12 +62,26 @@ const (
 const (
 	sourceInventory = "inventory"
 	sourceMetrics   = "metrics"
-	// Not produced here. This is the key reserved for the SEP inventory
-	// app's on-host facts -- argv, config paths, the installed binary version -- so the
-	// precedence table can already name it and the merge needs no change when it lands.
+	// The SEP inventory app's on-host facts -- argv, config paths, the installed binary
+	// version. Produced by probeSource in probe_source.go, which reads them off SEP's
+	// om_inventory app rather than probing anything itself; see that file for why.
 	sourceProbe = "probe"
 )
 
+// Fact is keyed by PMM service, deliberately, not by host.
+//
+// A host with three mongods and no service PMM has registered -- the case this product
+// exists to describe -- cannot contribute a fact the merge will keep, and neither can a
+// naturally per-host probe attribute like repo_reachable or executor_reachable. That is a
+// real gap and a decided one, not an oversight: host attributes live only on
+// /v1/om/inventory/hosts (inventory.go), reached through a separate API rather than
+// folded into this document. The alternative -- widening Fact with an optional node key
+// so the merge becomes (node|service, field) -- was considered and deferred, because
+// projection would then have to decide whether a host fact attaches to every service on
+// that node or to some new slot, which is bigger than a fact-source addition. Until that
+// lands, a naturally-per-host probe attribute must not be stuffed into every service row
+// on its node: the copies would disagree the moment one of them changed.
+//
 // Fact carries one field about one service, as one source saw it.
 type Fact struct {
 	// Service is the PMM service ID this is about.
@@ -300,6 +314,33 @@ func (f fieldSet) live(field string) (any, bool) {
 		return nil, false
 	}
 	return held.Value, true
+}
+
+// newestObservedAt returns the most recent observation among this row's live fields, or
+// nil when none of them carry one at all.
+//
+// This is the row's own provenance, as against Snapshot.observed_at which is the newest
+// across the whole estate and so cannot tell "this row is current" from "this row merely
+// did not drag the snapshot's headline age down". An inventory-only fact has no
+// ObservedAt to begin with, and a volatile fact that aged out is excluded the same way
+// live() excludes it from a read -- a fact too old to read as current should not read as
+// current here either.
+func (f fieldSet) newestObservedAt() *time.Time {
+	var newest *time.Time
+	for field, held := range f.fields {
+		if held.ObservedAt == nil {
+			continue
+		}
+		if volatileFields[field] {
+			if _, ok := f.live(field); !ok {
+				continue
+			}
+		}
+		if newest == nil || held.ObservedAt.After(*newest) {
+			newest = held.ObservedAt
+		}
+	}
+	return newest
 }
 
 // staleVolatile counts the volatile fields dropped for age, which the run receipt reports

--- a/managed/services/om/facts.go
+++ b/managed/services/om/facts.go
@@ -1,0 +1,318 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"slices"
+	"time"
+)
+
+// The common currency every collection source deals in.
+//
+// Collection reads the same MongoDB estate from several places -- PMM's inventory,
+// VictoriaMetrics, and (later) a SEP app running probes on Nomad clients -- and each
+// knows a different, overlapping subset of the truth. Rather than special-case the
+// sources against each other, every one of them emits the same thing: flat Fact records
+// keyed by (service, field). Adding a source is then implementing one interface and
+// changes nothing downstream.
+//
+// Merging is by declared precedence per field, never by call order. That is what makes
+// "who wins" a piece of configuration rather than an accident of which source happened
+// to run last, and it is why every merged field keeps its provenance: a document that
+// cannot say where a version came from cannot distinguish "the node reports 7.0.39" from
+// "the node reported 7.0.39 nine days ago and has been unreachable since".
+//
+// The field names and the precedence table are kept in step with om_inventory, whose
+// facts merge here.
+
+// SourceStatus says how completely one source answered.
+//
+// Recorded per source on the run, so a thin document is legible rather than merely thin:
+// a snapshot assembled with metrics=OK, probe=FAILED is still correct about every version
+// and honest about reachability.
+type SourceStatus string
+
+// The states a source can report.
+const (
+	// SourceOK means the source answered for every service asked about.
+	SourceOK SourceStatus = "ok"
+	// SourcePartial means it answered for some services but not all.
+	SourcePartial SourceStatus = "partial"
+	// SourceFailed means it answered for none, or errored.
+	SourceFailed SourceStatus = "failed"
+	// SourceDisabled means it was switched off and never ran.
+	SourceDisabled SourceStatus = "disabled"
+)
+
+// Source keys. These are the strings the precedence table and the run receipt use, and
+// they are part of the contract with anything that contributes facts.
+const (
+	sourceInventory = "inventory"
+	sourceMetrics   = "metrics"
+	// Not produced here. This is the key reserved for the SEP inventory
+	// app's on-host facts -- argv, config paths, the installed binary version -- so the
+	// precedence table can already name it and the merge needs no change when it lands.
+	sourceProbe = "probe"
+)
+
+// Fact carries one field about one service, as one source saw it.
+type Fact struct {
+	// Service is the PMM service ID this is about.
+	Service string
+	// Field is the document field this sets, e.g. "version".
+	Field string
+	// Value is the observed value.
+	Value any
+	// Source is the source key that produced it.
+	Source string
+	// ObservedAt is when the underlying observation was taken, or nil for a source that
+	// is not time-bounded. Inventory is not time-bounded: it is current by definition. A
+	// metric sample very much is.
+	ObservedAt *time.Time
+}
+
+// MergedField is one field after precedence has picked a winner, with its provenance.
+type MergedField struct {
+	Value      any
+	Source     string
+	ObservedAt *time.Time
+}
+
+// age returns how old the observation is at now, and whether it is datable at all.
+func (m MergedField) age(now time.Time) (time.Duration, bool) {
+	if m.ObservedAt == nil {
+		return 0, false
+	}
+	return now.Sub(*m.ObservedAt), true
+}
+
+// SourceResult reports everything one source produced in one collection run.
+type SourceResult struct {
+	// Source is the source key.
+	Source string
+	// Status is how completely it answered.
+	Status SourceStatus
+	// Facts is every fact it produced.
+	Facts []Fact
+	// Detail holds source-specific counters and errors, and lands verbatim in the run
+	// receipt. This is what makes a thin snapshot legible.
+	Detail map[string]any
+	// Errors are per-service or per-query failures worth surfacing on the run.
+	Errors []RunError
+}
+
+// RunError describes one thing that went wrong, scoped to whatever it concerns.
+type RunError struct {
+	Scope       string
+	ServiceName string
+	Code        string
+	Message     string
+}
+
+// precedenceDefaultKey is the key under which the table holds the fallback ordering used
+// by any field that does not name one of its own.
+const precedenceDefaultKey = "default"
+
+// defaultPrecedence declares, per field, which sources may set it and in what order.
+//
+// A source not listed for a field is forbidden from setting it, which is the point: it
+// makes "the probe must never override the exporter's idea of replica-set state" a line
+// in a table rather than a convention someone has to remember.
+//
+//   - version -- metrics first: mongodb_version_info is the running server's own report.
+//     The probe sees the same thing from the node and is the fallback.
+//   - installed_version -- probe only. The binary on disk is invisible to any metric,
+//     and it is the whole upgrade-readiness signal.
+//   - vendor / edition -- mongodb_version_info is the only source of either anywhere.
+//   - endpoint -- member_idx is how the replica set itself addresses the member, which
+//     beats inventory's record of where PMM reached the agent. Inventory stays the
+//     fallback, and is the only source for a mongos, which has no member_idx.
+//   - state -- metrics first, because a member's state as reported through the exporter
+//     covers services the probe cannot reach at all.
+//   - the exporter-only concepts -- reachability, load, role -- name metrics alone.
+var defaultPrecedence = map[string][]string{
+	precedenceDefaultKey: {sourceMetrics, sourceInventory, sourceProbe},
+
+	fieldVersion:          {sourceMetrics, sourceProbe},
+	fieldInstalledVersion: {sourceProbe},
+	fieldConfigPath:       {sourceProbe},
+	fieldArgv:             {sourceProbe},
+	fieldVendor:           {sourceMetrics},
+	fieldEdition:          {sourceMetrics},
+	fieldEndpoint:         {sourceMetrics, sourceInventory},
+	fieldState:            {sourceMetrics, sourceProbe},
+
+	fieldReplicationLag: {sourceMetrics},
+	fieldOplogHead:      {sourceMetrics},
+	fieldOplogTail:      {sourceMetrics},
+
+	fieldExporterUp:      {sourceMetrics},
+	fieldCPUUsage:        {sourceMetrics},
+	fieldConnectionsFree: {sourceMetrics},
+	fieldClusterRole:     {sourceMetrics},
+	fieldIsMongos:        {sourceMetrics},
+}
+
+// mergeFacts folds every source's facts into one merged view per service.
+//
+// For each (service, field) the winner is the fact from the earliest source listed for
+// that field. Facts from a source the field does not list are dropped rather than
+// silently accepted, and a nil value never wins: a source that looked and saw nothing
+// must not shadow one that looked and saw something.
+//
+// Ties at the same rank are broken by recency, which matters more than it sounds. One
+// service can carry several series of the same metric -- a replica-set reconfiguration
+// leaves the superseded mongodb_members_self behind, and it survives in the lookback
+// window alongside the live one. Measured here: one member reported PRIMARY at 0s,
+// SECONDARY at 7500s and PRIMARY at 68477s, all under its current service_id. Without
+// this rule the document takes whichever the query happened to return first, and calls a
+// live primary a secondary.
+func mergeFacts(results []SourceResult, precedence map[string][]string) map[string]map[string]MergedField {
+	merged := make(map[string]map[string]MergedField)
+
+	for _, result := range results {
+		for _, fact := range result.Facts {
+			if fact.Value == nil || fact.Service == "" {
+				continue
+			}
+			order, ok := precedence[fact.Field]
+			if !ok {
+				order = precedence[precedenceDefaultKey]
+			}
+			rank := slices.Index(order, fact.Source)
+			if rank < 0 {
+				continue
+			}
+
+			fields, ok := merged[fact.Service]
+			if !ok {
+				fields = make(map[string]MergedField)
+				merged[fact.Service] = fields
+			}
+			if held, ok := fields[fact.Field]; ok && !supersedes(fact, held, order, rank) {
+				continue
+			}
+			fields[fact.Field] = MergedField{
+				Value:      fact.Value,
+				Source:     fact.Source,
+				ObservedAt: fact.ObservedAt,
+			}
+		}
+	}
+	return merged
+}
+
+// supersedes reports whether an incoming fact should displace the one already held.
+//
+// Rank decides first. At equal rank -- the same source reporting the same field twice,
+// which is what several series for one service look like -- the newer observation wins.
+// An undatable fact never displaces a datable one, and never displaces its own kind:
+// with nothing to compare, first seen stays.
+func supersedes(fact Fact, held MergedField, order []string, rank int) bool {
+	heldRank := slices.Index(order, held.Source)
+	if heldRank != rank {
+		return heldRank > rank
+	}
+	if fact.ObservedAt == nil {
+		return false
+	}
+	if held.ObservedAt == nil {
+		return true
+	}
+	return fact.ObservedAt.After(*held.ObservedAt)
+}
+
+// fieldSet is one service's merged fields plus the freshness rule to read them under.
+//
+// The rule travels with the data rather than sitting in a package variable: it is
+// derived per run from PMM's configured scrape resolution, and a projection that read it
+// from somewhere else could disagree with the collection it is projecting.
+type fieldSet struct {
+	fields map[string]MergedField
+	now    time.Time
+	maxAge time.Duration
+}
+
+// str returns a string field, or "" when it is unset, stale, or of another type.
+func (f fieldSet) str(field string) string {
+	value, ok := f.live(field)
+	if !ok {
+		return ""
+	}
+	s, _ := value.(string)
+	return s
+}
+
+// f64 returns a float field, or nil when it is unset or stale.
+func (f fieldSet) f64(field string) *float64 {
+	value, ok := f.live(field)
+	if !ok {
+		return nil
+	}
+	v, ok := value.(float64)
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
+// truthy reports whether a boolean field is set, fresh and true.
+func (f fieldSet) truthy(field string) bool {
+	value, ok := f.live(field)
+	if !ok {
+		return false
+	}
+	v, _ := value.(bool)
+	return v
+}
+
+// live returns a field's value, dropping it when it is a volatile field whose
+// observation has aged out.
+//
+// This is the half SEP records but does not act on. Facts are collected over a long
+// window and kept with their age -- that is what tells "this service is gone" apart from
+// "this service has not been scraped since Tuesday" -- but a volatile fact past its age
+// must not be read as current. A replica-set state or an up flag from an hour ago is not
+// a fact about now; an edition is.
+func (f fieldSet) live(field string) (any, bool) {
+	held, ok := f.fields[field]
+	if !ok {
+		return nil, false
+	}
+	if !volatileFields[field] {
+		return held.Value, true
+	}
+	age, datable := held.age(f.now)
+	if datable && age > f.maxAge {
+		return nil, false
+	}
+	return held.Value, true
+}
+
+// staleVolatile counts the volatile fields dropped for age, which the run receipt reports
+// so a thin document says why it is thin.
+func (f fieldSet) staleVolatile() int {
+	stale := 0
+	for field, held := range f.fields {
+		if !volatileFields[field] {
+			continue
+		}
+		if age, datable := held.age(f.now); datable && age > f.maxAge {
+			stale++
+		}
+	}
+	return stale
+}

--- a/managed/services/om/facts_test.go
+++ b/managed/services/om/facts_test.go
@@ -1,0 +1,244 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeFacts(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+
+	t.Run("precedence decides, not call order", func(t *testing.T) {
+		t.Parallel()
+
+		// The probe is listed after metrics for version, so it loses however late it runs.
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceProbe, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: "7.0.1", Source: sourceProbe},
+			}},
+			{Source: sourceMetrics, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: "7.0.39", Source: sourceMetrics, ObservedAt: new(now)},
+			}},
+		}, defaultPrecedence)
+
+		require.Contains(t, merged, "s1")
+		assert.Equal(t, "7.0.39", merged["s1"][fieldVersion].Value)
+		assert.Equal(t, sourceMetrics, merged["s1"][fieldVersion].Source)
+	})
+
+	t.Run("the fallback source wins when the preferred one is silent", func(t *testing.T) {
+		t.Parallel()
+
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceInventory, Facts: []Fact{
+				{Service: "s1", Field: fieldEndpoint, Value: "host:27017", Source: sourceInventory},
+			}},
+			{Source: sourceMetrics, Facts: []Fact{}},
+		}, defaultPrecedence)
+
+		assert.Equal(t, "host:27017", merged["s1"][fieldEndpoint].Value)
+		assert.Equal(t, sourceInventory, merged["s1"][fieldEndpoint].Source)
+	})
+
+	t.Run("a source not listed for a field cannot set it", func(t *testing.T) {
+		t.Parallel()
+
+		// exporter_up names metrics alone: reachability is not the probe's to assert.
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceProbe, Facts: []Fact{
+				{Service: "s1", Field: fieldExporterUp, Value: 1.0, Source: sourceProbe},
+			}},
+		}, defaultPrecedence)
+
+		assert.NotContains(t, merged["s1"], fieldExporterUp)
+	})
+
+	t.Run("probe-only fields are reserved and merge untouched", func(t *testing.T) {
+		t.Parallel()
+
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceProbe, Facts: []Fact{
+				{Service: "s1", Field: fieldInstalledVersion, Value: "7.0.40", Source: sourceProbe},
+			}},
+			{Source: sourceMetrics, Facts: []Fact{
+				{Service: "s1", Field: fieldInstalledVersion, Value: "nonsense", Source: sourceMetrics},
+			}},
+		}, defaultPrecedence)
+
+		assert.Equal(t, "7.0.40", merged["s1"][fieldInstalledVersion].Value)
+	})
+
+	t.Run("a nil value never shadows a real one", func(t *testing.T) {
+		t.Parallel()
+
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceMetrics, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: nil, Source: sourceMetrics},
+			}},
+			{Source: sourceProbe, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: "7.0.39", Source: sourceProbe},
+			}},
+		}, defaultPrecedence)
+
+		assert.Equal(t, "7.0.39", merged["s1"][fieldVersion].Value)
+	})
+
+	t.Run("the freshest series wins when one service has several", func(t *testing.T) {
+		t.Parallel()
+
+		// A replica-set reconfiguration leaves the superseded mongodb_members_self behind,
+		// and it survives in the lookback window under the same service_id. Measured in
+		// the sandbox: PRIMARY at 0s, SECONDARY at 7500s, PRIMARY at 68477s. Rank cannot
+		// separate them -- they are all the metrics source -- so recency has to.
+		fresh := now
+		stale := now.Add(-7500 * time.Second)
+		ancient := now.Add(-68477 * time.Second)
+
+		for _, order := range [][]Fact{
+			{
+				{Service: "s1", Field: fieldState, Value: "SECONDARY", Source: sourceMetrics, ObservedAt: new(stale)},
+				{Service: "s1", Field: fieldState, Value: "PRIMARY", Source: sourceMetrics, ObservedAt: new(fresh)},
+				{Service: "s1", Field: fieldState, Value: "PRIMARY", Source: sourceMetrics, ObservedAt: new(ancient)},
+			},
+			// The same facts the other way round: the answer must not depend on the order
+			// VictoriaMetrics happened to return them in.
+			{
+				{Service: "s1", Field: fieldState, Value: "PRIMARY", Source: sourceMetrics, ObservedAt: new(fresh)},
+				{Service: "s1", Field: fieldState, Value: "SECONDARY", Source: sourceMetrics, ObservedAt: new(stale)},
+			},
+		} {
+			merged := mergeFacts([]SourceResult{{Source: sourceMetrics, Facts: order}}, defaultPrecedence)
+			assert.Equal(t, "PRIMARY", merged["s1"][fieldState].Value)
+			assert.Equal(t, fresh, *merged["s1"][fieldState].ObservedAt)
+		}
+	})
+
+	t.Run("a higher-precedence source still wins over a fresher low-precedence one", func(t *testing.T) {
+		t.Parallel()
+
+		// Recency only breaks ties. It must not let the probe outrank metrics for version
+		// just by having looked more recently.
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceMetrics, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: "7.0.39", Source: sourceMetrics, ObservedAt: new(now.Add(-time.Hour))},
+			}},
+			{Source: sourceProbe, Facts: []Fact{
+				{Service: "s1", Field: fieldVersion, Value: "7.0.1", Source: sourceProbe, ObservedAt: new(now)},
+			}},
+		}, defaultPrecedence)
+
+		assert.Equal(t, "7.0.39", merged["s1"][fieldVersion].Value)
+	})
+
+	t.Run("provenance survives the merge", func(t *testing.T) {
+		t.Parallel()
+
+		observed := now.Add(-90 * time.Second)
+		merged := mergeFacts([]SourceResult{
+			{Source: sourceMetrics, Facts: []Fact{
+				{Service: "s1", Field: fieldState, Value: "PRIMARY", Source: sourceMetrics, ObservedAt: new(observed)},
+			}},
+		}, defaultPrecedence)
+
+		held := merged["s1"][fieldState]
+		require.NotNil(t, held.ObservedAt)
+		assert.Equal(t, observed, *held.ObservedAt)
+
+		age, datable := held.age(now)
+		assert.True(t, datable)
+		assert.Equal(t, 90*time.Second, age)
+	})
+}
+
+func TestFieldSetFreshness(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	maxAge := 30 * time.Second
+
+	newFields := func(age time.Duration) fieldSet {
+		observed := now.Add(-age)
+		return fieldSet{
+			now:    now,
+			maxAge: maxAge,
+			fields: map[string]MergedField{
+				// Volatile: only meaningful while fresh.
+				fieldExporterUp: {Value: 1.0, Source: sourceMetrics, ObservedAt: new(observed)},
+				fieldState:      {Value: "PRIMARY", Source: sourceMetrics, ObservedAt: new(observed)},
+				// Durable: describes the service, not the moment.
+				fieldVersion: {Value: "7.0.39", Source: sourceMetrics, ObservedAt: new(observed)},
+				fieldEdition: {Value: "Community", Source: sourceMetrics, ObservedAt: new(observed)},
+			},
+		}
+	}
+
+	t.Run("fresh volatile facts read through", func(t *testing.T) {
+		t.Parallel()
+
+		fields := newFields(5 * time.Second)
+		assert.InDelta(t, 1.0, *fields.f64(fieldExporterUp), 0.001)
+		assert.Equal(t, "PRIMARY", fields.str(fieldState))
+		assert.Zero(t, fields.staleVolatile())
+	})
+
+	t.Run("stale volatile facts are dropped, durable ones are kept", func(t *testing.T) {
+		t.Parallel()
+
+		// This is the case that made a stopped database report UP: the sample survives in
+		// the long lookback window, and only the age says it is not about now.
+		fields := newFields(10 * time.Minute)
+		assert.Nil(t, fields.f64(fieldExporterUp))
+		assert.Empty(t, fields.str(fieldState))
+		assert.Equal(t, "7.0.39", fields.str(fieldVersion), "a version does not go stale")
+		assert.Equal(t, "Community", fields.str(fieldEdition))
+		assert.Equal(t, 2, fields.staleVolatile())
+	})
+
+	t.Run("an undatable fact is never stale", func(t *testing.T) {
+		t.Parallel()
+
+		// Inventory is current by definition and carries no observed_at.
+		fields := fieldSet{
+			now:    now,
+			maxAge: maxAge,
+			fields: map[string]MergedField{
+				fieldEndpoint: {Value: "host:27017", Source: sourceInventory},
+			},
+		}
+		assert.Equal(t, "host:27017", fields.str(fieldEndpoint))
+	})
+
+	t.Run("a missing or mistyped field reads as absent", func(t *testing.T) {
+		t.Parallel()
+
+		fields := fieldSet{
+			now:    now,
+			maxAge: maxAge,
+			fields: map[string]MergedField{fieldVersion: {Value: 42, Source: sourceMetrics}},
+		}
+		assert.Empty(t, fields.str(fieldVersion))
+		assert.Empty(t, fields.str(fieldVendor))
+		assert.Nil(t, fields.f64(fieldCPUUsage))
+		assert.False(t, fields.truthy(fieldIsMongos))
+	})
+}

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -58,12 +58,16 @@ const (
 // Reported as FailedPrecondition rather than Unimplemented or NotFound: the endpoints
 // exist and work, the deployment has simply not been told where SEP is, and that is an
 // operator's action rather than a missing feature.
-func (s *Service) inventoryProbe() (*probeSource, error) {
+//
+// Returns sepApp, not *probeSource: the inventory handlers below only ever need to call
+// against om_inventory, never any of probeSource's own factSource behaviour, and holding
+// the narrower handle is what keeps this file from knowing probeSource exists at all.
+func (s *Service) inventoryProbe() (sepApp, error) {
 	if s.probe == nil {
-		return nil, status.Error(codes.FailedPrecondition,
+		return sepApp{}, status.Error(codes.FailedPrecondition,
 			"SEP is not configured; set PMM_SEP_URL and PMM_SEP_TOKEN to reach the inventory app")
 	}
-	return s.probe, nil
+	return s.probe.app, nil
 }
 
 // ListInventoryHosts returns every host the inventory app has a row for.

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -93,7 +93,8 @@ func (s *Service) ListInventoryHosts(ctx context.Context, req *omv1.ListInventor
 
 	hosts := []sepHost{}
 	call := inventoryCall{method: http.MethodGet, path: "hosts", query: query}
-	if err := probe.call(ctx, call, &hosts); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &hosts)
+	if err != nil {
 		return nil, err
 	}
 
@@ -113,7 +114,8 @@ func (s *Service) GetInventoryHost(ctx context.Context, req *omv1.GetInventoryHo
 
 	host := sepHost{}
 	call := inventoryCall{method: http.MethodGet, path: inventoryPath("hosts", req.GetNodeId())}
-	if err := probe.call(ctx, call, &host); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &host)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.GetInventoryHostResponse{Host: inventoryHostToProto(host)}, nil
@@ -131,7 +133,8 @@ func (s *Service) DeleteInventoryHost(ctx context.Context, req *omv1.DeleteInven
 	}
 
 	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("hosts", req.GetNodeId())}
-	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, nil)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.DeleteInventoryHostResponse{}, nil
@@ -154,7 +157,8 @@ func (s *Service) ListInventoryServices(ctx context.Context, req *omv1.ListInven
 
 	services := []sepService{}
 	call := inventoryCall{method: http.MethodGet, path: "services", query: query}
-	if err := probe.call(ctx, call, &services); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &services)
+	if err != nil {
 		return nil, err
 	}
 
@@ -174,7 +178,8 @@ func (s *Service) GetInventoryService(ctx context.Context, req *omv1.GetInventor
 
 	service := sepService{}
 	call := inventoryCall{method: http.MethodGet, path: inventoryPath("services", req.GetServiceId())}
-	if err := probe.call(ctx, call, &service); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &service)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.GetInventoryServiceResponse{Service: inventoryServiceToProto(service)}, nil
@@ -188,7 +193,8 @@ func (s *Service) DeleteInventoryService(ctx context.Context, req *omv1.DeleteIn
 	}
 
 	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("services", req.GetServiceId())}
-	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, nil)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.DeleteInventoryServiceResponse{}, nil
@@ -223,7 +229,8 @@ func (s *Service) ListInventoryRuns(ctx context.Context, req *omv1.ListInventory
 
 	runs := []sepRun{}
 	call := inventoryCall{method: http.MethodGet, path: "runs", query: query}
-	if err := probe.call(ctx, call, &runs); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &runs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -243,7 +250,8 @@ func (s *Service) GetInventoryRun(ctx context.Context, req *omv1.GetInventoryRun
 
 	run := sepRun{}
 	call := inventoryCall{method: http.MethodGet, path: inventoryPath("runs", req.GetRunId())}
-	if err := probe.call(ctx, call, &run); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &run)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.GetInventoryRunResponse{
@@ -285,7 +293,8 @@ func (s *Service) TriggerInventoryRefresh(ctx context.Context, req *omv1.Trigger
 		Scope     []string `json:"scope"`
 	}{}
 	call := inventoryCall{method: http.MethodPost, path: "runs", body: body}
-	if err := probe.call(ctx, call, &accepted); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &accepted)
+	if err != nil {
 		return nil, err
 	}
 
@@ -311,7 +320,8 @@ func (s *Service) GetInventoryConfig(ctx context.Context, _ *omv1.GetInventoryCo
 
 	settings := []sepSetting{}
 	call := inventoryCall{method: http.MethodGet, path: "config"}
-	if err := probe.call(ctx, call, &settings); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &settings)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.GetInventoryConfigResponse{Settings: inventorySettingsToProto(settings)}, nil
@@ -399,7 +409,8 @@ func (s *Service) UpdateInventoryConfig(ctx context.Context, req *omv1.UpdateInv
 
 	applied := []sepSetting{}
 	call := inventoryCall{method: http.MethodPatch, path: "config", body: req.GetValues().AsMap()}
-	if err := probe.call(ctx, call, &applied); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, &applied)
+	if err != nil {
 		return nil, err
 	}
 
@@ -438,7 +449,8 @@ func (s *Service) DeleteInventoryConfigOverride(
 	}
 
 	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("config", req.GetKey())}
-	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+	err = probe.call(ctx, call, nil)
+	if err != nil {
 		return nil, err
 	}
 	return &omv1.DeleteInventoryConfigOverrideResponse{}, nil

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -1,0 +1,808 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+)
+
+// The /v1/om/inventory/* handlers: SEP's estate, served through PMM.
+//
+// Two different things are called a "run" one path segment apart, so they are mounted
+// apart on purpose. /v1/om/topology/runs is PMM's *own* collection pass -- inventory
+// plus VictoriaMetrics, a tenth of a second, never touches a host. /v1/om/inventory/runs
+// dispatches a Nomad job per host and takes tens of seconds. Nothing but the path tells
+// a caller which one they are about to start, which is why the surface does.
+//
+// The projection below is deliberately dull. Everything interesting about the estate --
+// what counts as failing, when a row is stale, which of three ways an executor is
+// unusable -- was decided in the app, and re-deciding any of it here would give a reader
+// two answers to the same question.
+
+// defaultInventoryRunLimit is what a caller who passes no limit gets, and
+// maxInventoryRunLimit is the most one can ask for. The ceiling exists because the value
+// is forwarded to SEP verbatim: without it a caller could ask the inventory app for an
+// unbounded page and wait on it through this proxy.
+const (
+	defaultInventoryRunLimit = 20
+	maxInventoryRunLimit     = 200
+)
+
+// inventoryProbe returns the configured SEP client, or an error saying it is not.
+//
+// Reported as FailedPrecondition rather than Unimplemented or NotFound: the endpoints
+// exist and work, the deployment has simply not been told where SEP is, and that is an
+// operator's action rather than a missing feature.
+func (s *Service) inventoryProbe() (*probeSource, error) {
+	if s.probe == nil {
+		return nil, status.Error(codes.FailedPrecondition,
+			"SEP is not configured; set PMM_SEP_URL and PMM_SEP_TOKEN to reach the inventory app")
+	}
+	return s.probe, nil
+}
+
+// ListInventoryHosts returns every host the inventory app has a row for.
+func (s *Service) ListInventoryHosts(ctx context.Context, req *omv1.ListInventoryHostsRequest) (*omv1.ListInventoryHostsResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if req.HasService != nil {
+		query.Set("has_service", strconv.FormatBool(req.GetHasService()))
+	}
+	if req.Failing != nil {
+		query.Set("failing", strconv.FormatBool(req.GetFailing()))
+	}
+	if req.Executor != nil {
+		query.Set("executor", strconv.FormatBool(req.GetExecutor()))
+	}
+
+	hosts := []sepHost{}
+	call := inventoryCall{method: http.MethodGet, path: "hosts", query: query}
+	if err := probe.call(ctx, call, &hosts); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	response := &omv1.ListInventoryHostsResponse{Hosts: make([]*omv1.InventoryHost, 0, len(hosts))}
+	for _, host := range hosts {
+		response.Hosts = append(response.Hosts, inventoryHostToProto(host))
+	}
+	return response, nil
+}
+
+// GetInventoryHost returns one host.
+func (s *Service) GetInventoryHost(ctx context.Context, req *omv1.GetInventoryHostRequest) (*omv1.GetInventoryHostResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	host := sepHost{}
+	call := inventoryCall{method: http.MethodGet, path: inventoryPath("hosts", req.GetNodeId())}
+	if err := probe.call(ctx, call, &host); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.GetInventoryHostResponse{Host: inventoryHostToProto(host)}, nil
+}
+
+// DeleteInventoryHost forgets a host and the services on it.
+//
+// Not suppression: an entity PMM still knows about returns on the next refresh. It is
+// for rows left behind when a node was replaced -- restarting a pmm-agent runs
+// `setup --force`, which mints a new node ID, so OM gains a row and keeps the old one.
+func (s *Service) DeleteInventoryHost(ctx context.Context, req *omv1.DeleteInventoryHostRequest) (*omv1.DeleteInventoryHostResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("hosts", req.GetNodeId())}
+	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.DeleteInventoryHostResponse{}, nil
+}
+
+// ListInventoryServices returns every service the inventory app has a row for.
+func (s *Service) ListInventoryServices(ctx context.Context, req *omv1.ListInventoryServicesRequest) (*omv1.ListInventoryServicesResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if nodeID := req.GetNodeId(); nodeID != "" {
+		query.Set("node_id", nodeID)
+	}
+	if req.Failing != nil {
+		query.Set("failing", strconv.FormatBool(req.GetFailing()))
+	}
+
+	services := []sepService{}
+	call := inventoryCall{method: http.MethodGet, path: "services", query: query}
+	if err := probe.call(ctx, call, &services); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	response := &omv1.ListInventoryServicesResponse{Services: make([]*omv1.InventoryService, 0, len(services))}
+	for _, service := range services {
+		response.Services = append(response.Services, inventoryServiceToProto(service))
+	}
+	return response, nil
+}
+
+// GetInventoryService returns one service.
+func (s *Service) GetInventoryService(ctx context.Context, req *omv1.GetInventoryServiceRequest) (*omv1.GetInventoryServiceResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	service := sepService{}
+	call := inventoryCall{method: http.MethodGet, path: inventoryPath("services", req.GetServiceId())}
+	if err := probe.call(ctx, call, &service); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.GetInventoryServiceResponse{Service: inventoryServiceToProto(service)}, nil
+}
+
+// DeleteInventoryService forgets one service.
+func (s *Service) DeleteInventoryService(ctx context.Context, req *omv1.DeleteInventoryServiceRequest) (*omv1.DeleteInventoryServiceResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("services", req.GetServiceId())}
+	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.DeleteInventoryServiceResponse{}, nil
+}
+
+// ListInventoryRuns returns the inventory app's refresh history.
+func (s *Service) ListInventoryRuns(ctx context.Context, req *omv1.ListInventoryRunsRequest) (*omv1.ListInventoryRunsResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	limit := req.GetLimit()
+	switch {
+	case limit <= 0:
+		limit = defaultInventoryRunLimit
+	case limit > maxInventoryRunLimit:
+		limit = maxInventoryRunLimit
+	}
+	query := url.Values{"limit": []string{strconv.FormatInt(int64(limit), 10)}}
+
+	runs := []sepRun{}
+	call := inventoryCall{method: http.MethodGet, path: "runs", query: query}
+	if err := probe.call(ctx, call, &runs); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	response := &omv1.ListInventoryRunsResponse{Runs: make([]*omv1.InventoryRun, 0, len(runs))}
+	for _, run := range runs {
+		response.Runs = append(response.Runs, inventoryRunToProto(run))
+	}
+	return response, nil
+}
+
+// GetInventoryRun returns one refresh.
+func (s *Service) GetInventoryRun(ctx context.Context, req *omv1.GetInventoryRunRequest) (*omv1.GetInventoryRunResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	run := sepRun{}
+	call := inventoryCall{method: http.MethodGet, path: inventoryPath("runs", req.GetRunId())}
+	if err := probe.call(ctx, call, &run); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.GetInventoryRunResponse{
+		Run:      inventoryRunToProto(run),
+		Entities: inventoryRunEntitiesToProto(run.Nodes),
+	}, nil
+}
+
+// TriggerInventoryRefresh probes the estate, or the named hosts within it.
+//
+// Returns as soon as the refresh is accepted. Conflict is judged per host on the app's
+// side, so a scoped refresh is not refused merely because the scheduled sweep happens to
+// be running -- only because something else already holds one of the same hosts.
+func (s *Service) TriggerInventoryRefresh(ctx context.Context, req *omv1.TriggerInventoryRefreshRequest) (*omv1.TriggerInventoryRefreshResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	// Node IDs pass through untranslated: PMM's node ID is also the app's key, which is
+	// the whole point of keying the estate on it.
+	//
+	// Materialised as an empty slice rather than passed through nil. Go marshals a nil
+	// slice as JSON `null`, and the app types the field `list[str]` with an empty
+	// default -- so `null` is a validation failure, not "no scope". Left as-is, every
+	// full-estate refresh through this proxy would have answered 422 while a scoped one
+	// worked, which is the shape of bug that gets diagnosed as "the trigger is broken
+	// sometimes".
+	nodeIDs := req.GetNodeIds()
+	if nodeIDs == nil {
+		nodeIDs = []string{}
+	}
+	body := map[string]any{"node_ids": nodeIDs}
+
+	accepted := struct {
+		RunID     string   `json:"run_id"`
+		Status    string   `json:"status"`
+		StartedAt *string  `json:"started_at"`
+		Scope     []string `json:"scope"`
+	}{}
+	call := inventoryCall{method: http.MethodPost, path: "runs", body: body}
+	if err := probe.call(ctx, call, &accepted); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	response := &omv1.TriggerInventoryRefreshResponse{
+		RunId:  accepted.RunID,
+		Status: sepRunStatusToProto(accepted.Status),
+		Scope:  accepted.Scope,
+	}
+	if accepted.StartedAt != nil {
+		if parsed := parseSepTime(*accepted.StartedAt); parsed != nil {
+			response.StartTime = parsed
+		}
+	}
+	return response, nil
+}
+
+// GetInventoryConfig returns the inventory app's configuration.
+func (s *Service) GetInventoryConfig(ctx context.Context, _ *omv1.GetInventoryConfigRequest) (*omv1.GetInventoryConfigResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	settings := []sepSetting{}
+	call := inventoryCall{method: http.MethodGet, path: "config"}
+	if err := probe.call(ctx, call, &settings); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.GetInventoryConfigResponse{Settings: inventorySettingsToProto(settings)}, nil
+}
+
+// Bounds on the shape of an update batch, not on its meaning.
+//
+// The app owns which keys exist and what values are legal, so these do not duplicate its
+// rules -- they bound how much structure may cross the hop at all. Both are orders of
+// magnitude above any real batch: the settings class this proxies has ten fields and
+// nests one level, SCHEDULE and its children.
+//
+// They are needed because neither hop bounds them. Measured against this tree:
+// protojson accepts 200k fields in a 2.3MB body, inside the 4MB default gRPC message
+// size, and nests to just under 10k before refusing. The app on the far side is Python,
+// where the default recursion limit is 1000, so forwarding either would make PMM the
+// thing that broke SEP. This endpoint is admin-only, which makes it a footgun rather
+// than an attack, but a 200k-key batch is an accident worth refusing by name.
+const (
+	maxConfigFields = 100
+	maxConfigDepth  = 10
+)
+
+// validateConfigValues refuses a batch that is empty, too wide, or too deeply nested.
+func validateConfigValues(values *structpb.Struct) error {
+	fields := values.GetFields()
+	switch {
+	case len(fields) == 0:
+		return status.Error(codes.InvalidArgument, "values must name at least one field to change")
+	case len(fields) > maxConfigFields:
+		return status.Errorf(codes.InvalidArgument,
+			"values names %d fields, at most %d may change in one call", len(fields), maxConfigFields)
+	}
+	for key, value := range fields {
+		if exceedsDepth(value, maxConfigDepth-1) {
+			return status.Errorf(codes.InvalidArgument,
+				"values.%s nests deeper than %d levels", key, maxConfigDepth)
+		}
+	}
+	return nil
+}
+
+// exceedsDepth reports whether value nests deeper than limit.
+//
+// It stops at the limit rather than measuring the true depth, so its own recursion is
+// bounded by maxConfigDepth however deep the input goes.
+func exceedsDepth(value *structpb.Value, limit int) bool {
+	if limit <= 0 {
+		return value.GetStructValue() != nil || value.GetListValue() != nil
+	}
+	for _, field := range value.GetStructValue().GetFields() {
+		if exceedsDepth(field, limit-1) {
+			return true
+		}
+	}
+	for _, element := range value.GetListValue().GetValues() {
+		if exceedsDepth(element, limit-1) {
+			return true
+		}
+	}
+	return false
+}
+
+// UpdateInventoryConfig applies a batch of configuration changes.
+//
+// The batch is passed through as the app received it and the app decides what is valid,
+// which is what keeps one set of validation rules rather than two. A single bad field
+// rejects the whole batch there and nothing is written. Only the batch's shape is
+// checked here, by validateConfigValues.
+//
+// PUT here, PATCH to the app below, deliberately. PMM's API guidelines require the
+// standard Update method to be PUT and every other update in this repo is one; SEP
+// reaches the same overrides through a generic settings router that PATCHes
+// `/{setting_class}` for every app, so the verb there is not this app's to pick.
+// Translating one method is what a proxy is for.
+func (s *Service) UpdateInventoryConfig(ctx context.Context, req *omv1.UpdateInventoryConfigRequest) (*omv1.UpdateInventoryConfigResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+	err = validateConfigValues(req.GetValues())
+	if err != nil {
+		return nil, err
+	}
+
+	applied := []sepSetting{}
+	call := inventoryCall{method: http.MethodPatch, path: "config", body: req.GetValues().AsMap()}
+	if err := probe.call(ctx, call, &applied); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+
+	// Read the whole configuration back rather than returning the rows the app echoed.
+	//
+	// Two reasons, and the second is the one that matters. The guidelines require an
+	// Update to answer with the resource, not a diff. And the app answers with one row per
+	// key *named in the request*, which is misleading for a nested write: overriding
+	// SCHEDULE as a whole object changes what SCHEDULE__every effectively resolves to, and
+	// no row says so. A caller that trusted the echo would render a stale child beside a
+	// fresh parent.
+	//
+	// This also retires the rule the UI had to follow -- "re-read after a write, never
+	// echo the submitted value" -- by doing it once here, for every caller rather than
+	// only the ones that remembered.
+	current := []sepSetting{}
+	read := inventoryCall{method: http.MethodGet, path: "config"}
+	err = probe.call(ctx, read, &current)
+	if err != nil {
+		// The write landed; only the read-back failed. Reporting an error here would tell
+		// a caller to retry a change that already applied, so answer with the narrower
+		// body the app gave us and log the shortfall.
+		s.l.Warnf("inventory config updated, but reading it back failed: %s", err)
+		return &omv1.UpdateInventoryConfigResponse{Settings: inventorySettingsToProto(applied)}, nil
+	}
+	return &omv1.UpdateInventoryConfigResponse{Settings: inventorySettingsToProto(current)}, nil
+}
+
+// DeleteInventoryConfigOverride reverts one field to its deployed value.
+func (s *Service) DeleteInventoryConfigOverride(
+	ctx context.Context, req *omv1.DeleteInventoryConfigOverrideRequest,
+) (*omv1.DeleteInventoryConfigOverrideResponse, error) {
+	probe, err := s.inventoryProbe()
+	if err != nil {
+		return nil, err
+	}
+
+	call := inventoryCall{method: http.MethodDelete, path: inventoryPath("config", req.GetKey())}
+	if err := probe.call(ctx, call, nil); err != nil { //nolint:noinlineerr
+		return nil, err
+	}
+	return &omv1.DeleteInventoryConfigOverrideResponse{}, nil
+}
+
+// inventoryHostToProto projects one host row for the wire.
+func inventoryHostToProto(host sepHost) *omv1.InventoryHost {
+	out := &omv1.InventoryHost{
+		NodeId:              host.NodeID,
+		Name:                host.Name,
+		Address:             optionalString(host.Address),
+		ExecutorHost:        optionalString(host.ExecutorHost),
+		Os:                  observedString(host.Observed, "os"),
+		Kernel:              observedString(host.Observed, "kernel"),
+		Executor:            executorToProto(host.Observed),
+		UnregisteredMongods: unregisteredMongodsToProto(host.Observed),
+		Observed:            observedToStruct(host.Observed),
+		Freshness:           freshnessToProto(host.sepFreshness),
+		Services:            make([]*omv1.InventoryService, 0, len(host.Services)),
+	}
+	for _, service := range host.Services {
+		out.Services = append(out.Services, inventoryServiceToProto(service))
+	}
+	return out
+}
+
+// inventoryServiceToProto projects one service row for the wire.
+func inventoryServiceToProto(service sepService) *omv1.InventoryService {
+	return &omv1.InventoryService{
+		ServiceId:        service.ServiceID,
+		NodeId:           service.NodeID,
+		Name:             service.Name,
+		Port:             optionalInt32(service.Port),
+		Role:             optionalString(service.Role),
+		InstalledVersion: observedString(service.Observed, "installed_version"),
+		RunningVersion:   observedString(service.Observed, "version"),
+		ConfigPath:       observedString(service.Observed, "config_path"),
+		Argv:             observedString(service.Observed, "argv"),
+		ProbeStatus:      observedString(service.Observed, "probe_status"),
+		ServerRunning:    observedBool(service.Observed, "server_running"),
+		UptimeSeconds:    observedDouble(service.Observed, "uptime_seconds"),
+		ReplicationSet:   observedString(service.Observed, "replication_set"),
+		Observed:         observedToStruct(service.Observed),
+		Freshness:        freshnessToProto(service.sepFreshness),
+	}
+}
+
+// inventoryRunToProto projects one refresh for the wire.
+func inventoryRunToProto(run sepRun) *omv1.InventoryRun {
+	return &omv1.InventoryRun{
+		RunId:     run.RunID,
+		Status:    sepRunStatusToProto(run.Status),
+		StartTime: optionalTimestamp(run.StartedAt),
+		EndTime:   optionalTimestamp(run.FinishedAt),
+		Counts: &omv1.InventoryRunCounts{
+			TotalServices:    run.Counts.ServicesTotal,
+			ResolvedServices: run.Counts.ServicesResolved,
+			OrphanedServices: run.Counts.ServicesOrphaned,
+			AnsweredServices: run.Counts.ServicesAnswered,
+			TotalHosts:       run.Counts.HostsTotal,
+			ProbeableHosts:   run.Counts.HostsProbeable,
+			AnsweredHosts:    run.Counts.HostsAnswered,
+		},
+		Scope: run.Scope,
+		Error: optionalString(run.Error),
+	}
+}
+
+// inventoryRunEntitiesToProto projects what a refresh attempted, one row per host.
+//
+// Host-oriented, because a refresh attempts hosts: a flat service list cannot show a
+// machine carrying a PMM client and no database, which is the case OM most exists to
+// describe. Each host carries the services on it, and empty is a meaningful answer.
+//
+// Outcomes only: which host, matched how, answered or not, how long, and the error.
+// What the probe found belongs to the estate, which is upserted and stays current --
+// carrying it here as well would be a second copy that goes stale the moment the next
+// refresh runs.
+func inventoryRunEntitiesToProto(nodes []sepRunNode) []*omv1.InventoryRunEntity {
+	entities := make([]*omv1.InventoryRunEntity, 0, len(nodes))
+	for _, node := range nodes {
+		services := make([]*omv1.InventoryRunEntityService, 0, len(node.Services))
+		for _, service := range node.Services {
+			services = append(services, &omv1.InventoryRunEntityService{
+				ServiceId:   optionalString(service.ServiceID),
+				ServiceName: optionalString(service.ServiceName),
+				Answered:    service.Answered,
+				Error:       optionalString(service.Error),
+			})
+		}
+		entities = append(entities, &omv1.InventoryRunEntity{
+			NodeId:          node.NodeID,
+			HostName:        optionalString(node.HostName),
+			ExecutorHost:    optionalString(node.ExecutorHost),
+			Resolution:      sepResolutionToProto(node.Resolution),
+			Answered:        node.Answered,
+			DurationSeconds: optionalDouble(node.Duration),
+			Error:           optionalString(node.Error),
+			Services:        services,
+		})
+	}
+	return entities
+}
+
+// inventorySettingsToProto projects the configuration rows for the wire.
+func inventorySettingsToProto(settings []sepSetting) []*omv1.InventorySetting {
+	out := make([]*omv1.InventorySetting, 0, len(settings))
+	for _, setting := range settings {
+		out = append(out, &omv1.InventorySetting{
+			Key:          setting.Key,
+			Value:        anyToValue(setting.Value),
+			DefaultValue: anyToValue(setting.DefaultValue),
+			Type:         setting.Type,
+			Reload:       sepReloadToProto(setting.Reload),
+			HasOverride:  setting.HasOverride,
+			IsAdvanced:   setting.IsAdvanced,
+			Description:  optionalString(setting.Description),
+		})
+	}
+	return out
+}
+
+// freshnessToProto projects the freshness block.
+func freshnessToProto(f sepFreshness) *omv1.InventoryFreshness {
+	return &omv1.InventoryFreshness{
+		FirstSeenAt:         optionalTimestamp(f.FirstSeenAt),
+		LastAttemptAt:       optionalTimestamp(f.LastAttemptAt),
+		LastSuccessAt:       optionalTimestamp(f.LastSuccessAt),
+		FailingSince:        optionalTimestamp(f.FailingSince),
+		ConsecutiveFailures: clampInt32(f.ConsecutiveFailures),
+		LastError:           optionalString(f.LastError),
+	}
+}
+
+// executorToProto lifts the executor block out of the host document.
+//
+// Returns nil when the app reported none, which is not the same as three false flags:
+// absent means "this sweep did not say", while false means "SEP looked and the answer
+// was no".
+func executorToProto(observed map[string]any) *omv1.InventoryExecutor {
+	nested, ok := observed["executor"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := &omv1.InventoryExecutor{}
+	if value, ok := nested["registered"].(bool); ok {
+		out.Registered = value
+	}
+	if value, ok := nested["reachable"].(bool); ok {
+		out.Reachable = value
+	}
+	if value, ok := nested["driver_healthy"].(bool); ok {
+		out.DriverHealthy = value
+	}
+	if value, ok := nested["detail"].(string); ok && value != "" {
+		out.Detail = &value
+	}
+	return out
+}
+
+// unregisteredMongodsToProto lifts the stranger list out of the host document.
+func unregisteredMongodsToProto(observed map[string]any) []*omv1.UnregisteredMongod {
+	entries, ok := observed["unregistered_mongods"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]*omv1.UnregisteredMongod, 0, len(entries))
+	for _, entry := range entries {
+		fields, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		out = append(out, &omv1.UnregisteredMongod{
+			Port:       observedInt32(fields, "port"),
+			ConfigPath: observedString(fields, "config_path"),
+			Argv:       observedString(fields, "argv"),
+			Program:    observedString(fields, "program"),
+			Pid:        observedInt32(fields, "pid"),
+		})
+	}
+	return out
+}
+
+// observedToStruct carries the whole document through untyped.
+//
+// The point of the app storing observations as JSON is that collecting a new attribute
+// is a payload change rather than a schema change. Enumerating every attribute as a
+// proto field would put that coupling back, so the fields above are the ones a table
+// sorts by and this is everything: a new attribute shows up in a detail panel the day it
+// is collected, and is promoted to a field only when something wants to sort by it.
+//
+// The collected_at key is dropped: it is metadata about the document rather than an observation,
+// and the freshness block already carries the same instant with a name that says so.
+func observedToStruct(observed map[string]any) *structpb.Struct {
+	if len(observed) == 0 {
+		return nil
+	}
+	filtered := make(map[string]any, len(observed))
+	for key, value := range observed {
+		if key == observedCollectedAt {
+			continue
+		}
+		filtered[key] = value
+	}
+	encoded, err := structpb.NewStruct(filtered)
+	if err != nil {
+		// Not fatal: the typed fields above are already extracted, and losing the detail
+		// panel is better than failing the whole listing over one unrepresentable value.
+		return nil
+	}
+	return encoded
+}
+
+// anyToValue wraps one decoded JSON value, or nil when it cannot be represented.
+func anyToValue(value any) *structpb.Value {
+	encoded, err := structpb.NewValue(value)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+// observedString reads one string attribute out of a document.
+//
+// Empty and absent are deliberately merged: a missing key and a key holding "" both
+// return nil, so the field is omitted from the response either way. For what these read
+// -- a config path, an argv, an OS name -- an empty string carries no more information
+// than no string at all, and collapsing them keeps the column from showing a blank cell
+// that a reader has to interpret.
+//
+// The pointer is what makes that omission reachable at all: protojson drops an unset
+// `optional` scalar entirely, even under EmitUnpopulated.
+func observedString(observed map[string]any, key string) *string {
+	value, ok := observed[key].(string)
+	if !ok || value == "" {
+		return nil
+	}
+	return &value
+}
+
+// clampInt32 narrows a count that arrived as a JSON number.
+//
+// SEP's counter is decoded into an int, which is 64-bit here, so a plain conversion could
+// wrap and report a negative number of consecutive failures. Saturating instead keeps the
+// column monotonic: a reader learns "very many", never "minus two billion".
+func clampInt32(value int) int32 {
+	switch {
+	case value > math.MaxInt32:
+		return math.MaxInt32
+	case value < math.MinInt32:
+		return math.MinInt32
+	}
+	return int32(value)
+}
+
+// observedBool reads one boolean attribute out of a document.
+func observedBool(observed map[string]any, key string) *bool {
+	value, ok := observed[key].(bool)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+// observedDouble reads one numeric attribute out of a document.
+func observedDouble(observed map[string]any, key string) *float64 {
+	value, ok := observed[key].(float64)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+// observedInt32 reads one integer attribute out of a document.
+//
+// JSON numbers decode as float64, so this narrows rather than asserts -- and a value that
+// will not fit is dropped rather than wrapped. Both callers are a port and a PID, where a
+// wrapped result reads as a plausible one: absent says "not collected", 4295 says a port
+// something is listening on.
+func observedInt32(observed map[string]any, key string) *int32 {
+	value, ok := observed[key].(float64)
+	if !ok {
+		return nil
+	}
+	if math.IsNaN(value) || value < math.MinInt32 || value > math.MaxInt32 {
+		return nil
+	}
+	narrowed := int32(value)
+	return &narrowed
+}
+
+// optionalString wraps a nullable string.
+func optionalString(value *string) *string {
+	if value == nil || *value == "" {
+		return nil
+	}
+	return value
+}
+
+// optionalInt32 wraps a nullable integer.
+func optionalInt32(value *int32) *int32 {
+	if value == nil {
+		return nil
+	}
+	return value
+}
+
+// optionalTimestamp wraps a nullable instant.
+func optionalTimestamp(value *time.Time) *timestamppb.Timestamp {
+	if value == nil {
+		return nil
+	}
+	return timestamppb.New(*value)
+}
+
+// parseSepTime parses one of the app's timestamps, tolerating either spelling.
+//
+// The app serves RFC 3339, but whether the offset is `Z` or `+00:00` depends on which
+// column it came from, and a run's started_at has been seen both ways.
+func parseSepTime(stamp string) *timestamppb.Timestamp {
+	parsed, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return nil
+	}
+	return timestamppb.New(parsed)
+}
+
+// The app's vocabularies, mapped onto the wire enums.
+//
+// Separate from store.go's mappers even where the values coincide, because these translate
+// a *different* system's strings: the app owns them, they arrive over HTTP, and a value OM
+// has never heard of is a real possibility rather than a corrupted row. Every one of these
+// falls through to UNSPECIFIED, which is how "the app said something new" reaches a caller
+// as an unknown rather than as a plausible wrong answer.
+
+// sepRunStatusToProto maps the app's run status onto the wire enum.
+func sepRunStatusToProto(status string) omv1.RunStatus {
+	switch status {
+	case "running":
+		return omv1.RunStatus_RUN_STATUS_RUNNING
+	case "success":
+		return omv1.RunStatus_RUN_STATUS_SUCCESS
+	case "partial":
+		return omv1.RunStatus_RUN_STATUS_PARTIAL
+	case "failed":
+		return omv1.RunStatus_RUN_STATUS_FAILED
+	case "skipped":
+		return omv1.RunStatus_RUN_STATUS_SKIPPED
+	default:
+		return omv1.RunStatus_RUN_STATUS_UNSPECIFIED
+	}
+}
+
+// sepResolutionToProto maps how the app matched a host to an executor client.
+func sepResolutionToProto(resolution string) omv1.ExecutorResolution {
+	switch resolution {
+	case "name":
+		return omv1.ExecutorResolution_EXECUTOR_RESOLUTION_NAME
+	case "address":
+		return omv1.ExecutorResolution_EXECUTOR_RESOLUTION_ADDRESS
+	case "orphaned":
+		return omv1.ExecutorResolution_EXECUTOR_RESOLUTION_ORPHANED
+	default:
+		return omv1.ExecutorResolution_EXECUTOR_RESOLUTION_UNSPECIFIED
+	}
+}
+
+// sepReloadToProto maps a setting's reload class.
+//
+// Mirrors ReloadClassification in the app's settings registry one-for-one. Collapsing
+// nested_only into "not overridable" was the tempting simplification and it is wrong: a
+// nested parent rejects a whole-object write while its children accept one, so a form
+// reading the parent would refuse to edit a leaf the API accepts.
+func sepReloadToProto(reload string) omv1.SettingReload {
+	switch reload {
+	case "hot":
+		return omv1.SettingReload_SETTING_RELOAD_HOT
+	case "nested_only":
+		return omv1.SettingReload_SETTING_RELOAD_NESTED_ONLY
+	case "not_overridable":
+		return omv1.SettingReload_SETTING_RELOAD_NOT_OVERRIDABLE
+	default:
+		return omv1.SettingReload_SETTING_RELOAD_UNSPECIFIED
+	}
+}

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -47,10 +47,13 @@ import (
 // defaultInventoryRunLimit is what a caller who passes no limit gets, and
 // maxInventoryRunLimit is the most one can ask for. The ceiling exists because the value
 // is forwarded to SEP verbatim: without it a caller could ask the inventory app for an
-// unbounded page and wait on it through this proxy.
+// unbounded page and wait on it through this proxy. Matches the proto's own
+// ListInventoryRunsRequest.limit validation (lte: 100) and SEP's le=100 -- any of the
+// three drifting from the others makes one of them dead code, since the request has to
+// clear all of them to reach the database.
 const (
 	defaultInventoryRunLimit = 20
-	maxInventoryRunLimit     = 200
+	maxInventoryRunLimit     = 100
 )
 
 // inventoryProbe returns the configured SEP client, or an error saying it is not.

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -198,6 +198,11 @@ func (s *Service) ListInventoryRuns(ctx context.Context, req *omv1.ListInventory
 		return nil, err
 	}
 
+	since, until := req.GetSince(), req.GetUntil()
+	if since != nil && until != nil && until.AsTime().Before(since.AsTime()) {
+		return nil, status.Error(codes.InvalidArgument, "until must not be before since")
+	}
+
 	limit := req.GetLimit()
 	switch {
 	case limit <= 0:
@@ -206,6 +211,12 @@ func (s *Service) ListInventoryRuns(ctx context.Context, req *omv1.ListInventory
 		limit = maxInventoryRunLimit
 	}
 	query := url.Values{"limit": []string{strconv.FormatInt(int64(limit), 10)}}
+	if since != nil {
+		query.Set("since", since.AsTime().UTC().Format(time.RFC3339Nano))
+	}
+	if until != nil {
+		query.Set("until", until.AsTime().UTC().Format(time.RFC3339Nano))
+	}
 
 	runs := []sepRun{}
 	call := inventoryCall{method: http.MethodGet, path: "runs", query: query}

--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -502,7 +502,9 @@ func inventoryRunToProto(run sepRun) *omv1.InventoryRun {
 // Outcomes only: which host, matched how, answered or not, how long, and the error.
 // What the probe found belongs to the estate, which is upserted and stays current --
 // carrying it here as well would be a second copy that goes stale the moment the next
-// refresh runs.
+// refresh runs. TaskHistoryID is the one exception, and not a contradiction of that
+// rule: it carries no observation, only a pointer to where the dispatch's raw output
+// -- the observations that were deliberately *not* kept here -- can still be read.
 func inventoryRunEntitiesToProto(nodes []sepRunNode) []*omv1.InventoryRunEntity {
 	entities := make([]*omv1.InventoryRunEntity, 0, len(nodes))
 	for _, node := range nodes {
@@ -522,6 +524,7 @@ func inventoryRunEntitiesToProto(nodes []sepRunNode) []*omv1.InventoryRunEntity 
 			Resolution:      sepResolutionToProto(node.Resolution),
 			Answered:        node.Answered,
 			DurationSeconds: optionalDouble(node.Duration),
+			TaskHistoryId:   node.TaskHistoryID,
 			Error:           optionalString(node.Error),
 			Services:        services,
 		})

--- a/managed/services/om/inventory_client.go
+++ b/managed/services/om/inventory_client.go
@@ -184,7 +184,8 @@ func (a sepApp) call(ctx context.Context, c inventoryCall, out any) error {
 	if out == nil || resp.StatusCode == http.StatusNoContent {
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil { //nolint:noinlineerr
+	err = json.NewDecoder(resp.Body).Decode(out)
+	if err != nil {
 		return status.Errorf(codes.Internal, "failed to decode the inventory app's answer: %s", err)
 	}
 	return nil
@@ -224,7 +225,8 @@ func sepStatusError(resp *http.Response) error {
 // sepErrorDetail extracts something readable from the app's error body.
 func sepErrorDetail(resp *http.Response) string {
 	var envelope sepError
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil || envelope.Detail == nil { //nolint:noinlineerr
+	err := json.NewDecoder(resp.Body).Decode(&envelope)
+	if err != nil || envelope.Detail == nil {
 		return resp.Status
 	}
 	if text, ok := envelope.Detail.(string); ok {

--- a/managed/services/om/inventory_client.go
+++ b/managed/services/om/inventory_client.go
@@ -1,0 +1,271 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// This file is the client half of the inventory proxy: the shapes SEP's om_inventory
+// app serves, and one place that speaks HTTP to it.
+//
+// It exists because the browser must not hold a SEP bearer. A page that talks to SEP
+// directly needs one minted from the PMM session, which means the page is gated on SEP
+// being up, configured and willing to exchange the token -- and it fails closed, so a
+// sick SEP blanks the page rather than showing an estate with an error on it. Proxying
+// here costs a second hop and buys "SEP is unreachable" as an error *inside* a page
+// that still renders.
+
+// inventoryRequestTimeout bounds a proxied request.
+//
+// Every path here is a database read on the other side; the one that starts work,
+// POST /runs, returns as soon as the run row is written and does not wait for the Nomad
+// jobs. So nothing behind this endpoint should take seconds, and one that does is a
+// sign the app is unwell rather than busy.
+const inventoryRequestTimeout = 15 * time.Second
+
+// sepFreshness is the freshness block both estate rows carry.
+type sepFreshness struct {
+	FirstSeenAt         *time.Time `json:"first_seen_at"`
+	LastAttemptAt       *time.Time `json:"last_attempt_at"`
+	LastSuccessAt       *time.Time `json:"last_success_at"`
+	FailingSince        *time.Time `json:"failing_since"`
+	ConsecutiveFailures int        `json:"consecutive_failures"`
+	LastError           *string    `json:"last_error"`
+}
+
+// sepService is one row of GET /services, and of the `services` list on a host.
+type sepService struct {
+	sepFreshness
+
+	ServiceID string         `json:"service_id"`
+	NodeID    string         `json:"node_id"`
+	Name      string         `json:"name"`
+	Port      *int32         `json:"port"`
+	Role      *string        `json:"role"`
+	Observed  map[string]any `json:"observed"`
+}
+
+// sepHost is one row of GET /hosts.
+type sepHost struct {
+	sepFreshness
+
+	NodeID       string         `json:"node_id"`
+	Name         string         `json:"name"`
+	Address      *string        `json:"address"`
+	ExecutorHost *string        `json:"executor_host"`
+	Observed     map[string]any `json:"observed"`
+	Services     []sepService   `json:"services"`
+}
+
+// sepRunCounts is what one refresh saw.
+type sepRunCounts struct {
+	ServicesTotal    int32 `json:"services_total"`
+	ServicesResolved int32 `json:"services_resolved"`
+	ServicesOrphaned int32 `json:"services_orphaned"`
+	ServicesAnswered int32 `json:"services_answered"`
+	HostsTotal       int32 `json:"hosts_total"`
+	HostsProbeable   int32 `json:"hosts_probeable"`
+	HostsAnswered    int32 `json:"hosts_answered"`
+}
+
+// sepRun is one row of GET /runs.
+type sepRun struct {
+	RunID      string       `json:"run_id"`
+	Status     string       `json:"status"`
+	StartedAt  *time.Time   `json:"started_at"`
+	FinishedAt *time.Time   `json:"finished_at"`
+	Counts     sepRunCounts `json:"counts"`
+	Scope      []string     `json:"scope"`
+	Error      *string      `json:"error"`
+	// Only the detail endpoint fills this; the list omits it.
+	Nodes []sepRunNode `json:"nodes"`
+}
+
+// sepRunNode is one host a refresh attempted, from GET /runs/{id}.
+type sepRunNode struct {
+	NodeID       string              `json:"node_id"`
+	HostName     *string             `json:"host_name"`
+	ExecutorHost *string             `json:"executor_host"`
+	Resolution   string              `json:"resolution"`
+	Answered     bool                `json:"answered"`
+	Duration     *float64            `json:"duration_seconds"`
+	Error        *string             `json:"error"`
+	Services     []sepRunNodeService `json:"services"`
+}
+
+// sepRunNodeService is one service on such a host.
+type sepRunNodeService struct {
+	ServiceID   *string `json:"service_id"`
+	ServiceName *string `json:"service_name"`
+	Answered    bool    `json:"answered"`
+	Error       *string `json:"error"`
+}
+
+// sepSetting is one row of GET /config.
+type sepSetting struct {
+	Key          string  `json:"key"`
+	Value        any     `json:"value"`
+	DefaultValue any     `json:"default_value"`
+	Type         string  `json:"type"`
+	Reload       string  `json:"reload"`
+	HasOverride  bool    `json:"has_override"`
+	IsAdvanced   bool    `json:"is_advanced"`
+	Description  *string `json:"description"`
+}
+
+// sepError is FastAPI's error envelope.
+//
+// `detail` is a string for the app's own errors and a list of per-field objects for a
+// validation failure, so it is decoded as `any` and rendered rather than typed.
+type sepError struct {
+	Detail any `json:"detail"`
+}
+
+// inventoryCall describes one proxied request.
+type inventoryCall struct {
+	method string
+	path   string
+	query  url.Values
+	// body is marshalled as JSON when non-nil. A nil body on a POST still sends `{}`
+	// when sendEmptyBody is set, because the app's trigger endpoint takes an optional
+	// object and FastAPI rejects a bodyless POST against a typed body.
+	body          any
+	sendEmptyBody bool
+}
+
+// call performs one proxied request and decodes the answer into out.
+//
+// The out parameter may be nil for a DELETE, whose 204 carries none. Errors come back as gRPC status
+// errors with the code the gateway will turn back into the status SEP gave, so a 404
+// from the app reaches the browser as a 404 rather than as a 500 about a 404.
+func (s probeSource) call(ctx context.Context, c inventoryCall, out any) error {
+	ctx, cancel := context.WithTimeout(ctx, inventoryRequestTimeout)
+	defer cancel()
+
+	endpoint := s.endpoint(c.path)
+	if len(c.query) > 0 {
+		endpoint += "?" + c.query.Encode()
+	}
+
+	var payload []byte
+	switch {
+	case c.body != nil:
+		encoded, err := json.Marshal(c.body)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to encode the request: %s", err)
+		}
+		payload = encoded
+	case c.sendEmptyBody:
+		payload = []byte("{}")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, c.method, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to build the request: %s", err)
+	}
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return status.Errorf(codes.Unavailable, "the inventory app is unreachable: %s", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return sepStatusError(resp)
+	}
+	if out == nil || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil { //nolint:noinlineerr
+		return status.Errorf(codes.Internal, "failed to decode the inventory app's answer: %s", err)
+	}
+	return nil
+}
+
+// sepStatusError turns the app's error response into a gRPC status error.
+//
+// The mapping is chosen so the gateway reproduces the app's own status where it can:
+// 404 stays 404 and 409 stays 409, because "no such host" and "another refresh already
+// holds this host" are both answers a caller acts on differently from a failure.
+//
+// The one exception is 422: gRPC has no code the gateway renders as 422, so a validation
+// failure arrives as InvalidArgument and the browser sees 400. The app's per-field
+// detail is carried through in the message rather than dropped, which is what the UI
+// needs to render inline errors; only the status number is lost.
+func sepStatusError(resp *http.Response) error {
+	detail := sepErrorDetail(resp)
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return status.Error(codes.NotFound, detail)
+	case http.StatusConflict:
+		return status.Error(codes.Aborted, detail)
+	case http.StatusUnprocessableEntity, http.StatusBadRequest:
+		return status.Error(codes.InvalidArgument, detail)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// Deliberately not passed through as-is: a 401 from PMM's own gateway means the
+		// *caller* is unauthenticated, and reflecting the app's 401 would tell the
+		// browser to re-authenticate against PMM when what actually failed is PMM's
+		// credential for SEP. That is an operator's problem, so it reads as one.
+		return status.Errorf(codes.Internal,
+			"PMM's credential for the inventory app was rejected (%s): %s", resp.Status, detail)
+	default:
+		return status.Errorf(codes.Internal, "the inventory app answered %s: %s", resp.Status, detail)
+	}
+}
+
+// sepErrorDetail extracts something readable from the app's error body.
+func sepErrorDetail(resp *http.Response) string {
+	var envelope sepError
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil || envelope.Detail == nil { //nolint:noinlineerr
+		return resp.Status
+	}
+	if text, ok := envelope.Detail.(string); ok {
+		return text
+	}
+	encoded, err := json.Marshal(envelope.Detail)
+	if err != nil {
+		return resp.Status
+	}
+	return string(encoded)
+}
+
+// inventoryPath joins path segments under the app, escaping each one.
+//
+// Escaping matters: an ID reaching here is PMM's, not the app's, and nothing guarantees
+// it is free of characters that would change which path it addresses.
+func inventoryPath(segments ...string) string {
+	escaped := make([]string, 0, len(segments))
+	for _, segment := range segments {
+		escaped = append(escaped, url.PathEscape(segment))
+	}
+	return strings.Join(escaped, "/")
+}

--- a/managed/services/om/inventory_client.go
+++ b/managed/services/om/inventory_client.go
@@ -107,14 +107,15 @@ type sepRun struct {
 
 // sepRunNode is one host a refresh attempted, from GET /runs/{id}.
 type sepRunNode struct {
-	NodeID       string              `json:"node_id"`
-	HostName     *string             `json:"host_name"`
-	ExecutorHost *string             `json:"executor_host"`
-	Resolution   string              `json:"resolution"`
-	Answered     bool                `json:"answered"`
-	Duration     *float64            `json:"duration_seconds"`
-	Error        *string             `json:"error"`
-	Services     []sepRunNodeService `json:"services"`
+	NodeID        string              `json:"node_id"`
+	HostName      *string             `json:"host_name"`
+	ExecutorHost  *string             `json:"executor_host"`
+	Resolution    string              `json:"resolution"`
+	Answered      bool                `json:"answered"`
+	Duration      *float64            `json:"duration_seconds"`
+	TaskHistoryID *int64              `json:"task_history_id"`
+	Error         *string             `json:"error"`
+	Services      []sepRunNodeService `json:"services"`
 }
 
 // sepRunNodeService is one service on such a host.

--- a/managed/services/om/inventory_client.go
+++ b/managed/services/om/inventory_client.go
@@ -16,7 +16,6 @@
 package om
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -29,7 +28,9 @@ import (
 )
 
 // This file is the client half of the inventory proxy: the shapes SEP's om_inventory
-// app serves, and one place that speaks HTTP to it.
+// app serves, and the estate-specific decoding of its answers. The transport itself --
+// where SEP is, the bearer token, the request/response mechanics -- is sep_client.go,
+// shared with every other SEP-backed source in this package.
 //
 // It exists because the browser must not hold a SEP bearer. A page that talks to SEP
 // directly needs one minted from the PMM session, which means the page is gated on SEP
@@ -161,39 +162,16 @@ type inventoryCall struct {
 // The out parameter may be nil for a DELETE, whose 204 carries none. Errors come back as gRPC status
 // errors with the code the gateway will turn back into the status SEP gave, so a 404
 // from the app reaches the browser as a 404 rather than as a 500 about a 404.
-func (s probeSource) call(ctx context.Context, c inventoryCall, out any) error {
+func (a sepApp) call(ctx context.Context, c inventoryCall, out any) error {
 	ctx, cancel := context.WithTimeout(ctx, inventoryRequestTimeout)
 	defer cancel()
 
-	endpoint := s.endpoint(c.path)
-	if len(c.query) > 0 {
-		endpoint += "?" + c.query.Encode()
-	}
-
-	var payload []byte
-	switch {
-	case c.body != nil:
-		encoded, err := json.Marshal(c.body)
-		if err != nil {
-			return status.Errorf(codes.Internal, "failed to encode the request: %s", err)
-		}
-		payload = encoded
-	case c.sendEmptyBody:
-		payload = []byte("{}")
-	}
-
-	req, err := http.NewRequestWithContext(ctx, c.method, endpoint, bytes.NewReader(payload))
+	req, err := a.request(ctx, c.method, c.path, c.query, c.body, c.sendEmptyBody)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to build the request: %s", err)
 	}
-	if s.token != "" {
-		req.Header.Set("Authorization", "Bearer "+s.token)
-	}
-	if payload != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
 
-	resp, err := s.client.Do(req)
+	resp, err := a.client.http.Do(req)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "the inventory app is unreachable: %s", err)
 	}

--- a/managed/services/om/inventory_test.go
+++ b/managed/services/om/inventory_test.go
@@ -707,15 +707,16 @@ func TestInventoryRunDetailIsHostOriented(t *testing.T) {
 	  "nodes": [
 	    {"node_id": "n1", "host_name": "db00", "executor_host": "db00",
 	     "resolution": "name", "answered": true, "duration_seconds": 12.5,
-	     "error": null,
+	     "task_history_id": 4711, "error": null,
 	     "services": [{"service_id": "s1", "service_name": "mongo-1",
 	                   "answered": true, "error": null}]},
 	    {"node_id": "n2", "host_name": "pmm-client-node00",
 	     "executor_host": "pmm-client-node00", "resolution": "name",
-	     "answered": true, "duration_seconds": 8.0, "error": null, "services": []},
+	     "answered": true, "duration_seconds": 8.0, "task_history_id": null,
+	     "error": null, "services": []},
 	    {"node_id": "n3", "host_name": "stranded", "executor_host": null,
 	     "resolution": "orphaned", "answered": false, "duration_seconds": null,
-	     "error": "no executor host", "services": []}
+	     "task_history_id": null, "error": "no executor host", "services": []}
 	  ]
 	}`)
 
@@ -728,6 +729,9 @@ func TestInventoryRunDetailIsHostOriented(t *testing.T) {
 	assert.Equal(t, "db00", withDatabase.GetHostName())
 	assert.True(t, withDatabase.GetAnswered())
 	assert.InDelta(t, 12.5, withDatabase.GetDurationSeconds(), 0.001)
+	// The pointer to this attempt's raw output -- the observations deliberately not
+	// kept on the receipt itself.
+	assert.Equal(t, int64(4711), withDatabase.GetTaskHistoryId())
 	require.Len(t, withDatabase.GetServices(), 1)
 	assert.Equal(t, "mongo-1", withDatabase.GetServices()[0].GetServiceName())
 
@@ -749,6 +753,7 @@ func TestInventoryRunDetailIsHostOriented(t *testing.T) {
 	// the key altogether, which is the wire form the UI reads as absent.
 	assert.Nil(t, orphan.ExecutorHost)
 	assert.Nil(t, orphan.DurationSeconds)
+	assert.Nil(t, orphan.TaskHistoryId)
 	assert.Equal(t, "no executor host", orphan.GetError())
 }
 

--- a/managed/services/om/inventory_test.go
+++ b/managed/services/om/inventory_test.go
@@ -138,7 +138,8 @@ func newSEPStubSeq(t *testing.T, code int, bodies ...string) *sepStub {
 	stub := &sepStub{bodies: bodies}
 	stub.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		call := stubCall{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery}
-		if raw, err := io.ReadAll(r.Body); err == nil { //nolint:noinlineerr
+		raw, err := io.ReadAll(r.Body)
+		if err == nil {
 			call.body = string(raw)
 		}
 		stub.method, stub.path, stub.query, stub.body = call.method, call.path, call.query, call.body

--- a/managed/services/om/inventory_test.go
+++ b/managed/services/om/inventory_test.go
@@ -1,0 +1,790 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+)
+
+// hostsBody is one om_inventory GET /hosts answer.
+//
+// Two hosts on purpose, because the pair is the whole reason the host table exists.
+// `n1` runs a registered database and reports an unregistered mongod beside it -- the
+// arbiter case, which PMM registers no service for, so nothing else in OM would mention
+// the process. `n2` carries a PMM client and no database at all, which is the case a
+// service-keyed inventory cannot represent.
+const hostsBody = `[
+  {
+    "node_id": "n1", "name": "db00", "address": "10.0.0.1", "executor_host": "db00",
+    "observed": {
+      "collected_at": "2026-08-18T09:00:00+00:00",
+      "os": "Ubuntu 24.04.3 LTS",
+      "kernel": "6.17.0-35-generic",
+      "executor": {"registered": true, "reachable": true, "driver_healthy": true, "detail": null},
+      "unregistered_mongods": [
+        {"pid": 10, "port": 27018, "program": "mongod",
+         "argv": "/usr/bin/mongod --config /etc/mongod-node.conf",
+         "config_path": "/etc/mongod-node.conf"}
+      ]
+    },
+    "first_seen_at": "2026-08-18T08:00:00Z", "last_attempt_at": "2026-08-18T09:00:00Z",
+    "last_success_at": "2026-08-18T09:00:00Z", "failing_since": null,
+    "consecutive_failures": 0, "last_error": null,
+    "services": [
+      {
+        "service_id": "s1", "node_id": "n1", "name": "mongo-1", "port": 27017, "role": "PRIMARY",
+        "observed": {
+          "collected_at": "2026-08-18T09:00:00+00:00",
+          "installed_version": "7.0.40-22", "version": "7.0.39-21",
+          "config_path": "/etc/mongod-node.conf",
+          "argv": "/usr/bin/mongod --config /etc/mongod-node.conf",
+          "probe_status": "ok", "server_running": true, "uptime_seconds": 11699,
+          "replication_set": "rs0"
+        },
+        "first_seen_at": "2026-08-18T08:00:00Z", "last_attempt_at": "2026-08-18T09:00:00Z",
+        "last_success_at": "2026-08-18T09:00:00Z", "failing_since": null,
+        "consecutive_failures": 0, "last_error": null
+      }
+    ]
+  },
+  {
+    "node_id": "n2", "name": "pmm-client-node00", "address": "10.0.0.2", "executor_host": null,
+    "observed": {},
+    "first_seen_at": "2026-08-18T08:00:00Z", "last_attempt_at": "2026-08-18T09:00:00Z",
+    "last_success_at": null, "failing_since": "2026-08-18T08:30:00Z",
+    "consecutive_failures": 3, "last_error": "no executor host",
+    "services": []
+  }
+]`
+
+// configBody is one om_inventory GET /config answer, trimmed to the two rows that make
+// the point: a nested schedule leaf and a field the deployment owns outright.
+const configBody = `[
+  {"key": "SCHEDULE__every", "value": 10, "default_value": null, "type": "int",
+   "reload": "hot", "has_override": false, "is_advanced": false, "description": null},
+  {"key": "CREDENTIALS_PATH", "value": null, "default_value": null, "type": "str",
+   "reload": "not_overridable", "has_override": false, "is_advanced": false,
+   "description": null}
+]`
+
+// stubCall is one request the stub was asked to serve.
+type stubCall struct {
+	method string
+	path   string
+	query  string
+	body   string
+}
+
+// sepStub stands in for the inventory app, recording what it was asked.
+type sepStub struct {
+	server *httptest.Server
+
+	method string
+	path   string
+	query  string
+	body   string
+
+	// calls records every request in order. The fields above keep only the last, which
+	// is enough for a handler that makes one call and wrong for one that writes and then
+	// reads back.
+	calls []stubCall
+	// bodies, when set, is served one entry per request so a read-after-write can be
+	// given a different answer from the write itself. The last entry repeats once
+	// exhausted.
+	bodies []string
+}
+
+// newSEPStub serves one canned answer and records the request that fetched it.
+func newSEPStub(t *testing.T, code int, body string) *sepStub {
+	t.Helper()
+
+	return newSEPStubSeq(t, code, body)
+}
+
+// newSEPStubSeq serves one canned answer per request, in order.
+func newSEPStubSeq(t *testing.T, code int, bodies ...string) *sepStub {
+	t.Helper()
+
+	stub := &sepStub{bodies: bodies}
+	stub.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := stubCall{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery}
+		if raw, err := io.ReadAll(r.Body); err == nil { //nolint:noinlineerr
+			call.body = string(raw)
+		}
+		stub.method, stub.path, stub.query, stub.body = call.method, call.path, call.query, call.body
+		body := ""
+		if len(stub.bodies) > 0 {
+			body = stub.bodies[min(len(stub.calls), len(stub.bodies)-1)]
+		}
+		stub.calls = append(stub.calls, call)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(stub.server.Close)
+	return stub
+}
+
+// service returns an OM service wired to the stub.
+func (s *sepStub) service(t *testing.T) *Service {
+	t.Helper()
+
+	svc := &Service{l: logrus.WithField("test", t.Name())}
+	return svc.WithProbeSource(s.server.URL, "test-token")
+}
+
+func TestInventoryNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	// An unconfigured SEP is a deployment that has not been told where SEP is, not a
+	// missing feature and not a broken app. FailedPrecondition says so; NotFound would
+	// read as "there is no such endpoint" and send the reader looking for a version
+	// problem.
+	svc := &Service{l: logrus.WithField("test", t.Name())}
+
+	_, err := svc.ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestListInventoryHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("projects both hosts", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+
+		require.NoError(t, err)
+		require.Len(t, response.GetHosts(), 2)
+		assert.Equal(t, "/api/apps/om_inventory/hosts", stub.path)
+	})
+
+	t.Run("promotes the attributes a table sorts by", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		host := response.GetHosts()[0]
+		assert.Equal(t, "n1", host.GetNodeId())
+		assert.Equal(t, "Ubuntu 24.04.3 LTS", host.GetOs())
+		assert.Equal(t, "6.17.0-35-generic", host.GetKernel())
+		assert.Equal(t, "db00", host.GetExecutorHost())
+	})
+
+	t.Run("carries the whole document for a detail panel", func(t *testing.T) {
+		t.Parallel()
+
+		// The app stores observations as JSON so a new attribute is a payload change
+		// rather than a schema change. Enumerating every attribute as a proto field
+		// would put that coupling straight back, so anything without a field of its own
+		// still has to arrive.
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		observed := response.GetHosts()[0].GetObserved().GetFields()
+		assert.Contains(t, observed, "unregistered_mongods")
+		assert.NotContains(t, observed, observedCollectedAt,
+			"collected_at is metadata about the document; freshness already carries the instant")
+	})
+
+	t.Run("reports an unregistered mongod on its host", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		strangers := response.GetHosts()[0].GetUnregisteredMongods()
+		require.Len(t, strangers, 1)
+		assert.Equal(t, int32(27018), strangers[0].GetPort())
+		assert.Equal(t, "/etc/mongod-node.conf", strangers[0].GetConfigPath())
+	})
+
+	t.Run("splits the executor state three ways", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		executor := response.GetHosts()[0].GetExecutor()
+		require.NotNil(t, executor)
+		assert.True(t, executor.GetRegistered())
+		assert.True(t, executor.GetReachable())
+		assert.True(t, executor.GetDriverHealthy())
+	})
+
+	t.Run("a host with no probe reports absent, not false", func(t *testing.T) {
+		t.Parallel()
+
+		// Three false flags would claim SEP looked and the answer was no. A nil block
+		// says this sweep did not say, which is what an empty document means.
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		empty := response.GetHosts()[1]
+		assert.Nil(t, empty.GetExecutor())
+		assert.Nil(t, empty.GetObserved())
+		assert.Empty(t, empty.GetServices(), "a host with no database is a row, not an omission")
+	})
+
+	t.Run("a failing host carries why and since when", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+		response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+		require.NoError(t, err)
+
+		freshness := response.GetHosts()[1].GetFreshness()
+		assert.Equal(t, int32(3), freshness.GetConsecutiveFailures())
+		assert.Equal(t, "no executor host", freshness.GetLastError())
+		assert.NotNil(t, freshness.GetFailingSince())
+		assert.Nil(t, freshness.GetLastSuccessAt(),
+			"never having answered is different from having answered nothing")
+	})
+
+	t.Run("passes the filters through", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, `[]`)
+
+		// Addressable locals rather than a helper: these are proto3 `optional` bools, so
+		// what the request carries is a plain *bool, and false has to be distinguishable
+		// from unset -- which is the whole point of the three assertions below.
+		hasService, failing, executor := false, true, false
+
+		_, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{
+			HasService: &hasService,
+			Failing:    &failing,
+			Executor:   &executor,
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, stub.query, "has_service=false")
+		assert.Contains(t, stub.query, "failing=true")
+		// The app types this one bool as well: it filters on whether an executor is
+		// matched at all, not on which client. A host name here is a 422 from the app,
+		// which is what this assertion used to require.
+		assert.Contains(t, stub.query, "executor=false")
+	})
+
+	t.Run("an unset filter is not sent as false", func(t *testing.T) {
+		t.Parallel()
+
+		// has_service=false means "only hosts with no database", which is a very
+		// different listing from the default. Sending it because the caller said nothing
+		// would silently hide every host that has one.
+		stub := newSEPStub(t, http.StatusOK, `[]`)
+
+		_, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+
+		require.NoError(t, err)
+		assert.Empty(t, stub.query)
+	})
+}
+
+func TestInventoryServiceProjection(t *testing.T) {
+	t.Parallel()
+
+	stub := newSEPStub(t, http.StatusOK, hostsBody)
+
+	response, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+	require.NoError(t, err)
+
+	services := response.GetHosts()[0].GetServices()
+	require.Len(t, services, 1)
+	service := services[0]
+
+	// installed_version against running version is the whole reason the probe exists:
+	// their divergence is the upgraded-but-not-restarted case, and no metric carries it.
+	assert.Equal(t, "7.0.40-22", service.GetInstalledVersion())
+	assert.Equal(t, "7.0.39-21", service.GetRunningVersion())
+	assert.Equal(t, "PRIMARY", service.GetRole())
+	assert.Equal(t, int32(27017), service.GetPort())
+	assert.Equal(t, "ok", service.GetProbeStatus())
+	assert.True(t, service.GetServerRunning())
+	assert.InDelta(t, 11699.0, service.GetUptimeSeconds(), 0.001)
+	assert.Equal(t, "rs0", service.GetReplicationSet())
+}
+
+func TestTriggerInventoryRefresh(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes node ids through untranslated", func(t *testing.T) {
+		t.Parallel()
+
+		// The whole argument for keying the estate on PMM's node ID is that no
+		// translation step exists. If one appeared here, it would be the bug that
+		// argument was meant to prevent.
+		stub := newSEPStub(t, http.StatusAccepted,
+			`{"run_id": "r1", "status": "running", "started_at": "2026-08-18T09:00:00Z", "scope": ["n1"]}`)
+
+		response, err := stub.service(t).TriggerInventoryRefresh(t.Context(),
+			&omv1.TriggerInventoryRefreshRequest{NodeIds: []string{"n1"}})
+
+		require.NoError(t, err)
+		assert.Equal(t, "r1", response.GetRunId())
+		assert.Equal(t, []string{"n1"}, response.GetScope())
+		assert.JSONEq(t, `{"node_ids": ["n1"]}`, stub.body)
+		assert.Equal(t, http.MethodPost, stub.method)
+	})
+
+	t.Run("no scope means the whole estate", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusAccepted,
+			`{"run_id": "r2", "status": "running", "started_at": "2026-08-18T09:00:00Z", "scope": null}`)
+
+		response, err := stub.service(t).TriggerInventoryRefresh(t.Context(),
+			&omv1.TriggerInventoryRefreshRequest{})
+
+		require.NoError(t, err)
+		assert.Empty(t, response.GetScope())
+		assert.JSONEq(t, `{"node_ids": []}`, stub.body)
+	})
+
+	t.Run("a held host answers 409, not 500", func(t *testing.T) {
+		t.Parallel()
+
+		// Conflict is an answer a caller acts on -- wait, or refresh something else --
+		// so it has to survive the hop as a conflict. Aborted is the code the gateway
+		// renders as 409.
+		stub := newSEPStub(t, http.StatusConflict,
+			`{"detail": "Probe run abc is already refreshing n1"}`)
+
+		_, err := stub.service(t).TriggerInventoryRefresh(t.Context(),
+			&omv1.TriggerInventoryRefreshRequest{NodeIds: []string{"n1"}})
+
+		require.Error(t, err)
+		assert.Equal(t, codes.Aborted, status.Code(err))
+		assert.Contains(t, status.Convert(err).Message(), "already refreshing n1")
+	})
+}
+
+func TestInventoryErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		code  int
+		body  string
+		want  codes.Code
+		hides bool
+	}{
+		{
+			name: "a missing host stays missing",
+			code: http.StatusNotFound,
+			body: `{"detail": "No host with node_id n9"}`,
+			want: codes.NotFound,
+		},
+		{
+			name: "a validation failure is the caller's fault",
+			code: http.StatusUnprocessableEntity,
+			body: `{"detail": [{"loc": ["SCHEDULE__every"], "msg": "must be positive"}]}`,
+			want: codes.InvalidArgument,
+		},
+		{
+			// PMM's credential being rejected is an operator's problem, not the
+			// browser's. Reflecting the app's 401 would tell the browser to
+			// re-authenticate against PMM, which would not fix anything.
+			name:  "a rejected credential does not read as the caller's",
+			code:  http.StatusUnauthorized,
+			body:  `{"detail": "Not authenticated"}`,
+			want:  codes.Internal,
+			hides: true,
+		},
+		{
+			name: "anything else is internal",
+			code: http.StatusInternalServerError,
+			body: `{"detail": "boom"}`,
+			want: codes.Internal,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stub := newSEPStub(t, tc.code, tc.body)
+
+			_, err := stub.service(t).GetInventoryHost(t.Context(),
+				&omv1.GetInventoryHostRequest{NodeId: "n9"})
+
+			require.Error(t, err)
+			assert.Equal(t, tc.want, status.Code(err))
+			if tc.hides {
+				assert.Contains(t, status.Convert(err).Message(), "PMM's credential")
+			}
+		})
+	}
+}
+
+func TestInventoryDeleteSendsDelete(t *testing.T) {
+	t.Parallel()
+
+	stub := newSEPStub(t, http.StatusNoContent, ``)
+
+	_, err := stub.service(t).DeleteInventoryHost(t.Context(),
+		&omv1.DeleteInventoryHostRequest{NodeId: "n1"})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodDelete, stub.method)
+	assert.Equal(t, "/api/apps/om_inventory/hosts/n1", stub.path)
+}
+
+func TestInventoryConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports every field and where its value came from", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, configBody)
+
+		response, err := stub.service(t).GetInventoryConfig(t.Context(), &omv1.GetInventoryConfigRequest{})
+
+		require.NoError(t, err)
+		require.Len(t, response.GetSettings(), 2)
+
+		schedule := response.GetSettings()[0]
+		assert.Equal(t, "SCHEDULE__every", schedule.GetKey())
+		assert.InDelta(t, 10.0, schedule.GetValue().GetNumberValue(), 0.001)
+		assert.Equal(t, omv1.SettingReload_SETTING_RELOAD_HOT, schedule.GetReload())
+		assert.False(t, schedule.GetHasOverride())
+
+		// A field the deployment owns outright is listed rather than hidden, so a UI can
+		// show it greyed out instead of leaving the reader to wonder where it went.
+		assert.Equal(t, omv1.SettingReload_SETTING_RELOAD_NOT_OVERRIDABLE, response.GetSettings()[1].GetReload())
+	})
+
+	t.Run("a change is passed through as the app will validate it", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusOK, configBody)
+		values, err := structpb.NewStruct(map[string]any{"SCHEDULE__every": 25})
+		require.NoError(t, err)
+
+		_, err = stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.NoError(t, err)
+		require.Len(t, stub.calls, 2, "the write, then the read-back")
+		assert.Equal(t, http.MethodPatch, stub.calls[0].method, "the app's own verb, not PMM's PUT")
+		assert.JSONEq(t, `{"SCHEDULE__every": 25}`, stub.calls[0].body)
+	})
+
+	t.Run("the answer is the whole configuration, not the submitted keys", func(t *testing.T) {
+		t.Parallel()
+
+		// The app answers a PATCH with one row per key *named in the request*. That is
+		// misleading for a nested write -- overriding a parent moves what its children
+		// resolve to, and no row says so -- so the handler reads the configuration back
+		// and answers with that. The two canned bodies differ precisely so this asserts
+		// which one was returned.
+		applied := `[{"key": "SCHEDULE__every", "value": 25, "default_value": null,
+		              "type": "int", "reload": "hot", "has_override": true,
+		              "is_advanced": false, "description": null}]`
+		stub := newSEPStubSeq(t, http.StatusOK, applied, configBody)
+		values, err := structpb.NewStruct(map[string]any{"SCHEDULE__every": 25})
+		require.NoError(t, err)
+
+		response, err := stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.NoError(t, err)
+		require.Len(t, stub.calls, 2)
+		assert.Equal(t, http.MethodGet, stub.calls[1].method)
+		assert.Equal(t, "/api/apps/om_inventory/config", stub.calls[1].path)
+		// Two rows, from the read-back -- not the one row the write echoed.
+		require.Len(t, response.GetSettings(), 2)
+		assert.Equal(t, "CREDENTIALS_PATH", response.GetSettings()[1].GetKey())
+	})
+
+	t.Run("a failed read-back does not report the write as failed", func(t *testing.T) {
+		t.Parallel()
+
+		// The write landed. Answering with an error would tell a caller to retry a change
+		// that already applied, so the narrower body is served instead.
+		applied := `[{"key": "SCHEDULE__every", "value": 25, "default_value": null,
+		              "type": "int", "reload": "hot", "has_override": true,
+		              "is_advanced": false, "description": null}]`
+		stub := newSEPStubSeq(t, http.StatusOK, applied, `not json`)
+		values, err := structpb.NewStruct(map[string]any{"SCHEDULE__every": 25})
+		require.NoError(t, err)
+
+		response, err := stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.NoError(t, err)
+		require.Len(t, response.GetSettings(), 1)
+		assert.Equal(t, "SCHEDULE__every", response.GetSettings()[0].GetKey())
+	})
+
+	t.Run("an empty batch is refused here", func(t *testing.T) {
+		t.Parallel()
+
+		// Not forwarded: an empty PATCH would succeed on the app's side and change
+		// nothing, so a caller who built the body wrongly would see success.
+		stub := newSEPStub(t, http.StatusOK, configBody)
+
+		_, err := stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{})
+
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Empty(t, stub.method, "nothing should have been sent")
+	})
+
+	t.Run("a batch wider than the settings class is refused here", func(t *testing.T) {
+		t.Parallel()
+
+		// Nothing bounds this on either hop: protojson takes 200k fields inside the 4MB
+		// gRPC default, and the app would then attempt every one of them.
+		stub := newSEPStub(t, http.StatusOK, configBody)
+		wide := map[string]any{}
+		for i := 0; i <= maxConfigFields; i++ {
+			wide["KEY_"+strconv.Itoa(i)] = i
+		}
+		values, err := structpb.NewStruct(wide)
+		require.NoError(t, err)
+
+		_, err = stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "at most 100 may change in one call")
+		assert.Empty(t, stub.method, "nothing should have been sent")
+	})
+
+	t.Run("a batch nested deeper than the app can parse is refused here", func(t *testing.T) {
+		t.Parallel()
+
+		// The app is Python, where the default recursion limit is 1000, while protojson
+		// accepts nesting just short of 10k. Forwarding that would make PMM the thing
+		// that broke SEP.
+		stub := newSEPStub(t, http.StatusOK, configBody)
+		nested := map[string]any{"leaf": 1}
+		for range maxConfigDepth + 1 {
+			nested = map[string]any{"SCHEDULE": nested}
+		}
+		values, err := structpb.NewStruct(nested)
+		require.NoError(t, err)
+
+		_, err = stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		assert.Contains(t, err.Error(), "nests deeper than 10 levels")
+		assert.Empty(t, stub.method, "nothing should have been sent")
+	})
+
+	t.Run("the nesting a real batch uses is not refused", func(t *testing.T) {
+		t.Parallel()
+
+		// The bounds must not touch what the settings class actually looks like: a
+		// whole-object write of SCHEDULE, which is the deepest legitimate shape.
+		stub := newSEPStub(t, http.StatusOK, configBody)
+		values, err := structpb.NewStruct(map[string]any{
+			"SCHEDULE": map[string]any{"every": 25, "period": "seconds"},
+		})
+		require.NoError(t, err)
+
+		_, err = stub.service(t).UpdateInventoryConfig(t.Context(),
+			&omv1.UpdateInventoryConfigRequest{Values: values})
+
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"SCHEDULE": {"every": 25, "period": "seconds"}}`, stub.calls[0].body)
+	})
+
+	t.Run("a revert names the field in the path", func(t *testing.T) {
+		t.Parallel()
+
+		stub := newSEPStub(t, http.StatusNoContent, ``)
+
+		_, err := stub.service(t).DeleteInventoryConfigOverride(t.Context(),
+			&omv1.DeleteInventoryConfigOverrideRequest{Key: "SCHEDULE__every"})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.MethodDelete, stub.method)
+		assert.Equal(t, "/api/apps/om_inventory/config/SCHEDULE__every", stub.path)
+	})
+}
+
+func TestInventoryRunsDefaultLimit(t *testing.T) {
+	t.Parallel()
+
+	stub := newSEPStub(t, http.StatusOK, `[]`)
+
+	_, err := stub.service(t).ListInventoryRuns(t.Context(), &omv1.ListInventoryRunsRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "limit=20", stub.query)
+}
+
+func TestInventoryRunCarriesHostCounters(t *testing.T) {
+	t.Parallel()
+
+	// A refresh attempts hosts as well as the services on them. Counting only
+	// services made a refresh of a host with no database read as "0 of 0", which is
+	// what a run that did nothing also looks like -- on the one kind of host OM most
+	// exists to describe.
+	stub := newSEPStub(t, http.StatusOK, `[{
+	  "run_id": "r1", "status": "success",
+	  "started_at": "2026-08-18T12:00:00Z", "finished_at": "2026-08-18T12:00:30Z",
+	  "counts": {"services_total": 0, "services_resolved": 0, "services_orphaned": 0,
+	             "services_answered": 0,
+	             "hosts_total": 3, "hosts_probeable": 2, "hosts_answered": 1},
+	  "scope": ["node-1"], "error": null
+	}]`)
+
+	res, err := stub.service(t).ListInventoryRuns(t.Context(), &omv1.ListInventoryRunsRequest{})
+
+	require.NoError(t, err)
+	require.Len(t, res.GetRuns(), 1)
+	counts := res.GetRuns()[0].GetCounts()
+	assert.Equal(t, int32(3), counts.GetTotalHosts())
+	assert.Equal(t, int32(2), counts.GetProbeableHosts())
+	assert.Equal(t, int32(1), counts.GetAnsweredHosts())
+	// Zero services is the honest answer for a host-only refresh, and the reason the
+	// host counters had to exist rather than the service ones being reinterpreted.
+	assert.Equal(t, int32(0), counts.GetTotalServices())
+}
+
+func TestInventoryRunDetailIsHostOriented(t *testing.T) {
+	t.Parallel()
+
+	// A refresh attempts hosts, so the receipt lists hosts. A flat service list -- which
+	// this was -- cannot show a machine carrying a PMM client and no database, however
+	// many times it is probed, and that machine is the case OM most exists to describe.
+	stub := newSEPStub(t, http.StatusOK, `{
+	  "run_id": "r1", "status": "partial",
+	  "started_at": "2026-08-19T12:00:00Z", "finished_at": "2026-08-19T12:00:30Z",
+	  "counts": {"services_total": 1, "services_resolved": 1, "services_orphaned": 0,
+	             "services_answered": 1,
+	             "hosts_total": 3, "hosts_probeable": 2, "hosts_answered": 2},
+	  "scope": [], "error": null,
+	  "nodes": [
+	    {"node_id": "n1", "host_name": "db00", "executor_host": "db00",
+	     "resolution": "name", "answered": true, "duration_seconds": 12.5,
+	     "error": null,
+	     "services": [{"service_id": "s1", "service_name": "mongo-1",
+	                   "answered": true, "error": null}]},
+	    {"node_id": "n2", "host_name": "pmm-client-node00",
+	     "executor_host": "pmm-client-node00", "resolution": "name",
+	     "answered": true, "duration_seconds": 8.0, "error": null, "services": []},
+	    {"node_id": "n3", "host_name": "stranded", "executor_host": null,
+	     "resolution": "orphaned", "answered": false, "duration_seconds": null,
+	     "error": "no executor host", "services": []}
+	  ]
+	}`)
+
+	res, err := stub.service(t).GetInventoryRun(t.Context(), &omv1.GetInventoryRunRequest{RunId: "r1"})
+
+	require.NoError(t, err)
+	require.Len(t, res.GetEntities(), 3)
+
+	withDatabase := res.GetEntities()[0]
+	assert.Equal(t, "db00", withDatabase.GetHostName())
+	assert.True(t, withDatabase.GetAnswered())
+	assert.InDelta(t, 12.5, withDatabase.GetDurationSeconds(), 0.001)
+	require.Len(t, withDatabase.GetServices(), 1)
+	assert.Equal(t, "mongo-1", withDatabase.GetServices()[0].GetServiceName())
+
+	// The row a service-oriented receipt could not produce at all: probed, answered,
+	// and carrying no services because there is no database on it.
+	bare := res.GetEntities()[1]
+	assert.Equal(t, "pmm-client-node00", bare.GetHostName())
+	assert.True(t, bare.GetAnswered())
+	assert.Empty(t, bare.GetServices())
+
+	// An orphan keeps its row rather than being dropped: "2 of 3 answered" cannot say
+	// which one was missed, and the orphan is the one worth acting on.
+	orphan := res.GetEntities()[2]
+	assert.Equal(t, omv1.ExecutorResolution_EXECUTOR_RESOLUTION_ORPHANED, orphan.GetResolution())
+	assert.False(t, orphan.GetAnswered())
+	// Asserted on the fields rather than the getters: these are proto3 `optional`
+	// scalars, so the getter returns the zero value for an unset field and only the
+	// pointer distinguishes "no executor host" from "an empty one". protojson omits
+	// the key altogether, which is the wire form the UI reads as absent.
+	assert.Nil(t, orphan.ExecutorHost)
+	assert.Nil(t, orphan.DurationSeconds)
+	assert.Equal(t, "no executor host", orphan.GetError())
+}
+
+func TestInventoryBearerIsSent(t *testing.T) {
+	t.Parallel()
+
+	// The browser holds no SEP token -- that is the point of proxying -- so this hop is
+	// the only place the app's credential is presented. Without it every request is a
+	// 401 the page cannot explain.
+	var seen string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	svc := (&Service{l: logrus.WithField("test", t.Name())}).WithProbeSource(server.URL, "test-token")
+
+	_, err := svc.ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token", seen)
+}
+
+// ensure the canned bodies stay valid JSON as they are edited.
+func TestInventoryFixturesAreValid(t *testing.T) {
+	t.Parallel()
+
+	for name, body := range map[string]string{"hosts": hostsBody, "config": configBody} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var parsed []map[string]any
+			require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+			assert.NotEmpty(t, parsed)
+		})
+	}
+}

--- a/managed/services/om/inventory_test.go
+++ b/managed/services/om/inventory_test.go
@@ -20,8 +20,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	omv1 "github.com/percona/pmm/api/om/v1"
 )
@@ -662,6 +665,41 @@ func TestInventoryRunsDefaultLimit(t *testing.T) {
 	assert.Equal(t, "limit=20", stub.query)
 }
 
+func TestInventoryRunsForwardsDateRange(t *testing.T) {
+	t.Parallel()
+
+	stub := newSEPStub(t, http.StatusOK, `[]`)
+	since := timestamppb.New(mustParseTime(t, "2026-08-18T00:00:00Z"))
+	until := timestamppb.New(mustParseTime(t, "2026-08-25T00:00:00Z"))
+
+	_, err := stub.service(t).ListInventoryRuns(t.Context(), &omv1.ListInventoryRunsRequest{
+		Since: since,
+		Until: until,
+	})
+
+	require.NoError(t, err)
+	query, err := url.ParseQuery(stub.query)
+	require.NoError(t, err)
+	assert.Equal(t, "20", query.Get("limit"))
+	assert.Equal(t, "2026-08-18T00:00:00Z", query.Get("since"))
+	assert.Equal(t, "2026-08-25T00:00:00Z", query.Get("until"))
+}
+
+func TestInventoryRunsRejectsInvertedDateRange(t *testing.T) {
+	t.Parallel()
+
+	stub := newSEPStub(t, http.StatusOK, `[]`)
+
+	_, err := stub.service(t).ListInventoryRuns(t.Context(), &omv1.ListInventoryRunsRequest{
+		Since: timestamppb.New(mustParseTime(t, "2026-08-25T00:00:00Z")),
+		Until: timestamppb.New(mustParseTime(t, "2026-08-18T00:00:00Z")),
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Empty(t, stub.query)
+}
+
 func TestInventoryRunCarriesHostCounters(t *testing.T) {
 	t.Parallel()
 
@@ -777,6 +815,13 @@ func TestInventoryBearerIsSent(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer test-token", seen)
+}
+
+func mustParseTime(t *testing.T, stamp string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, stamp)
+	require.NoError(t, err)
+	return parsed
 }
 
 // ensure the canned bodies stay valid JSON as they are edited.

--- a/managed/services/om/om_metrics.go
+++ b/managed/services/om/om_metrics.go
@@ -1,0 +1,105 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"time"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prometheusNamespace = "pmm_managed"
+	prometheusSubsystem = "om"
+)
+
+// MetricsCollector exposes OM's own collection health to Prometheus -- otherwise a
+// degraded pass is visible only in the run history, which prunes at runHistory, and in a
+// log line at Info.
+//
+// The following metrics are exposed:
+//
+//   - pmm_managed_om_runs_total{status="success|partial|failed"} -- completed collection
+//     runs so far, by outcome. A rising "partial" or "failed" rate says collection itself
+//     is unhealthy, before any caller notices the document is stale.
+//
+//   - pmm_managed_om_document_age_seconds -- how old the newest observation in the
+//     document PMM currently serves is. This is the same age Snapshot.Stale is computed
+//     from, exposed as a number so it can be alerted on rather than only rendered. Unset
+//     until the estate has been observed at least once.
+//
+//   - pmm_managed_om_services{state="total|up|down"} -- how much of the estate the last
+//     collection pass saw, and how much of it answered.
+type MetricsCollector struct {
+	svc *Service
+
+	mRunsTotal   *prom.Desc
+	mDocumentAge *prom.Desc
+	mServices    *prom.Desc
+}
+
+// NewMetricsCollector creates a new MetricsCollector backed by the given OM service.
+func NewMetricsCollector(svc *Service) *MetricsCollector {
+	return &MetricsCollector{
+		svc: svc,
+		mRunsTotal: prom.NewDesc(
+			prom.BuildFQName(prometheusNamespace, prometheusSubsystem, "runs_total"),
+			"Total number of OM topology collection runs, by outcome status.",
+			[]string{"status"},
+			nil,
+		),
+		mDocumentAge: prom.NewDesc(
+			prom.BuildFQName(prometheusNamespace, prometheusSubsystem, "document_age_seconds"),
+			"Age, in seconds, of the newest observation in the topology document PMM currently serves.",
+			nil,
+			nil,
+		),
+		mServices: prom.NewDesc(
+			prom.BuildFQName(prometheusNamespace, prometheusSubsystem, "services"),
+			"Services in the topology document PMM currently serves, by state.",
+			[]string{"state"},
+			nil,
+		),
+	}
+}
+
+// Describe implements prom.Collector.
+func (c *MetricsCollector) Describe(ch chan<- *prom.Desc) {
+	prom.DescribeByCollect(c, ch)
+}
+
+// Collect implements prom.Collector.
+func (c *MetricsCollector) Collect(ch chan<- prom.Metric) {
+	ch <- prom.MustNewConstMetric(c.mRunsTotal, prom.CounterValue, float64(c.svc.runsSuccess.Load()), runStatusSuccess)
+	ch <- prom.MustNewConstMetric(c.mRunsTotal, prom.CounterValue, float64(c.svc.runsPartial.Load()), runStatusPartial)
+	ch <- prom.MustNewConstMetric(c.mRunsTotal, prom.CounterValue, float64(c.svc.runsFailed.Load()), runStatusFailed)
+
+	snap := c.svc.snapshot()
+	if snap.GetSnapshot().GetObservedAt() == nil {
+		// Nothing has been observed yet -- a fresh estate whose leader has not completed
+		// its first pass. Reporting age 0 would read as "current" rather than "no data".
+		return
+	}
+	age := time.Since(snap.Snapshot.ObservedAt.AsTime()).Seconds()
+	ch <- prom.MustNewConstMetric(c.mDocumentAge, prom.GaugeValue, age)
+
+	summary := snap.Summary
+	ch <- prom.MustNewConstMetric(c.mServices, prom.GaugeValue, float64(summary.GetTotalServices()), "total")
+	ch <- prom.MustNewConstMetric(c.mServices, prom.GaugeValue, float64(summary.GetUpServices()), "up")
+	ch <- prom.MustNewConstMetric(c.mServices, prom.GaugeValue, float64(summary.GetDownServices()), "down")
+}
+
+var _ prom.Collector = (*MetricsCollector)(nil)

--- a/managed/services/om/probe_source.go
+++ b/managed/services/om/probe_source.go
@@ -1,0 +1,286 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/percona/pmm/managed/models"
+)
+
+// probeSource reads on-host facts from SEP's om_inventory app.
+//
+// The facts it contributes are the ones nothing on this side can answer: the command
+// line a mongod was started with, the config file it read, and the *installed* binary
+// version as against the *running* server the metrics report. Their divergence is the
+// upgraded-but-not-restarted case, and no metric anywhere carries it.
+//
+// It pulls; it does not drive. The app sweeps its estate over Nomad on its own
+// schedule and serves whatever the last completed sweep stored, so this is a database
+// read on the other side rather than a fan-out waiting to happen. That is what keeps
+// an OM run in the tenth-of-a-second range with a source attached whose own work
+// takes tens of seconds.
+type probeSource struct {
+	// sepURL is where SEP is, e.g. http://127.0.0.1:8000 -- not where the app hangs
+	// off it. Which app to ask is this source's business, not the operator's, and the
+	// next source will point at a different app on the same SEP. Empty means the
+	// source is not configured, which is a normal state and reported as disabled
+	// rather than failed.
+	sepURL string
+	token  string
+	client *http.Client
+	l      *logrus.Entry
+}
+
+// probeAppPath is where SEP mounts the inventory app, under the `/api/apps/<module>`
+// convention every SEP app follows. Paths passed around below are relative to it.
+const probeAppPath = "api/apps/om_inventory"
+
+// probeServicesPath is the app's estate, flat. /hosts nests the same service rows
+// under their host and carries host-level attributes besides, which this source has
+// nothing to do with: the document it feeds is keyed by service.
+const probeServicesPath = "services"
+
+func (probeSource) key() string { return sourceProbe }
+
+// probeService is one row of the app's GET /services contract.
+//
+// The app used to serve a flat fact list at GET /facts, assembled per sweep. It now
+// keeps an estate -- a row per host and a row per service, upserted -- and the facts
+// this source wants are the `observed` document on the service row. Reading the
+// estate rather than the last sweep's output is what makes a service that has not
+// been probed for a week still carry what it was running a week ago, with a timestamp
+// saying so, instead of vanishing when a sweep misses it.
+type probeService struct {
+	ServiceID string         `json:"service_id"`
+	NodeID    string         `json:"node_id"`
+	Name      string         `json:"name"`
+	Observed  map[string]any `json:"observed"`
+
+	// LastSuccessAt is the age of everything in Observed. Null means this service has
+	// never answered a probe, which is different from having answered nothing.
+	LastSuccessAt *time.Time `json:"last_success_at"`
+	// FailingSince is the *first* failure after the last success, so it says "failing
+	// for three days" rather than "failed a minute ago".
+	FailingSince        *time.Time `json:"failing_since"`
+	ConsecutiveFailures int        `json:"consecutive_failures"`
+	LastError           string     `json:"last_error"`
+}
+
+// observedCollectedAt is the key the app stamps on every document it stores. It is
+// metadata about the document rather than a fact about the service, so it is used for
+// the timestamp and never emitted as a field.
+const observedCollectedAt = "collected_at"
+
+// probeRequestTimeout bounds the pull.
+//
+// Generous for a database read on the other side and far short of anything that would
+// make an OM run feel slow. The app never probes on this path, so a request that takes
+// longer than this is a sign the app is unwell rather than busy -- and the run reports
+// the source as failed and carries on with the sources that answered.
+const probeRequestTimeout = 10 * time.Second
+
+func (s probeSource) collect(ctx context.Context, services []*models.Service) SourceResult {
+	result := SourceResult{Source: sourceProbe, Status: SourceDisabled}
+	if s.sepURL == "" {
+		result.Detail = map[string]any{"reason": "no SEP endpoint configured"}
+		return result
+	}
+
+	known := make(map[string]bool, len(services))
+	for _, service := range services {
+		known[service.ServiceID] = true
+	}
+
+	answer, err := s.fetch(ctx)
+	if err != nil {
+		s.l.Warnf("probe source: %s", err)
+		return SourceResult{
+			Source: sourceProbe,
+			Status: SourceFailed,
+			Errors: []RunError{{Scope: "source", Code: "probe_fetch_failed", Message: err.Error()}},
+			Detail: map[string]any{"endpoint": s.endpoint(probeServicesPath)},
+		}
+	}
+
+	var (
+		covered  = make(map[string]bool)
+		unknown  int
+		failing  int
+		oldest   float64
+		failures []string
+	)
+	now := time.Now()
+
+	for _, service := range answer {
+		// A service the app knows and this PMM does not is not an error: the app reads
+		// its own inventory, which can be a moment ahead or behind. Counting them is
+		// enough -- merging them would put facts in the document for services it has no
+		// row for.
+		if !known[service.ServiceID] {
+			unknown++
+			continue
+		}
+
+		if service.FailingSince != nil {
+			failing++
+			if len(failures) < probeFailuresReported {
+				failures = append(failures, service.failureSummary())
+			}
+		}
+
+		observedAt := service.observedAt()
+		if observedAt == nil || len(service.Observed) == 0 {
+			// Seen but never successfully probed. Not covered, and not a fact.
+			continue
+		}
+		covered[service.ServiceID] = true
+		if age := now.Sub(*observedAt).Seconds(); age > oldest {
+			oldest = age
+		}
+
+		for field, value := range service.Observed {
+			if field == observedCollectedAt {
+				continue
+			}
+			at := *observedAt
+			result.Facts = append(result.Facts, Fact{
+				Service:    service.ServiceID,
+				Field:      field,
+				Value:      value,
+				Source:     sourceProbe,
+				ObservedAt: &at,
+			})
+		}
+	}
+
+	// The estate's own condition is part of the answer, not a detail. Every service
+	// failing its probe means something is wrong on the probe side, and reporting that
+	// as "ok, 0 facts" reads as "there is nothing to probe here" -- the opposite of
+	// what happened.
+	switch {
+	case len(services) == 0:
+		// Nothing to cover. Not this source's failure, and not a partial answer.
+		result.Status = SourceOK
+	case len(covered) == 0 && failing > 0:
+		result.Status = SourceFailed
+		result.Errors = append(result.Errors, RunError{
+			Scope:   "source",
+			Code:    "probe_all_failing",
+			Message: "no service answered its probe: " + strings.Join(failures, "; "),
+		})
+	case len(covered) < len(services):
+		// The usual steady state, and not an alarm: a service whose node runs no
+		// healthy executor is a fact about the estate rather than a failure here.
+		result.Status = SourcePartial
+	default:
+		result.Status = SourceOK
+	}
+
+	result.Detail = map[string]any{
+		"endpoint":           s.endpoint(probeServicesPath),
+		"services":           len(services),
+		"services_covered":   len(covered),
+		"services_unknown":   unknown,
+		"services_failing":   failing,
+		"oldest_age_seconds": int(oldest),
+		"facts":              len(result.Facts),
+	}
+	s.l.Infof("probe source: %d/%d service(s) covered, %d failing, oldest %ds",
+		len(covered), len(services), failing, int(oldest))
+	return result
+}
+
+// probeFailuresReported bounds how many failures reach the run receipt.
+//
+// A whole estate failing the same way produces one message per service, and the
+// receipt is meant to be read. The count is reported in full either way.
+const probeFailuresReported = 3
+
+// observedAt is when this service's document was collected.
+//
+// The last_success_at column is authoritative because the app maintains it; the document's own
+// collected_at is the fallback for a row written before that column carried a value.
+func (p probeService) observedAt() *time.Time {
+	if p.LastSuccessAt != nil {
+		return p.LastSuccessAt
+	}
+	stamp, ok := p.Observed[observedCollectedAt].(string)
+	if !ok {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, stamp)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+// failureSummary explains one failing service in the run's own receipt, so a reader is
+// told the cause here rather than having to go and ask the other service.
+func (p probeService) failureSummary() string {
+	name := p.Name
+	if name == "" {
+		name = p.ServiceID
+	}
+	if p.LastError == "" {
+		return fmt.Sprintf("%s failing since %s", name, p.FailingSince.Format(time.RFC3339))
+	}
+	return fmt.Sprintf("%s: %s", name, p.LastError)
+}
+
+// endpoint builds an absolute URL for a path relative to the inventory app.
+func (s probeSource) endpoint(path string) string {
+	return strings.TrimSuffix(s.sepURL, "/") + "/" + probeAppPath + "/" + strings.TrimPrefix(path, "/")
+}
+
+// fetch reads the app's service estate.
+func (s probeSource) fetch(ctx context.Context) ([]probeService, error) {
+	ctx, cancel := context.WithTimeout(ctx, probeRequestTimeout)
+	defer cancel()
+
+	url := s.endpoint(probeServicesPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the request: %w", err)
+	}
+	if s.token != "" {
+		req.Header.Set("Authorization", "Bearer "+s.token)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: unexpected status %s", url, resp.Status)
+	}
+
+	answer := []probeService{}
+	if err := json.NewDecoder(resp.Body).Decode(&answer); err != nil { //nolint:noinlineerr
+		return nil, fmt.Errorf("GET %s: failed to decode the response: %w", url, err)
+	}
+	return answer, nil
+}

--- a/managed/services/om/probe_source.go
+++ b/managed/services/om/probe_source.go
@@ -40,21 +40,22 @@ import (
 // read on the other side rather than a fan-out waiting to happen. That is what keeps
 // an OM run in the tenth-of-a-second range with a source attached whose own work
 // takes tens of seconds.
+//
+// This is the only job a probeSource has. Where SEP is, how PMM authenticates to it and
+// how a request against it is built are sepApp's and sepClient's, in sep_client.go --
+// shared with inventory.go's proxy handlers rather than duplicated for them, and ready
+// for the next SEP-backed source to reuse the same way.
 type probeSource struct {
-	// sepURL is where SEP is, e.g. http://127.0.0.1:8000 -- not where the app hangs
-	// off it. Which app to ask is this source's business, not the operator's, and the
-	// next source will point at a different app on the same SEP. Empty means the
-	// source is not configured, which is a normal state and reported as disabled
-	// rather than failed.
-	sepURL string
-	token  string
-	client *http.Client
-	l      *logrus.Entry
+	// app is the zero value, with a nil client, when the source is not configured -- a
+	// normal state, reported as disabled rather than failed. See Service.WithProbeSource.
+	app sepApp
+	l   *logrus.Entry
 }
 
-// probeAppPath is where SEP mounts the inventory app, under the `/api/apps/<module>`
-// convention every SEP app follows. Paths passed around below are relative to it.
-const probeAppPath = "api/apps/om_inventory"
+// probeAppModule is where SEP mounts the inventory app: the module name under the
+// `/api/apps/<module>` convention every SEP app follows, and what Service.WithProbeSource
+// hands to sepClient.app to build this source's handle.
+const probeAppModule = "om_inventory"
 
 // probeServicesPath is the app's estate, flat. /hosts nests the same service rows
 // under their host and carries host-level attributes besides, which this source has
@@ -102,7 +103,7 @@ const probeRequestTimeout = 10 * time.Second
 
 func (s probeSource) collect(ctx context.Context, services []*models.Service) SourceResult {
 	result := SourceResult{Source: sourceProbe, Status: SourceDisabled}
-	if s.sepURL == "" {
+	if s.app.client == nil {
 		result.Detail = map[string]any{"reason": "no SEP endpoint configured"}
 		return result
 	}
@@ -119,7 +120,7 @@ func (s probeSource) collect(ctx context.Context, services []*models.Service) So
 			Source: sourceProbe,
 			Status: SourceFailed,
 			Errors: []RunError{{Scope: "source", Code: "probe_fetch_failed", Message: err.Error()}},
-			Detail: map[string]any{"endpoint": s.endpoint(probeServicesPath)},
+			Detail: map[string]any{"endpoint": s.app.endpoint(probeServicesPath)},
 		}
 	}
 
@@ -198,7 +199,7 @@ func (s probeSource) collect(ctx context.Context, services []*models.Service) So
 	}
 
 	result.Detail = map[string]any{
-		"endpoint":           s.endpoint(probeServicesPath),
+		"endpoint":           s.app.endpoint(probeServicesPath),
 		"services":           len(services),
 		"services_covered":   len(covered),
 		"services_unknown":   unknown,
@@ -249,26 +250,18 @@ func (p probeService) failureSummary() string {
 	return fmt.Sprintf("%s: %s", name, p.LastError)
 }
 
-// endpoint builds an absolute URL for a path relative to the inventory app.
-func (s probeSource) endpoint(path string) string {
-	return strings.TrimSuffix(s.sepURL, "/") + "/" + probeAppPath + "/" + strings.TrimPrefix(path, "/")
-}
-
 // fetch reads the app's service estate.
 func (s probeSource) fetch(ctx context.Context) ([]probeService, error) {
 	ctx, cancel := context.WithTimeout(ctx, probeRequestTimeout)
 	defer cancel()
 
-	url := s.endpoint(probeServicesPath)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	url := s.app.endpoint(probeServicesPath)
+	req, err := s.app.request(ctx, http.MethodGet, probeServicesPath, nil, nil, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build the request: %w", err)
 	}
-	if s.token != "" {
-		req.Header.Set("Authorization", "Bearer "+s.token)
-	}
 
-	resp, err := s.client.Do(req)
+	resp, err := s.app.client.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("GET %s: %w", url, err)
 	}

--- a/managed/services/om/probe_source.go
+++ b/managed/services/om/probe_source.go
@@ -272,7 +272,8 @@ func (s probeSource) fetch(ctx context.Context) ([]probeService, error) {
 	}
 
 	answer := []probeService{}
-	if err := json.NewDecoder(resp.Body).Decode(&answer); err != nil { //nolint:noinlineerr
+	err = json.NewDecoder(resp.Body).Decode(&answer)
+	if err != nil {
 		return nil, fmt.Errorf("GET %s: failed to decode the response: %w", url, err)
 	}
 	return answer, nil

--- a/managed/services/om/probe_source_test.go
+++ b/managed/services/om/probe_source_test.go
@@ -1,0 +1,332 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+)
+
+// servicesBody is one om_inventory GET /services answer, shaped as the app sends it:
+// a row per service PMM has registered, each carrying the document the last successful
+// probe stored. `gone` is a service the app knows and this PMM does not.
+const servicesBody = `[
+  {
+    "service_id": "s1", "node_id": "n1", "name": "mongo-1", "port": 27017, "role": null,
+    "observed": {
+      "collected_at": "2026-08-11T11:32:30+00:00",
+      "installed_version": "7.0.40-22",
+      "config_path": "/etc/mongod-node.conf",
+      "argv": "/usr/bin/mongod --config /etc/mongod-node.conf",
+      "uptime_seconds": 10295,
+      "server_running": true
+    },
+    "first_seen_at": "2026-08-11T10:00:00Z", "last_attempt_at": "2026-08-11T11:32:30Z",
+    "last_success_at": "2026-08-11T11:32:30Z", "failing_since": null,
+    "consecutive_failures": 0, "last_error": null
+  },
+  {
+    "service_id": "gone", "node_id": "n9", "name": "mongo-9", "port": 27017, "role": null,
+    "observed": {"collected_at": "2026-08-11T11:32:30+00:00", "installed_version": "6.0.1"},
+    "first_seen_at": "2026-08-11T10:00:00Z", "last_attempt_at": "2026-08-11T11:32:30Z",
+    "last_success_at": "2026-08-11T11:32:30Z", "failing_since": null,
+    "consecutive_failures": 0, "last_error": null
+  }
+]`
+
+// unprobedBody is a service the app holds a row for and has never reached: an empty
+// document and null timestamps, which is a normal state rather than an absence.
+const unprobedBody = `[
+  {
+    "service_id": "s1", "node_id": "n1", "name": "mongo-1", "port": 27017, "role": null,
+    "observed": {}, "first_seen_at": "2026-08-11T10:00:00Z",
+    "last_attempt_at": null, "last_success_at": null, "failing_since": null,
+    "consecutive_failures": 0, "last_error": null
+  }
+]`
+
+func probeTestServices() []*models.Service {
+	return []*models.Service{
+		mongoService("s1", "mongo-1", "cl1", "rs0", "prod"),
+		mongoService("s2", "mongo-2", "cl1", "rs0", "prod"),
+	}
+}
+
+func newProbeSource(t *testing.T, handler http.HandlerFunc) probeSource {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return probeSource{
+		sepURL: server.URL,
+		token:  "test-token",
+		client: server.Client(),
+		l:      logrus.WithField("test", t.Name()),
+	}
+}
+
+func TestProbeSource(t *testing.T) {
+	t.Parallel()
+
+	t.Run("facts arrive typed, with their own age", func(t *testing.T) {
+		t.Parallel()
+
+		var gotAuth, gotPath string
+		source := newProbeSource(t, func(w http.ResponseWriter, r *http.Request) {
+			gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+			_, _ = w.Write([]byte(servicesBody))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, "Bearer test-token", gotAuth)
+		// The caller configures where SEP is; this side appends the app path. A path of
+		// just "/services" would mean the app name had leaked into configuration.
+		assert.Equal(t, "/"+probeAppPath+"/"+probeServicesPath, gotPath)
+		assert.Equal(t, SourcePartial, result.Status, "one of two services was covered")
+
+		byField := make(map[string]any, len(result.Facts))
+		for _, fact := range result.Facts {
+			assert.Equal(t, sourceProbe, fact.Source)
+			require.NotNil(t, fact.ObservedAt, "a probe fact has to be datable")
+			byField[fact.Field] = fact.Value
+		}
+		assert.Equal(t, "7.0.40-22", byField[fieldInstalledVersion])
+		assert.Equal(t, "/etc/mongod-node.conf", byField[fieldConfigPath])
+		assert.InDelta(t, 10295.0, byField["uptime_seconds"], 0.001, "a JSON number decodes to float64")
+		assert.Equal(t, true, byField["server_running"])
+		// collected_at describes the document rather than the service, and the age it
+		// carries is already on every fact.
+		assert.NotContains(t, byField, observedCollectedAt)
+	})
+
+	t.Run("facts for services this PMM does not have are counted, not merged", func(t *testing.T) {
+		t.Parallel()
+
+		// The app reads its own inventory, which can be a moment ahead or behind. A row
+		// for a service with none here has nothing to attach to.
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(servicesBody))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		for _, fact := range result.Facts {
+			assert.NotEqual(t, "gone", fact.Service)
+		}
+		assert.Equal(t, "1", detailStrings(result.Detail)["services_unknown"])
+	})
+
+	t.Run("an unconfigured source is disabled, not failed", func(t *testing.T) {
+		t.Parallel()
+
+		// "No probe has run here" is a normal state of a PMM that has not enabled the
+		// app, and must not read as an error on the run.
+		source := probeSource{l: logrus.WithField("test", t.Name())} // no sepURL
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourceDisabled, result.Status)
+		assert.Empty(t, result.Facts)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("an unreachable app fails the source and not the run", func(t *testing.T) {
+		t.Parallel()
+
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourceFailed, result.Status)
+		require.Len(t, result.Errors, 1)
+		assert.Equal(t, "probe_fetch_failed", result.Errors[0].Code)
+		assert.Empty(t, result.Facts)
+	})
+
+	t.Run("an estate with no rows is partial and empty", func(t *testing.T) {
+		t.Parallel()
+
+		// The app is installed and has never swept. Not anybody's failure.
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`[]`))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourcePartial, result.Status, "nothing covered, but nothing failing either")
+		assert.Empty(t, result.Facts)
+		assert.Empty(t, result.Errors)
+	})
+
+	t.Run("a service seen but never probed contributes no facts", func(t *testing.T) {
+		t.Parallel()
+
+		// An empty document is not a fact set of size zero to merge; it is the absence
+		// of a probe, and the row exists so the estate view can say so.
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(unprobedBody))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Empty(t, result.Facts)
+		assert.Equal(t, SourcePartial, result.Status)
+		assert.Equal(t, "0", detailStrings(result.Detail)["services_covered"])
+	})
+
+	t.Run("an estate that is entirely failing fails the source and says why", func(t *testing.T) {
+		t.Parallel()
+
+		// The app is reachable and answering; every service it holds is failing its
+		// probe. Reporting that as "ok, 0 facts" reads as "there is nothing to probe
+		// here", which is the opposite of what happened.
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`[
+			  {"service_id":"s1","node_id":"n1","name":"mongo-1","observed":{},
+			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
+			   "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
+			   "consecutive_failures":37,"last_error":"Cannot connect to host localhost:8000"},
+			  {"service_id":"s2","node_id":"n2","name":"mongo-2","observed":{},
+			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
+			   "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
+			   "consecutive_failures":37,"last_error":"Cannot connect to host localhost:8000"}]`))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourceFailed, result.Status)
+		require.Len(t, result.Errors, 1)
+		assert.Equal(t, "probe_all_failing", result.Errors[0].Code)
+		// The cause travels with it, so the receipt is readable without going to ask
+		// the other service.
+		assert.Contains(t, result.Errors[0].Message, "Cannot connect to host")
+		assert.Contains(t, result.Errors[0].Message, "mongo-1")
+		assert.Equal(t, "2", detailStrings(result.Detail)["services_failing"])
+	})
+
+	t.Run("a failure with no recorded reason still says since when", func(t *testing.T) {
+		t.Parallel()
+
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`[{"service_id":"s1","node_id":"n1","name":"mongo-1","observed":{},
+			  "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
+			  "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
+			  "consecutive_failures":37,"last_error":null}]`))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourceFailed, result.Status)
+		require.Len(t, result.Errors, 1)
+		assert.Contains(t, result.Errors[0].Message, "failing since")
+	})
+
+	t.Run("some covered and some failing is partial", func(t *testing.T) {
+		t.Parallel()
+
+		// The steady state of a real estate: one node unreachable, the rest answering.
+		// Not a failure of this source, and not a clean run either.
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`[
+			  {"service_id":"s1","node_id":"n1","name":"mongo-1",
+			   "observed":{"collected_at":"2026-08-11T11:32:30+00:00","installed_version":"7.0.40-22"},
+			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T11:32:30Z",
+			   "last_success_at":"2026-08-11T11:32:30Z","failing_since":null,
+			   "consecutive_failures":0,"last_error":null},
+			  {"service_id":"s2","node_id":"n2","name":"mongo-2","observed":{},
+			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T11:32:30Z",
+			   "last_success_at":null,"failing_since":"2026-08-11T11:00:00Z",
+			   "consecutive_failures":2,"last_error":"unreachable"}]`))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+
+		assert.Equal(t, SourcePartial, result.Status)
+		assert.Len(t, result.Facts, 1)
+		assert.Equal(t, "1", detailStrings(result.Detail)["services_failing"])
+	})
+
+	t.Run("garbage does not become facts", func(t *testing.T) {
+		t.Parallel()
+
+		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("this is not json"))
+		})
+
+		result := source.collect(context.Background(), probeTestServices())
+		assert.Equal(t, SourceFailed, result.Status)
+		assert.Empty(t, result.Facts)
+	})
+}
+
+func TestProbeFactsReachTheDocument(t *testing.T) {
+	t.Parallel()
+
+	// End to end through the seam: what the app serves, merged under the precedence
+	// table, projected into the document.
+	source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(servicesBody))
+	})
+	services := probeTestServices()
+	observed := projectionNow.Add(-5 * time.Second)
+
+	metrics := SourceResult{Source: sourceMetrics, Facts: []Fact{
+		{Service: "s1", Field: fieldExporterUp, Value: 1.0, Source: sourceMetrics, ObservedAt: &observed},
+		{Service: "s1", Field: fieldVersion, Value: "7.0.39-21", Source: sourceMetrics, ObservedAt: &observed},
+	}}
+	probe := source.collect(context.Background(), services)
+
+	merged := mergeFacts([]SourceResult{metrics, probe}, defaultPrecedence)
+	doc := buildDocument(services, merged, projectionNow, projectionMaxAge)
+
+	var svc *omv1.TopologyService
+	for _, cluster := range doc.environments[0].Clusters {
+		for _, candidate := range cluster.Services {
+			if candidate.ServiceName == "mongo-1" {
+				svc = candidate
+			}
+		}
+	}
+	require.NotNil(t, svc)
+
+	// The upgraded-but-not-restarted case, which is the whole reason the probe exists:
+	// the binary on disk is ahead of the server that is running.
+	assert.Equal(t, "7.0.40-22", svc.GetInstalledVersion())
+	assert.Equal(t, "7.0.39-21", svc.GetVersion(), "metrics still own the running version")
+	assert.Equal(t, "/etc/mongod-node.conf", svc.GetConfigPath())
+	assert.Contains(t, svc.GetArgv(), "mongod")
+
+	// And the service the probe never reached carries nulls rather than another's facts.
+	for _, cluster := range doc.environments[0].Clusters {
+		for _, candidate := range cluster.Services {
+			if candidate.ServiceName == "mongo-2" {
+				assert.Nil(t, candidate.InstalledVersion)
+				assert.Nil(t, candidate.ConfigPath)
+			}
+		}
+	}
+}

--- a/managed/services/om/probe_source_test.go
+++ b/managed/services/om/probe_source_test.go
@@ -79,11 +79,10 @@ func newProbeSource(t *testing.T, handler http.HandlerFunc) probeSource {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
+	client := &sepClient{baseURL: server.URL, token: "test-token", http: server.Client()}
 	return probeSource{
-		sepURL: server.URL,
-		token:  "test-token",
-		client: server.Client(),
-		l:      logrus.WithField("test", t.Name()),
+		app: client.app(probeAppModule),
+		l:   logrus.WithField("test", t.Name()),
 	}
 }
 
@@ -104,7 +103,7 @@ func TestProbeSource(t *testing.T) {
 		assert.Equal(t, "Bearer test-token", gotAuth)
 		// The caller configures where SEP is; this side appends the app path. A path of
 		// just "/services" would mean the app name had leaked into configuration.
-		assert.Equal(t, "/"+probeAppPath+"/"+probeServicesPath, gotPath)
+		assert.Equal(t, "/api/apps/"+probeAppModule+"/"+probeServicesPath, gotPath)
 		assert.Equal(t, SourcePartial, result.Status, "one of two services was covered")
 
 		byField := make(map[string]any, len(result.Facts))
@@ -144,7 +143,7 @@ func TestProbeSource(t *testing.T) {
 
 		// "No probe has run here" is a normal state of a PMM that has not enabled the
 		// app, and must not read as an error on the run.
-		source := probeSource{l: logrus.WithField("test", t.Name())} // no sepURL
+		source := probeSource{l: logrus.WithField("test", t.Name())} // zero-value app, no sepURL
 		result := source.collect(context.Background(), probeTestServices())
 
 		assert.Equal(t, SourceDisabled, result.Status)

--- a/managed/services/om/projection.go
+++ b/managed/services/om/projection.go
@@ -17,10 +17,13 @@ package om
 
 import (
 	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
 	"slices"
 	"time"
 
 	"github.com/AlekSi/pointer"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	omv1 "github.com/percona/pmm/api/om/v1"
 	"github.com/percona/pmm/managed/models"
@@ -82,13 +85,29 @@ func buildDocument(services []*models.Service, merged map[string]map[string]Merg
 			slices.SortFunc(svcs, func(a, b *omv1.TopologyService) int {
 				return cmp.Compare(a.ServiceName, b.ServiceName)
 			})
-			clusters = append(clusters, &omv1.Cluster{Name: named(cluster), Services: svcs})
+			clusters = append(clusters, &omv1.Cluster{
+				Name:     named(cluster),
+				Services: svcs,
+				Id:       clusterID(env, cluster),
+				Type:     clusterType(svcs),
+			})
 		}
 		out.environments = append(out.environments, &omv1.Environment{EnvName: named(env), Clusters: clusters})
 	}
 
 	out.summary = buildSummary(out.environments)
 	return out
+}
+
+// applyHealth evaluates advisories and rollup statuses over the assembled document.
+//
+// A separate pipeline stage so the observational projection above stays pure: buildDocument
+// reports what was observed, and a verdict about what that means belongs downstream of it,
+// not folded into the same pass. No-op today -- there are no health rules yet -- and kept as
+// its own stage rather than an `if` bolted onto serviceDocument so the first rule has a place
+// to land without restructuring the pipeline around it.
+func applyHealth(doc document) document {
+	return doc
 }
 
 // serviceDocument builds one service entry.
@@ -129,6 +148,62 @@ func serviceDocument(service *models.Service, fields fieldSet) *omv1.TopologySer
 		InstalledVersion: optional(fields.str(fieldInstalledVersion)),
 		ConfigPath:       optional(fields.str(fieldConfigPath)),
 		Argv:             optional(fields.str(fieldArgv)),
+
+		// This row's own provenance, as against Snapshot.observed_at's estate-wide
+		// newest -- see fieldSet.newestObservedAt.
+		ObservedAt: observedAtTimestamp(fields.newestObservedAt()),
+	}
+}
+
+// observedAtTimestamp adapts fieldSet.newestObservedAt's *time.Time to the wire's
+// *timestamppb.Timestamp, nil to nil.
+func observedAtTimestamp(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}
+
+// clusterID derives a stable, opaque id for one grouped service inventory.
+//
+// (environment, grouping key) is already the unique key buildDocument groups services
+// under -- groupingKeys has already folded replication_set into it as cluster's fallback
+// -- so hashing that pair is enough to give two clusters that happen to share a label
+// (two generations of a sandbox both called "sharded-cluster") two different ids.
+// Deterministic rather than random, so the same estate group derives the same id run
+// over run without needing to be stored anywhere: id is a projection of the grouping,
+// not new state.
+func clusterID(env, groupKey string) string {
+	sum := sha256.Sum256([]byte(env + "\x00" + groupKey))
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// clusterType infers a grouped service inventory's shape from what is in the group.
+//
+// Inferred, not reconstructed -- this package does not walk a replica set's own config to
+// discover its member list, it looks at what buildDocument already grouped: a mongos
+// present, or more than one replication_set label sharing this cluster label, is SHARDED;
+// exactly one replication_set and no mongos is REPLICA_SET; neither is STANDALONE. A
+// later schema_version can grow an actual shard map without this needing to change --
+// the enum names a shape, it does not commit to having discovered one.
+func clusterType(services []*omv1.TopologyService) omv1.ClusterType {
+	replicationSets := make(map[string]bool)
+	mongos := false
+	for _, svc := range services {
+		if svc.GetProcessRole() == omv1.ProcessRole_PROCESS_ROLE_MONGOS {
+			mongos = true
+		}
+		if rs := svc.GetReplicationSet(); rs != "" {
+			replicationSets[rs] = true
+		}
+	}
+	switch {
+	case mongos || len(replicationSets) > 1:
+		return omv1.ClusterType_CLUSTER_TYPE_SHARDED
+	case len(replicationSets) == 1:
+		return omv1.ClusterType_CLUSTER_TYPE_REPLICA_SET
+	default:
+		return omv1.ClusterType_CLUSTER_TYPE_STANDALONE
 	}
 }
 

--- a/managed/services/om/projection.go
+++ b/managed/services/om/projection.go
@@ -1,0 +1,272 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"cmp"
+	"slices"
+	"time"
+
+	"github.com/AlekSi/pointer"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+)
+
+// Four rules the document shape enforces, all of them load-bearing for the UI:
+//
+//   - A service that inventory knows and no source ever saw is still in the document, as
+//     status DOWN. Dropping it would shrink the estate every time something broke.
+//   - Grouping is by environment then cluster, where cluster falls back to the replica
+//     set. Both keys are emitted as null rather than the internal sentinel, so the
+//     document never invents a name.
+//   - Numeric gauges use -1 for "not measured", not 0 and not null.
+//   - Nothing here is a verdict. The document reports what was observed; health rules
+//     read it, they do not live here.
+
+// document is one assembled topology document plus what it took to assemble it.
+type document struct {
+	summary      *omv1.Summary
+	environments []*omv1.Environment
+	// observedAt is the newest observation behind the document, or the zero time when
+	// nothing datable went into it.
+	observedAt time.Time
+	// staleServices is how many services carry a volatile fact too old to read.
+	staleServices int
+}
+
+// buildDocument folds inventory and the merged facts into the topology document.
+func buildDocument(services []*models.Service, merged map[string]map[string]MergedField, now time.Time, maxAge time.Duration) document {
+	out := document{}
+	grouped := make(map[string]map[string][]*omv1.TopologyService)
+
+	for _, service := range services {
+		fields := fieldSet{fields: merged[service.ServiceID], now: now, maxAge: maxAge}
+		if fields.fields == nil {
+			fields.fields = map[string]MergedField{}
+		}
+		if stale := fields.staleVolatile(); stale > 0 {
+			out.staleServices++
+		}
+		for _, held := range fields.fields {
+			if held.ObservedAt != nil && held.ObservedAt.After(out.observedAt) {
+				out.observedAt = *held.ObservedAt
+			}
+		}
+
+		env, cluster := groupingKeys(service, fields)
+		if _, ok := grouped[env]; !ok {
+			grouped[env] = make(map[string][]*omv1.TopologyService)
+		}
+		grouped[env][cluster] = append(grouped[env][cluster], serviceDocument(service, fields))
+	}
+
+	out.environments = make([]*omv1.Environment, 0, len(grouped))
+	for _, env := range sortedKeys(grouped) {
+		clusters := make([]*omv1.Cluster, 0, len(grouped[env]))
+		for _, cluster := range sortedKeys(grouped[env]) {
+			svcs := grouped[env][cluster]
+			slices.SortFunc(svcs, func(a, b *omv1.TopologyService) int {
+				return cmp.Compare(a.ServiceName, b.ServiceName)
+			})
+			clusters = append(clusters, &omv1.Cluster{Name: named(cluster), Services: svcs})
+		}
+		out.environments = append(out.environments, &omv1.Environment{EnvName: named(env), Clusters: clusters})
+	}
+
+	out.summary = buildSummary(out.environments)
+	return out
+}
+
+// serviceDocument builds one service entry.
+func serviceDocument(service *models.Service, fields fieldSet) *omv1.TopologyService {
+	host := fields.str(fieldHost)
+	if host == "" {
+		host = service.ServiceName
+	}
+	serviceType := fields.str(fieldServiceType)
+	if serviceType == "" {
+		serviceType = string(models.MongoDBServiceType)
+	}
+
+	up := pointer.GetFloat64(fields.f64(fieldExporterUp)) == 1
+
+	return &omv1.TopologyService{
+		ServiceName:            service.ServiceName,
+		Host:                   optional(host),
+		Endpoint:               optional(fields.str(fieldEndpoint)),
+		ServiceId:              optional(service.ServiceID),
+		ServiceType:            optional(serviceType),
+		Version:                optional(fields.str(fieldVersion)),
+		Vendor:                 optional(fields.str(fieldVendor)),
+		Edition:                optional(fields.str(fieldEdition)),
+		ReplicationSet:         optional(fields.str(fieldReplicationSet)),
+		State:                  optional(fields.str(fieldState)),
+		Status:                 serviceStatus(up),
+		CpuUsagePercent:        gauge(fields.f64(fieldCPUUsage), up),
+		ConnectionsFreePercent: gauge(fields.f64(fieldConnectionsFree), up),
+		ProcessRole:            processRole(fields),
+		ReplicationLagSeconds:  optionalDouble(fields.f64(fieldReplicationLag)),
+		OplogWindowSeconds:     optionalDouble(oplogWindow(fields)),
+
+		// Probe-only, and null wherever no probe has run. Not volatile: an installed
+		// binary and a config path are properties of the node, not of this moment, so
+		// they keep reporting what the last sweep found rather than blanking between
+		// sweeps that are minutes apart.
+		InstalledVersion: optional(fields.str(fieldInstalledVersion)),
+		ConfigPath:       optional(fields.str(fieldConfigPath)),
+		Argv:             optional(fields.str(fieldArgv)),
+	}
+}
+
+// groupingKeys returns the (environment, cluster) keys a service groups under.
+//
+// Cluster falls back to the replica set, because a replica set registered without a
+// --cluster= string is still a cluster and would otherwise land in one anonymous bucket
+// with everything else. The merged fields already carry inventory as the fallback source
+// for both, so this reads them once rather than re-deriving the precedence.
+func groupingKeys(_ *models.Service, fields fieldSet) (string, string) {
+	env := firstNonEmpty(fields.str(fieldEnvironment), unspecified)
+	cluster := firstNonEmpty(fields.str(fieldCluster), fields.str(fieldReplicationSet), unspecified)
+	return env, cluster
+}
+
+// processRole returns a service's process role.
+//
+// The mongodb_mongos_sharding_shards_total metric is emitted only by a router, so its
+// presence is the test -- no port-convention guessing. Otherwise the exporter's cl_role
+// names a config or shard server, and anything else is a plain mongod.
+func processRole(fields fieldSet) omv1.ProcessRole {
+	if fields.truthy(fieldIsMongos) {
+		return omv1.ProcessRole_PROCESS_ROLE_MONGOS
+	}
+	if role, ok := clusterRoles[fields.str(fieldClusterRole)]; ok {
+		return role
+	}
+	return omv1.ProcessRole_PROCESS_ROLE_MONGOD
+}
+
+// gauge returns a reading, or the unmeasured sentinel when there is none.
+//
+// A DOWN service reports the sentinel even if a reading survives in the query window: a
+// CPU figure for a process that is not running would be read as current, and a number
+// nobody can act on is worse than an explicit "not measured".
+func gauge(value *float64, up bool) float64 {
+	if !up || value == nil {
+		return unmeasured
+	}
+	return *value
+}
+
+// oplogWindow returns the oplog window in seconds, or nil when it cannot be computed.
+//
+// Head and tail come from the same scrape, so subtracting two separately queried values
+// is safe in practice. The head >= tail guard still rejects the pathological case --
+// mismatched scrapes, clock skew -- as unknown rather than surfacing a negative duration.
+func oplogWindow(fields fieldSet) *float64 {
+	head, tail := fields.f64(fieldOplogHead), fields.f64(fieldOplogTail)
+	if head == nil || tail == nil || *head < *tail {
+		return nil
+	}
+	window := *head - *tail
+	return &window
+}
+
+// buildSummary builds the fleet-level counts the list view shows above the table.
+//
+// The down_services count is the honest headline and is a first-class field rather than
+// something every caller re-derives.
+//
+// The process_role_counts map is keyed by the ProcessRole enum's name rather than its
+// number, so it reads as itself in JSON instead of as {"1": 5}.
+func buildSummary(environments []*omv1.Environment) *omv1.Summary {
+	summary := &omv1.Summary{
+		Environments:      int32(len(environments)), //nolint:gosec
+		ProcessRoleCounts: make(map[string]int32),
+	}
+	for _, env := range environments {
+		summary.Clusters += int32(len(env.Clusters)) //nolint:gosec
+		for _, cluster := range env.Clusters {
+			for _, service := range cluster.Services {
+				summary.TotalServices++
+				if service.Status == omv1.ServiceStatus_SERVICE_STATUS_UP {
+					summary.UpServices++
+				} else {
+					summary.DownServices++
+				}
+				summary.ProcessRoleCounts[service.ProcessRole.String()]++
+			}
+		}
+	}
+	return summary
+}
+
+func serviceStatus(up bool) omv1.ServiceStatus {
+	if up {
+		return omv1.ServiceStatus_SERVICE_STATUS_UP
+	}
+	return omv1.ServiceStatus_SERVICE_STATUS_DOWN
+}
+
+// named returns a grouping key as the document spells it: null for the internal
+// sentinel, the key itself otherwise.
+func named(key string) *string {
+	if key == unspecified {
+		return nil
+	}
+	return &key
+}
+
+// optional returns nil for an empty string, so the document omits the key rather than
+// carrying "".
+//
+// These fields were `google.protobuf.StringValue` originally, because protojson renders
+// an unset message field as an explicit null while it omits an unset proto3 `optional`
+// scalar entirely, even under EmitUnpopulated. The explicit null read better. It was not
+// worth what it cost: protoc-gen-openapiv2 does not mark a wrapper field `x-nullable`,
+// so the REST schema and the generated Go client both flattened to a value type and lost
+// the distinction altogether -- `{}`, null and 0 arrived as 0. An absent key is a weaker
+// signal than a null one, but it is a signal that survives the whole contract, and it is
+// what every other proto in PMM does.
+func optional(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// optionalDouble is optional's counterpart for a gauge that may not apply at all.
+func optionalDouble(value *float64) *float64 {
+	return value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/managed/services/om/projection_test.go
+++ b/managed/services/om/projection_test.go
@@ -1,0 +1,323 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"maps"
+	"testing"
+	"time"
+
+	"github.com/AlekSi/pointer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+)
+
+var (
+	projectionNow    = time.Date(2026, 8, 11, 12, 0, 0, 0, time.UTC)
+	projectionMaxAge = 30 * time.Second
+)
+
+func mongoService(id, name, cluster, replicationSet, environment string) *models.Service {
+	return &models.Service{
+		ServiceID:      id,
+		ServiceName:    name,
+		ServiceType:    models.MongoDBServiceType,
+		Cluster:        cluster,
+		ReplicationSet: replicationSet,
+		Environment:    environment,
+		NodeID:         "node-" + id,
+	}
+}
+
+// liveFacts is a healthy replica-set member as the metrics source would report it.
+func liveFacts(state string, extra map[string]MergedField) map[string]MergedField {
+	observed := projectionNow.Add(-5 * time.Second)
+	fields := map[string]MergedField{
+		fieldExporterUp:      {Value: 1.0, Source: sourceMetrics, ObservedAt: &observed},
+		fieldState:           {Value: state, Source: sourceMetrics, ObservedAt: &observed},
+		fieldVersion:         {Value: "7.0.39-21", Source: sourceMetrics, ObservedAt: &observed},
+		fieldVendor:          {Value: "Percona", Source: sourceMetrics, ObservedAt: &observed},
+		fieldEdition:         {Value: "Community", Source: sourceMetrics, ObservedAt: &observed},
+		fieldHost:            {Value: "host-a", Source: sourceMetrics, ObservedAt: &observed},
+		fieldEndpoint:        {Value: "host-a:27017", Source: sourceMetrics, ObservedAt: &observed},
+		fieldCPUUsage:        {Value: 12.5, Source: sourceMetrics, ObservedAt: &observed},
+		fieldConnectionsFree: {Value: 99.5, Source: sourceMetrics, ObservedAt: &observed},
+	}
+	maps.Copy(fields, extra)
+	return fields
+}
+
+func onlyService(t *testing.T, doc document) *omv1.TopologyService {
+	t.Helper()
+	require.Len(t, doc.environments, 1)
+	require.Len(t, doc.environments[0].Clusters, 1)
+	require.Len(t, doc.environments[0].Clusters[0].Services, 1)
+	return doc.environments[0].Clusters[0].Services[0]
+}
+
+func TestBuildDocument(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a service no source saw is present and DOWN", func(t *testing.T) {
+		t.Parallel()
+
+		// Dropping it would shrink the estate every time something broke.
+		services := []*models.Service{mongoService("s1", "mongo-1", "c1", "rs0", "prod")}
+		doc := buildDocument(services, map[string]map[string]MergedField{}, projectionNow, projectionMaxAge)
+
+		svc := onlyService(t, doc)
+		assert.Equal(t, "mongo-1", svc.ServiceName)
+		assert.Equal(t, omv1.ServiceStatus_SERVICE_STATUS_DOWN, svc.Status)
+		assert.InDelta(t, float64(unmeasured), svc.CpuUsagePercent, 0.001)
+		assert.InDelta(t, float64(unmeasured), svc.ConnectionsFreePercent, 0.001)
+		assert.Nil(t, svc.Version)
+		assert.Equal(t, int32(1), doc.summary.TotalServices)
+		assert.Equal(t, int32(1), doc.summary.DownServices)
+	})
+
+	t.Run("a stopped service reads DOWN once its up flag ages out", func(t *testing.T) {
+		t.Parallel()
+
+		// The regression that mattered: the sample survives the long lookback window, so
+		// only the age can tell that it is not a fact about now.
+		stale := projectionNow.Add(-10 * time.Minute)
+		fields := liveFacts("PRIMARY", nil)
+		for _, key := range []string{fieldExporterUp, fieldState, fieldCPUUsage, fieldConnectionsFree} {
+			held := fields[key]
+			held.ObservedAt = &stale
+			fields[key] = held
+		}
+
+		services := []*models.Service{mongoService("s1", "mongo-1", "c1", "rs0", "prod")}
+		doc := buildDocument(services, map[string]map[string]MergedField{"s1": fields}, projectionNow, projectionMaxAge)
+
+		svc := onlyService(t, doc)
+		assert.Equal(t, omv1.ServiceStatus_SERVICE_STATUS_DOWN, svc.Status)
+		assert.Nil(t, svc.State, "a replica-set state from ten minutes ago is not current")
+		assert.InDelta(t, float64(unmeasured), svc.CpuUsagePercent, 0.001)
+		assert.Equal(t, "7.0.39-21", svc.GetVersion(), "identity is still worth reporting")
+		assert.Equal(t, 1, doc.staleServices)
+	})
+
+	t.Run("gauges are suppressed for a service that is not up", func(t *testing.T) {
+		t.Parallel()
+
+		fields := liveFacts("PRIMARY", nil)
+		delete(fields, fieldExporterUp)
+
+		services := []*models.Service{mongoService("s1", "mongo-1", "c1", "rs0", "prod")}
+		doc := buildDocument(services, map[string]map[string]MergedField{"s1": fields}, projectionNow, projectionMaxAge)
+
+		svc := onlyService(t, doc)
+		assert.Equal(t, omv1.ServiceStatus_SERVICE_STATUS_DOWN, svc.Status)
+		assert.InDelta(t, float64(unmeasured), svc.CpuUsagePercent, 0.001, "a CPU figure for a stopped process reads as current")
+	})
+
+	t.Run("the oplog window is the difference, and nil when it cannot be one", func(t *testing.T) {
+		t.Parallel()
+
+		observed := projectionNow.Add(-5 * time.Second)
+		withOplog := func(head, tail float64) map[string]MergedField {
+			return liveFacts("PRIMARY", map[string]MergedField{
+				fieldOplogHead: {Value: head, Source: sourceMetrics, ObservedAt: &observed},
+				fieldOplogTail: {Value: tail, Source: sourceMetrics, ObservedAt: &observed},
+			})
+		}
+		services := []*models.Service{mongoService("s1", "mongo-1", "c1", "rs0", "prod")}
+
+		doc := buildDocument(services, map[string]map[string]MergedField{"s1": withOplog(1000, 400)}, projectionNow, projectionMaxAge)
+		assert.InDelta(t, 600.0, onlyService(t, doc).GetOplogWindowSeconds(), 0.001)
+
+		// head < tail is mismatched scrapes or clock skew: unknown, not a negative duration.
+		doc = buildDocument(services, map[string]map[string]MergedField{"s1": withOplog(400, 1000)}, projectionNow, projectionMaxAge)
+		assert.Nil(t, onlyService(t, doc).OplogWindowSeconds)
+
+		// A standalone emits neither.
+		doc = buildDocument(services, map[string]map[string]MergedField{"s1": liveFacts("PRIMARY", nil)}, projectionNow, projectionMaxAge)
+		assert.Nil(t, onlyService(t, doc).OplogWindowSeconds)
+	})
+
+	t.Run("the process role comes from the exporter, not a port convention", func(t *testing.T) {
+		t.Parallel()
+
+		observed := projectionNow.Add(-5 * time.Second)
+		services := []*models.Service{mongoService("s1", "mongo-1", "c1", "rs0", "prod")}
+
+		for _, tc := range []struct {
+			name  string
+			extra map[string]MergedField
+			want  omv1.ProcessRole
+		}{
+			{"plain mongod", nil, omv1.ProcessRole_PROCESS_ROLE_MONGOD},
+			{"router", map[string]MergedField{
+				fieldIsMongos: {Value: true, Source: sourceMetrics, ObservedAt: &observed},
+			}, omv1.ProcessRole_PROCESS_ROLE_MONGOS},
+			{"config server", map[string]MergedField{
+				fieldClusterRole: {Value: "configsvr", Source: sourceMetrics, ObservedAt: &observed},
+			}, omv1.ProcessRole_PROCESS_ROLE_CONFIGSVR},
+			{"shard server", map[string]MergedField{
+				fieldClusterRole: {Value: "shardsvr", Source: sourceMetrics, ObservedAt: &observed},
+			}, omv1.ProcessRole_PROCESS_ROLE_SHARDSVR},
+		} {
+			doc := buildDocument(services,
+				map[string]map[string]MergedField{"s1": liveFacts("PRIMARY", tc.extra)},
+				projectionNow, projectionMaxAge)
+			assert.Equal(t, tc.want, onlyService(t, doc).ProcessRole, tc.name)
+		}
+	})
+
+	t.Run("grouping falls back replica set, then to null", func(t *testing.T) {
+		t.Parallel()
+
+		observed := projectionNow.Add(-5 * time.Second)
+		inv := func(cluster, rs, env string) map[string]MergedField {
+			fields := map[string]MergedField{}
+			for key, value := range map[string]string{
+				fieldCluster: cluster, fieldReplicationSet: rs, fieldEnvironment: env,
+			} {
+				if value != "" {
+					fields[key] = MergedField{Value: value, Source: sourceInventory, ObservedAt: &observed}
+				}
+			}
+			return fields
+		}
+
+		services := []*models.Service{
+			mongoService("s1", "a", "", "", ""),
+			mongoService("s2", "b", "", "rs0", "prod"),
+			mongoService("s3", "c", "cl1", "rs0", "prod"),
+		}
+		doc := buildDocument(services, map[string]map[string]MergedField{
+			"s1": inv("", "", ""),
+			"s2": inv("", "rs0", "prod"),
+			"s3": inv("cl1", "rs0", "prod"),
+		}, projectionNow, projectionMaxAge)
+
+		// Environments sort by the internal grouping key, so the unnamed bucket --
+		// "UNSPECIFIED" -- sorts ahead of "prod" by codepoint. Matches SEP, whose
+		// sorted() orders the same way.
+		require.Len(t, doc.environments, 2)
+		assert.Nil(t, doc.environments[0].EnvName, "an unset environment is null, never invented")
+		assert.Equal(t, "prod", doc.environments[1].GetEnvName())
+
+		require.Len(t, doc.environments[0].Clusters, 1)
+		assert.Nil(t, doc.environments[0].Clusters[0].Name)
+
+		require.Len(t, doc.environments[1].Clusters, 2)
+		assert.Equal(t, "cl1", doc.environments[1].Clusters[0].GetName())
+		assert.Equal(t, "rs0", doc.environments[1].Clusters[1].GetName(), "cluster falls back to the replica set")
+	})
+
+	t.Run("services sort by name inside a cluster", func(t *testing.T) {
+		t.Parallel()
+
+		services := []*models.Service{
+			mongoService("s1", "mongo-c", "cl1", "rs0", "prod"),
+			mongoService("s2", "mongo-a", "cl1", "rs0", "prod"),
+			mongoService("s3", "mongo-b", "cl1", "rs0", "prod"),
+		}
+		merged := map[string]map[string]MergedField{}
+		for _, service := range services {
+			merged[service.ServiceID] = liveFacts("SECONDARY", nil)
+		}
+		doc := buildDocument(services, merged, projectionNow, projectionMaxAge)
+
+		names := make([]string, 0, len(doc.environments[0].Clusters[0].Services))
+		for _, svc := range doc.environments[0].Clusters[0].Services {
+			names = append(names, svc.ServiceName)
+		}
+		assert.Equal(t, []string{"mongo-a", "mongo-b", "mongo-c"}, names)
+	})
+
+	t.Run("the summary counts what the tree holds", func(t *testing.T) {
+		t.Parallel()
+
+		observed := projectionNow.Add(-5 * time.Second)
+		services := []*models.Service{
+			mongoService("s1", "mongo-1", "cl1", "rs0", "prod"),
+			mongoService("s2", "mongo-2", "cl1", "rs0", "prod"),
+			mongoService("s3", "router", "cl1", "", "prod"),
+		}
+		doc := buildDocument(services, map[string]map[string]MergedField{
+			"s1": liveFacts("PRIMARY", nil),
+			"s2": {}, // never seen
+			"s3": liveFacts("", map[string]MergedField{
+				fieldIsMongos: {Value: true, Source: sourceMetrics, ObservedAt: &observed},
+			}),
+		}, projectionNow, projectionMaxAge)
+
+		assert.Equal(t, int32(3), doc.summary.TotalServices)
+		assert.Equal(t, int32(2), doc.summary.UpServices)
+		assert.Equal(t, int32(1), doc.summary.DownServices)
+		// Keyed by the enum's name, not its number, so the map reads as itself in JSON.
+		assert.Equal(t, map[string]int32{
+			omv1.ProcessRole_PROCESS_ROLE_MONGOD.String(): 2,
+			omv1.ProcessRole_PROCESS_ROLE_MONGOS.String(): 1,
+		}, doc.summary.ProcessRoleCounts)
+	})
+
+	t.Run("observed_at is the newest observation behind the document", func(t *testing.T) {
+		t.Parallel()
+
+		newest := projectionNow.Add(-3 * time.Second)
+		older := projectionNow.Add(-20 * time.Second)
+		services := []*models.Service{
+			mongoService("s1", "mongo-1", "cl1", "rs0", "prod"),
+			mongoService("s2", "mongo-2", "cl1", "rs0", "prod"),
+		}
+		doc := buildDocument(services, map[string]map[string]MergedField{
+			"s1": {fieldExporterUp: {Value: 1.0, Source: sourceMetrics, ObservedAt: &older}},
+			"s2": {fieldExporterUp: {Value: 1.0, Source: sourceMetrics, ObservedAt: &newest}},
+		}, projectionNow, projectionMaxAge)
+
+		assert.Equal(t, newest, doc.observedAt)
+		assert.False(t, isStale(doc, projectionNow))
+	})
+}
+
+func TestInventoryEndpoint(t *testing.T) {
+	t.Parallel()
+
+	service := mongoService("s1", "mongo-1", "cl1", "rs0", "prod")
+	service.Port = pointer.ToUint16(27017)
+	service.Address = new("127.0.0.1")
+
+	t.Run("prefers the node over the service address", func(t *testing.T) {
+		t.Parallel()
+
+		// A service address is where its own agent reaches it -- 127.0.0.1 for a local
+		// agent, which is true and useless to anyone else.
+		node := &models.Node{NodeName: "db-host-1", Address: "10.0.0.11"}
+		assert.Equal(t, "10.0.0.11:27017", inventoryEndpoint(service, node))
+	})
+
+	t.Run("falls back to the node name, then the service address", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "db-host-1:27017", inventoryEndpoint(service, &models.Node{NodeName: "db-host-1"}))
+		assert.Equal(t, "127.0.0.1:27017", inventoryEndpoint(service, nil))
+	})
+
+	t.Run("no port means no endpoint", func(t *testing.T) {
+		t.Parallel()
+
+		portless := mongoService("s2", "mongo-2", "", "", "")
+		assert.Empty(t, inventoryEndpoint(portless, &models.Node{NodeName: "db-host-1"}))
+	})
+}

--- a/managed/services/om/sep_client.go
+++ b/managed/services/om/sep_client.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// sepClient is where SEP is and how PMM authenticates to it: the base URL, the bearer
+// token, the http.Client every SEP-backed source and proxy handler shares.
+//
+// It knows nothing about a specific app -- that is app()'s job. Splitting the two is what
+// lets a second SEP-backed source (restart, upgrade, whatever om_actions turns out to
+// need) get a client of its own by calling app() again on the one sepClient the Service
+// already holds, rather than by copying the transport. Before this split, probeSource was
+// three things at once: the on-host fact source, the transport to SEP, and (through
+// inventory.go's use of it) half of the inventory REST surface. Only the first of those
+// is a probeSource's business; the other two are this file's.
+type sepClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+// app returns a handle addressed relative to /api/apps/<module>, the mount every SEP app
+// follows. Which app to ask is the caller's business, not the operator's: `--sep-url`
+// points at SEP, not at an app, so the same setting serves every source this package
+// gains.
+func (c *sepClient) app(module string) sepApp {
+	return sepApp{client: c, path: "api/apps/" + module}
+}
+
+// sepApp addresses one SEP app through a shared sepClient. Cheap to copy: it is a
+// pointer and a path.
+type sepApp struct {
+	client *sepClient
+	path   string
+}
+
+// endpoint builds an absolute URL for a path relative to this app.
+func (a sepApp) endpoint(path string) string {
+	return strings.TrimSuffix(a.client.baseURL, "/") + "/" + a.path + "/" + strings.TrimPrefix(path, "/")
+}
+
+// request builds one HTTP request against this app.
+//
+// Body is marshalled as JSON when non-nil, and when sendEmptyBody is set instead sends
+// "{}" -- some proxied endpoints need that: the app's trigger endpoint takes an optional
+// object and FastAPI rejects a bodyless POST against a typed body.
+//
+// The caller sets its own deadline on ctx and performs the request itself -- callers want
+// different timeouts (a probe's own read of its estate is budgeted tighter than a proxied
+// request the browser is waiting on) and different error mappings (a gRPC status for the
+// inventory proxy, a plain error for a factSource's run receipt), and only the request
+// itself -- the URL, the query, the body encoding, the bearer header -- is common to both.
+func (a sepApp) request(ctx context.Context, method, path string, query url.Values, body any, sendEmptyBody bool) (*http.Request, error) {
+	endpoint := a.endpoint(path)
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+
+	var payload []byte
+	switch {
+	case body != nil:
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode the request: %w", err)
+		}
+		payload = encoded
+	case sendEmptyBody:
+		payload = []byte("{}")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err //nolint:wrapcheck
+	}
+	if a.client.token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.client.token)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}

--- a/managed/services/om/service.go
+++ b/managed/services/om/service.go
@@ -1,0 +1,491 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Package om implements OM -- the OpenManager topology and health API.
+//
+// It reconstructs the MongoDB estate from the sources PMM already owns: the inventory in
+// PostgreSQL and the exporter metrics in VictoriaMetrics. PMM stores cluster and
+// replication_set as flat string columns on a service and has no topology object; this
+// service is what turns those labels back into replica sets and sharded clusters, folds
+// in reachability and load, and serves the result as one document.
+//
+// It is the read half of a split: derivation over data PMM owns lives here, while work
+// that has to run on a database host -- collecting argv and installed binary versions,
+// restarts, upgrades, configuration changes -- lives in SEP apps driving Nomad clients.
+// Those arrive here as another factSource, which is why the merge is by declared
+// precedence rather than by which source ran last.
+package om
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/reform.v1"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+)
+
+const (
+	// How long a document is served from cache before the next read rebuilds it. Short
+	// enough that the page is never meaningfully behind, long enough that a browser
+	// refresh does not re-query VictoriaMetrics a dozen times.
+	refreshInterval = 30 * time.Second
+
+	// How old the newest observation may be before the document declares itself stale. A
+	// stale document is still served -- the UI shows the age and lets the reader judge,
+	// which beats replacing data with an error.
+	staleAfter = 5 * time.Minute
+
+	// How many runs the in-memory history keeps.
+	runHistory = 100
+
+	// What the UI asks for when it passes no limit, and the most a caller may ask for.
+	// The ceiling is runHistory: asking for more than the history keeps cannot return
+	// more rows, so a larger number is only a larger query.
+	defaultRunLimit = 25
+	maxRunLimit     = runHistory
+)
+
+// Run statuses, as the run row stores them. A run whose sources all answered is a success
+// even if some services were never seen: a service that inventory knows and metrics have
+// not is a fact about the estate, not a failure of the run.
+//
+// Kept as strings because they are persisted. The wire carries omv1.RunStatus instead, and
+// runStatusToProto in store.go is the only crossing -- a stored row stays legible in psql
+// and survives a renumbering of the enum.
+const (
+	runStatusSuccess = "success"
+	runStatusPartial = "partial"
+	runStatusFailed  = "failed"
+)
+
+// Service provides the OM topology API.
+type Service struct {
+	omv1.UnimplementedOmServiceServer
+
+	db       *reform.DB
+	vmClient victoriaMetricsClient
+	l        *logrus.Entry
+
+	// probe is the on-host fact source, or nil when SEP's om_inventory app is not
+	// configured. Held rather than constructed per run so the HTTP client is reused.
+	probe *probeSource
+
+	// restored guards the one-time read of the stored document on a cold start.
+	restored sync.Once
+
+	// running serialises collection. One collection at a time is enough, and two
+	// concurrent ones would issue the same queries twice and race to publish.
+	running sync.Mutex
+
+	mu      sync.Mutex
+	latest  *omv1.GetTopologyResponse
+	builtAt time.Time
+}
+
+// New returns a new OM service.
+func New(db *reform.DB, vmClient victoriaMetricsClient, l *logrus.Entry) *Service {
+	return &Service{
+		db:       db,
+		vmClient: vmClient,
+		l:        l,
+	}
+}
+
+// WithProbeSource attaches SEP's om_inventory app as a fact source.
+//
+// Takes where SEP is, not where the app is: the app path is this package's business,
+// and the sources that follow -- upgrade, restart -- will hang off the same SEP.
+//
+// Optional by design: an empty URL leaves the source off, and the document is built
+// from PMM's own inventory and metrics alone. That is the difference between "no probe
+// has run here" and "the probe failed", and the run receipt reports which.
+func (s *Service) WithProbeSource(sepURL, token string) *Service {
+	if sepURL == "" {
+		s.l.Info("SEP is not configured; on-host facts will be absent")
+		return s
+	}
+	probe := &probeSource{
+		sepURL: sepURL,
+		token:  token,
+		client: &http.Client{Timeout: probeRequestTimeout},
+		l:      s.l.WithField("source", sourceProbe),
+	}
+	s.probe = probe
+	s.l.Infof("om_inventory estate at %s", probe.endpoint(""))
+	return s
+}
+
+// GetTopology returns the whole MongoDB estate as one document, rebuilding it when the
+// cached one has aged past refreshInterval.
+func (s *Service) GetTopology(ctx context.Context, _ *omv1.GetTopologyRequest) (*omv1.GetTopologyResponse, error) {
+	s.restoreOnce(ctx)
+	if cached, ok := s.cached(); ok {
+		return cached, nil
+	}
+
+	response, err := s.discover(ctx)
+	if err != nil {
+		// Serving a stale document beats serving an error, as long as the envelope says
+		// so -- which it does, because stale is computed from observed_at.
+		if cached := s.snapshot(); cached != nil {
+			s.l.Warnf("serving the cached topology, rebuild failed: %s", err)
+			return cached, nil
+		}
+		return nil, err
+	}
+	return response, nil
+}
+
+// ListTopologyRuns returns the recorded runs, newest first.
+func (s *Service) ListTopologyRuns(ctx context.Context, req *omv1.ListTopologyRunsRequest) (*omv1.ListTopologyRunsResponse, error) {
+	limit := int(req.GetLimit())
+	switch {
+	case limit <= 0:
+		limit = defaultRunLimit
+	case limit > maxRunLimit:
+		limit = maxRunLimit
+	}
+
+	runs, err := s.listRuns(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &omv1.ListTopologyRunsResponse{Runs: runs}, nil
+}
+
+// GetTopologyRun returns one recorded run.
+func (s *Service) GetTopologyRun(ctx context.Context, req *omv1.GetTopologyRunRequest) (*omv1.GetTopologyRunResponse, error) {
+	run, err := s.getRun(ctx, req.GetRunId())
+	if err != nil {
+		if errors.Is(err, models.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "Run %s not found.", req.GetRunId())
+		}
+		return nil, err
+	}
+	return &omv1.GetTopologyRunResponse{Run: run}, nil
+}
+
+// TriggerTopologyCollection rebuilds the topology document now and records the run.
+//
+// Synchronous, unlike SEP's, and it answers with a terminal status: there is no fan-out
+// to remote executors to wait on here, so there is nothing to poll for. It refuses
+// rather than queues while one is in flight -- two collections would issue the same
+// queries twice and race to publish, and the caller wants the answer, not a second run.
+func (s *Service) TriggerTopologyCollection(ctx context.Context, _ *omv1.TriggerTopologyCollectionRequest) (*omv1.TriggerTopologyCollectionResponse, error) {
+	if !s.running.TryLock() {
+		// Aborted, not FailedPrecondition: the gateway maps it to 409 Conflict, which is
+		// what the UI's Sync button already treats as an expected outcome rather than a
+		// failure.
+		return nil, status.Error(codes.Aborted, "A collection run is already in flight.")
+	}
+	defer s.running.Unlock()
+
+	_, run, err := s.collect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &omv1.TriggerTopologyCollectionResponse{
+		RunId:     run.RunId,
+		Status:    run.Status,
+		StartTime: run.StartTime,
+	}, nil
+}
+
+// Run refreshes the document on a timer until ctx is cancelled.
+//
+// Collection is driven rather than left to whoever happens to read: the run history is
+// only worth having if it exists when nobody is looking, and a document assembled purely
+// on demand can say nothing about the interval since the last one.
+func (s *Service) Run(ctx context.Context) {
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_, err := s.discover(ctx)
+			if err != nil && ctx.Err() == nil {
+				s.l.Warnf("scheduled collection failed: %s", err)
+			}
+		}
+	}
+}
+
+// discover rebuilds unless another caller is already doing it, in which case it waits for
+// that one and serves what it published. Two collections of the same estate at the same
+// moment differ only in cost.
+func (s *Service) discover(ctx context.Context) (*omv1.GetTopologyResponse, error) {
+	if !s.running.TryLock() {
+		s.running.Lock()
+		s.running.Unlock() //nolint:staticcheck // waiting out the in-flight run, not guarding
+		if cached := s.snapshot(); cached != nil {
+			return cached, nil
+		}
+		return nil, status.Error(codes.Unavailable, "A collection is in flight and no document is available yet.")
+	}
+	defer s.running.Unlock()
+
+	response, _, err := s.collect(ctx)
+	return response, err
+}
+
+// collect reads every source, merges, builds the document and records the run. The caller
+// must hold s.running.
+func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1.TopologyRun, error) {
+	startedAt := time.Now()
+	runID := uuid.New().String()
+
+	services, nodes, originNode, maxAge, err := s.readInventory(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read inventory: %w", err)
+	}
+
+	sources := []factSource{
+		inventorySource{nodes: nodes},
+		metricsSource{vm: s.vmClient, l: s.l, now: startedAt},
+	}
+	if s.probe != nil {
+		sources = append(sources, *s.probe)
+	}
+	results := make([]SourceResult, 0, len(sources))
+	for _, source := range sources {
+		results = append(results, source.collect(ctx, services))
+	}
+
+	merged := mergeFacts(results, defaultPrecedence)
+	generatedAt := time.Now()
+	doc := buildDocument(services, merged, generatedAt, maxAge)
+
+	response := &omv1.GetTopologyResponse{
+		Snapshot: &omv1.Snapshot{
+			GeneratedAt:   timestamppb.New(generatedAt),
+			ObservedAt:    observedAt(doc),
+			Stale:         isStale(doc, generatedAt),
+			SchemaVersion: schemaVersion,
+			RunId:         runID,
+		},
+		OriginNode:    optional(originNode),
+		SourceQueries: sourceQueries,
+		Summary:       doc.summary,
+		Environments:  doc.environments,
+	}
+	run := buildRun(runID, startedAt, generatedAt, services, merged, doc, results)
+
+	s.mu.Lock()
+	s.latest, s.builtAt = response, generatedAt
+	s.mu.Unlock()
+
+	// Recorded after publishing, and never fatal: the document is already correct and
+	// already served, so losing the record of a collection is worth less than refusing to
+	// answer with it.
+	err = s.persist(ctx, response, run, originNode)
+	if err != nil {
+		s.l.Warnf("run %s: failed to record: %s", runID, err)
+	}
+
+	s.l.Infof("run %s: %d service(s), %d up, %d cluster(s), %d stale, %s max age, status %s",
+		runID, doc.summary.TotalServices, doc.summary.UpServices, doc.summary.Clusters,
+		doc.staleServices, maxAge, run.Status)
+
+	return response, run, nil
+}
+
+// restoreOnce loads the newest stored document into the cache the first time it is
+// needed, so a restarted pmm-managed answers from the last known estate rather than
+// starting from nothing.
+//
+// It is restored with the age it actually has, not as if it were just collected, so it
+// then obeys the same cache rule as anything else: young enough and it is served, too old
+// and the read that wanted it rebuilds. Either way there is now something to fall back on
+// when a rebuild fails, which is the case that made this worth storing.
+func (s *Service) restoreOnce(ctx context.Context) {
+	s.restored.Do(func() {
+		response, generatedAt, err := s.restore(ctx)
+		if err != nil {
+			s.l.Warnf("failed to restore the stored topology: %s", err)
+			return
+		}
+		if response == nil {
+			return
+		}
+		s.mu.Lock()
+		if s.latest == nil {
+			s.latest, s.builtAt = response, generatedAt
+		}
+		s.mu.Unlock()
+		s.l.Infof("restored the topology document generated at %s (%s ago)",
+			generatedAt.Format(time.RFC3339), time.Since(generatedAt).Truncate(time.Second))
+	})
+}
+
+// cached returns the published document while it is younger than refreshInterval.
+func (s *Service) cached() (*omv1.GetTopologyResponse, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.latest != nil && time.Since(s.builtAt) < refreshInterval {
+		return s.latest, true
+	}
+	return nil, false
+}
+
+// snapshot returns the published document, however old.
+func (s *Service) snapshot() *omv1.GetTopologyResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latest
+}
+
+// readInventory returns every MongoDB service, its nodes by ID, the PMM Server node name
+// to record as the document's vantage point, and how old a volatile observation may be.
+func (s *Service) readInventory(ctx context.Context) ([]*models.Service, map[string]*models.Node, string, time.Duration, error) {
+	var (
+		services   []*models.Service
+		nodesByID  map[string]*models.Node
+		originNode string
+		maxAge     time.Duration
+	)
+
+	serviceType := models.MongoDBServiceType
+	errTX := s.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		var err error
+		services, err = models.FindServices(tx.Querier, models.ServiceFilters{ServiceType: &serviceType})
+		if err != nil {
+			return err
+		}
+
+		// The freshness rule follows whatever PMM is actually scraping at, rather than
+		// hardcoding an interval that a settings change would silently invalidate.
+		settings, err := models.GetSettings(tx)
+		if err != nil {
+			return err
+		}
+		maxAge = max(settings.MetricsResolutions.HR*volatileMaxAgeFactor, minVolatileMaxAge)
+
+		nodes, err := models.FindNodes(tx.Querier, models.NodeFilters{})
+		if err != nil {
+			return err
+		}
+		nodesByID = make(map[string]*models.Node, len(nodes))
+		for _, node := range nodes {
+			nodesByID[node.NodeID] = node
+			if node.IsPMMServerNode {
+				originNode = node.NodeName
+			}
+		}
+		return nil
+	})
+	if errTX != nil {
+		return nil, nil, "", 0, errTX
+	}
+	return services, nodesByID, originNode, maxAge, nil
+}
+
+// buildRun records what one pass saw.
+//
+// The resolved_services versus successful_probes pair is the diagnostic split: the first says a
+// source produced facts for the service at all, the second says it was observed as reachable.
+// A run with resolved=9, successful=0 is a healthy join and nine unreachable databases.
+func buildRun(
+	runID string, startedAt, finishedAt time.Time,
+	services []*models.Service, merged map[string]map[string]MergedField,
+	doc document, results []SourceResult,
+) *omv1.TopologyRun {
+	counts := &omv1.TopologyRunCounts{TotalServices: int32(len(services))} //nolint:gosec
+	for _, service := range services {
+		if len(merged[service.ServiceID]) == 0 {
+			counts.OrphanedServices++
+			continue
+		}
+		counts.ResolvedServices++
+	}
+	counts.SuccessfulProbes = doc.summary.UpServices
+	counts.StaleServices = int32(doc.staleServices) //nolint:gosec
+
+	run := &omv1.TopologyRun{
+		RunId:     runID,
+		Status:    omv1.RunStatus_RUN_STATUS_SUCCESS,
+		StartTime: timestamppb.New(startedAt),
+		EndTime:   timestamppb.New(finishedAt),
+		Counts:    counts,
+		Sources:   make([]*omv1.SourceReport, 0, len(results)),
+		Errors:    []*omv1.TopologyRunError{},
+	}
+
+	failed := 0
+	for _, result := range results {
+		run.Sources = append(run.Sources, &omv1.SourceReport{
+			Source: result.Source,
+			Status: sourceStatusToProto(result.Status),
+			Facts:  int32(len(result.Facts)), //nolint:gosec
+			Detail: detailStrings(result.Detail),
+		})
+		for _, e := range result.Errors {
+			run.Errors = append(run.Errors, &omv1.TopologyRunError{
+				Scope:       e.Scope,
+				ServiceName: optional(e.ServiceName),
+				Code:        e.Code,
+				Message:     e.Message,
+			})
+		}
+		if result.Status == SourceFailed {
+			failed++
+		}
+	}
+
+	switch {
+	case failed > 0 && failed == len(results):
+		run.Status = omv1.RunStatus_RUN_STATUS_FAILED
+	case len(run.Errors) > 0 || failed > 0:
+		run.Status = omv1.RunStatus_RUN_STATUS_PARTIAL
+	}
+	return run
+}
+
+// detailStrings renders a source's counters for the wire, which carries them as strings
+// so a source can report whatever it has without the contract naming every counter.
+func detailStrings(detail map[string]any) map[string]string {
+	out := make(map[string]string, len(detail))
+	for key, value := range detail {
+		out[key] = fmt.Sprint(value)
+	}
+	return out
+}
+
+func observedAt(doc document) *timestamppb.Timestamp {
+	if doc.observedAt.IsZero() {
+		return nil
+	}
+	return timestamppb.New(doc.observedAt)
+}
+
+func isStale(doc document, generatedAt time.Time) bool {
+	if doc.observedAt.IsZero() {
+		return false
+	}
+	return generatedAt.Sub(doc.observedAt) > staleAfter
+}

--- a/managed/services/om/service.go
+++ b/managed/services/om/service.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -110,6 +111,13 @@ type Service struct {
 
 	mu     sync.Mutex
 	latest *omv1.GetTopologyResponse
+
+	// Completed-run tally by status, read by MetricsCollector on every Prometheus scrape
+	// and written once per run by recordRunOutcome. Atomic because a scrape can land while
+	// a collection is in flight.
+	runsSuccess atomic.Int64
+	runsPartial atomic.Int64
+	runsFailed  atomic.Int64
 }
 
 // New returns a new OM service.
@@ -314,6 +322,7 @@ func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1
 		Environments:  doc.environments,
 	}
 	run := buildRun(runID, startedAt, generatedAt, services, merged, doc, results)
+	s.recordRunOutcome(run.Status)
 
 	s.mu.Lock()
 	s.latest = response
@@ -537,6 +546,21 @@ func buildRun(
 		run.Status = omv1.RunStatus_RUN_STATUS_PARTIAL
 	}
 	return run
+}
+
+// recordRunOutcome tallies one completed run by status, for MetricsCollector's
+// pmm_managed_om_runs_total counter.
+func (s *Service) recordRunOutcome(status omv1.RunStatus) {
+	switch status {
+	case omv1.RunStatus_RUN_STATUS_SUCCESS:
+		s.runsSuccess.Add(1)
+	case omv1.RunStatus_RUN_STATUS_PARTIAL:
+		s.runsPartial.Add(1)
+	case omv1.RunStatus_RUN_STATUS_FAILED:
+		s.runsFailed.Add(1)
+	default:
+		// buildRun only ever sets one of the three above.
+	}
 }
 
 // detailStrings renders a source's counters for the wire, which carries them as strings

--- a/managed/services/om/service.go
+++ b/managed/services/om/service.go
@@ -15,11 +15,14 @@
 
 // Package om implements OM -- the OpenManager topology and health API.
 //
-// It reconstructs the MongoDB estate from the sources PMM already owns: the inventory in
+// It groups the MongoDB estate from the sources PMM already owns: the inventory in
 // PostgreSQL and the exporter metrics in VictoriaMetrics. PMM stores cluster and
 // replication_set as flat string columns on a service and has no topology object; this
-// service is what turns those labels back into replica sets and sharded clusters, folds
-// in reachability and load, and serves the result as one document.
+// service groups services that share a label, folds in reachability and load, and serves
+// the result as one document. That is a grouped service inventory, not a reconstructed
+// topology graph: a sharded cluster here is a flat list of mongos, configsvr and shardsvr
+// rows that happen to share a label, not a shard map with a discovered member list. See
+// ClusterType in api/om/v1/om.proto for the one thing inferred about a group's shape.
 //
 // It is the read half of a split: derivation over data PMM owns lives here, while work
 // that has to run on a database host -- collecting argv and installed binary versions,
@@ -48,9 +51,9 @@ import (
 )
 
 const (
-	// How long a document is served from cache before the next read rebuilds it. Short
-	// enough that the page is never meaningfully behind, long enough that a browser
-	// refresh does not re-query VictoriaMetrics a dozen times.
+	// How often the leader's own ticker rebuilds the document. Collection is
+	// leader-driven, not request-driven -- see Run and GetTopology -- so this paces the
+	// ticker rather than gating a read.
 	refreshInterval = 30 * time.Second
 
 	// How old the newest observation may be before the document declares itself stale. A
@@ -89,6 +92,11 @@ type Service struct {
 	vmClient victoriaMetricsClient
 	l        *logrus.Entry
 
+	// ha reports leadership, so TriggerTopologyCollection can refuse on a follower. Nil
+	// in most tests, which is read as "every node is the leader" -- the single-node
+	// default.
+	ha haChecker
+
 	// probe is the on-host fact source, or nil when SEP's om_inventory app is not
 	// configured. Held rather than constructed per run so the HTTP client is reused.
 	probe *probeSource
@@ -100,16 +108,16 @@ type Service struct {
 	// concurrent ones would issue the same queries twice and race to publish.
 	running sync.Mutex
 
-	mu      sync.Mutex
-	latest  *omv1.GetTopologyResponse
-	builtAt time.Time
+	mu     sync.Mutex
+	latest *omv1.GetTopologyResponse
 }
 
 // New returns a new OM service.
-func New(db *reform.DB, vmClient victoriaMetricsClient, l *logrus.Entry) *Service {
+func New(db *reform.DB, vmClient victoriaMetricsClient, ha haChecker, l *logrus.Entry) *Service {
 	return &Service{
 		db:       db,
 		vmClient: vmClient,
+		ha:       ha,
 		l:        l,
 	}
 }
@@ -127,36 +135,39 @@ func (s *Service) WithProbeSource(sepURL, token string) *Service {
 		s.l.Info("SEP is not configured; on-host facts will be absent")
 		return s
 	}
+	client := &sepClient{
+		baseURL: sepURL,
+		token:   token,
+		http:    &http.Client{Timeout: probeRequestTimeout},
+	}
 	probe := &probeSource{
-		sepURL: sepURL,
-		token:  token,
-		client: &http.Client{Timeout: probeRequestTimeout},
-		l:      s.l.WithField("source", sourceProbe),
+		app: client.app(probeAppModule),
+		l:   s.l.WithField("source", sourceProbe),
 	}
 	s.probe = probe
-	s.l.Infof("om_inventory estate at %s", probe.endpoint(""))
+	s.l.Infof("om_inventory estate at %s", probe.app.endpoint(""))
 	return s
 }
 
-// GetTopology returns the whole MongoDB estate as one document, rebuilding it when the
-// cached one has aged past refreshInterval.
-func (s *Service) GetTopology(ctx context.Context, _ *omv1.GetTopologyRequest) (*omv1.GetTopologyResponse, error) {
+// GetTopology returns the whole MongoDB estate as one document.
+//
+// A pure read path: memory, then the stored snapshot, never a collection. Collection is
+// leader-only (Run, TriggerTopologyCollection), and a request-triggered rebuild here
+// would make every follower behind the load balancer a writer and a pruner racing the
+// leader. Staleness is recomputed against the clock on every call rather than trusted
+// from whenever the document was built or restored, so a follower that never collects
+// still reports its document's true age.
+func (s *Service) GetTopology(ctx context.Context, _ *omv1.GetTopologyRequest) (*omv1.GetTopologyResponse, error) { //nolint:unparam
 	s.restoreOnce(ctx)
-	if cached, ok := s.cached(); ok {
-		return cached, nil
+	if cached := s.snapshot(); cached != nil {
+		return withFreshStale(cached), nil
 	}
-
-	response, err := s.discover(ctx)
-	if err != nil {
-		// Serving a stale document beats serving an error, as long as the envelope says
-		// so -- which it does, because stale is computed from observed_at.
-		if cached := s.snapshot(); cached != nil {
-			s.l.Warnf("serving the cached topology, rebuild failed: %s", err)
-			return cached, nil
-		}
-		return nil, err
-	}
-	return response, nil
+	// Genuinely cold: no in-memory document and nothing stored yet, e.g. a fresh estate
+	// whose leader has not completed its first pass. An empty document with stale=true
+	// is the honest answer -- Unavailable would read as an error for a normal startup
+	// state, and blocking for the leader's first run would reintroduce the
+	// request-triggered wait this path exists to remove.
+	return emptyTopologyResponse(), nil
 }
 
 // ListTopologyRuns returns the recorded runs, newest first.
@@ -194,7 +205,21 @@ func (s *Service) GetTopologyRun(ctx context.Context, req *omv1.GetTopologyRunRe
 // to remote executors to wait on here, so there is nothing to poll for. It refuses
 // rather than queues while one is in flight -- two collections would issue the same
 // queries twice and race to publish, and the caller wants the answer, not a second run.
+//
+// Refuses on a non-leader for the same reason: a follower that collected would persist a
+// run and prune the shared history right alongside the leader's own pass.
+//
+//nolint:unparam
 func (s *Service) TriggerTopologyCollection(ctx context.Context, _ *omv1.TriggerTopologyCollectionRequest) (*omv1.TriggerTopologyCollectionResponse, error) {
+	if s.ha != nil && !s.ha.IsLeader() {
+		if leader := s.ha.LeaderID(); leader != "" {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"This node is not the HA leader; %s is. Only the leader collects.", leader)
+		}
+		return nil, status.Error(codes.FailedPrecondition,
+			"This node is not the HA leader. Only the leader collects.")
+	}
+
 	if !s.running.TryLock() {
 		// Aborted, not FailedPrecondition: the gateway maps it to 409 Conflict, which is
 		// what the UI's Sync button already treats as an expected outcome rather than a
@@ -265,13 +290,7 @@ func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1
 		return nil, nil, fmt.Errorf("failed to read inventory: %w", err)
 	}
 
-	sources := []factSource{
-		inventorySource{nodes: nodes},
-		metricsSource{vm: s.vmClient, l: s.l, now: startedAt},
-	}
-	if s.probe != nil {
-		sources = append(sources, *s.probe)
-	}
+	sources := s.sources(nodes, startedAt)
 	results := make([]SourceResult, 0, len(sources))
 	for _, source := range sources {
 		results = append(results, source.collect(ctx, services))
@@ -279,7 +298,7 @@ func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1
 
 	merged := mergeFacts(results, defaultPrecedence)
 	generatedAt := time.Now()
-	doc := buildDocument(services, merged, generatedAt, maxAge)
+	doc := applyHealth(buildDocument(services, merged, generatedAt, maxAge))
 
 	response := &omv1.GetTopologyResponse{
 		Snapshot: &omv1.Snapshot{
@@ -297,7 +316,7 @@ func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1
 	run := buildRun(runID, startedAt, generatedAt, services, merged, doc, results)
 
 	s.mu.Lock()
-	s.latest, s.builtAt = response, generatedAt
+	s.latest = response
 	s.mu.Unlock()
 
 	// Recorded after publishing, and never fatal: the document is already correct and
@@ -315,14 +334,30 @@ func (s *Service) collect(ctx context.Context) (*omv1.GetTopologyResponse, *omv1
 	return response, run, nil
 }
 
-// restoreOnce loads the newest stored document into the cache the first time it is
-// needed, so a restarted pmm-managed answers from the last known estate rather than
-// starting from nothing.
+// sources returns the fact sources one collection reads, in the order they run.
 //
-// It is restored with the age it actually has, not as if it were just collected, so it
-// then obeys the same cache rule as anything else: young enough and it is served, too old
-// and the read that wanted it rebuilds. Either way there is now something to fall back on
-// when a rebuild fails, which is the case that made this worth storing.
+// Extracted so a test can see the set and its order without driving a whole collection:
+// which sources are wired in, and whether probe is included, is exactly what review
+// found untested. Both nodes and startedAt are per-run state the sources close over
+// rather than package globals, so two overlapping calls (the ticker and a manual
+// trigger racing, however briefly) never share one.
+func (s *Service) sources(nodes map[string]*models.Node, startedAt time.Time) []factSource {
+	sources := []factSource{
+		inventorySource{nodes: nodes},
+		metricsSource{vm: s.vmClient, l: s.l, now: startedAt},
+	}
+	if s.probe != nil {
+		sources = append(sources, *s.probe)
+	}
+	return sources
+}
+
+// restoreOnce loads the newest stored document into memory the first time it is needed,
+// so a restarted pmm-managed answers from the last known estate rather than nothing.
+//
+// Only "is there a document at all" is decided here. How fresh it is remains a question
+// the read path answers itself, every time it is asked -- see withFreshStale -- rather
+// than baking the answer in as of the moment this ran.
 func (s *Service) restoreOnce(ctx context.Context) {
 	s.restored.Do(func() {
 		response, generatedAt, err := s.restore(ctx)
@@ -335,7 +370,7 @@ func (s *Service) restoreOnce(ctx context.Context) {
 		}
 		s.mu.Lock()
 		if s.latest == nil {
-			s.latest, s.builtAt = response, generatedAt
+			s.latest = response
 		}
 		s.mu.Unlock()
 		s.l.Infof("restored the topology document generated at %s (%s ago)",
@@ -343,21 +378,59 @@ func (s *Service) restoreOnce(ctx context.Context) {
 	})
 }
 
-// cached returns the published document while it is younger than refreshInterval.
-func (s *Service) cached() (*omv1.GetTopologyResponse, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.latest != nil && time.Since(s.builtAt) < refreshInterval {
-		return s.latest, true
-	}
-	return nil, false
-}
-
 // snapshot returns the published document, however old.
 func (s *Service) snapshot() *omv1.GetTopologyResponse {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.latest
+}
+
+// withFreshStale returns response with Snapshot.Stale recomputed against the current
+// time, leaving the rest of the message untouched.
+//
+// A document served from memory can sit there for a long time on a node that never
+// collects -- every follower, once GetTopology stops triggering a collection of its own
+// -- so staleness has to be a property of when it is read, not frozen as of whenever it
+// was built or restored. Response is shared across concurrent readers, so this returns a
+// shallow copy rather than mutating it in place.
+func withFreshStale(response *omv1.GetTopologyResponse) *omv1.GetTopologyResponse {
+	if response == nil || response.Snapshot == nil {
+		return response
+	}
+	// Built field by field rather than copied (`clone := *response`): a proto message
+	// carries a sync.Mutex in its generated MessageState, and copying that by value is
+	// exactly the bug go vet's copylocks check exists to catch.
+	snapshot := &omv1.Snapshot{
+		GeneratedAt:   response.Snapshot.GeneratedAt,
+		ObservedAt:    response.Snapshot.ObservedAt,
+		Stale:         snapshotStale(response.Snapshot.ObservedAt),
+		SchemaVersion: response.Snapshot.SchemaVersion,
+		RunId:         response.Snapshot.RunId,
+	}
+	return &omv1.GetTopologyResponse{
+		Snapshot:      snapshot,
+		OriginNode:    response.OriginNode,
+		SourceQueries: response.SourceQueries,
+		Summary:       response.Summary,
+		Environments:  response.Environments,
+	}
+}
+
+// emptyTopologyResponse is what GetTopology answers on a genuinely cold estate: nothing
+// in memory, nothing stored yet. That is the normal state for the first moments of a
+// fresh install, not an error -- observed_at stays unset and stale is true so the UI can
+// render "collecting, no data yet" rather than a blank document that looks like an empty
+// estate.
+func emptyTopologyResponse() *omv1.GetTopologyResponse {
+	return &omv1.GetTopologyResponse{
+		Snapshot: &omv1.Snapshot{
+			Stale:         true,
+			SchemaVersion: schemaVersion,
+		},
+		SourceQueries: sourceQueries,
+		Summary:       &omv1.Summary{ProcessRoleCounts: map[string]int32{}},
+		Environments:  []*omv1.Environment{},
+	}
 }
 
 // readInventory returns every MongoDB service, its nodes by ID, the PMM Server node name

--- a/managed/services/om/service_test.go
+++ b/managed/services/om/service_test.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gopkg.in/reform.v1"
+	"gopkg.in/reform.v1/dialects/postgresql"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+	"github.com/percona/pmm/managed/utils/testdb"
+)
+
+// panicVM fails the test the moment it is queried. GetTopology's whole point after the
+// PMM-15326 read-path fix is that it never reaches VictoriaMetrics -- collection is
+// leader-only and request-triggered nowhere -- so any test that exercises the read path
+// wires this in and lets a query panic rather than silently succeed.
+type panicVM struct{ t *testing.T }
+
+func (p panicVM) Query(context.Context, string, time.Time, ...v1.Option) (model.Value, v1.Warnings, error) {
+	p.t.Helper()
+	p.t.Fatal("GetTopology must not query VictoriaMetrics: it is a pure read path")
+	return nil, nil, nil
+}
+
+// fakeHA is a haChecker double.
+type fakeHA struct {
+	leader   bool
+	leaderID string
+}
+
+func (f fakeHA) IsLeader() bool   { return f.leader }
+func (f fakeHA) LeaderID() string { return f.leaderID }
+
+func serviceTestDB(t *testing.T) *reform.DB {
+	t.Helper()
+	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
+	return reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
+}
+
+// TestGetTopologyNeverCollects is the regression guard for PMM-15326's read-path fix:
+// GetTopology must serve memory or the stored snapshot and never reach collect(), on a
+// freshly restored service or on any later call. Before the fix, a restored document
+// older than 30s missed the cache immediately and every request rebuilt it -- see
+// service.go's package comment history in the PR for the mechanism.
+func TestGetTopologyNeverCollects(t *testing.T) {
+	db := serviceTestDB(t)
+
+	// Written by one Service instance, as if by a leader that has since gone away --
+	// restored by a second, as pmm-managed does across a restart.
+	writer := &Service{db: db, l: logrus.WithField("test", t.Name())}
+	generatedAt := time.Now().Truncate(time.Microsecond)
+	response, run := testTopologyResponse("restored-run", generatedAt, generatedAt.Add(-2*time.Second))
+	require.NoError(t, writer.persist(t.Context(), response, run, "pmm-server"))
+
+	reader := &Service{db: db, vmClient: panicVM{t: t}, l: logrus.WithField("test", t.Name())}
+
+	first, err := reader.GetTopology(t.Context(), &omv1.GetTopologyRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, "restored-run", first.Snapshot.RunId)
+	assert.False(t, first.Snapshot.Stale, "just-restored document should read as fresh")
+
+	// The DB is gone from here on. sync.Once guarantees restoreOnce's own query never
+	// repeats, but this proves the read path holds that guarantee rather than assuming
+	// it -- a second GetTopology call has nothing to fall back on but memory.
+	require.NoError(t, db.DBInterface().(interface{ Close() error }).Close())
+
+	second, err := reader.GetTopology(t.Context(), &omv1.GetTopologyRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, first.Snapshot.RunId, second.Snapshot.RunId)
+}
+
+// TestGetTopologyColdStart covers the estate that has never collected anywhere: no
+// memory, nothing stored. GetTopology must answer with an empty, explicitly stale
+// document rather than an error or a wait for a collection that GetTopology itself must
+// never start.
+func TestGetTopologyColdStart(t *testing.T) {
+	db := serviceTestDB(t)
+	svc := &Service{db: db, vmClient: panicVM{t: t}, l: logrus.WithField("test", t.Name())}
+
+	response, err := svc.GetTopology(t.Context(), &omv1.GetTopologyRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.True(t, response.Snapshot.Stale)
+	assert.Nil(t, response.Snapshot.ObservedAt)
+	assert.Empty(t, response.Environments)
+}
+
+// TestGetTopologyConcurrentReadsDoNotRace exercises the read path from many goroutines
+// at once. Run with -race: the point is that GetTopology touches only s.mu and
+// s.restored, never s.running, so concurrent readers never contend with each other or
+// with a collection.
+func TestGetTopologyConcurrentReadsDoNotRace(t *testing.T) {
+	db := serviceTestDB(t)
+	svc := &Service{db: db, vmClient: panicVM{t: t}, l: logrus.WithField("test", t.Name())}
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			_, err := svc.GetTopology(t.Context(), &omv1.GetTopologyRequest{})
+			assert.NoError(t, err)
+		})
+	}
+	wg.Wait()
+}
+
+func TestTriggerTopologyCollectionRefusesOnNonLeader(t *testing.T) {
+	svc := &Service{ha: fakeHA{leader: false, leaderID: "node-b"}, l: logrus.WithField("test", t.Name())}
+
+	_, err := svc.TriggerTopologyCollection(t.Context(), &omv1.TriggerTopologyCollectionRequest{})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	assert.Contains(t, err.Error(), "node-b")
+}
+
+func TestTriggerTopologyCollectionRefusesOnNonLeaderWithoutKnownLeader(t *testing.T) {
+	svc := &Service{ha: fakeHA{leader: false, leaderID: ""}, l: logrus.WithField("test", t.Name())}
+
+	_, err := svc.TriggerTopologyCollection(t.Context(), &omv1.TriggerTopologyCollectionRequest{})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+// TestTriggerTopologyCollectionAllowsLeaderOrNoHA covers the common cases: an explicit
+// leader, and no ha wired in at all -- every test in this package but the ones above, and
+// single-node PMM without HA enabled at all (ha.Service.IsLeader() is true when HA is
+// disabled, so the same "every node is the leader" reading applies).
+func TestTriggerTopologyCollectionAllowsLeaderOrNoHA(t *testing.T) {
+	for name, ha := range map[string]haChecker{"leader": fakeHA{leader: true}, "no ha wired in": nil} {
+		t.Run(name, func(t *testing.T) {
+			svc := &Service{ha: ha, l: logrus.WithField("test", t.Name())}
+			svc.running.Lock() // short-circuit before collect() needs a database.
+			defer svc.running.Unlock()
+
+			_, err := svc.TriggerTopologyCollection(t.Context(), &omv1.TriggerTopologyCollectionRequest{})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.Aborted, status.Code(err), "should reach the in-flight check, not refuse as a follower")
+		})
+	}
+}
+
+func TestTriggerTopologyCollectionAbortsWhileRunInFlight(t *testing.T) {
+	svc := &Service{l: logrus.WithField("test", t.Name())}
+	svc.running.Lock()
+	defer svc.running.Unlock()
+
+	_, err := svc.TriggerTopologyCollection(t.Context(), &omv1.TriggerTopologyCollectionRequest{})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Aborted, status.Code(err))
+}
+
+func TestSourcesOrdering(t *testing.T) {
+	t.Run("without a probe, just inventory and metrics", func(t *testing.T) {
+		svc := &Service{l: logrus.WithField("test", t.Name())}
+		sources := svc.sources(nil, time.Now())
+
+		require.Len(t, sources, 2)
+		assert.Equal(t, sourceInventory, sources[0].key())
+		assert.Equal(t, sourceMetrics, sources[1].key())
+	})
+
+	t.Run("with a probe configured, probe is appended last", func(t *testing.T) {
+		client := &sepClient{baseURL: "http://sep.example", http: nil}
+		svc := &Service{
+			l:     logrus.WithField("test", t.Name()),
+			probe: &probeSource{app: client.app(probeAppModule), l: logrus.WithField("source", sourceProbe)},
+		}
+		sources := svc.sources(nil, time.Now())
+
+		require.Len(t, sources, 3)
+		assert.Equal(t, sourceInventory, sources[0].key())
+		assert.Equal(t, sourceMetrics, sources[1].key())
+		assert.Equal(t, sourceProbe, sources[2].key())
+	})
+}
+
+// TestCollectPersistFailureStillReturnsDocument covers the run whose write fails: the
+// document was already built and is already correct, so losing the run record must not
+// turn into losing the response.
+func TestCollectPersistFailureStillReturnsDocument(t *testing.T) {
+	db := serviceTestDB(t)
+
+	node, err := models.CreateNode(db.Querier, models.GenericNodeType, &models.CreateNodeParams{NodeName: "node00"})
+	require.NoError(t, err)
+	port := uint16(27017)
+	address := "127.0.0.1"
+	_, err = models.AddNewService(db.Querier, models.MongoDBServiceType, &models.AddDBMSServiceParams{
+		ServiceName: "mongo-1",
+		NodeID:      node.NodeID,
+		Address:     &address,
+		Port:        &port,
+	})
+	require.NoError(t, err)
+
+	// om_topology_runs is gone, so persist()'s INSERT fails -- collect() must log that
+	// and still hand back the response it already built and published.
+	_, err = db.Exec(`ALTER TABLE om_topology_runs RENAME TO om_topology_runs_test_gone`)
+	require.NoError(t, err)
+
+	svc := &Service{db: db, vmClient: &recordingVM{}, l: logrus.WithField("test", t.Name())}
+	response, run, err := svc.collect(t.Context())
+
+	require.NoError(t, err, "a failed persist must not fail collect")
+	require.NotNil(t, response)
+	require.NotNil(t, run)
+	assert.Equal(t, int32(1), response.Summary.TotalServices)
+	assert.Same(t, response, svc.snapshot(), "the response collect returned is the one it published")
+}

--- a/managed/services/om/sources.go
+++ b/managed/services/om/sources.go
@@ -234,41 +234,102 @@ func (r *metricsRun) signal(ctx context.Context, matcher string, signal metricSi
 	// value is the age rather than the metric's.
 	query := fmt.Sprintf("last_over_time(%s{%s}[%s])", signal.metric, matcher, metricsLookback)
 	r.queries++
-	values := make(map[string]float64)
-	r.src.each(ctx, r.result, query, func(serviceID string, _ model.Metric, v float64) {
-		if held, ok := values[serviceID]; ok && signal.reduceMax && held >= v {
+	values := make(map[string]seriesSample)
+	r.src.each(ctx, r.result, query, func(serviceID string, m model.Metric, v float64) {
+		age, dated := ages[seriesKey(m)]
+		sample := seriesSample{value: v, age: age, dated: dated}
+		if held, ok := values[serviceID]; ok && !sample.supersedes(held, signal.reduceMax) {
 			return
 		}
-		values[serviceID] = v
+		values[serviceID] = sample
 	})
 
-	for serviceID, v := range values {
-		fact := Fact{Service: serviceID, Field: signal.valueField, Value: v, Source: sourceMetrics}
-		// Dated by the matching age query, so a value read over a day-long window still
-		// knows how old it is -- and with the oldest of that service's series, because the
-		// winner above was chosen without reference to which series was freshest.
-		if age, ok := ages[serviceID]; ok {
-			fact.ObservedAt = r.observedAt(age)
+	for serviceID, sample := range values {
+		fact := Fact{Service: serviceID, Field: signal.valueField, Value: sample.value, Source: sourceMetrics}
+		// Dated by its own series' age, so a value read over a day-long window still knows
+		// how old it is -- and the fact that survives the reduction carries the age of the
+		// series it actually came from.
+		if sample.dated {
+			fact.ObservedAt = r.observedAt(sample.age)
 		}
 		r.result.Facts = append(r.result.Facts, fact)
 	}
 }
 
-// ages runs the age query, harvesting the labels it carries, and returns the *oldest* age
-// per service so the value query can date its own facts.
+// seriesSample is one series' contribution to a valued signal: the sample the value query
+// returned, and the age of that same series' last raw sample.
+type seriesSample struct {
+	value float64
+	age   float64
+	// dated is false when the age query returned no matching series, which leaves the
+	// fact undatable rather than pretending to an age of zero.
+	dated bool
+}
+
+// supersedes reports whether this sample should displace the one already held for the
+// service.
 //
-// Oldest rather than freshest, which is the conservative pairing. The value query reduces
-// across every series for a service -- the largest sample when reduceMax is set, whichever
-// arrives last otherwise -- and it picks that winner independently of this query. So the
-// value a fact carries need not come from the series that produced the freshest age. A
-// node reporting two replication-lag series, one current and one hours stale with a larger
-// lag, would otherwise hand back the stale maximum stamped as current, and fieldSet.live
-// would read it as a statement about now. Dating the reduced value with the oldest age
-// makes such a pair read as stale, which is wrong in the direction that shows rather than
-// the direction that misleads.
+// Several series of one metric under one service_id is the ordinary case rather than a
+// pathology, and the two kinds need different reducers:
 //
-// The label and presence facts below are unaffected: each is dated with its own series'
-// age inside the callback, because each comes from exactly one series.
+// Under reduceMax the largest sample wins, which is the point of the reducer --
+// mongodb_mongod_replset_member_replication_lag emits one series per peer and the worst of
+// them is what the node saw. The winner is then dated by its own series, so a stale maximum
+// reads as stale and fieldSet.live drops it, rather than being reported as a statement about
+// now.
+//
+// Otherwise the freshest series wins, because the series are successive generations of one
+// reading rather than peers: an exporter that learns cluster_role only after startup
+// abandons its first mongodb_up series and begins another under the same service_id, and the
+// abandoned one is not evidence about the present. Dating the reduction from the oldest of
+// them -- which is what this used to do -- made every such service report DOWN with its live
+// sample seconds old.
+//
+// An undated sample never displaces a dated one, and never displaces its own kind: with no
+// age to compare, first seen stays.
+func (s seriesSample) supersedes(held seriesSample, reduceMax bool) bool {
+	if reduceMax && s.value != held.value {
+		return s.value > held.value
+	}
+	if !s.dated {
+		return false
+	}
+	if !held.dated {
+		return true
+	}
+	return s.age < held.age
+}
+
+// seriesKey identifies one series across the two queries a valued signal issues.
+//
+// Every label except __name__, because the age query wraps the metric in lag() and a
+// rollup need not carry the metric name through, while last_over_time() does. Keying on
+// the rest pairs each sample with its own series' age, which is what a service carrying
+// several series of one metric needs and what a per-service key cannot express.
+func seriesKey(m model.Metric) model.Fingerprint {
+	if _, ok := m[model.MetricNameLabel]; !ok {
+		return m.Fingerprint()
+	}
+	trimmed := make(model.Metric, len(m)-1)
+	for name, value := range m {
+		if name != model.MetricNameLabel {
+			trimmed[name] = value
+		}
+	}
+	return trimmed.Fingerprint()
+}
+
+// ages runs the age query, harvesting the labels it carries, and returns each series' age
+// so the value query can date its own facts.
+//
+// Keyed per series rather than per service, because a service can carry several series of
+// one metric and they do not share an age. Reducing them here -- to the oldest, which this
+// used to do -- loses the pairing the value query needs: the sample that survives its own
+// reduction then gets stamped with an age no series it came from ever reported. See
+// seriesSample.supersedes for what each reducer does with the pairing.
+//
+// The label and presence facts below were always unaffected: each is dated with its own
+// series' age inside the callback, because each comes from exactly one series.
 //
 // MetricsQL's lag() answers the seconds since the series' last raw sample and preserves
 // every label, so one query yields both the labels the catalog reads and the staleness
@@ -277,19 +338,17 @@ func (r *metricsRun) signal(ctx context.Context, matcher string, signal metricSi
 // Wrapping timestamp() around a last_over_time() looks like it should do the same and
 // does not: it reports the evaluation time rounded to the step, which reads as "fresh"
 // for a series last scraped days ago -- the single most dangerous way to be wrong here.
-func (r *metricsRun) ages(ctx context.Context, matcher string, signal metricSignal) map[string]float64 {
+func (r *metricsRun) ages(ctx context.Context, matcher string, signal metricSignal) map[model.Fingerprint]float64 {
 	query := fmt.Sprintf("lag(%s{%s}[%s])", signal.metric, matcher, metricsLookback)
 	r.queries++
-	ages := make(map[string]float64)
+	ages := make(map[model.Fingerprint]float64)
 
 	r.src.each(ctx, r.result, query, func(serviceID string, m model.Metric, age float64) {
 		r.covered[serviceID] = true
 		if age > r.oldest {
 			r.oldest = age
 		}
-		if held, ok := ages[serviceID]; !ok || age > held {
-			ages[serviceID] = age
-		}
+		ages[seriesKey(m)] = age
 		observedAt := r.observedAt(age)
 
 		for _, label := range signal.labels {

--- a/managed/services/om/sources.go
+++ b/managed/services/om/sources.go
@@ -1,0 +1,386 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/AlekSi/pointer"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+
+	"github.com/percona/pmm/managed/models"
+)
+
+// factSource is one place collection reads the estate from.
+//
+// The interface is the extension point: the SEP inventory app's on-host facts arrive as
+// another implementation of this and nothing downstream changes, because the merge
+// resolves overlap by the precedence table rather than by which source ran.
+type factSource interface {
+	// key is the source key every fact it produces carries.
+	key() string
+	// collect reads the estate. It reports rather than returns an error: a source that
+	// could not answer is a fact about the run, and losing the sources that did answer
+	// because one did not is the opposite of useful.
+	collect(ctx context.Context, services []*models.Service) SourceResult
+}
+
+// inventorySource restates PMM's inventory as facts.
+//
+// Not time-bounded -- every fact carries a nil observed_at -- because inventory is
+// current by definition. That is the distinction Fact.ObservedAt exists to keep: a
+// version read from a metric sample can be nine days old, a cluster label read from the
+// services table cannot.
+type inventorySource struct {
+	nodes map[string]*models.Node
+}
+
+func (inventorySource) key() string { return sourceInventory }
+
+func (s inventorySource) collect(_ context.Context, services []*models.Service) SourceResult {
+	result := SourceResult{Source: sourceInventory, Status: SourceOK}
+	for _, service := range services {
+		node := s.nodes[service.NodeID]
+		add := func(field string, value any) {
+			if value == nil || value == "" {
+				return
+			}
+			result.Facts = append(result.Facts, Fact{
+				Service: service.ServiceID,
+				Field:   field,
+				Value:   value,
+				Source:  sourceInventory,
+			})
+		}
+		add(fieldServiceType, string(service.ServiceType))
+		add(fieldCluster, service.Cluster)
+		add(fieldReplicationSet, service.ReplicationSet)
+		add(fieldEnvironment, service.Environment)
+		if node != nil {
+			add(fieldHost, node.NodeName)
+		}
+		add(fieldEndpoint, inventoryEndpoint(service, node))
+	}
+	result.Detail = map[string]any{"services": len(services), "facts": len(result.Facts)}
+	return result
+}
+
+// inventoryEndpoint builds the host:port inventory knows the service by.
+//
+// The node, not the service. A service's address is where its own pmm-agent reaches it,
+// which for an agent on the same host is 127.0.0.1 -- true, and useless as an endpoint
+// for anyone else. The node's address is the one that means something off the box.
+func inventoryEndpoint(service *models.Service, node *models.Node) string {
+	var host string
+	if node != nil {
+		host = firstNonEmpty(node.Address, node.NodeName)
+	}
+	if host == "" {
+		host = pointer.GetString(service.Address)
+	}
+	if host == "" || service.Port == nil {
+		return ""
+	}
+	return net.JoinHostPort(host, strconv.Itoa(int(*service.Port)))
+}
+
+// metricsSource reads the signal catalog out of VictoriaMetrics.
+type metricsSource struct {
+	vm  victoriaMetricsClient
+	l   *logrus.Entry
+	now time.Time
+}
+
+func (metricsSource) key() string { return sourceMetrics }
+
+// queryBatch is how many services are pinned per query.
+//
+// Each contributes a 37-byte UUID to a regex matcher, so this bounds the query string
+// rather than the result set. Without it a few hundred services build a matcher tens of
+// kilobytes long on every one of the queries below.
+const queryBatch = 50
+
+// labelSignal maps one series label onto one document field.
+type labelSignal struct {
+	field string
+	label string
+}
+
+// metricSignals says, per metric, which labels to read off it and whether its sample
+// value is wanted too.
+//
+// The age query carries the labels, so a label-only metric costs one query. A metric
+// whose value matters costs two, because lag()'s value is the age rather than the
+// metric's own.
+type metricSignal struct {
+	metric     string
+	labels     []labelSignal
+	valueField string
+	// presenceField is set from the series existing at all, whatever its value.
+	presenceField string
+	// reduceMax folds several series for one service into the largest.
+	reduceMax bool
+}
+
+var metricSignals = []metricSignal{
+	{
+		metric: metricVersionInfo,
+		labels: []labelSignal{
+			{fieldHost, "node_name"},
+			{fieldServiceType, "service_type"},
+			{fieldCluster, "cluster"},
+			{fieldReplicationSet, "replication_set"},
+			{fieldEnvironment, "environment"},
+			{fieldVersion, "mongodb"},
+			{fieldVendor, "vendor"},
+			{fieldEdition, "edition"},
+		},
+	},
+	{
+		metric: metricMembersSelf,
+		labels: []labelSignal{
+			{fieldState, "member_state"},
+			// member_idx is the host:port the replica set itself knows the member by,
+			// which is a truer endpoint than inventory's address.
+			{fieldEndpoint, "member_idx"},
+			{fieldClusterRole, "cl_role"},
+		},
+	},
+	{metric: metricUp, valueField: fieldExporterUp},
+	{metric: metricMongosShards, presenceField: fieldIsMongos},
+	// Each member reports lag against every secondary, so the worst of them is "the worst
+	// lag this node saw". Double-counting is harmless under max.
+	{metric: metricReplicationLag, valueField: fieldReplicationLag, reduceMax: true},
+	{metric: metricOplogHead, valueField: fieldOplogHead},
+	{metric: metricOplogTail, valueField: fieldOplogTail},
+}
+
+// metricsRun is the mutable state of one pass over the catalog, kept out of collect so
+// each stage stays readable on its own.
+type metricsRun struct {
+	src     metricsSource
+	result  *SourceResult
+	covered map[string]bool
+	oldest  float64
+	queries int
+}
+
+func (s metricsSource) collect(ctx context.Context, services []*models.Service) SourceResult {
+	result := SourceResult{Source: sourceMetrics, Status: SourceOK}
+	if len(services) == 0 {
+		return result
+	}
+
+	ids := make([]string, 0, len(services))
+	for _, service := range services {
+		ids = append(ids, service.ServiceID)
+	}
+
+	run := &metricsRun{src: s, result: &result, covered: make(map[string]bool, len(ids))}
+	for batch := range slicesChunk(ids, queryBatch) {
+		matcher := fmt.Sprintf(`service_id=~%q,%s`, strings.Join(batch, "|"), highResolutionJob)
+		for _, signal := range metricSignals {
+			run.signal(ctx, matcher, signal)
+		}
+		run.expressions(ctx, matcher)
+	}
+
+	switch {
+	case len(result.Errors) > 0 && len(run.covered) == 0:
+		result.Status = SourceFailed
+	case len(result.Errors) > 0 || len(run.covered) < len(services):
+		result.Status = SourcePartial
+	}
+	result.Detail = map[string]any{
+		"services":           len(services),
+		"services_covered":   len(run.covered),
+		"facts":              len(result.Facts),
+		"queries":            run.queries,
+		"oldest_age_seconds": int(run.oldest),
+	}
+	s.l.Infof("metrics source: %d/%d service(s) covered by %d queries, oldest sample %ds",
+		len(run.covered), len(services), run.queries, int(run.oldest))
+	return result
+}
+
+// signal reads one catalog entry: its age query, and its value query when the metric's
+// own value is wanted.
+func (r *metricsRun) signal(ctx context.Context, matcher string, signal metricSignal) {
+	ages := r.ages(ctx, matcher, signal)
+	if signal.valueField == "" {
+		return
+	}
+
+	// The value query, issued only when the metric's own value is wanted, because lag()'s
+	// value is the age rather than the metric's.
+	query := fmt.Sprintf("last_over_time(%s{%s}[%s])", signal.metric, matcher, metricsLookback)
+	r.queries++
+	values := make(map[string]float64)
+	r.src.each(ctx, r.result, query, func(serviceID string, _ model.Metric, v float64) {
+		if held, ok := values[serviceID]; ok && signal.reduceMax && held >= v {
+			return
+		}
+		values[serviceID] = v
+	})
+
+	for serviceID, v := range values {
+		fact := Fact{Service: serviceID, Field: signal.valueField, Value: v, Source: sourceMetrics}
+		// Dated by the matching age query, so a value read over a day-long window still
+		// knows how old it is -- and with the oldest of that service's series, because the
+		// winner above was chosen without reference to which series was freshest.
+		if age, ok := ages[serviceID]; ok {
+			fact.ObservedAt = r.observedAt(age)
+		}
+		r.result.Facts = append(r.result.Facts, fact)
+	}
+}
+
+// ages runs the age query, harvesting the labels it carries, and returns the *oldest* age
+// per service so the value query can date its own facts.
+//
+// Oldest rather than freshest, which is the conservative pairing. The value query reduces
+// across every series for a service -- the largest sample when reduceMax is set, whichever
+// arrives last otherwise -- and it picks that winner independently of this query. So the
+// value a fact carries need not come from the series that produced the freshest age. A
+// node reporting two replication-lag series, one current and one hours stale with a larger
+// lag, would otherwise hand back the stale maximum stamped as current, and fieldSet.live
+// would read it as a statement about now. Dating the reduced value with the oldest age
+// makes such a pair read as stale, which is wrong in the direction that shows rather than
+// the direction that misleads.
+//
+// The label and presence facts below are unaffected: each is dated with its own series'
+// age inside the callback, because each comes from exactly one series.
+//
+// MetricsQL's lag() answers the seconds since the series' last raw sample and preserves
+// every label, so one query yields both the labels the catalog reads and the staleness
+// the run records.
+//
+// Wrapping timestamp() around a last_over_time() looks like it should do the same and
+// does not: it reports the evaluation time rounded to the step, which reads as "fresh"
+// for a series last scraped days ago -- the single most dangerous way to be wrong here.
+func (r *metricsRun) ages(ctx context.Context, matcher string, signal metricSignal) map[string]float64 {
+	query := fmt.Sprintf("lag(%s{%s}[%s])", signal.metric, matcher, metricsLookback)
+	r.queries++
+	ages := make(map[string]float64)
+
+	r.src.each(ctx, r.result, query, func(serviceID string, m model.Metric, age float64) {
+		r.covered[serviceID] = true
+		if age > r.oldest {
+			r.oldest = age
+		}
+		if held, ok := ages[serviceID]; !ok || age > held {
+			ages[serviceID] = age
+		}
+		observedAt := r.observedAt(age)
+
+		for _, label := range signal.labels {
+			if value := string(m[model.LabelName(label.label)]); value != "" {
+				r.result.Facts = append(r.result.Facts, Fact{
+					Service: serviceID, Field: label.field, Value: value,
+					Source: sourceMetrics, ObservedAt: observedAt,
+				})
+			}
+		}
+		if signal.presenceField != "" {
+			r.result.Facts = append(r.result.Facts, Fact{
+				Service: serviceID, Field: signal.presenceField, Value: true,
+				Source: sourceMetrics, ObservedAt: observedAt,
+			})
+		}
+	})
+	return ages
+}
+
+// expressions reads the two derived percentages.
+//
+// Neither exists as a series, so lag() has nothing to report on and their facts are dated
+// to the run. That is safe because both are gauges the projection already suppresses for
+// a service that is not up.
+func (r *metricsRun) expressions(ctx context.Context, matcher string) {
+	for _, expr := range []struct {
+		query string
+		field string
+	}{
+		{fmt.Sprintf(queryCPUUsage, matcher, metricsLookback), fieldCPUUsage},
+		{fmt.Sprintf(queryConnectionsFree, matcher, metricsLookback), fieldConnectionsFree},
+	} {
+		r.queries++
+		r.src.each(ctx, r.result, expr.query, func(serviceID string, _ model.Metric, v float64) {
+			observedAt := r.src.now
+			r.result.Facts = append(r.result.Facts, Fact{
+				Service: serviceID, Field: expr.field, Value: v,
+				Source: sourceMetrics, ObservedAt: &observedAt,
+			})
+		})
+	}
+}
+
+// observedAt turns an age in seconds into the moment the sample was taken.
+func (r *metricsRun) observedAt(age float64) *time.Time {
+	observed := r.src.now.Add(-time.Duration(age * float64(time.Second)))
+	return &observed
+}
+
+// each runs one instant query and applies apply to every sample, keyed by service_id.
+//
+// A sample carrying no service_id label is skipped: it cannot be attributed to a service,
+// and guessing from the instance label is how generations get mixed.
+func (s metricsSource) each(ctx context.Context, result *SourceResult, query string, apply func(string, model.Metric, float64)) {
+	value, warnings, err := s.vm.Query(ctx, query, s.now)
+	if err != nil {
+		s.l.Warnf("query %q failed: %s", query, err)
+		result.Errors = append(result.Errors, RunError{
+			Scope: "query", Code: "vm_query_failed",
+			Message: fmt.Sprintf("%s: %s", query, err),
+		})
+		return
+	}
+	for _, w := range warnings {
+		s.l.Warnf("query %q: %s", query, w)
+	}
+
+	vector, ok := value.(model.Vector)
+	if !ok {
+		result.Errors = append(result.Errors, RunError{
+			Scope: "query", Code: "vm_unexpected_result",
+			Message: fmt.Sprintf("%s: unexpected result type %T", query, value),
+		})
+		return
+	}
+	for _, sample := range vector {
+		if serviceID := string(sample.Metric["service_id"]); serviceID != "" {
+			apply(serviceID, sample.Metric, float64(sample.Value))
+		}
+	}
+}
+
+// slicesChunk yields successive size-length chunks of s, the last one short.
+func slicesChunk[T any](s []T, size int) func(func([]T) bool) {
+	return func(yield func([]T) bool) {
+		for start := 0; start < len(s); start += size {
+			end := min(start+size, len(s))
+			if !yield(s[start:end]) {
+				return
+			}
+		}
+	}
+}

--- a/managed/services/om/sources.go
+++ b/managed/services/om/sources.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -196,7 +197,7 @@ func (s metricsSource) collect(ctx context.Context, services []*models.Service) 
 	}
 
 	run := &metricsRun{src: s, result: &result, covered: make(map[string]bool, len(ids))}
-	for batch := range slicesChunk(ids, queryBatch) {
+	for batch := range slices.Chunk(ids, queryBatch) {
 		matcher := fmt.Sprintf(`service_id=~%q,%s`, strings.Join(batch, "|"), highResolutionJob)
 		for _, signal := range metricSignals {
 			run.signal(ctx, matcher, signal)
@@ -428,18 +429,6 @@ func (s metricsSource) each(ctx context.Context, result *SourceResult, query str
 	for _, sample := range vector {
 		if serviceID := string(sample.Metric["service_id"]); serviceID != "" {
 			apply(serviceID, sample.Metric, float64(sample.Value))
-		}
-	}
-}
-
-// slicesChunk yields successive size-length chunks of s, the last one short.
-func slicesChunk[T any](s []T, size int) func(func([]T) bool) {
-	return func(yield func([]T) bool) {
-		for start := 0; start < len(s); start += size {
-			end := min(start+size, len(s))
-			if !yield(s[start:end]) {
-				return
-			}
 		}
 	}
 }

--- a/managed/services/om/sources_test.go
+++ b/managed/services/om/sources_test.go
@@ -1,0 +1,145 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/pmm/managed/models"
+)
+
+// stubVM answers the two queries metricsSource issues per signal: lag() for ages and
+// last_over_time() for values. Keyed by metric name so one stub can cover a whole pass.
+type stubVM struct {
+	lag    map[string]model.Vector
+	values map[string]model.Vector
+}
+
+func (s stubVM) Query(_ context.Context, query string, _ time.Time, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+	for metric, vector := range s.lag {
+		if strings.HasPrefix(query, "lag("+metric+"{") {
+			return vector, nil, nil
+		}
+	}
+	for metric, vector := range s.values {
+		if strings.HasPrefix(query, "last_over_time("+metric+"{") {
+			return vector, nil, nil
+		}
+	}
+	return model.Vector{}, nil, nil
+}
+
+// recordingVM answers nothing and keeps what it was asked, for the tests that are about
+// the queries the catalog issues rather than about the samples they return.
+type recordingVM struct {
+	queries []string
+}
+
+func (r *recordingVM) Query(_ context.Context, query string, _ time.Time, _ ...v1.Option) (model.Value, v1.Warnings, error) {
+	r.queries = append(r.queries, query)
+	return model.Vector{}, nil, nil
+}
+
+func lagSample(serviceID string, age float64) *model.Sample {
+	return &model.Sample{
+		Metric: model.Metric{"service_id": model.LabelValue(serviceID)},
+		Value:  model.SampleValue(age),
+	}
+}
+
+// TestReducedValueIsDatedByTheOldestSeries pins the pairing between a reduced value and
+// the age it is stamped with.
+//
+// The value query folds every series for a service into one sample -- the largest, for
+// replication lag -- and it chooses that winner without reference to which series was
+// freshest. So the age has to come from the oldest series, or a stale maximum would be
+// reported as a statement about now.
+func TestReducedValueIsDatedByTheOldestSeries(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	const serviceID = "svc-1"
+
+	vm := stubVM{
+		lag: map[string]model.Vector{
+			// Two series for one service: one scraped 30s ago, one 4 hours ago.
+			metricReplicationLag: {
+				lagSample(serviceID, 30),
+				lagSample(serviceID, 4*60*60),
+			},
+		},
+		values: map[string]model.Vector{
+			// reduceMax keeps the larger lag, which is the one from the stale series.
+			metricReplicationLag: {
+				&model.Sample{
+					Metric: model.Metric{"service_id": model.LabelValue(serviceID)},
+					Value:  model.SampleValue(900),
+				},
+			},
+		},
+	}
+
+	src := metricsSource{vm: vm, l: logrus.WithField("test", t.Name()), now: now}
+	result := src.collect(t.Context(), []*models.Service{{ServiceID: serviceID}})
+
+	var lag *Fact
+	for i := range result.Facts {
+		if result.Facts[i].Field == fieldReplicationLag {
+			lag = &result.Facts[i]
+		}
+	}
+	require.NotNil(t, lag, "expected a replication-lag fact")
+	assert.InDelta(t, 900.0, lag.Value, 0.001)
+	require.NotNil(t, lag.ObservedAt)
+
+	// Dated by the 4-hour-old series, not the 30-second-old one.
+	assert.Equal(t, now.Add(-4*time.Hour), lag.ObservedAt.UTC(),
+		"a reduced value must carry the oldest contributing series' age")
+}
+
+// TestEveryQueryNarrowsToTheHighResolutionJob pins the other half of that pairing: the
+// series a reduction may see.
+//
+// A mongodb_exporter is scraped at two resolutions, so a metric it emits on every scrape
+// -- mongodb_up -- exists as an hr and an lr series per service. Reduced across both,
+// exporter_up is dated by the lr series, whose age exceeds volatileMaxAge for most of every
+// minute, and a healthy service reports DOWN half the time it is asked.
+func TestEveryQueryNarrowsToTheHighResolutionJob(t *testing.T) {
+	t.Parallel()
+
+	vm := &recordingVM{}
+	src := metricsSource{
+		vm:  vm,
+		l:   logrus.WithField("test", t.Name()),
+		now: time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC),
+	}
+	src.collect(t.Context(), []*models.Service{{ServiceID: "svc-1"}})
+
+	require.NotEmpty(t, vm.queries, "expected the catalog to issue queries")
+	for _, query := range vm.queries {
+		assert.Contains(t, query, highResolutionJob,
+			"every query must select the high-resolution job")
+	}
+}

--- a/managed/services/om/sources_test.go
+++ b/managed/services/om/sources_test.go
@@ -62,61 +62,142 @@ func (r *recordingVM) Query(_ context.Context, query string, _ time.Time, _ ...v
 	return model.Vector{}, nil, nil
 }
 
-func lagSample(serviceID string, age float64) *model.Sample {
-	return &model.Sample{
-		Metric: model.Metric{"service_id": model.LabelValue(serviceID)},
-		Value:  model.SampleValue(age),
+// testServiceID is the one service the sample helpers below build series for.
+const testServiceID = "svc-1"
+
+// seriesLabels builds one series' label set: service_id plus the given name/value pairs,
+// which is what distinguishes two series of the same metric under one service.
+func seriesLabels(labels ...string) model.Metric {
+	m := model.Metric{"service_id": testServiceID}
+	for i := 0; i+1 < len(labels); i += 2 {
+		m[model.LabelName(labels[i])] = model.LabelValue(labels[i+1])
 	}
+	return m
 }
 
-// TestReducedValueIsDatedByTheOldestSeries pins the pairing between a reduced value and
-// the age it is stamped with.
+// lagSample is a sample as the age query returns it: lag() is a rollup, so it carries no
+// __name__ -- which is why seriesKey pairs the two queries on everything else.
+func lagSample(age float64, labels ...string) *model.Sample {
+	return &model.Sample{Metric: seriesLabels(labels...), Value: model.SampleValue(age)}
+}
+
+// valueSample is a sample as the value query returns it, __name__ included.
+func valueSample(metric string, value float64, labels ...string) *model.Sample {
+	m := seriesLabels(labels...)
+	m[model.MetricNameLabel] = model.LabelValue(metric)
+	return &model.Sample{Metric: m, Value: model.SampleValue(value)}
+}
+
+// factFor returns the last fact collected for a field, or nil.
+func factFor(result SourceResult, field string) *Fact {
+	var found *Fact
+	for i := range result.Facts {
+		if result.Facts[i].Field == field {
+			found = &result.Facts[i]
+		}
+	}
+	return found
+}
+
+// TestReducedValueCarriesItsOwnSeriesAge pins the pairing between a reduced value and the
+// age it is stamped with.
 //
 // The value query folds every series for a service into one sample -- the largest, for
-// replication lag -- and it chooses that winner without reference to which series was
-// freshest. So the age has to come from the oldest series, or a stale maximum would be
-// reported as a statement about now.
-func TestReducedValueIsDatedByTheOldestSeries(t *testing.T) {
+// replication lag -- and the fact has to carry the age of the series that sample came
+// from. Dating it from the oldest series of the set instead reports an age no contributing
+// series ever had, in whichever direction the set happens to be arranged.
+func TestReducedValueCarriesItsOwnSeriesAge(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
-	const serviceID = "svc-1"
+
+	// Two series for one service -- one per peer, as replication lag is emitted -- scraped
+	// 30s and 4h ago respectively.
+	lag := map[string]model.Vector{
+		metricReplicationLag: {
+			lagSample(30, "member_idx", "peer-a"),
+			lagSample(4*60*60, "member_idx", "peer-b"),
+		},
+	}
+
+	t.Run("the max is fresh", func(t *testing.T) {
+		t.Parallel()
+
+		vm := stubVM{lag: lag, values: map[string]model.Vector{
+			metricReplicationLag: {
+				valueSample(metricReplicationLag, 900, "member_idx", "peer-a"),
+				valueSample(metricReplicationLag, 100, "member_idx", "peer-b"),
+			},
+		}}
+		src := metricsSource{vm: vm, l: logrus.WithField("test", t.Name()), now: now}
+		fact := factFor(src.collect(t.Context(), []*models.Service{{ServiceID: testServiceID}}), fieldReplicationLag)
+
+		require.NotNil(t, fact, "expected a replication-lag fact")
+		assert.InDelta(t, 900.0, fact.Value, 0.001)
+		require.NotNil(t, fact.ObservedAt)
+		assert.Equal(t, now.Add(-30*time.Second), fact.ObservedAt.UTC(),
+			"the largest lag came from the 30s-old series, so that is its age")
+	})
+
+	t.Run("the max is stale", func(t *testing.T) {
+		t.Parallel()
+
+		vm := stubVM{lag: lag, values: map[string]model.Vector{
+			metricReplicationLag: {
+				valueSample(metricReplicationLag, 100, "member_idx", "peer-a"),
+				valueSample(metricReplicationLag, 900, "member_idx", "peer-b"),
+			},
+		}}
+		src := metricsSource{vm: vm, l: logrus.WithField("test", t.Name()), now: now}
+		fact := factFor(src.collect(t.Context(), []*models.Service{{ServiceID: testServiceID}}), fieldReplicationLag)
+
+		require.NotNil(t, fact, "expected a replication-lag fact")
+		assert.InDelta(t, 900.0, fact.Value, 0.001)
+		require.NotNil(t, fact.ObservedAt)
+
+		// Still reported, and still dated 4 hours old, so fieldSet.live drops it rather
+		// than the projection reading a stale maximum as a statement about now.
+		assert.Equal(t, now.Add(-4*time.Hour), fact.ObservedAt.UTC(),
+			"the largest lag came from the 4h-old series, so that is its age")
+	})
+}
+
+// TestAbandonedSeriesDoesNotStaleTheLiveOne pins the fix for a live service reporting DOWN.
+//
+// An exporter's label set changes over its own lifetime: mongodb_up is emitted without
+// cluster_role until the exporter can determine the role, at which point the series is
+// abandoned and another begins under the same service_id. Both stay inside metricsLookback,
+// so both come back, and dating exporter_up from the oldest of them made the fact age out of
+// volatileMaxAge while the live sample was seconds old. Measured against a 14-service
+// sandbox: 6 of them DOWN, stably, every one of them up in PMM's own inventory.
+func TestAbandonedSeriesDoesNotStaleTheLiveOne(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
 
 	vm := stubVM{
 		lag: map[string]model.Vector{
-			// Two series for one service: one scraped 30s ago, one 4 hours ago.
-			metricReplicationLag: {
-				lagSample(serviceID, 30),
-				lagSample(serviceID, 4*60*60),
+			metricUp: {
+				lagSample(2, "cluster_role", "mongod"),
+				lagSample(540),
 			},
 		},
 		values: map[string]model.Vector{
-			// reduceMax keeps the larger lag, which is the one from the stale series.
-			metricReplicationLag: {
-				&model.Sample{
-					Metric: model.Metric{"service_id": model.LabelValue(serviceID)},
-					Value:  model.SampleValue(900),
-				},
+			metricUp: {
+				valueSample(metricUp, 1, "cluster_role", "mongod"),
+				valueSample(metricUp, 1),
 			},
 		},
 	}
 
 	src := metricsSource{vm: vm, l: logrus.WithField("test", t.Name()), now: now}
-	result := src.collect(t.Context(), []*models.Service{{ServiceID: serviceID}})
+	fact := factFor(src.collect(t.Context(), []*models.Service{{ServiceID: testServiceID}}), fieldExporterUp)
 
-	var lag *Fact
-	for i := range result.Facts {
-		if result.Facts[i].Field == fieldReplicationLag {
-			lag = &result.Facts[i]
-		}
-	}
-	require.NotNil(t, lag, "expected a replication-lag fact")
-	assert.InDelta(t, 900.0, lag.Value, 0.001)
-	require.NotNil(t, lag.ObservedAt)
-
-	// Dated by the 4-hour-old series, not the 30-second-old one.
-	assert.Equal(t, now.Add(-4*time.Hour), lag.ObservedAt.UTC(),
-		"a reduced value must carry the oldest contributing series' age")
+	require.NotNil(t, fact, "expected an exporter-up fact")
+	assert.InDelta(t, 1.0, fact.Value, 0.001)
+	require.NotNil(t, fact.ObservedAt)
+	assert.Equal(t, now.Add(-2*time.Second), fact.ObservedAt.UTC(),
+		"exporter_up must carry the live series' age, not the abandoned one's")
 }
 
 // TestEveryQueryNarrowsToTheHighResolutionJob pins the other half of that pairing: the

--- a/managed/services/om/store.go
+++ b/managed/services/om/store.go
@@ -1,0 +1,278 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/reform.v1"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+)
+
+// documentJSON is how a snapshot is stored and read back.
+//
+// Deliberately protojson rather than encoding/json: the document is a protobuf message,
+// and only protojson agrees with the wire format the API serves -- wrapper types as bare
+// values or null, timestamps as RFC 3339. Round-tripping through encoding/json would
+// store a differently-shaped document than the one the UI receives.
+var (
+	documentJSON      = protojson.MarshalOptions{UseProtoNames: true, EmitUnpopulated: true}
+	documentJSONParse = protojson.UnmarshalOptions{DiscardUnknown: true}
+)
+
+// persist writes one run and its document, then prunes the history.
+//
+// Both rows go in one transaction: a run without its document is not a state any reader
+// should have to handle. Failure is reported but not fatal -- the document is already
+// published in memory, and losing the record of a collection is worth less than refusing
+// to serve the collection.
+func (s *Service) persist(ctx context.Context, response *omv1.GetTopologyResponse, run *omv1.TopologyRun, originNode string) error {
+	document, err := documentJSON.Marshal(response)
+	if err != nil {
+		return fmt.Errorf("failed to marshal the topology document: %w", err)
+	}
+
+	row := &models.OmTopologyRun{
+		RunID:            run.RunId,
+		StartedAt:        run.StartTime.AsTime(),
+		Status:           runStatusFromProto(run.Status),
+		ServicesTotal:    run.Counts.TotalServices,
+		ServicesResolved: run.Counts.ResolvedServices,
+		ServicesOrphaned: run.Counts.OrphanedServices,
+		ProbesOK:         run.Counts.SuccessfulProbes,
+		ServicesStale:    run.Counts.StaleServices,
+		OriginNode:       originNode,
+		Sources:          make(models.OmTopologySourceReports, 0, len(run.Sources)),
+		Errors:           make(models.OmTopologyRunErrors, 0, len(run.Errors)),
+	}
+	if run.EndTime != nil {
+		finished := run.EndTime.AsTime()
+		row.FinishedAt = &finished
+	}
+	for _, source := range run.Sources {
+		row.Sources = append(row.Sources, models.OmTopologySourceReport{
+			Source: source.Source, Status: string(sourceStatusFromProto(source.Status)),
+			Facts: source.Facts, Detail: source.Detail,
+		})
+	}
+	for _, e := range run.Errors {
+		row.Errors = append(row.Errors, models.OmTopologyRunError{
+			Scope: e.Scope, ServiceName: e.GetServiceName(),
+			Code: e.Code, Message: e.Message,
+		})
+	}
+
+	snapshot := &models.OmTopologySnapshot{
+		GeneratedAt:   response.Snapshot.GeneratedAt.AsTime(),
+		Stale:         response.Snapshot.Stale,
+		SchemaVersion: response.Snapshot.SchemaVersion,
+		Document:      document,
+	}
+	if response.Snapshot.ObservedAt != nil {
+		observed := response.Snapshot.ObservedAt.AsTime()
+		snapshot.ObservedAt = &observed
+	}
+
+	// InTransactionContext rather than InTransaction so a shutdown or a cancelled
+	// collection aborts the write instead of finishing it. managed/AGENTS.md prescribes
+	// this form, and it is what most of managed/services uses.
+	return s.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		err := models.CreateOmTopologyRun(tx.Querier, row, snapshot)
+		if err != nil {
+			return err
+		}
+		return models.PruneOmTopologyRuns(tx.Querier, runHistory)
+	})
+}
+
+// restore loads the newest stored document, so a restarted pmm-managed can answer before
+// it has collected anything of its own.
+//
+// A document read back from the database is re-staled against the clock rather than
+// trusted: stale was computed when it was written, and the whole point of restoring one
+// is that time has passed since.
+func (s *Service) restore(ctx context.Context) (*omv1.GetTopologyResponse, time.Time, error) {
+	var snapshot *models.OmTopologySnapshot
+	errTX := s.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		var err error
+		snapshot, err = models.FindLatestOmTopologySnapshot(tx.Querier)
+		return err
+	})
+	if errTX != nil {
+		if errors.Is(errTX, models.ErrNotFound) {
+			return nil, time.Time{}, nil
+		}
+		return nil, time.Time{}, errTX
+	}
+
+	response := &omv1.GetTopologyResponse{}
+	err := documentJSONParse.Unmarshal(snapshot.Document, response)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("failed to parse the stored topology document: %w", err)
+	}
+	if response.Snapshot != nil {
+		response.Snapshot.Stale = snapshotStale(response.Snapshot.ObservedAt)
+	}
+	return response, snapshot.GeneratedAt, nil
+}
+
+// listRuns reads the run history back out of the database.
+func (s *Service) listRuns(ctx context.Context, limit int) ([]*omv1.TopologyRun, error) {
+	var rows []*models.OmTopologyRun
+	errTX := s.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		var err error
+		rows, err = models.FindOmTopologyRuns(tx.Querier, limit)
+		return err
+	})
+	if errTX != nil {
+		return nil, errTX
+	}
+	runs := make([]*omv1.TopologyRun, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, runFromModel(row))
+	}
+	return runs, nil
+}
+
+// getRun reads one run back out of the database.
+func (s *Service) getRun(ctx context.Context, runID string) (*omv1.TopologyRun, error) {
+	var row *models.OmTopologyRun
+	errTX := s.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
+		var err error
+		row, err = models.FindOmTopologyRunByID(tx.Querier, runID)
+		return err
+	})
+	if errTX != nil {
+		return nil, errTX
+	}
+	return runFromModel(row), nil
+}
+
+func runFromModel(row *models.OmTopologyRun) *omv1.TopologyRun {
+	run := &omv1.TopologyRun{
+		RunId:     row.RunID,
+		Status:    runStatusToProto(row.Status),
+		StartTime: timestamppb.New(row.StartedAt),
+		Counts: &omv1.TopologyRunCounts{
+			TotalServices:    row.ServicesTotal,
+			ResolvedServices: row.ServicesResolved,
+			OrphanedServices: row.ServicesOrphaned,
+			SuccessfulProbes: row.ProbesOK,
+			StaleServices:    row.ServicesStale,
+		},
+		Sources: make([]*omv1.SourceReport, 0, len(row.Sources)),
+		Errors:  make([]*omv1.TopologyRunError, 0, len(row.Errors)),
+	}
+	if row.FinishedAt != nil {
+		run.EndTime = timestamppb.New(*row.FinishedAt)
+	}
+	for _, source := range row.Sources {
+		run.Sources = append(run.Sources, &omv1.SourceReport{
+			Source: source.Source, Status: sourceStatusToProto(SourceStatus(source.Status)),
+			Facts: source.Facts, Detail: source.Detail,
+		})
+	}
+	for _, e := range row.Errors {
+		run.Errors = append(run.Errors, &omv1.TopologyRunError{
+			Scope: e.Scope, ServiceName: optional(e.ServiceName),
+			Code: e.Code, Message: e.Message,
+		})
+	}
+	return run
+}
+
+// snapshotStale reports whether an observation is older than the grace period.
+func snapshotStale(observedAt *timestamppb.Timestamp) bool {
+	if observedAt == nil {
+		return false
+	}
+	return time.Since(observedAt.AsTime()) > staleAfter
+}
+
+// The enum boundary. Statuses are stored as the collector's own lowercase strings and
+// translated here, in one place, rather than persisted as enum numbers: a run row stays
+// readable in psql, and renumbering the enum cannot silently reinterpret history.
+//
+// An unrecognised stored value maps to UNSPECIFIED rather than being guessed at. That is
+// the honest answer for a row written by a newer version, and it is visible on the wire
+// instead of masquerading as a status the caller knows.
+
+// runStatusToProto maps a stored run status onto the wire enum.
+func runStatusToProto(status models.OmTopologyRunStatus) omv1.RunStatus {
+	switch string(status) {
+	case runStatusSuccess:
+		return omv1.RunStatus_RUN_STATUS_SUCCESS
+	case runStatusPartial:
+		return omv1.RunStatus_RUN_STATUS_PARTIAL
+	case runStatusFailed:
+		return omv1.RunStatus_RUN_STATUS_FAILED
+	default:
+		return omv1.RunStatus_RUN_STATUS_UNSPECIFIED
+	}
+}
+
+// runStatusFromProto maps the wire enum back onto the stored representation.
+func runStatusFromProto(status omv1.RunStatus) models.OmTopologyRunStatus {
+	switch status {
+	case omv1.RunStatus_RUN_STATUS_SUCCESS:
+		return models.OmTopologyRunStatus(runStatusSuccess)
+	case omv1.RunStatus_RUN_STATUS_PARTIAL:
+		return models.OmTopologyRunStatus(runStatusPartial)
+	case omv1.RunStatus_RUN_STATUS_FAILED:
+		return models.OmTopologyRunStatus(runStatusFailed)
+	default:
+		return ""
+	}
+}
+
+// sourceStatusToProto maps a stored source status onto the wire enum.
+func sourceStatusToProto(status SourceStatus) omv1.SourceStatus {
+	switch status {
+	case SourceOK:
+		return omv1.SourceStatus_SOURCE_STATUS_OK
+	case SourcePartial:
+		return omv1.SourceStatus_SOURCE_STATUS_PARTIAL
+	case SourceFailed:
+		return omv1.SourceStatus_SOURCE_STATUS_FAILED
+	case SourceDisabled:
+		return omv1.SourceStatus_SOURCE_STATUS_DISABLED
+	default:
+		return omv1.SourceStatus_SOURCE_STATUS_UNSPECIFIED
+	}
+}
+
+// sourceStatusFromProto maps the wire enum back onto the stored representation.
+func sourceStatusFromProto(status omv1.SourceStatus) SourceStatus {
+	switch status {
+	case omv1.SourceStatus_SOURCE_STATUS_OK:
+		return SourceOK
+	case omv1.SourceStatus_SOURCE_STATUS_PARTIAL:
+		return SourcePartial
+	case omv1.SourceStatus_SOURCE_STATUS_FAILED:
+		return SourceFailed
+	case omv1.SourceStatus_SOURCE_STATUS_DISABLED:
+		return SourceDisabled
+	default:
+		return ""
+	}
+}

--- a/managed/services/om/store_test.go
+++ b/managed/services/om/store_test.go
@@ -1,0 +1,214 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package om
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/reform.v1"
+	"gopkg.in/reform.v1/dialects/postgresql"
+
+	omv1 "github.com/percona/pmm/api/om/v1"
+	"github.com/percona/pmm/managed/models"
+	"github.com/percona/pmm/managed/utils/testdb"
+)
+
+// storeTestDB opens a fresh test database and wraps it as a *reform.DB, the shape
+// store.go's methods take.
+func storeTestDB(t *testing.T) *reform.DB {
+	t.Helper()
+	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
+	return reform.NewDB(sqlDB, postgresql.Dialect, reform.NewPrintfLogger(t.Logf))
+}
+
+// testTopologyResponse builds one document and the run that produced it, shaped like
+// what collect() would have built, so a round trip through persist/restore has
+// something realistic to preserve.
+func testTopologyResponse(runID string, generatedAt, observedAt time.Time) (*omv1.GetTopologyResponse, *omv1.TopologyRun) {
+	response := &omv1.GetTopologyResponse{
+		Snapshot: &omv1.Snapshot{
+			GeneratedAt:   timestamppb.New(generatedAt),
+			ObservedAt:    timestamppb.New(observedAt),
+			Stale:         false,
+			SchemaVersion: schemaVersion,
+			RunId:         runID,
+		},
+		OriginNode:    optional("pmm-server"),
+		SourceQueries: sourceQueries,
+		Summary: &omv1.Summary{
+			Environments:      1,
+			Clusters:          1,
+			TotalServices:     1,
+			UpServices:        1,
+			ProcessRoleCounts: map[string]int32{"PROCESS_ROLE_MONGOD": 1},
+		},
+		Environments: []*omv1.Environment{
+			{
+				EnvName: optional("prod"),
+				Clusters: []*omv1.Cluster{
+					{
+						Name: optional("rs0"),
+						Id:   clusterID("prod", "rs0"),
+						Type: omv1.ClusterType_CLUSTER_TYPE_REPLICA_SET,
+						Services: []*omv1.TopologyService{
+							{
+								ServiceName: "mongo-1",
+								ServiceId:   optional("svc-1"),
+								Status:      omv1.ServiceStatus_SERVICE_STATUS_UP,
+								ProcessRole: omv1.ProcessRole_PROCESS_ROLE_MONGOD,
+								ObservedAt:  timestamppb.New(observedAt),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	run := &omv1.TopologyRun{
+		RunId:     runID,
+		Status:    omv1.RunStatus_RUN_STATUS_SUCCESS,
+		StartTime: timestamppb.New(generatedAt.Add(-time.Second)),
+		EndTime:   timestamppb.New(generatedAt),
+		Counts: &omv1.TopologyRunCounts{
+			TotalServices:    1,
+			ResolvedServices: 1,
+			SuccessfulProbes: 1,
+		},
+		Sources: []*omv1.SourceReport{
+			{Source: sourceMetrics, Status: omv1.SourceStatus_SOURCE_STATUS_OK, Facts: 3},
+		},
+		Errors: []*omv1.TopologyRunError{},
+	}
+	return response, run
+}
+
+func TestStorePersistRestoreRoundTrip(t *testing.T) {
+	db := storeTestDB(t)
+	svc := &Service{db: db, l: logrus.WithField("test", t.Name())}
+
+	// Observed recently enough to restore as fresh: restore() recomputes Stale against
+	// the clock rather than trusting what was written (see
+	// TestStoreRestoreRestalesAgainstNow), so a round trip of the rest of the document
+	// needs the timestamp to still be within staleAfter by the time restore() runs.
+	// Truncated to microseconds because TopologyRun's StartTime/EndTime round-trip
+	// through plain timestamp columns rather than protojson, and Postgres does not
+	// keep more precision than that.
+	generatedAt := time.Now().Truncate(time.Microsecond)
+	observedAt := generatedAt.Add(-4 * time.Second)
+	runID := uuid.New().String()
+	response, run := testTopologyResponse(runID, generatedAt, observedAt)
+
+	err := svc.persist(t.Context(), response, run, "pmm-server")
+	require.NoError(t, err)
+
+	restored, restoredGeneratedAt, err := svc.restore(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, restored)
+	assert.WithinDuration(t, generatedAt, restoredGeneratedAt, time.Millisecond)
+
+	// protojson through the store is lossy about nothing: every field persist wrote
+	// comes back unchanged, down to the cluster id and the per-service observed_at
+	// this test exists to guard.
+	diff := cmp.Diff(response, restored, protocmp.Transform())
+	assert.Empty(t, diff, "restored document should equal what was persisted")
+
+	run2, err := svc.getRun(t.Context(), runID)
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(run, run2, protocmp.Transform()))
+}
+
+func TestStoreRestoreRestalesAgainstNow(t *testing.T) {
+	db := storeTestDB(t)
+	svc := &Service{db: db, l: logrus.WithField("test", t.Name())}
+
+	// Written as fresh (Stale: false), but observed long enough ago that restoring it
+	// now must recompute Stale as true. The written value is deliberately wrong, to
+	// prove restore() does not just trust what was stored -- see snapshotStale's own
+	// comment for why that recomputation exists.
+	generatedAt := time.Now().Add(-time.Hour)
+	observedAt := generatedAt
+	response, run := testTopologyResponse(uuid.New().String(), generatedAt, observedAt)
+	response.Snapshot.Stale = false
+
+	require.NoError(t, svc.persist(t.Context(), response, run, "pmm-server"))
+
+	restored, _, err := svc.restore(t.Context())
+	require.NoError(t, err)
+	assert.True(t, restored.Snapshot.Stale, "an hour-old observation must restore as stale")
+}
+
+func TestStoreRestoreNoSnapshot(t *testing.T) {
+	db := storeTestDB(t)
+	svc := &Service{db: db, l: logrus.WithField("test", t.Name())}
+
+	response, generatedAt, err := svc.restore(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, response)
+	assert.True(t, generatedAt.IsZero())
+}
+
+func TestPruneOmTopologyRunsKeepsExactlyKeep(t *testing.T) {
+	db := storeTestDB(t)
+	svc := &Service{db: db, l: logrus.WithField("test", t.Name())}
+
+	const total = 5
+	const keep = 3
+	base := time.Date(2026, 8, 20, 9, 0, 0, 0, time.UTC)
+	runIDs := make([]string, 0, total)
+	for i := range total {
+		generatedAt := base.Add(time.Duration(i) * time.Minute)
+		runID := uuid.New().String()
+		runIDs = append(runIDs, runID)
+		response, run := testTopologyResponse(runID, generatedAt, generatedAt)
+		run.StartTime = timestamppb.New(generatedAt)
+		require.NoError(t, svc.persist(t.Context(), response, run, "pmm-server"))
+	}
+
+	err := db.InTransactionContext(t.Context(), nil, func(tx *reform.TX) error {
+		return models.PruneOmTopologyRuns(tx.Querier, keep)
+	})
+	require.NoError(t, err)
+
+	runs, err := svc.listRuns(t.Context(), total)
+	require.NoError(t, err)
+	require.Len(t, runs, keep)
+
+	// Newest first, and the newest `keep` of them: the last `keep` run IDs persisted,
+	// in reverse order.
+	gotIDs := make([]string, 0, len(runs))
+	for _, r := range runs {
+		gotIDs = append(gotIDs, r.RunId)
+	}
+	wantIDs := []string{runIDs[4], runIDs[3], runIDs[2]}
+	assert.Equal(t, wantIDs, gotIDs)
+
+	// The run row is gone, and so is its snapshot -- CreateOmTopologyRun writes both in
+	// one transaction, and a cascade that prunes the run but leaves its snapshot behind
+	// would leak one row per pruned run forever.
+	_, err = models.FindOmTopologyRunByID(db.Querier, runIDs[0])
+	require.ErrorIs(t, err, models.ErrNotFound)
+
+	_, err = db.FindByPrimaryKeyFrom(models.OmTopologySnapshotTable, runIDs[0])
+	require.ErrorIs(t, err, reform.ErrNoRows)
+}


### PR DESCRIPTION
Ticket number: PMM-15326

Feature build: N/A on its own - this serves the OM API but nothing renders it until the UI PRs land. Happy to produce one alongside the UI branches if that is more useful than one per PR.

## What

`managed/services/om` implements `OmService`, and `cmd/pmm-managed/main.go` wires it in - registered on the gRPC server, on the HTTP gateway, and started on a ticker under the HA leader service.

Two halves, sharing a gRPC facade.

**Topology.** Derives a MongoDB view from PMM's own data. Two sources feed it: `inventorySource` reads services and nodes from `managed/models`, `metricsSource` evaluates a fixed set of queries against VictoriaMetrics. Facts from each source are merged by a documented precedence (`facts.go`), and the merge records which source won each field and how old it was. `projection.go` turns merged facts into the emitted document; `store.go` persists the run and snapshot through the models added in #5812.

**Inventory.** Proxies SEP's `om_inventory` app - hosts, services, runs, config - so that no browser path needs a SEP bearer. pmm-managed holds the credential; the Grafana session authorises the caller.

## What this PR is not: a topology graph

The document is a **grouped service inventory**, and the wording throughout now says so. Services are grouped by `(environment, cluster-or-replication-set label)` and each row is stamped with a `process_role`; `ClusterType` is the one thing inferred about a group's shape. What it does *not* do is reconstruct a shard map - a sharded cluster appears as a flat list of mongos, configsvr and shardsvr rows that share a label, not as shards with their members.

That is deliberate for this PR rather than an omission, and `schema_version` is how a later build grows `replica_sets` / `shards` without a retraction. Calling it "reconstructs replica sets and sharded clusters", as an earlier draft of the package comment did, would have been the version worth objecting to.

## The one structural thing to know before reading

`sep_client.go` owns everything about talking to SEP: base URL, token, HTTP client, timeout, status mapping. Callers ask it for an app handle (`.app(module)`) whose paths are relative to `/api/apps/<module>`, and hold that handle rather than each other.

So `probeSource` is now only a `factSource` - it collects on-host facts for the topology merge - and the inventory handlers hold their own handle instead of reaching through the probe source for its transport. The next SEP-backed consumer (actions, when they land) asks for a third handle rather than copying the transport or hanging its verbs off a type called `probeSource`.

Dependency direction is one-way and worth checking if you disagree with the layout: nothing on the topology side references any inventory symbol.

## Behaviours that are decisions, not accidents

**Reads never collect.** `GetTopology` serves memory, then the stored snapshot, and never runs a collection. Collection happens on a 30s ticker on the HA **leader**, which is where it belongs: a pass persists a run and then prunes shared history. `TriggerTopologyCollection` refuses on a non-leader with `FailedPrecondition`, naming the leader when it knows it.

**A cold estate answers, and says so.** No memory, no snapshot, leader has not ticked yet: the response is an empty document with `stale = true` and `observed_at` unset - not an error. An empty document therefore means "nothing collected yet", never "your estate is empty", and the proto comment says that where a client will read it. Staleness is recomputed against the clock on every read rather than frozen when the document was built, so a restored snapshot is reported by its real age.

**SEP is optional.** With no `PMM_SEP_URL`, the probe source reports itself disabled and the document is built from PMM's own inventory and metrics alone. OM degrades rather than failing.

**The kingpin flags point at SEP, not at one of its apps.** `--sep-url` is the base URL; each consumer appends its own `/api/apps/<module>` path.

**The document is schema-versioned** (`schemaVersion = 1`), so a stored snapshot written by an older build is recognisable rather than misread. It starts at 1 because nothing has shipped - there is no stored snapshot anywhere that predates this, so there is nothing for a higher number to be compatible with.

**`staleAfter` is 5 minutes**; past that a fact is reported stale rather than silently trusted.

**Per-source outcomes are recorded on the run.** This is the part I would most like a second opinion on: it exists so that a thin document is distinguishable from a broken collector. A run that produced little because a source failed looks different from one that produced little because there is little to see.

**Cluster rows carry a server-issued opaque id.** `Cluster.id` is derived deterministically from `(environment, cluster, replication_set)`. Clients must not parse it: two clusters can and do share a display label - two generations of a sandbox both called `sharded-cluster` - and the label is the thing that may change without the row being a different cluster.

**Provenance, one field of it.** `TopologyService.observed_at` carries the age of the newest live field on that row, so one lagging service in an otherwise fresh fleet is visible. Deliberately deferred: a per-field `map<string, string> field_sources`. The merge does record which source won each field, and the run receipts hold it, but nothing consumes it yet and it is the expensive half on the wire. Worth adding when something reads it, not before.

**Facts stay keyed by PMM service id.** A naturally per-host attribute - `repo_reachable`, `executor_reachable` - has nowhere to go in the merge, and that is a known cost written down in `facts.go` rather than an oversight. Host attributes live on `/v1/om/inventory/hosts` instead. The alternative, widening `Fact` with an optional node key so the merge becomes `(node|service, field)`, forces a decision about whether a host fact attaches to every service on that node or to a new slot, and that is bigger than this PR. What it buys by waiting: the copies cannot silently disagree, because there are no copies.

**`applyHealth` is a named no-op.** `package om` is documented as the topology *and health* API, and `projection.go` says the document reports observations rather than verdicts. Both can be true only if there is a place the health rules are supposed to go, so there is one: a pipeline stage called from `collect` after `buildDocument`, plus a reserved `ClusterHealth` enum. It does nothing today. It exists so that the first health rule does not land as another `if` on `exporter_up` inside the projection.

## Reviewing this

~6.1k lines, of which ~2.4k are tests. The parts carrying the most judgement, in order: `facts.go` (the precedence and staleness rules), `projection.go` (what the document actually says), `service.go` (the read/collect split and the leader rules), then `inventory.go` (error mapping and the config-write validation).

`inventory.go` bounds what a config write may contain - depth and shape - because those values are passed through to SEP. Worth a look from that angle specifically. Its 401 mapping is also deliberate: a 401 from SEP is pmm-managed's credential failing, not the caller's session expiring, and the two must not be reported the same way.

`service_test.go` and `store_test.go` cover the lifecycle, which previously had no tests at all: restore-then-serve never reaching `collect`, the cold-start answer, concurrent reads not each starting a pass, the non-leader refusal both with and without a known leader, `Aborted` while a run is in flight, which sources are in the slice and in what order, persist failure still returning the in-memory document, protojson round-trip fidelity, a restored snapshot being re-staled against the clock, and pruning keeping exactly `runHistory` rows.

## Related work

Fourth of seven stacked PRs splitting #5795 ("OpenManager initial implementation") into area-owned reviews.

- #5812 - the topology tables and models this persists through
- #5813 - the OM API this implements (**this PR's base**)
- #5815 - the role rules for these routes
- #5811 - redaction of the SEP URL and token in logs

Unlike some of the others, this base is a **real dependency**: the service will not compile without the generated code in #5813, and it needs the models from #5812.

Two independent architectural reviews were run against this branch; the six items they agreed on are settled in `2ac39a7a4` - the leader-only read path (the one actual bug), the SEP client extraction, cluster identity and type, the health seam, per-service provenance, and the fact-grain decision above - together with the lifecycle tests that keep the first of them from regressing.
