### PR TITLE
PMM-15326: Mount OM in the PMM app and its navigation

### DIFF
--- a/ui/apps/pmm/package.json
+++ b/ui/apps/pmm/package.json
@@ -33,6 +33,7 @@
     "@sep/api": "workspace:*",
     "@sep/framework": "workspace:*",
     "@sep/plugins-atw": "workspace:*",
+    "@sep/plugins-om": "workspace:*",
     "@tanstack/react-query": "^5.100.7",
     "axios": "^1.13.5",
     "axios-case-converter": "^1.1.1",

--- a/ui/apps/pmm/src/contexts/navigation/navigation.provider.tsx
+++ b/ui/apps/pmm/src/contexts/navigation/navigation.provider.tsx
@@ -13,6 +13,7 @@ import {
   addUsersAndAccess,
   addHomePage,
   addSepApps,
+  addOm,
 } from './navigation.utils';
 import { useUser } from 'contexts/user';
 import { useAdvisors } from 'hooks/api/useAdvisors';
@@ -93,6 +94,9 @@ export const NavigationProvider: FC<PropsWithChildren> = ({ children }) => {
         // SEP apps mounted as native routes (migration). Shown once the session
         // is established; role/flag gating comes with real auth (Option B).
         items.push(...addSepApps());
+
+        // Served by pmm-managed, so it is not gated with the SEP group.
+        items.push(...addOm());
 
         if (settings.backupManagementEnabled) {
           items.push(NAV_BACKUPS);

--- a/ui/apps/pmm/src/contexts/navigation/navigation.utils.tsx
+++ b/ui/apps/pmm/src/contexts/navigation/navigation.utils.tsx
@@ -1,7 +1,7 @@
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 import LightModeOutlined from '@mui/icons-material/LightModeOutlined';
 import MonitorHeartIcon from '@mui/icons-material/MonitorHeart';
-import { MySqlIcon } from '@percona/peak-ui';
+import { MongoIcon, MySqlIcon } from '@percona/peak-ui';
 import { NavItem } from 'types/navigation.types';
 import { ServiceType } from 'types/services.types';
 import { User, UserPreferences } from 'types/user.types';
@@ -11,6 +11,7 @@ import {
   PMM_NEW_NAV_GRAFANA_PATH,
   SEP_ATW_PATH,
   SEP_MYSQL_BACKUPS_PATH,
+  OM_PATH,
 } from 'lib/constants';
 import { ColorMode } from '@pmm/shared';
 import {
@@ -317,5 +318,49 @@ export const addSepApps = (): NavItem[] => [
     icon: MySqlIcon,
     url: SEP_MYSQL_BACKUPS_PATH,
     matches: [SEP_MYSQL_BACKUPS_PATH],
+  },
+];
+
+/**
+ * OM's navigation, deliberately not part of `addSepApps`.
+ *
+ * Those entries are gated as a group on SEP, and the group is expected to gain a
+ * flag gate with real auth. OM is served by pmm-managed and reads PMM's own data,
+ * so hiding it when SEP is off or unreachable would hide a working page.
+ */
+export const addOm = (): NavItem[] => [
+  {
+    id: 'om',
+    text: 'OpenManager',
+    icon: MongoIcon,
+    url: OM_PATH,
+    matches: [OM_PATH],
+    children: [
+      {
+        id: 'om-overview',
+        text: 'Overview',
+        url: OM_PATH,
+      },
+      {
+        id: 'om-services',
+        text: 'Services',
+        url: `${OM_PATH}/services`,
+        matches: [`${OM_PATH}/services`],
+      },
+      {
+        // The page a host with no database appears on, which no other OM page can
+        // show: it has no service to be listed through.
+        id: 'om-hosts',
+        text: 'Hosts',
+        url: `${OM_PATH}/hosts`,
+        matches: [`${OM_PATH}/hosts`],
+      },
+      {
+        id: 'om-inventory',
+        text: 'Inventory',
+        url: `${OM_PATH}/inventory`,
+        matches: [`${OM_PATH}/inventory`],
+      },
+    ],
   },
 ];

--- a/ui/apps/pmm/src/lib/constants.ts
+++ b/ui/apps/pmm/src/lib/constants.ts
@@ -23,6 +23,11 @@ export const PMM_NEW_NAV_HOME_URL = `${PMM_NEW_NAV_PATH}/graph/d/pmm-home`;
 export const SEP_ATW_PATH = `${PMM_NEW_NAV_PATH}/sep/atw`;
 export const SEP_MYSQL_BACKUPS_PATH = `${PMM_NEW_NAV_PATH}/sep/mysql-backups`;
 
+// OM (OpenManager) is a PMM page, not a SEP one. Its API is pmm-managed's own
+// `/v1/om`, authorised by the Grafana session, and no request it makes needs a SEP
+// bearer -- which is why it sits beside the SEP mounts above rather than under them.
+export const OM_PATH = `${PMM_NEW_NAV_PATH}/om`;
+
 export const INTERVALS_MS = {
   // 5 mins
   SERVICE_TYPES: 300000,

--- a/ui/apps/pmm/src/om/OmPage.tsx
+++ b/ui/apps/pmm/src/om/OmPage.tsx
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { FC, PropsWithChildren } from 'react';
+import Stack from '@mui/material/Stack';
+import { Page } from 'components/page';
+import { useUser } from 'contexts/user';
+import { OrgRole } from 'types/user.types';
+
+/**
+ * Host chrome for the OM page.
+ *
+ * Deliberately not `SepPage`, which OM used while its backend was a SEP app. That
+ * wrapper holds its children behind `SepAuthGate` until a SEP bearer has been minted
+ * from the PMM session, and fails closed — so a SEP that is down, unconfigured or
+ * refusing the exchange would blank a page whose data comes from pmm-managed's own
+ * inventory, VictoriaMetrics and stored snapshot. OM has no SEP call on any browser
+ * path, so it must not inherit SEP's availability.
+ *
+ * The PMM-admin restriction is kept, and enforced here rather than left to the
+ * sidebar: NavigationProvider only *hides* the entry for non-admins, while the route
+ * still matches on direct navigation. The predicate is the nav's own — `isPMMAdmin` is
+ * `isGrafanaAdmin || orgRole === Admin`, and `roles` (org-role only) cannot express the
+ * Grafana-admin half on its own, so it gates the remaining case and `Page` renders its
+ * standard unauthorized card.
+ */
+export const OmPage: FC<PropsWithChildren> = ({ children }) => {
+  const { user } = useUser();
+
+  return (
+    <Page
+      maxWidth="full"
+      roles={user?.isPMMAdmin ? undefined : [OrgRole.Admin]}
+    >
+      <Stack gap={3} sx={{ flex: 1 }}>
+        <div>{children}</div>
+      </Stack>
+    </Page>
+  );
+};

--- a/ui/apps/pmm/src/router.tsx
+++ b/ui/apps/pmm/src/router.tsx
@@ -12,6 +12,7 @@ import {
   PMM_NEW_NAV_PATH,
   SEP_ATW_PATH,
   SEP_MYSQL_BACKUPS_PATH,
+  OM_PATH,
 } from 'lib/constants';
 import { RealtimeSessionsPage } from 'pages/rta/sessions';
 import { Redirect, SettingsRedirect } from 'components/redirect';
@@ -19,6 +20,8 @@ import RealtimeOverviewPage from 'pages/rta/overview/RealtimeOverview';
 import RealtimeTab from 'pages/rta/tab/RealtimeTab';
 import { AlertsPage } from 'pages/alerting/status';
 import { AtwApp } from '@sep/plugins-atw';
+import { OmApp } from '@sep/plugins-om';
+import { OmPage } from 'om/OmPage';
 import { SchemaDrivenPlugin } from '@sep/framework';
 import { SepPage } from './sep/SepPage';
 
@@ -99,6 +102,24 @@ const router = createBrowserRouter(
                 <SepPage>
                   <AtwApp />
                 </SepPage>
+              ),
+            },
+            {
+              // OM (OpenManager) is bespoke like ATW: OmApp composes its
+              // own <Routes>, so this must be a splat.
+              //
+              // All four pages are under it now. Inventory used to be mounted
+              // separately inside SepPage, because it read SEP's app directly and
+              // needed a bearer minted from the PMM session; pmm-managed proxies the
+              // estate at /v1/om/inventory, so no OM path in the browser talks to SEP
+              // any more. That is why OmPage rather than SepPage, and why a sick SEP
+              // now shows an error inside a page that still renders instead of
+              // blanking it -- SepAuthGate fails closed.
+              path: `${relativeToNav(OM_PATH)}/*`,
+              element: (
+                <OmPage>
+                  <OmApp />
+                </OmPage>
               ),
             },
             {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@sep/plugins-atw':
         specifier: workspace:*
         version: link:../../packages/plugins/atw
+      '@sep/plugins-om':
+        specifier: workspace:*
+        version: link:../../packages/plugins/om
       '@tanstack/react-query':
         specifier: ^5.100.7
         version: 5.101.4(react@19.2.8)


### PR DESCRIPTION
Ticket number: PMM-15326

Feature build: N/A on its own - this is the last piece, so a build here covers the whole OM feature. Happy to produce one.

## What

Mounts the OM plugin in the PMM app: the sidebar entry with its four children, the route, and the page chrome. Seven files, ~130 lines.

This is deliberately separated from the plugin itself (#5817) because it carries the decisions a plugin reviewer is the wrong person for - where OpenManager appears, what it is called, and who may see it.

## The three decisions in here

**OM is not part of `addSepApps`, and that is deliberate.** Those entries are gated as a group on SEP, and the group is expected to gain a flag gate with real auth. OM is served by pmm-managed over PMM's own inventory and metrics, so hiding it when SEP is off or unreachable would hide a working page. It goes in as its own entry instead.

**The chrome is `OmPage`, not `SepPage`.** `SepPage` holds its children behind `SepAuthGate` until a SEP bearer has been minted from the PMM session, and it fails closed - so a SEP that is down, unconfigured or refusing the exchange would blank a page whose data comes from pmm-managed's own inventory, VictoriaMetrics and stored snapshot. OM has no SEP call on any browser path, so it must not inherit SEP's availability. It used `SepPage` while its backend was a SEP app; #5816 moved the estate behind `/v1/om/inventory`, which is what makes this correct now.

**Admin-only, enforced on the route rather than in the sidebar.** `NavigationProvider` only *hides* the entry for non-admins - the route still matches on direct navigation. So `OmPage` gates it too, using the nav's own predicate: `isPMMAdmin` is `isGrafanaAdmin || orgRole === Admin`, and `roles` (org-role only) cannot express the Grafana-admin half, so it covers the remaining case and `Page` renders its standard unauthorized card.

Worth a second opinion on the label and the icon: the entry reads **OpenManager** with `MongoIcon`, on the grounds that the feature is MongoDB-only today. If the intent is to widen it later, a Mongo icon is a thing to regret.

## The route is a splat

`OmApp` composes its own `<Routes>`, like `AtwApp`, so the mount is `${OM_PATH}/*`. All four pages sit under it. Inventory used to be mounted separately inside `SepPage` because it read SEP's app directly; it does not any more.

## The lockfile line

The three lines adding `'@sep/plugins-om'` to the `apps/pmm` importer are here rather than in #5817, with the `package.json` that declares the dependency. Splitting it that way is what lets `pnpm install --frozen-lockfile` pass on both branches. Verified on each.

## Related work

Last of seven stacked PRs splitting #5795 ("OpenManager initial implementation") into area-owned reviews.

- #5811 - `PMM_SEP_URL` / `PMM_SEP_TOKEN` redaction
- #5812 - the OM topology tables and models
- #5813 - the OM API
- #5815 - the role rules for the OM routes
- #5816 - the OM service in pmm-managed
- #5817 - the OM UI plugin (**this PR's base**)

The base is a real dependency: the router imports `OmApp` from `@sep/plugins-om`, so this does not typecheck without #5817.

**One thing the reviewer should know:** `PMM-15299-open-manager` currently conflicts with `main`, and two of this PR's files - `ui/apps/pmm/package.json` and `src/contexts/navigation/navigation.provider.tsx` - are among the seven conflicting ones, because the same pnpm toolchain migration (PMM-15288) landed on `main` as #5728 and on this branch via its own line. That conflict predates this work and does not affect merging into the base, but reconciling it later will touch these files, `navigation.provider.tsx` most sharply since that is where `addOm()` is wired in.
