### PR TITLE
PMM-15228 Split the pmm-managed DB connection pool

### DIFF
--- a/managed/AGENTS.md
+++ b/managed/AGENTS.md
@@ -36,6 +36,15 @@ func New(db *reform.DB, logger *logrus.Entry, ...) *Service {
 
 All services are composed and wired in `managed/cmd/pmm-managed/main.go`.
 
+**Two connection pools.** `main.go` opens two independent pools against the same PostgreSQL database and hands each service one of them:
+
+| pool | for | give it to |
+|------|-----|-----------|
+| `apiDB` | pmm-agent traffic and request-scoped work: agent connect, state updates, QAN collection, RTA, authentication, and everything reached through `gRPCServerDeps` | services on the agent or API request path |
+| `internalDB` | background work that must keep running when the API pool is saturated: VictoriaMetrics scrape config, settings, cleanup, telemetry, checks, alerting, backups, scheduler | services driven by timers, leader election or the config rebuild |
+
+A reconnect storm from a fleet of agents must not be able to starve the internal services — that is the whole point of the split (PMM-15228). When adding a service, pick the pool by what drives it, not by what it does; if a service is driven by both, the agent-facing side decides. A wrong pick does not fail to compile: watch `go_sql_connections_in_use{db="pmm-managed/internal"}` correlating with agent activity.
+
 ### API Layer
 
 - **gRPC** (port 7771) — primary API protocol

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -154,25 +154,17 @@ const (
 	internalDBOpenConnsPerP = 3
 	apiDBOpenConnsPerP      = 12
 
-	// Both pools together must stay below PostgreSQL max_connections (2000 in PMM Server).
-	// The remainder is reserved for Grafana, telemetry, encryption rotation and maintenance sessions.
-	postgresMaxConnections      = 2000
-	postgresConnectionsReserved = 500
-	postgresPoolBudget          = postgresMaxConnections - postgresConnectionsReserved
-
 	internalDBPoolCap = 100
-	apiDBPoolCap      = postgresPoolBudget - internalDBPoolCap
-)
+	apiDBPoolCap      = 1400
 
-var (
-	// Internal pool: sized for the background services that keep the server itself alive.
-	internalDBMaxOpenConns = int32(min(max(internalDBMinOpenConns, runtime.GOMAXPROCS(0)*internalDBOpenConnsPerP), internalDBPoolCap))
-	internalDBMaxIdleConns = internalDBMaxOpenConns
+	// Share of max_connections left to PostgreSQL internals, Grafana, telemetry,
+	// encryption rotation and maintenance sessions, capped in absolute terms.
+	postgresConnsReservedShare = 4
+	postgresConnsReservedMax   = 500
 
-	// API pool: sized to give the pmm-agent facing paths enough headroom during a
-	// reconnect storm while staying within the shared PostgreSQL budget.
-	apiDBMaxOpenConns = int32(min(max(apiDBMinOpenConns, runtime.GOMAXPROCS(0)*apiDBOpenConnsPerP), apiDBPoolCap))
-	apiDBMaxIdleConns = apiDBMaxOpenConns
+	// Share of the budget kept for the internal pool when the budget cannot
+	// accommodate both pools at their preferred size.
+	internalDBBudgetShare = 4
 )
 
 var pprofSemaphore = semaphore.NewWeighted(1)
@@ -628,6 +620,59 @@ func setup(ctx context.Context, deps *setupDeps) bool {
 	return true
 }
 
+// dbPoolSizes holds the maximum number of open connections per pmm-managed pool.
+type dbPoolSizes struct {
+	internal int32
+	api      int32
+}
+
+// preferredDBPoolSizes returns the pool sizes for the available parallelism,
+// disregarding how many connections the PostgreSQL server can actually serve.
+func preferredDBPoolSizes() dbPoolSizes {
+	return dbPoolSizes{
+		internal: int32(min(max(internalDBMinOpenConns, runtime.GOMAXPROCS(0)*internalDBOpenConnsPerP), internalDBPoolCap)), //nolint:gosec
+		api:      int32(min(max(apiDBMinOpenConns, runtime.GOMAXPROCS(0)*apiDBOpenConnsPerP), apiDBPoolCap)),                //nolint:gosec
+	}
+}
+
+// dbPoolBudget returns how many connections a single pmm-managed instance may open,
+// given the server's max_connections and the number of instances sharing it.
+func dbPoolBudget(maxConns, instances int) int {
+	reserved := min(maxConns/postgresConnsReservedShare, postgresConnsReservedMax)
+
+	return max((maxConns-reserved)/max(instances, 1), 1)
+}
+
+// fitDBPoolSizes shrinks the pool sizes to fit the budget of a single pmm-managed instance.
+// PMM Server runs PostgreSQL with max_connections=2000, so the preferred sizes normally fit;
+// an external PostgreSQL, or an HA cluster sharing one server, may leave a lot less room.
+func fitDBPoolSizes(sizes dbPoolSizes, budget int) dbPoolSizes {
+	if int(sizes.internal)+int(sizes.api) <= budget {
+		return sizes
+	}
+
+	internal := max(budget/internalDBBudgetShare, 1)
+
+	return dbPoolSizes{
+		internal: int32(internal),                //nolint:gosec
+		api:      int32(max(budget-internal, 1)), //nolint:gosec
+	}
+}
+
+// postgresMaxConnections reads the max_connections setting of the PostgreSQL server.
+func postgresMaxConnections(ctx context.Context, sqlDB *sql.DB) (int, error) {
+	var maxConns int
+	err := sqlDB.QueryRowContext(ctx, `SELECT current_setting('max_connections')::int`).Scan(&maxConns)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read max_connections: %w", err)
+	}
+	if maxConns <= 0 {
+		return 0, fmt.Errorf("unexpected max_connections value: %d", maxConns)
+	}
+
+	return maxConns, nil
+}
+
 func getQANClient(sqlDB *sql.DB, dbName, qanAPIAddr string) *qan.Client {
 	bc := backoff.DefaultConfig
 	bc.MaxDelay = time.Second
@@ -901,6 +946,8 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		l.Panicf("cannot load victoriametrics params problem: %+v", err)
 	}
 
+	poolSizes := preferredDBPoolSizes()
+
 	// The internal pool serves the background services that keep the server itself alive:
 	// VictoriaMetrics scrape config rebuild, settings, cleanup, telemetry, checks, backups.
 	// It is deliberately kept away from the pmm-agent facing paths, so that a reconnect
@@ -918,8 +965,8 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		HAPeers:         nodes,
 		ConnMaxLifetime: dbConnMaxLifetime,
 		ConnMaxIdleTime: dbConnMaxIdleTime,
-		MaxIdleConns:    internalDBMaxIdleConns,
-		MaxOpenConns:    internalDBMaxOpenConns,
+		MaxIdleConns:    poolSizes.internal,
+		MaxOpenConns:    poolSizes.internal,
 	}
 
 	sqlInternalDB, err := models.OpenDB(setupInternalDBParams)
@@ -934,6 +981,20 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	migrateDB(ctx, sqlInternalDB, setupInternalDBParams)
 
+	// The pools must fit what the server can serve: max_connections is not ours to assume
+	// (an external PostgreSQL is supported), and in HA every instance draws from the same server.
+	maxConns, err := postgresMaxConnections(ctx, sqlInternalDB)
+	if err != nil {
+		l.Warnf("Could not read PostgreSQL max_connections, falling back to minimal pools: %s", err)
+		poolSizes = dbPoolSizes{internal: internalDBMinOpenConns, api: apiDBMinOpenConns}
+	} else {
+		budget := dbPoolBudget(maxConns, len(nodes))
+		poolSizes = fitDBPoolSizes(poolSizes, budget)
+		l.Infof("PostgreSQL max_connections=%d, connection budget for this instance: %d.", maxConns, budget)
+	}
+	sqlInternalDB.SetMaxOpenConns(int(poolSizes.internal))
+	sqlInternalDB.SetMaxIdleConns(int(poolSizes.internal))
+
 	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/internal", sqlInternalDB))
 	internalReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/internal", logrus.WithField("component", "reform").Tracef)
 	prom.MustRegister(internalReformL)
@@ -943,8 +1004,8 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	// collection, RTA, authentication) and the gRPC/REST API handlers. Saturating it
 	// degrades those paths only; the internal services keep making progress.
 	setupAPIDBParams := setupInternalDBParams
-	setupAPIDBParams.MaxIdleConns = apiDBMaxIdleConns
-	setupAPIDBParams.MaxOpenConns = apiDBMaxOpenConns
+	setupAPIDBParams.MaxIdleConns = poolSizes.api
+	setupAPIDBParams.MaxOpenConns = poolSizes.api
 
 	sqlAPIDB, err := models.OpenDB(setupAPIDBParams)
 	if err != nil {
@@ -957,7 +1018,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	prom.MustRegister(apiReformL)
 	apiDB := reform.NewDB(sqlAPIDB, postgresql.Dialect, apiReformL)
 
-	l.Infof("Database connection pools: internal %d, API %d.", internalDBMaxOpenConns, apiDBMaxOpenConns)
+	l.Infof("Database connection pools: internal %d, API %d.", poolSizes.internal, poolSizes.api)
 
 	// Generate unique PMM Server ID if it's not already.
 	err = models.SetPMMServerID(internalDB)

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -159,6 +159,8 @@ const (
 	internalDBOpenConnsPerP = 3
 	apiDBOpenConnsPerP      = 12
 
+	// The two caps sum to the budget PMM Server leaves (2000 max_connections less the
+	// reserve below), so on PMM Server they bind before the budget does.
 	internalDBPoolCap = 100
 	apiDBPoolCap      = 1400
 
@@ -174,7 +176,6 @@ const (
 	// Used when the server's max_connections cannot be read. PostgreSQL's own default is
 	// far below what PMM Server configures, which makes it the conservative assumption.
 	assumedMaxConnections = 100
-	maxConnectionsTimeout = 10 * time.Second
 )
 
 var pprofSemaphore = semaphore.NewWeighted(1)
@@ -632,17 +633,8 @@ func setup(ctx context.Context, deps *setupDeps) bool {
 
 // dbPoolSizes holds the maximum number of open connections per pmm-managed pool.
 type dbPoolSizes struct {
-	internal int32
-	api      int32
-}
-
-// preferredDBPoolSizes returns the pool sizes for the available parallelism,
-// disregarding how many connections the PostgreSQL server can actually serve.
-func preferredDBPoolSizes() dbPoolSizes {
-	return dbPoolSizes{
-		internal: int32(min(max(internalDBMinOpenConns, runtime.GOMAXPROCS(0)*internalDBOpenConnsPerP), internalDBPoolCap)), //nolint:gosec
-		api:      int32(min(max(apiDBMinOpenConns, runtime.GOMAXPROCS(0)*apiDBOpenConnsPerP), apiDBPoolCap)),                //nolint:gosec
-	}
+	internal int
+	api      int
 }
 
 // dbPoolInstances returns how many pmm-managed instances share one PostgreSQL server.
@@ -672,22 +664,21 @@ func dbPoolBudget(maxConns, instances int) int {
 	return max((maxConns-reserved)/max(instances, 1), 1)
 }
 
-// fitDBPoolSizes shrinks the pool sizes to fit the budget of a single pmm-managed instance.
-// PMM Server runs PostgreSQL with max_connections=2000, so the preferred sizes normally fit;
-// an external PostgreSQL, or an HA cluster sharing one server, may leave a lot less room.
-func fitDBPoolSizes(sizes dbPoolSizes, budget int) dbPoolSizes {
-	if int(sizes.internal)+int(sizes.api) <= budget {
-		return sizes
+// dbPoolSizesFor returns the size of each pool: proportional to the available parallelism,
+// then shrunk to the budget of a single pmm-managed instance. PMM Server runs PostgreSQL with
+// max_connections=2000, so the proportional sizes normally fit; an external PostgreSQL, or an
+// HA cluster sharing one server, may leave a lot less room.
+func dbPoolSizesFor(procs, budget int) dbPoolSizes {
+	internal := min(max(internalDBMinOpenConns, procs*internalDBOpenConnsPerP), internalDBPoolCap)
+	api := min(max(apiDBMinOpenConns, procs*apiDBOpenConnsPerP), apiDBPoolCap)
+
+	if internal+api > budget {
+		// Never above what the parallelism asked for: a tighter budget must not grow a pool.
+		internal = min(max(budget/internalDBBudgetShare, 1), internal)
+		api = min(max(budget-internal, 1), api)
 	}
 
-	// Never above what the parallelism asked for: a tighter budget must not grow a pool.
-	internal := min(max(budget/internalDBBudgetShare, 1), int(sizes.internal))
-	api := min(max(budget-internal, 1), int(sizes.api))
-
-	return dbPoolSizes{
-		internal: int32(internal), //nolint:gosec
-		api:      int32(api),      //nolint:gosec
-	}
+	return dbPoolSizes{internal: internal, api: api}
 }
 
 // postgresMaxConnections reads the max_connections setting of the PostgreSQL server.
@@ -726,11 +717,17 @@ func getQANClient(sqlDB *sql.DB, dbName, qanAPIAddr string) *qan.Client {
 		logrus.Fatalf("Failed to connect QAN API %s: %s.", qanAPIAddr, err)
 	}
 
-	l := logrus.WithField("component", "reform/qan")
-	reformL := sqlmetrics.NewReform("postgres", dbName+"/qan", l.Tracef)
-	prom.MustRegister(reformL)
-	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)
+	db := reform.NewDB(sqlDB, postgresql.Dialect, newReformLogger(dbName, "qan"))
 	return qan.NewClient(conn, db)
+}
+
+// newReformLogger returns a registered reform logger for one connection pool. The pool name
+// separates both the metrics and the trace logs of the pools sharing a database.
+func newReformLogger(dbName, pool string) *sqlmetrics.Reform {
+	reformL := sqlmetrics.NewReform("postgres", dbName+"/"+pool, logrus.WithField("component", "reform/"+pool).Tracef)
+	prom.MustRegister(reformL)
+
+	return reformL
 }
 
 func migrateDB(ctx context.Context, sqlDB *sql.DB, params models.SetupDBParams) {
@@ -977,8 +974,6 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		l.Panicf("cannot load victoriametrics params problem: %+v", err)
 	}
 
-	poolSizes := preferredDBPoolSizes()
-
 	// The internal pool serves the background services that keep the server itself alive:
 	// VictoriaMetrics scrape config rebuild, settings, cleanup, telemetry, checks, backups.
 	// It is deliberately kept away from the pmm-agent facing paths, so that a reconnect
@@ -996,8 +991,8 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		HAPeers:         nodes,
 		ConnMaxLifetime: dbConnMaxLifetime,
 		ConnMaxIdleTime: dbConnMaxIdleTime,
-		MaxIdleConns:    poolSizes.internal,
-		MaxOpenConns:    poolSizes.internal,
+		// The final size needs max_connections, which needs a connection. Migrations run
+		// on the default pool size, and both pools are sized right after.
 	}
 
 	sqlInternalDB, err := models.OpenDB(setupInternalDBParams)
@@ -1014,7 +1009,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	// The pools must fit what the server can serve: max_connections is not ours to assume
 	// (an external PostgreSQL is supported), and in HA every instance draws from the same server.
-	detectCtx, detectCancel := context.WithTimeout(ctx, maxConnectionsTimeout)
+	detectCtx, detectCancel := context.WithTimeout(ctx, defaultContextTimeout)
 	maxConns, err := postgresMaxConnections(detectCtx, sqlInternalDB)
 	detectCancel()
 	if err != nil {
@@ -1026,22 +1021,19 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	instances := dbPoolInstances(*haEnabled, nodes)
 	budget := dbPoolBudget(maxConns, instances)
-	poolSizes = fitDBPoolSizes(poolSizes, budget)
-	sqlInternalDB.SetMaxOpenConns(int(poolSizes.internal))
-	sqlInternalDB.SetMaxIdleConns(int(poolSizes.internal))
+	poolSizes := dbPoolSizesFor(runtime.GOMAXPROCS(0), budget)
+	sqlInternalDB.SetMaxOpenConns(poolSizes.internal)
+	sqlInternalDB.SetMaxIdleConns(poolSizes.internal)
 	l.Infof("PostgreSQL max_connections=%d shared by %d pmm-managed instance(s), connection budget %d.",
 		maxConns, instances, budget)
 
 	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/internal", sqlInternalDB))
-	internalReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/internal", logrus.WithField("component", "reform/internal").Tracef)
-	prom.MustRegister(internalReformL)
-	internalDB := reform.NewDB(sqlInternalDB, postgresql.Dialect, internalReformL)
+	internalDB := reform.NewDB(sqlInternalDB, postgresql.Dialect, newReformLogger(*postgresDBNameF, "internal"))
 
 	// The API pool serves the pmm-agent facing paths (agent connect, state updates, QAN
 	// collection, RTA, authentication) and the gRPC/REST API handlers. Saturating it
 	// degrades those paths only; the internal services keep making progress.
 	setupAPIDBParams := setupInternalDBParams
-	setupAPIDBParams.MaxIdleConns = poolSizes.api
 	setupAPIDBParams.MaxOpenConns = poolSizes.api
 
 	sqlAPIDB, err := models.OpenDB(setupAPIDBParams)
@@ -1051,9 +1043,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	defer sqlAPIDB.Close() //nolint:errcheck
 
 	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/api", sqlAPIDB))
-	apiReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/api", logrus.WithField("component", "reform/api").Tracef)
-	prom.MustRegister(apiReformL)
-	apiDB := reform.NewDB(sqlAPIDB, postgresql.Dialect, apiReformL)
+	apiDB := reform.NewDB(sqlAPIDB, postgresql.Dialect, newReformLogger(*postgresDBNameF, "api"))
 
 	l.Infof("Database connection pools: internal %d, API %d.", poolSizes.internal, poolSizes.api)
 

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -170,6 +170,11 @@ const (
 	// Share of the budget kept for the internal pool when the budget cannot
 	// accommodate both pools at their preferred size.
 	internalDBBudgetShare = 4
+
+	// Used when the server's max_connections cannot be read. PostgreSQL's own default is
+	// far below what PMM Server configures, which makes it the conservative assumption.
+	assumedMaxConnections = 100
+	maxConnectionsTimeout = 10 * time.Second
 )
 
 var pprofSemaphore = semaphore.NewWeighted(1)
@@ -640,6 +645,25 @@ func preferredDBPoolSizes() dbPoolSizes {
 	}
 }
 
+// dbPoolInstances returns how many pmm-managed instances share one PostgreSQL server.
+// PMM_HA_PEERS lists every node of the cluster, not only the remote ones: the Helm chart
+// pushes the same value to all pods, and services/ha/ha.go derives ExpectedNodes from its
+// length. The list is generated externally, so empty entries are not counted.
+func dbPoolInstances(haEnabled bool, peers []string) int {
+	if !haEnabled {
+		return 1
+	}
+
+	instances := 0
+	for _, peer := range peers {
+		if strings.TrimSpace(peer) != "" {
+			instances++
+		}
+	}
+
+	return max(instances, 1)
+}
+
 // dbPoolBudget returns how many connections a single pmm-managed instance may open,
 // given the server's max_connections and the number of instances sharing it.
 func dbPoolBudget(maxConns, instances int) int {
@@ -656,11 +680,13 @@ func fitDBPoolSizes(sizes dbPoolSizes, budget int) dbPoolSizes {
 		return sizes
 	}
 
-	internal := max(budget/internalDBBudgetShare, 1)
+	// Never above what the parallelism asked for: a tighter budget must not grow a pool.
+	internal := min(max(budget/internalDBBudgetShare, 1), int(sizes.internal))
+	api := min(max(budget-internal, 1), int(sizes.api))
 
 	return dbPoolSizes{
-		internal: int32(internal),                //nolint:gosec
-		api:      int32(max(budget-internal, 1)), //nolint:gosec
+		internal: int32(internal), //nolint:gosec
+		api:      int32(api),      //nolint:gosec
 	}
 }
 
@@ -988,24 +1014,26 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	// The pools must fit what the server can serve: max_connections is not ours to assume
 	// (an external PostgreSQL is supported), and in HA every instance draws from the same server.
-	maxConns, err := postgresMaxConnections(ctx, sqlInternalDB)
+	detectCtx, detectCancel := context.WithTimeout(ctx, maxConnectionsTimeout)
+	maxConns, err := postgresMaxConnections(detectCtx, sqlInternalDB)
+	detectCancel()
 	if err != nil {
-		l.Warnf("Could not read PostgreSQL max_connections, falling back to minimal pools: %s", err)
-		poolSizes = dbPoolSizes{internal: internalDBMinOpenConns, api: apiDBMinOpenConns}
-	} else {
-		// PMM_HA_PEERS lists every node of the cluster, not only the remote ones: the Helm
-		// chart pushes the same value to all pods, and services/ha/ha.go derives
-		// ExpectedNodes from its length. So len(nodes) is the number of instances sharing
-		// the server, and 0 (HA disabled) means this process is alone.
-		budget := dbPoolBudget(maxConns, len(nodes))
-		poolSizes = fitDBPoolSizes(poolSizes, budget)
-		l.Infof("PostgreSQL max_connections=%d, connection budget for this instance: %d.", maxConns, budget)
+		// Assume PostgreSQL's own default rather than what PMM Server configures: if the
+		// setting cannot be read, the smaller server is the safer guess.
+		l.Warnf("Could not read PostgreSQL max_connections, assuming %d: %s", assumedMaxConnections, err)
+		maxConns = assumedMaxConnections
 	}
+
+	instances := dbPoolInstances(*haEnabled, nodes)
+	budget := dbPoolBudget(maxConns, instances)
+	poolSizes = fitDBPoolSizes(poolSizes, budget)
 	sqlInternalDB.SetMaxOpenConns(int(poolSizes.internal))
 	sqlInternalDB.SetMaxIdleConns(int(poolSizes.internal))
+	l.Infof("PostgreSQL max_connections=%d shared by %d pmm-managed instance(s), connection budget %d.",
+		maxConns, instances, budget)
 
 	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/internal", sqlInternalDB))
-	internalReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/internal", logrus.WithField("component", "reform").Tracef)
+	internalReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/internal", logrus.WithField("component", "reform/internal").Tracef)
 	prom.MustRegister(internalReformL)
 	internalDB := reform.NewDB(sqlInternalDB, postgresql.Dialect, internalReformL)
 
@@ -1023,7 +1051,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	defer sqlAPIDB.Close() //nolint:errcheck
 
 	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/api", sqlAPIDB))
-	apiReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/api", logrus.WithField("component", "reform").Tracef)
+	apiReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/api", logrus.WithField("component", "reform/api").Tracef)
 	prom.MustRegister(apiReformL)
 	apiDB := reform.NewDB(sqlAPIDB, postgresql.Dialect, apiReformL)
 

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -142,6 +143,36 @@ const (
 
 	distributionInfoFilePath = "/srv/pmm-distribution"
 	osInfoFilePath           = "/proc/version"
+
+	dbConnMaxLifetime = 0
+	dbConnMaxIdleTime = 5 * time.Minute
+
+	internalDBMinOpenConns = 20
+	apiDBMinOpenConns      = 50
+
+	// Pool growth is proportional to the scheduler parallelism.
+	internalDBOpenConnsPerP = 3
+	apiDBOpenConnsPerP      = 12
+
+	// Both pools together must stay below PostgreSQL max_connections (2000 in PMM Server).
+	// The remainder is reserved for Grafana, telemetry, encryption rotation and maintenance sessions.
+	postgresMaxConnections      = 2000
+	postgresConnectionsReserved = 500
+	postgresPoolBudget          = postgresMaxConnections - postgresConnectionsReserved
+
+	internalDBPoolCap = 100
+	apiDBPoolCap      = postgresPoolBudget - internalDBPoolCap
+)
+
+var (
+	// Internal pool: sized for the background services that keep the server itself alive.
+	internalDBMaxOpenConns = int32(min(max(internalDBMinOpenConns, runtime.GOMAXPROCS(0)*internalDBOpenConnsPerP), internalDBPoolCap))
+	internalDBMaxIdleConns = internalDBMaxOpenConns
+
+	// API pool: sized to give the pmm-agent facing paths enough headroom during a
+	// reconnect storm while staying within the shared PostgreSQL budget.
+	apiDBMaxOpenConns = int32(min(max(apiDBMinOpenConns, runtime.GOMAXPROCS(0)*apiDBOpenConnsPerP), apiDBPoolCap))
+	apiDBMaxIdleConns = apiDBMaxOpenConns
 )
 
 var pprofSemaphore = semaphore.NewWeighted(1)
@@ -870,45 +901,73 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		l.Panicf("cannot load victoriametrics params problem: %+v", err)
 	}
 
-	setupParams := models.SetupDBParams{
-		Address:     *postgresAddrF,
-		Name:        *postgresDBNameF,
-		Username:    *postgresDBUsernameF,
-		Password:    *postgresDBPasswordF,
-		SSLMode:     *postgresSSLModeF,
-		SSLCAPath:   *postgresSSLCAPathF,
-		SSLKeyPath:  *postgresSSLKeyPathF,
-		SSLCertPath: *postgresSSLCertPathF,
-		HANodeID:    *haNodeID,
-		HAPeers:     nodes,
+	// The internal pool serves the background services that keep the server itself alive:
+	// VictoriaMetrics scrape config rebuild, settings, cleanup, telemetry, checks, backups.
+	// It is deliberately kept away from the pmm-agent facing paths, so that a reconnect
+	// storm from a fleet of agents can no longer starve them of connections.
+	setupInternalDBParams := models.SetupDBParams{
+		Address:         *postgresAddrF,
+		Name:            *postgresDBNameF,
+		Username:        *postgresDBUsernameF,
+		Password:        *postgresDBPasswordF,
+		SSLMode:         *postgresSSLModeF,
+		SSLCAPath:       *postgresSSLCAPathF,
+		SSLKeyPath:      *postgresSSLKeyPathF,
+		SSLCertPath:     *postgresSSLCertPathF,
+		HANodeID:        *haNodeID,
+		HAPeers:         nodes,
+		ConnMaxLifetime: dbConnMaxLifetime,
+		ConnMaxIdleTime: dbConnMaxIdleTime,
+		MaxIdleConns:    internalDBMaxIdleConns,
+		MaxOpenConns:    internalDBMaxOpenConns,
 	}
 
-	sqlDB, err := models.OpenDB(setupParams)
+	sqlInternalDB, err := models.OpenDB(setupInternalDBParams)
 	if err != nil {
 		l.Panicf("Failed to connect to database: %+v", err)
 	}
-	defer sqlDB.Close() //nolint:errcheck
+	defer sqlInternalDB.Close() //nolint:errcheck
 
 	if *haEnabled {
 		models.AgentConfigFilePath = "/srv/pmm-agent/config/pmm-agent.yaml"
 	}
 
-	migrateDB(ctx, sqlDB, setupParams)
+	migrateDB(ctx, sqlInternalDB, setupInternalDBParams)
 
-	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF, sqlDB))
-	reformL := sqlmetrics.NewReform("postgres", *postgresDBNameF, logrus.WithField("component", "reform").Tracef)
-	prom.MustRegister(reformL)
-	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)
+	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/internal", sqlInternalDB))
+	internalReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/internal", logrus.WithField("component", "reform").Tracef)
+	prom.MustRegister(internalReformL)
+	internalDB := reform.NewDB(sqlInternalDB, postgresql.Dialect, internalReformL)
+
+	// The API pool serves the pmm-agent facing paths (agent connect, state updates, QAN
+	// collection, RTA, authentication) and the gRPC/REST API handlers. Saturating it
+	// degrades those paths only; the internal services keep making progress.
+	setupAPIDBParams := setupInternalDBParams
+	setupAPIDBParams.MaxIdleConns = apiDBMaxIdleConns
+	setupAPIDBParams.MaxOpenConns = apiDBMaxOpenConns
+
+	sqlAPIDB, err := models.OpenDB(setupAPIDBParams)
+	if err != nil {
+		l.Panicf("Failed to connect to database: %+v", err)
+	}
+	defer sqlAPIDB.Close() //nolint:errcheck
+
+	prom.MustRegister(sqlmetrics.NewCollector("postgres", *postgresDBNameF+"/api", sqlAPIDB))
+	apiReformL := sqlmetrics.NewReform("postgres", *postgresDBNameF+"/api", logrus.WithField("component", "reform").Tracef)
+	prom.MustRegister(apiReformL)
+	apiDB := reform.NewDB(sqlAPIDB, postgresql.Dialect, apiReformL)
+
+	l.Infof("Database connection pools: internal %d, API %d.", internalDBMaxOpenConns, apiDBMaxOpenConns)
 
 	// Generate unique PMM Server ID if it's not already.
-	err = models.SetPMMServerID(db)
+	err = models.SetPMMServerID(internalDB)
 	if err != nil {
 		l.Panicf("failed to set PMM Server ID")
 	}
 
-	cleaner := clean.New(db)
+	cleaner := clean.New(internalDB)
 	externalRules := vmalert.NewExternalRules()
-	vmdb, err := victoriametrics.NewVictoriaMetrics(*victoriaMetricsConfigF, db, vmParams, chParams, haService)
+	vmdb, err := victoriametrics.NewVictoriaMetrics(*victoriaMetricsConfigF, internalDB, vmParams, chParams, haService)
 	if err != nil {
 		l.Panicf("VictoriaMetrics service problem: %+v", err)
 	}
@@ -921,9 +980,9 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	minioClient := minio.New()
 
-	qanClient := getQANClient(sqlDB, *postgresDBNameF, *qanAPIAddrF)
+	qanClient := getQANClient(sqlAPIDB, *postgresDBNameF, *qanAPIAddrF)
 
-	agentsRegistry := agents.NewRegistry(db, vmParams, haService)
+	agentsRegistry := agents.NewRegistry(apiDB, vmParams, haService)
 
 	// TODO remove once PMM cluster is Active-Active
 	// TODO kick non-pmm-server agents only
@@ -933,11 +992,11 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	// 	func() { agentsRegistry.KickAll(ctx) }))
 
 	pbmPITRService := backup.NewPBMPITRService()
-	backupRemovalService := backup.NewRemovalService(db, pbmPITRService)
-	backupRetentionService := backup.NewRetentionService(db, backupRemovalService)
+	backupRemovalService := backup.NewRemovalService(internalDB, pbmPITRService)
+	backupRetentionService := backup.NewRetentionService(internalDB, backupRemovalService)
 	prom.MustRegister(agentsRegistry)
 
-	inventoryMetrics := inventory.NewInventoryMetrics(db, agentsRegistry)
+	inventoryMetrics := inventory.NewInventoryMetrics(internalDB, agentsRegistry)
 	inventoryMetricsCollector := inventory.NewInventoryMetricsCollector(inventoryMetrics)
 	prom.MustRegister(inventoryMetricsCollector)
 
@@ -947,7 +1006,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	connectionCheck := agents.NewConnectionChecker(agentsRegistry)
 	serviceInfoBroker := agents.NewServiceInfoBroker(agentsRegistry)
 
-	updater := server.NewUpdater(db)
+	updater := server.NewUpdater(internalDB)
 
 	logs := server.NewLogs(version.FullInfo(), updater, vmParams)
 
@@ -983,7 +1042,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	platformClient := platformClient.NewClient(platformAddress)
 
 	dus := distribution.NewService(distributionInfoFilePath, osInfoFilePath, l)
-	telemetry, err := telemetry.NewService(db, platformClient, version.Version, dus, cfg.Config.Services.Telemetry)
+	telemetry, err := telemetry.NewService(internalDB, platformClient, version.Version, dus, cfg.Config.Services.Telemetry)
 	if err != nil {
 		l.Fatalf("Could not create telemetry service: %s", err)
 	}
@@ -998,14 +1057,14 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		GCMaxAllocs:           *nomadGCMaxAllocsF,
 		GCParallelDestroys:    *nomadGCParallelDestroysF,
 	}
-	nomad, err := nomad.New(db, nomadClientConfig)
+	nomad, err := nomad.New(internalDB, nomadClientConfig)
 	if err != nil {
 		l.Fatalf("Could not create Nomad client: %s", err)
 	}
 
-	jobsService := agents.NewJobsService(db, agentsRegistry, backupRetentionService)
-	agentsStateUpdater := agents.NewStateUpdater(db, agentsRegistry, vmdb, vmParams, nomad)
-	agentsHandler := agents.NewHandler(db, qanClient, vmdb, agentsRegistry, agentsStateUpdater, jobsService)
+	jobsService := agents.NewJobsService(internalDB, agentsRegistry, backupRetentionService)
+	agentsStateUpdater := agents.NewStateUpdater(apiDB, agentsRegistry, vmdb, vmParams, nomad)
+	agentsHandler := agents.NewHandler(apiDB, qanClient, vmdb, agentsRegistry, agentsStateUpdater, jobsService)
 
 	actionsService := agents.NewActionsService(qanClient, agentsRegistry)
 
@@ -1018,12 +1077,12 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	if err != nil {
 		l.Fatalf("Could not create Clickhouse client: %s", err)
 	}
-	externalExporterStatusSvc := agents.NewExternalExporterStatusService(db, v1.NewAPI(vmClient))
+	externalExporterStatusSvc := agents.NewExternalExporterStatusService(internalDB, v1.NewAPI(vmClient))
 
-	checksService := checks.New(db, actionsService, v1.NewAPI(vmClient), clickhouseClient)
+	checksService := checks.New(internalDB, actionsService, v1.NewAPI(vmClient), clickhouseClient)
 	prom.MustRegister(checksService)
 
-	alertingService, err := alerting.NewService(db, grafanaClient)
+	alertingService, err := alerting.NewService(internalDB, grafanaClient)
 	if err != nil {
 		l.Fatalf("Could not create alerting service: %s", err)
 	}
@@ -1032,21 +1091,21 @@ func main() { //nolint:gocognit,maintidx,cyclop
 	agentService := agents.NewAgentService(agentsRegistry)
 
 	versioner := agents.NewVersionerService(agentsRegistry)
-	compatibilityService := backup.NewCompatibilityService(db, versioner)
-	backupService := backup.NewService(db, jobsService, agentService, compatibilityService, pbmPITRService)
-	backupMetricsCollector := backup.NewMetricsCollector(db)
+	compatibilityService := backup.NewCompatibilityService(internalDB, versioner)
+	backupService := backup.NewService(internalDB, jobsService, agentService, compatibilityService, pbmPITRService)
+	backupMetricsCollector := backup.NewMetricsCollector(internalDB)
 	prom.MustRegister(backupMetricsCollector)
 
-	schedulerService := scheduler.New(db, backupService)
-	versionCache := versioncache.New(db, versioner)
+	schedulerService := scheduler.New(internalDB, backupService)
+	versionCache := versioncache.New(internalDB, versioner)
 
-	dumpService := dump.New(db, &dump.URLs{
+	dumpService := dump.New(internalDB, &dump.URLs{
 		ClickhouseURL: chParams.URL().String(),
 		VMURL:         *victoriaMetricsURLF,
 	})
 
 	serverParams := &server.Params{
-		DB:                   db,
+		DB:                   internalDB,
 		VMDB:                 vmdb,
 		VMAlert:              vmalert,
 		AgentsStateUpdater:   agentsStateUpdater,
@@ -1095,7 +1154,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 
 	// try synchronously once, then retry in the background
 	deps := &setupDeps{
-		sqlDB:       sqlDB,
+		sqlDB:       sqlInternalDB,
 		ha:          haService,
 		supervisord: supervisord,
 		vmdb:        vmdb,
@@ -1123,12 +1182,12 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		}()
 	}
 
-	settings, err := models.GetSettings(sqlDB)
+	settings, err := models.GetSettings(sqlInternalDB)
 	if err != nil {
 		l.Fatalf("Failed to get settings: %+v.", err)
 	}
 
-	authServer := grafana.NewAuthServer(grafanaClient, db)
+	authServer := grafana.NewAuthServer(grafanaClient, apiDB)
 
 	l.Info("Starting services...")
 	var wg sync.WaitGroup
@@ -1187,7 +1246,7 @@ func main() { //nolint:gocognit,maintidx,cyclop
 				compatibilityService:      compatibilityService,
 				config:                    &cfg.Config,
 				connectionCheck:           connectionCheck,
-				db:                        db,
+				db:                        apiDB,
 				dumpService:               dumpService,
 				grafanaClient:             grafanaClient,
 				handler:                   agentsHandler,

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -144,8 +144,13 @@ const (
 	distributionInfoFilePath = "/srv/pmm-distribution"
 	osInfoFilePath           = "/proc/version"
 
-	dbConnMaxLifetime = 0
-	dbConnMaxIdleTime = 5 * time.Minute
+	// A reconnect storm grows both pools to their maximum, and every connection is a
+	// PostgreSQL backend process. Idle connections are returned to the server a minute
+	// after the storm subsides instead of being kept for the whole 5 minutes that used
+	// to be the default, and every connection is recycled twice an hour, so a pool
+	// cannot pin the same backends indefinitely (also helps HA failover recover).
+	dbConnMaxLifetime = 30 * time.Minute
+	dbConnMaxIdleTime = 1 * time.Minute
 
 	internalDBMinOpenConns = 20
 	apiDBMinOpenConns      = 50

--- a/managed/cmd/pmm-managed/main.go
+++ b/managed/cmd/pmm-managed/main.go
@@ -993,6 +993,10 @@ func main() { //nolint:gocognit,maintidx,cyclop
 		l.Warnf("Could not read PostgreSQL max_connections, falling back to minimal pools: %s", err)
 		poolSizes = dbPoolSizes{internal: internalDBMinOpenConns, api: apiDBMinOpenConns}
 	} else {
+		// PMM_HA_PEERS lists every node of the cluster, not only the remote ones: the Helm
+		// chart pushes the same value to all pods, and services/ha/ha.go derives
+		// ExpectedNodes from its length. So len(nodes) is the number of instances sharing
+		// the server, and 0 (HA disabled) means this process is alone.
 		budget := dbPoolBudget(maxConns, len(nodes))
 		poolSizes = fitDBPoolSizes(poolSizes, budget)
 		l.Infof("PostgreSQL max_connections=%d, connection budget for this instance: %d.", maxConns, budget)

--- a/managed/cmd/pmm-managed/main_test.go
+++ b/managed/cmd/pmm-managed/main_test.go
@@ -240,6 +240,9 @@ func TestFitDBPoolSizes(t *testing.T) {
 		{name: "budget to spare", budget: 1500, expected: preferred},
 		{name: "exactly enough", budget: 70, expected: preferred},
 		{name: "too small, split", budget: 40, expected: dbPoolSizes{internal: 10, api: 30}},
+		// A tighter budget must never grow a pool above what the parallelism asked for.
+		{name: "internal share above preferred", budget: 68, expected: dbPoolSizes{internal: 17, api: 50}},
+		{name: "budget just below the sum", budget: 69, expected: dbPoolSizes{internal: 17, api: 50}},
 		{name: "way too small", budget: 4, expected: dbPoolSizes{internal: 1, api: 3}},
 		{name: "never zero", budget: 1, expected: dbPoolSizes{internal: 1, api: 1}},
 	} {
@@ -249,6 +252,28 @@ func TestFitDBPoolSizes(t *testing.T) {
 			if tc.budget >= 2 {
 				assert.LessOrEqual(t, int(sizes.internal)+int(sizes.api), tc.budget)
 			}
+		})
+	}
+}
+
+func TestDBPoolInstances(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		haEnabled bool
+		peers     []string
+		expected  int
+	}{
+		{name: "HA disabled", haEnabled: false, peers: nil, expected: 1},
+		// PMM_HA_PEERS can outlive the HA setting it was configured for.
+		{name: "HA disabled with leftover peers", haEnabled: false, peers: []string{"a", "b", "c"}, expected: 1},
+		{name: "HA with 3 nodes", haEnabled: true, peers: []string{"a", "b", "c"}, expected: 3},
+		// The list is generated externally, so it can carry empty entries.
+		{name: "HA with a trailing comma", haEnabled: true, peers: []string{"a", "b", ""}, expected: 2},
+		{name: "HA with whitespace", haEnabled: true, peers: []string{"a", " "}, expected: 1},
+		{name: "HA without peers", haEnabled: true, peers: nil, expected: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, dbPoolInstances(tc.haEnabled, tc.peers))
 		})
 	}
 }

--- a/managed/cmd/pmm-managed/main_test.go
+++ b/managed/cmd/pmm-managed/main_test.go
@@ -229,28 +229,29 @@ func TestDBPoolBudget(t *testing.T) {
 	}
 }
 
-func TestFitDBPoolSizes(t *testing.T) {
-	preferred := dbPoolSizes{internal: 20, api: 50}
-
+func TestDBPoolSizesFor(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
+		procs    int
 		budget   int
 		expected dbPoolSizes
 	}{
-		{name: "budget to spare", budget: 1500, expected: preferred},
-		{name: "exactly enough", budget: 70, expected: preferred},
-		{name: "too small, split", budget: 40, expected: dbPoolSizes{internal: 10, api: 30}},
-		// A tighter budget must never grow a pool above what the parallelism asked for.
-		{name: "internal share above preferred", budget: 68, expected: dbPoolSizes{internal: 17, api: 50}},
-		{name: "budget just below the sum", budget: 69, expected: dbPoolSizes{internal: 17, api: 50}},
-		{name: "way too small", budget: 4, expected: dbPoolSizes{internal: 1, api: 3}},
-		{name: "never zero", budget: 1, expected: dbPoolSizes{internal: 1, api: 1}},
+		// PMM Server: 1500 of budget, so the parallelism decides.
+		{name: "4 CPUs", procs: 4, budget: 1500, expected: dbPoolSizes{internal: 20, api: 50}},
+		{name: "16 CPUs", procs: 16, budget: 1500, expected: dbPoolSizes{internal: 48, api: 192}},
+		{name: "caps bind", procs: 256, budget: 1500, expected: dbPoolSizes{internal: 100, api: 1400}},
+		// A tighter budget shrinks both pools, and must never grow either of them.
+		{name: "exactly enough", procs: 4, budget: 70, expected: dbPoolSizes{internal: 20, api: 50}},
+		{name: "too small, split", procs: 4, budget: 40, expected: dbPoolSizes{internal: 10, api: 30}},
+		{name: "internal share above preferred", procs: 4, budget: 68, expected: dbPoolSizes{internal: 17, api: 50}},
+		{name: "way too small", procs: 4, budget: 4, expected: dbPoolSizes{internal: 1, api: 3}},
+		{name: "never zero", procs: 4, budget: 1, expected: dbPoolSizes{internal: 1, api: 1}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			sizes := fitDBPoolSizes(preferred, tc.budget)
+			sizes := dbPoolSizesFor(tc.procs, tc.budget)
 			assert.Equal(t, tc.expected, sizes)
 			if tc.budget >= 2 {
-				assert.LessOrEqual(t, int(sizes.internal)+int(sizes.api), tc.budget)
+				assert.LessOrEqual(t, sizes.internal+sizes.api, tc.budget)
 			}
 		})
 	}
@@ -276,13 +277,4 @@ func TestDBPoolInstances(t *testing.T) {
 			assert.Equal(t, tc.expected, dbPoolInstances(tc.haEnabled, tc.peers))
 		})
 	}
-}
-
-func TestPreferredDBPoolSizes(t *testing.T) {
-	sizes := preferredDBPoolSizes()
-
-	assert.GreaterOrEqual(t, sizes.internal, int32(internalDBMinOpenConns))
-	assert.LessOrEqual(t, sizes.internal, int32(internalDBPoolCap))
-	assert.GreaterOrEqual(t, sizes.api, int32(apiDBMinOpenConns))
-	assert.LessOrEqual(t, sizes.api, int32(apiDBPoolCap))
 }

--- a/managed/cmd/pmm-managed/main_test.go
+++ b/managed/cmd/pmm-managed/main_test.go
@@ -206,3 +206,58 @@ func formatPkgName(t *testing.T, name string) string {
 
 	return name
 }
+
+func TestDBPoolBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		maxConns  int
+		instances int
+		expected  int
+	}{
+		// PMM Server runs PostgreSQL with max_connections=2000.
+		{name: "PMM Server", maxConns: 2000, instances: 0, expected: 1500},
+		{name: "PMM Server, HA with 3 nodes", maxConns: 2000, instances: 3, expected: 500},
+		// A stock managed PostgreSQL keeps a quarter of its connections.
+		{name: "external PostgreSQL", maxConns: 100, instances: 1, expected: 75},
+		{name: "external PostgreSQL, HA with 3 nodes", maxConns: 100, instances: 3, expected: 25},
+		{name: "tiny PostgreSQL", maxConns: 4, instances: 1, expected: 3},
+		{name: "never zero", maxConns: 1, instances: 8, expected: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, dbPoolBudget(tc.maxConns, tc.instances))
+		})
+	}
+}
+
+func TestFitDBPoolSizes(t *testing.T) {
+	preferred := dbPoolSizes{internal: 20, api: 50}
+
+	for _, tc := range []struct {
+		name     string
+		budget   int
+		expected dbPoolSizes
+	}{
+		{name: "budget to spare", budget: 1500, expected: preferred},
+		{name: "exactly enough", budget: 70, expected: preferred},
+		{name: "too small, split", budget: 40, expected: dbPoolSizes{internal: 10, api: 30}},
+		{name: "way too small", budget: 4, expected: dbPoolSizes{internal: 1, api: 3}},
+		{name: "never zero", budget: 1, expected: dbPoolSizes{internal: 1, api: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sizes := fitDBPoolSizes(preferred, tc.budget)
+			assert.Equal(t, tc.expected, sizes)
+			if tc.budget >= 2 {
+				assert.LessOrEqual(t, int(sizes.internal)+int(sizes.api), tc.budget)
+			}
+		})
+	}
+}
+
+func TestPreferredDBPoolSizes(t *testing.T) {
+	sizes := preferredDBPoolSizes()
+
+	assert.GreaterOrEqual(t, sizes.internal, int32(internalDBMinOpenConns))
+	assert.LessOrEqual(t, sizes.internal, int32(internalDBPoolCap))
+	assert.GreaterOrEqual(t, sizes.api, int32(apiDBMinOpenConns))
+	assert.LessOrEqual(t, sizes.api, int32(apiDBPoolCap))
+}

--- a/managed/cmd/pmm-managed/packages.dot
+++ b/managed/cmd/pmm-managed/packages.dot
@@ -1,5 +1,6 @@
 digraph packages {
 	"/cmd/pmm-managed-init" -> "/models";
+	"/cmd/pmm-managed-init" -> "/services/clickhouse";
 	"/cmd/pmm-managed-init" -> "/services/supervisord";
 	"/cmd/pmm-managed-starlark" -> "/pi/check";
 	"/cmd/pmm-managed-starlark" -> "/pi/starlark";

--- a/managed/cmd/pmm-managed/packages.dot
+++ b/managed/cmd/pmm-managed/packages.dot
@@ -1,6 +1,5 @@
 digraph packages {
 	"/cmd/pmm-managed-init" -> "/models";
-	"/cmd/pmm-managed-init" -> "/services/clickhouse";
 	"/cmd/pmm-managed-init" -> "/services/supervisord";
 	"/cmd/pmm-managed-starlark" -> "/pi/check";
 	"/cmd/pmm-managed-starlark" -> "/pi/starlark";

--- a/managed/models/agent_helpers.go
+++ b/managed/models/agent_helpers.go
@@ -322,26 +322,30 @@ func FindAgentByID(q *reform.Querier, id string) (*Agent, error) {
 
 // FindAgentsByIDs finds Agents by IDs.
 func FindAgentsByIDs(q *reform.Querier, ids []string) ([]*Agent, error) {
+	ids = uniqueIDs(ids)
 	if len(ids) == 0 {
 		return []*Agent{}, nil
 	}
 
-	p := strings.Join(q.Placeholders(1, len(ids)), ", ")
-	tail := fmt.Sprintf("WHERE agent_id IN (%s) ORDER BY agent_id", p)
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	structs, err := q.SelectAllFrom(AgentTable, tail, args...)
-	if err != nil {
-		return nil, err
+	res := make([]*Agent, 0, len(ids))
+	for chunk := range slices.Chunk(ids, maxQueryIDs) {
+		p := strings.Join(q.Placeholders(1, len(chunk)), ", ")
+		tail := fmt.Sprintf("WHERE agent_id IN (%s) ORDER BY agent_id", p)
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+		structs, err := q.SelectAllFrom(AgentTable, tail, args...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range structs {
+			decryptedAgent := DecryptAgent(*s.(*Agent)) //nolint:forcetypeassert
+			res = append(res, &decryptedAgent)
+		}
 	}
 
-	res := make([]*Agent, len(structs))
-	for i, s := range structs {
-		decryptedAgent := DecryptAgent(*s.(*Agent)) //nolint:forcetypeassert
-		res[i] = &decryptedAgent
-	}
 	return res, nil
 }
 

--- a/managed/models/database.go
+++ b/managed/models/database.go
@@ -1190,9 +1190,25 @@ var databaseSchema = [][]string{
 // ^^^ Avoid default values in schema definition. ^^^
 // Go's zero values and non-zero default values in database do play nicely together in INSERTs and UPDATEs.
 
+// Connection pool defaults, applied when SetupDBParams leaves the corresponding field unset.
+const (
+	defaultConnMaxIdleTime = 5 * time.Minute
+	defaultMaxConns        = 50
+)
+
 // OpenDB returns configured connection pool for PostgreSQL.
 // OpenDB just validates its arguments without creating a connection to the database.
 func OpenDB(params SetupDBParams) (*sql.DB, error) {
+	if params.ConnMaxIdleTime <= 0 {
+		params.ConnMaxIdleTime = defaultConnMaxIdleTime
+	}
+	if params.MaxOpenConns <= 0 {
+		params.MaxOpenConns = defaultMaxConns
+	}
+	if params.MaxIdleConns <= 0 {
+		params.MaxIdleConns = params.MaxOpenConns
+	}
+
 	q := make(url.Values)
 	if params.SSLMode == "" {
 		params.SSLMode = DisableSSLMode
@@ -1222,13 +1238,10 @@ func OpenDB(params SetupDBParams) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to create a connection pool to PostgreSQL: %w", err)
 	}
 
-	db.SetConnMaxLifetime(0)
-	db.SetConnMaxIdleTime(5 * time.Minute) //nolint:mnd
-	// Sized to give DB-bound auth/role/settings paths enough headroom during
-	// a reconnect storm from a fleet of agents, while staying well within
-	// Postgres max_connections (set to 2000 by PMM Server).
-	db.SetMaxIdleConns(50) //nolint:mnd
-	db.SetMaxOpenConns(50) //nolint:mnd
+	db.SetConnMaxLifetime(params.ConnMaxLifetime)
+	db.SetConnMaxIdleTime(params.ConnMaxIdleTime)
+	db.SetMaxIdleConns(int(params.MaxIdleConns))
+	db.SetMaxOpenConns(int(params.MaxOpenConns))
 
 	return db, nil
 }
@@ -1258,6 +1271,10 @@ type SetupDBParams struct {
 	HAPeers          []string
 	SetupFixtures    SetupFixturesMode
 	MigrationVersion *int
+	ConnMaxLifetime  time.Duration
+	ConnMaxIdleTime  time.Duration
+	MaxIdleConns     int32
+	MaxOpenConns     int32
 }
 
 // SetupDB checks minimal required PostgreSQL version and runs database migrations. Optionally creates database and adds initial data.

--- a/managed/models/database.go
+++ b/managed/models/database.go
@@ -1191,9 +1191,11 @@ var databaseSchema = [][]string{
 // Go's zero values and non-zero default values in database do play nicely together in INSERTs and UPDATEs.
 
 // Connection pool defaults, applied when SetupDBParams leaves the corresponding field unset.
+// A zero ConnMaxLifetime is not defaulted: database/sql reads it as "never expire", which is
+// what callers that do not care about pool geometry want.
 const (
 	defaultConnMaxIdleTime = 5 * time.Minute
-	defaultMaxConns        = 50
+	defaultMaxOpenConns    = 50
 )
 
 // OpenDB returns configured connection pool for PostgreSQL.
@@ -1203,10 +1205,7 @@ func OpenDB(params SetupDBParams) (*sql.DB, error) {
 		params.ConnMaxIdleTime = defaultConnMaxIdleTime
 	}
 	if params.MaxOpenConns <= 0 {
-		params.MaxOpenConns = defaultMaxConns
-	}
-	if params.MaxIdleConns <= 0 {
-		params.MaxIdleConns = params.MaxOpenConns
+		params.MaxOpenConns = defaultMaxOpenConns
 	}
 
 	q := make(url.Values)
@@ -1240,8 +1239,10 @@ func OpenDB(params SetupDBParams) (*sql.DB, error) {
 
 	db.SetConnMaxLifetime(params.ConnMaxLifetime)
 	db.SetConnMaxIdleTime(params.ConnMaxIdleTime)
-	db.SetMaxIdleConns(int(params.MaxIdleConns))
-	db.SetMaxOpenConns(int(params.MaxOpenConns))
+	db.SetMaxOpenConns(params.MaxOpenConns)
+	// Keeping every connection idle-eligible avoids closing one just because the pool is
+	// above its idle size; ConnMaxIdleTime is what returns them to the server.
+	db.SetMaxIdleConns(params.MaxOpenConns)
 
 	return db, nil
 }
@@ -1273,8 +1274,7 @@ type SetupDBParams struct {
 	MigrationVersion *int
 	ConnMaxLifetime  time.Duration
 	ConnMaxIdleTime  time.Duration
-	MaxIdleConns     int32
-	MaxOpenConns     int32
+	MaxOpenConns     int
 }
 
 // SetupDB checks minimal required PostgreSQL version and runs database migrations. Optionally creates database and adds initial data.

--- a/managed/models/models.go
+++ b/managed/models/models.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -38,6 +39,21 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// maxQueryIDs bounds the number of IDs one "IN" list carries. The Find*ByIDs helpers bind one
+// parameter per ID, and PostgreSQL accepts at most 65535 of them per statement, so callers that
+// pass the whole inventory (the VictoriaMetrics configuration rebuild does) are chunked instead
+// of failing.
+const maxQueryIDs = 1000
+
+// uniqueIDs returns the given IDs sorted and deduplicated, so that a repeated ID does not
+// become a repeated bind parameter and chunking keeps the result ordered.
+func uniqueIDs(ids []string) []string {
+	res := slices.Clone(ids)
+	slices.Sort(res)
+
+	return slices.Compact(res)
+}
 
 // Now returns current time with database precision.
 var Now = func() time.Time {

--- a/managed/models/node_helpers.go
+++ b/managed/models/node_helpers.go
@@ -18,6 +18,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/AlekSi/pointer"
@@ -132,25 +133,29 @@ func FindNodeByID(q *reform.Querier, id string) (*Node, error) {
 
 // FindNodesByIDs finds Nodes by IDs.
 func FindNodesByIDs(q *reform.Querier, ids []string) ([]*Node, error) {
+	ids = uniqueIDs(ids)
 	if len(ids) == 0 {
 		return []*Node{}, nil
 	}
 
-	p := strings.Join(q.Placeholders(1, len(ids)), ", ")
-	tail := fmt.Sprintf("WHERE node_id IN (%s) ORDER BY node_id", p)
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	structs, err := q.SelectAllFrom(NodeTable, tail, args...)
-	if err != nil {
-		return nil, err
+	res := make([]*Node, 0, len(ids))
+	for chunk := range slices.Chunk(ids, maxQueryIDs) {
+		p := strings.Join(q.Placeholders(1, len(chunk)), ", ")
+		tail := fmt.Sprintf("WHERE node_id IN (%s) ORDER BY node_id", p)
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
+		structs, err := q.SelectAllFrom(NodeTable, tail, args...)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, s := range structs {
+			res = append(res, s.(*Node)) //nolint:forcetypeassert
+		}
 	}
 
-	res := make([]*Node, len(structs))
-	for i, s := range structs {
-		res[i] = s.(*Node) //nolint:forcetypeassert
-	}
 	return res, nil
 }
 

--- a/managed/models/service_helpers.go
+++ b/managed/models/service_helpers.go
@@ -18,6 +18,7 @@ package models
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -212,26 +213,25 @@ func FindServiceByID(q *reform.Querier, id string) (*Service, error) {
 
 // FindServicesByIDs finds Services by IDs.
 func FindServicesByIDs(q *reform.Querier, ids []string) (map[string]*Service, error) {
-	if len(ids) == 0 {
-		return make(map[string]*Service), nil
-	}
+	ids = uniqueIDs(ids)
+	services := make(map[string]*Service, len(ids))
+	for chunk := range slices.Chunk(ids, maxQueryIDs) {
+		p := strings.Join(q.Placeholders(1, len(chunk)), ", ")
+		tail := fmt.Sprintf("WHERE service_id IN (%s) ORDER BY service_id", p)
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
+		}
 
-	p := strings.Join(q.Placeholders(1, len(ids)), ", ")
-	tail := fmt.Sprintf("WHERE service_id IN (%s) ORDER BY service_id", p)
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
+		all, err := q.SelectAllFrom(ServiceTable, tail, args...)
+		if err != nil {
+			return nil, err
+		}
 
-	all, err := q.SelectAllFrom(ServiceTable, tail, args...)
-	if err != nil {
-		return nil, err
-	}
-
-	services := make(map[string]*Service, len(all))
-	for _, s := range all {
-		service := s.(*Service) //nolint:forcetypeassert
-		services[service.ServiceID] = service
+		for _, s := range all {
+			service := s.(*Service) //nolint:forcetypeassert
+			services[service.ServiceID] = service
+		}
 	}
 
 	return services, nil

--- a/managed/services/agents/deps.go
+++ b/managed/services/agents/deps.go
@@ -23,6 +23,7 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/reform.v1"
 
 	agentv1 "github.com/percona/pmm/api/agent/v1"
 	qanv1 "github.com/percona/pmm/api/qan/v1"
@@ -38,7 +39,7 @@ type prometheusService interface {
 	// ForceConfigurationUpdate triggers immediate synchronous configuration update,
 	// bypassing the batch delay. Use this for critical updates like port changes.
 	ForceConfigurationUpdate(ctx context.Context) error
-	BuildScrapeConfigForVMAgent(ctx context.Context, pmmAgentID string) ([]byte, error)
+	BuildScrapeConfigForVMAgent(q *reform.Querier, pmmAgentID string) ([]byte, error)
 }
 
 // qanClient is a subset of methods of qan.Client used by this package.

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -254,7 +254,10 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			if err != nil {
 				return err
 			}
-			node, _ := models.FindNodeByID(q, pointer.GetString(pmmAgent.RunsOnNodeID))
+			node, err := models.FindNodeByID(q, pointer.GetString(pmmAgent.RunsOnNodeID))
+			if err != nil {
+				return fmt.Errorf("failed to get the Node the pmm-agent runs on: %w", err)
+			}
 			switch row.AgentType { //nolint:exhaustive
 			case models.MySQLdExporterType:
 				cfg, err := mysqldExporterConfig(node, service, row, redactMode, pmmAgentVersion)

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -78,7 +78,7 @@ func (u *StateUpdater) RequestStateUpdate(ctx context.Context, pmmAgentID string
 
 // UpdateAgentsState sends SetStateRequest to all pmm-agents with push metrics agents.
 func (u *StateUpdater) UpdateAgentsState(ctx context.Context) error {
-	pmmAgents, err := models.FindAllPMMAgentsIDs(u.db.Querier)
+	pmmAgents, err := models.FindAllPMMAgentsIDs(u.db.WithContext(ctx))
 	if err != nil {
 		return fmt.Errorf("cannot find pmmAgentsIDs for AgentsState update: %w", err)
 	}
@@ -182,6 +182,59 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 		return fmt.Errorf("failed to collect agents: %w", err)
 	}
 
+	// Resolve the Services and Nodes the rows reference in two queries. The loop below read
+	// them one row at a time, and re-read the Node the pmm-agent runs on for every row - on a
+	// host with many services that is hundreds of sequential round trips, which now have to
+	// fit into stateChangeTimeout.
+	serviceIDs := make([]string, 0, len(agents))
+	nodeIDs := make([]string, 0, len(agents)+1)
+	if id := pointer.GetString(pmmAgent.RunsOnNodeID); id != "" {
+		nodeIDs = append(nodeIDs, id)
+	}
+	for _, row := range agents {
+		if id := pointer.GetString(row.ServiceID); id != "" {
+			serviceIDs = append(serviceIDs, id)
+		}
+		if id := pointer.GetString(row.NodeID); id != "" {
+			nodeIDs = append(nodeIDs, id)
+		}
+	}
+
+	services, err := models.FindServicesByIDs(q, serviceIDs)
+	if err != nil {
+		return fmt.Errorf("failed to collect services: %w", err)
+	}
+	nodeRows, err := models.FindNodesByIDs(q, nodeIDs)
+	if err != nil {
+		return fmt.Errorf("failed to collect nodes: %w", err)
+	}
+	nodes := make(map[string]*models.Node, len(nodeRows))
+	for _, node := range nodeRows {
+		nodes[node.NodeID] = node
+	}
+
+	// Rows that appear after the bulk queries are read individually, so a missing row
+	// still fails the way it did before.
+	findService := func(id string) (*models.Service, error) {
+		if service, ok := services[id]; ok {
+			return service, nil
+		}
+
+		return models.FindServiceByID(q, id)
+	}
+	findNode := func(id string) (*models.Node, error) {
+		if node, ok := nodes[id]; ok {
+			return node, nil
+		}
+
+		return models.FindNodeByID(q, id)
+	}
+
+	pmmAgentNode, err := findNode(pointer.GetString(pmmAgent.RunsOnNodeID))
+	if err != nil {
+		return fmt.Errorf("failed to get the Node the pmm-agent runs on: %w", err)
+	}
+
 	redactMode := redactSecrets
 	if l.Logger.GetLevel() >= logrus.DebugLevel {
 		redactMode = exposeSecrets
@@ -201,7 +254,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			}
 			agentProcesses[row.AgentID] = vmAgentConfig(string(scrapeCfg), u.vmParams)
 		case models.NomadAgentType:
-			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
+			node, err := findNode(pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
@@ -212,7 +265,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			agentProcesses[row.AgentID] = params
 
 		case models.NodeExporterType:
-			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
+			node, err := findNode(pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
@@ -224,17 +277,20 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			agentProcesses[row.AgentID] = params
 
 		case models.RDSExporterType:
-			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
+			node, err := findNode(pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
-			rdsExporters[node] = row
+			// rdsExporters is keyed by pointer, so each row keeps its own copy even when
+			// several exporters share a Node.
+			rdsNode := *node
+			rdsExporters[&rdsNode] = row
 
 		case models.ExternalExporterType:
 			// ignore
 
 		case models.AzureDatabaseExporterType:
-			service, err := models.FindServiceByID(q, pointer.GetString(row.ServiceID))
+			service, err := findService(pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
 			}
@@ -250,14 +306,11 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			models.QANMongoDBProfilerAgentType, models.QANMongoDBMongologAgentType,
 			models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType,
 			models.RTAMongoDBAgentType:
-			service, err := models.FindServiceByID(q, pointer.GetString(row.ServiceID))
+			service, err := findService(pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
 			}
-			node, err := models.FindNodeByID(q, pointer.GetString(pmmAgent.RunsOnNodeID))
-			if err != nil {
-				return fmt.Errorf("failed to get the Node the pmm-agent runs on: %w", err)
-			}
+			node := pmmAgentNode
 			switch row.AgentType { //nolint:exhaustive
 			case models.MySQLdExporterType:
 				cfg, err := mysqldExporterConfig(node, service, row, redactMode, pmmAgentVersion)

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -28,6 +28,7 @@ import (
 
 	agentv1 "github.com/percona/pmm/api/agent/v1"
 	"github.com/percona/pmm/managed/models"
+	"github.com/percona/pmm/managed/utils/stringset"
 	"github.com/percona/pmm/utils/logger"
 	"github.com/percona/pmm/version"
 )
@@ -186,25 +187,25 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 	// them one row at a time, and re-read the Node the pmm-agent runs on for every row - on a
 	// host with many services that is hundreds of sequential round trips, which now have to
 	// fit into stateChangeTimeout.
-	serviceIDs := make([]string, 0, len(agents))
-	nodeIDs := make([]string, 0, len(agents)+1)
-	if id := pointer.GetString(pmmAgent.RunsOnNodeID); id != "" {
-		nodeIDs = append(nodeIDs, id)
-	}
-	for _, row := range agents {
-		if id := pointer.GetString(row.ServiceID); id != "" {
-			serviceIDs = append(serviceIDs, id)
-		}
-		if id := pointer.GetString(row.NodeID); id != "" {
-			nodeIDs = append(nodeIDs, id)
+	serviceIDs := make(map[string]struct{}, len(agents))
+	nodeIDs := make(map[string]struct{}, len(agents))
+	addID := func(ids map[string]struct{}, id string) {
+		if id != "" {
+			ids[id] = struct{}{}
 		}
 	}
 
-	services, err := models.FindServicesByIDs(q, serviceIDs)
+	addID(nodeIDs, pointer.GetString(pmmAgent.RunsOnNodeID))
+	for _, row := range agents {
+		addID(serviceIDs, pointer.GetString(row.ServiceID))
+		addID(nodeIDs, pointer.GetString(row.NodeID))
+	}
+
+	services, err := models.FindServicesByIDs(q, stringset.ToSlice(serviceIDs))
 	if err != nil {
 		return fmt.Errorf("failed to collect services: %w", err)
 	}
-	nodeRows, err := models.FindNodesByIDs(q, nodeIDs)
+	nodeRows, err := models.FindNodesByIDs(q, stringset.ToSlice(nodeIDs))
 	if err != nil {
 		return fmt.Errorf("failed to collect nodes: %w", err)
 	}
@@ -281,8 +282,9 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			if err != nil {
 				return err
 			}
-			// rdsExporters is keyed by pointer, so each row keeps its own copy even when
-			// several exporters share a Node.
+			// rdsExporters is keyed by *Node, so two exporters sharing a Node would collapse
+			// into one entry - and one exporter would be dropped - now that the lookup
+			// returns the same pointer for both.
 			rdsNode := *node
 			rdsExporters[&rdsNode] = row
 
@@ -310,30 +312,29 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			if err != nil {
 				return err
 			}
-			node := pmmAgentNode
 			switch row.AgentType { //nolint:exhaustive
 			case models.MySQLdExporterType:
-				cfg, err := mysqldExporterConfig(node, service, row, redactMode, pmmAgentVersion)
+				cfg, err := mysqldExporterConfig(pmmAgentNode, service, row, redactMode, pmmAgentVersion)
 				if err != nil {
 					return err
 				}
 				agentProcesses[row.AgentID] = cfg
 			case models.MongoDBExporterType:
-				cfg, err := mongodbExporterConfig(node, service, row, redactMode, pmmAgentVersion)
+				cfg, err := mongodbExporterConfig(pmmAgentNode, service, row, redactMode, pmmAgentVersion)
 				if err != nil {
 					return err
 				}
 				agentProcesses[row.AgentID] = cfg
 			case models.PostgresExporterType:
-				cfg, err := postgresExporterConfig(node, service, row, redactMode, pmmAgentVersion)
+				cfg, err := postgresExporterConfig(pmmAgentNode, service, row, redactMode, pmmAgentVersion)
 				if err != nil {
 					return err
 				}
 				agentProcesses[row.AgentID] = cfg
 			case models.ProxySQLExporterType:
-				agentProcesses[row.AgentID] = proxysqlExporterConfig(node, service, row, redactMode, pmmAgentVersion)
+				agentProcesses[row.AgentID] = proxysqlExporterConfig(pmmAgentNode, service, row, redactMode, pmmAgentVersion)
 			case models.ValkeyExporterType:
-				agentProcesses[row.AgentID] = valkeyExporterConfig(node, service, row, redactMode, pmmAgentVersion)
+				agentProcesses[row.AgentID] = valkeyExporterConfig(pmmAgentNode, service, row, redactMode, pmmAgentVersion)
 			case models.QANMySQLPerfSchemaAgentType:
 				builtinAgents[row.AgentID] = qanMySQLPerfSchemaAgentConfig(service, row, pmmAgentVersion)
 			case models.QANMySQLSlowlogAgentType:

--- a/managed/services/agents/state.go
+++ b/managed/services/agents/state.go
@@ -153,7 +153,11 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			l.Warnf("sendSetStateRequest took %s.", dur)
 		}
 	}()
-	pmmAgent, err := models.FindAgentByID(u.db.Querier, agent.id)
+	// Bind the queries to the request context, so that waiting for a free connection
+	// in the pool is bounded by stateChangeTimeout instead of blocking indefinitely.
+	q := u.db.WithContext(ctx)
+
+	pmmAgent, err := models.FindAgentByID(q, agent.id)
 	if err != nil {
 		return fmt.Errorf("failed to get PMM Agent: %w", err)
 	}
@@ -162,7 +166,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 		return fmt.Errorf("failed to parse PMM agent version %q: %w", *pmmAgent.Version, err)
 	}
 
-	settings, err := models.GetSettings(u.db.Querier)
+	settings, err := models.GetSettings(q)
 	if err != nil {
 		return fmt.Errorf("failed to get settings: %w", err)
 	}
@@ -173,7 +177,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 		// fetch enabled only
 		Disabled: new(false),
 	}
-	agents, err := models.FindAgents(u.db.Querier, filters)
+	agents, err := models.FindAgents(q, filters)
 	if err != nil {
 		return fmt.Errorf("failed to collect agents: %w", err)
 	}
@@ -191,13 +195,13 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 		case models.PMMAgentType:
 			continue
 		case models.VMAgentType:
-			scrapeCfg, err := u.vmdb.BuildScrapeConfigForVMAgent(ctx, agent.id)
+			scrapeCfg, err := u.vmdb.BuildScrapeConfigForVMAgent(q, agent.id)
 			if err != nil {
 				return fmt.Errorf("cannot get agent scrape config for agent %s: %w", agent.id, err)
 			}
 			agentProcesses[row.AgentID] = vmAgentConfig(string(scrapeCfg), u.vmParams)
 		case models.NomadAgentType:
-			node, err := models.FindNodeByID(u.db.Querier, pointer.GetString(row.NodeID))
+			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
@@ -208,7 +212,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			agentProcesses[row.AgentID] = params
 
 		case models.NodeExporterType:
-			node, err := models.FindNodeByID(u.db.Querier, pointer.GetString(row.NodeID))
+			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
@@ -220,7 +224,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			agentProcesses[row.AgentID] = params
 
 		case models.RDSExporterType:
-			node, err := models.FindNodeByID(u.db.Querier, pointer.GetString(row.NodeID))
+			node, err := models.FindNodeByID(q, pointer.GetString(row.NodeID))
 			if err != nil {
 				return err
 			}
@@ -230,7 +234,7 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			// ignore
 
 		case models.AzureDatabaseExporterType:
-			service, err := models.FindServiceByID(u.db.Querier, pointer.GetString(row.ServiceID))
+			service, err := models.FindServiceByID(q, pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
 			}
@@ -246,11 +250,11 @@ func (u *StateUpdater) sendSetStateRequest(ctx context.Context, agent *pmmAgentI
 			models.QANMongoDBProfilerAgentType, models.QANMongoDBMongologAgentType,
 			models.QANPostgreSQLPgStatementsAgentType, models.QANPostgreSQLPgStatMonitorAgentType,
 			models.RTAMongoDBAgentType:
-			service, err := models.FindServiceByID(u.db.Querier, pointer.GetString(row.ServiceID))
+			service, err := models.FindServiceByID(q, pointer.GetString(row.ServiceID))
 			if err != nil {
 				return err
 			}
-			node, _ := models.FindNodeByID(u.db.Querier, pointer.GetString(pmmAgent.RunsOnNodeID))
+			node, _ := models.FindNodeByID(q, pointer.GetString(pmmAgent.RunsOnNodeID))
 			switch row.AgentType { //nolint:exhaustive
 			case models.MySQLdExporterType:
 				cfg, err := mysqldExporterConfig(node, service, row, redactMode, pmmAgentVersion)

--- a/managed/services/victoriametrics/prometheus.go
+++ b/managed/services/victoriametrics/prometheus.go
@@ -17,8 +17,6 @@ package victoriametrics
 
 import (
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/AlekSi/pointer"
 	config "github.com/percona/promconfig"
@@ -26,13 +24,9 @@ import (
 	"gopkg.in/reform.v1"
 
 	"github.com/percona/pmm/managed/models"
+	"github.com/percona/pmm/managed/utils/stringset"
 	"github.com/percona/pmm/version"
 )
-
-// bulkLookupChunk bounds the IN list of the lookups below: the full configuration rebuild
-// resolves every Service and Node in the inventory, and one bind parameter per ID would run
-// into PostgreSQL's 65535-parameter limit.
-const bulkLookupChunk = 1000
 
 // scrapeConfigLookup resolves the Services, Nodes and pmm-agents referenced by a set of Agents.
 // They are fetched in three bulk queries up front: a node running a dozen services used to cost
@@ -48,15 +42,6 @@ type scrapeConfigLookup struct {
 }
 
 func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.Agent) (*scrapeConfigLookup, error) {
-	lookup := &scrapeConfigLookup{
-		l:         l,
-		q:         q,
-		services:  make(map[string]*models.Service, len(agents)),
-		nodes:     make(map[string]*models.Node, len(agents)),
-		pmmAgents: make(map[string]*models.Agent, len(agents)),
-		versions:  make(map[string]*version.Parsed, len(agents)),
-	}
-
 	serviceIDs := make(map[string]struct{}, len(agents))
 	pmmAgentIDs := make(map[string]struct{}, len(agents))
 	nodeIDs := make(map[string]struct{}, len(agents))
@@ -67,54 +52,44 @@ func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.
 	}
 
 	for _, agent := range agents {
-		if agent.AgentType == models.PMMAgentType {
-			// pmm-agents are part of the same result set, no need to read them again.
-			lookup.pmmAgents[agent.AgentID] = agent
-		}
 		addID(serviceIDs, pointer.GetString(agent.ServiceID))
 		addID(pmmAgentIDs, pointer.GetString(agent.PMMAgentID))
 		addID(nodeIDs, pointer.GetString(agent.NodeID))
 		addID(nodeIDs, pointer.GetString(agent.RunsOnNodeID))
 	}
 
-	for chunk := range slices.Chunk(slices.Collect(maps.Keys(serviceIDs)), bulkLookupChunk) {
-		services, err := models.FindServicesByIDs(q, chunk)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
-		}
-		for id, service := range services {
-			lookup.services[id] = service
-			addID(nodeIDs, service.NodeID)
-		}
+	services, err := models.FindServicesByIDs(q, stringset.ToSlice(serviceIDs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
+	}
+	for _, service := range services {
+		addID(nodeIDs, service.NodeID)
 	}
 
-	missingAgentIDs := make([]string, 0, len(pmmAgentIDs))
-	for id := range pmmAgentIDs {
-		if _, ok := lookup.pmmAgents[id]; !ok {
-			missingAgentIDs = append(missingAgentIDs, id)
-		}
+	pmmAgents, err := models.FindAgentsByIDs(q, stringset.ToSlice(pmmAgentIDs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find pmm-agents for scrape config: %w", err)
 	}
-	for chunk := range slices.Chunk(missingAgentIDs, bulkLookupChunk) {
-		pmmAgents, err := models.FindAgentsByIDs(q, chunk)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find pmm-agents for scrape config: %w", err)
-		}
-		for _, pmmAgent := range pmmAgents {
-			lookup.pmmAgents[pmmAgent.AgentID] = pmmAgent
-		}
+	lookup := &scrapeConfigLookup{
+		l:         l,
+		q:         q,
+		services:  services,
+		nodes:     make(map[string]*models.Node, len(nodeIDs)),
+		pmmAgents: make(map[string]*models.Agent, len(pmmAgents)),
+		versions:  make(map[string]*version.Parsed, len(pmmAgents)),
 	}
-	for _, pmmAgent := range lookup.pmmAgents {
+	for _, pmmAgent := range pmmAgents {
+		lookup.pmmAgents[pmmAgent.AgentID] = pmmAgent
+		// The Node a pmm-agent runs on is only known once the pmm-agent row is in hand.
 		addID(nodeIDs, pointer.GetString(pmmAgent.RunsOnNodeID))
 	}
 
-	for chunk := range slices.Chunk(slices.Collect(maps.Keys(nodeIDs)), bulkLookupChunk) {
-		nodes, err := models.FindNodesByIDs(q, chunk)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find nodes for scrape config: %w", err)
-		}
-		for _, node := range nodes {
-			lookup.nodes[node.NodeID] = node
-		}
+	nodes, err := models.FindNodesByIDs(q, stringset.ToSlice(nodeIDs))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find nodes for scrape config: %w", err)
+	}
+	for _, node := range nodes {
+		lookup.nodes[node.NodeID] = node
 	}
 
 	return lookup, nil

--- a/managed/services/victoriametrics/prometheus.go
+++ b/managed/services/victoriametrics/prometheus.go
@@ -17,6 +17,8 @@ package victoriametrics
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/AlekSi/pointer"
 	config "github.com/percona/promconfig"
@@ -27,6 +29,146 @@ import (
 	"github.com/percona/pmm/version"
 )
 
+// scrapeConfigLookup resolves the Services, Nodes and pmm-agents referenced by a set of Agents.
+// They are fetched in three bulk queries up front: a node running a dozen services used to cost
+// one Service, one Node and one pmm-agent lookup per exporter, re-reading the very same pmm-agent
+// row and its Node for every exporter of that node.
+type scrapeConfigLookup struct {
+	l         *logrus.Entry
+	q         *reform.Querier
+	services  map[string]*models.Service
+	nodes     map[string]*models.Node
+	pmmAgents map[string]*models.Agent
+	versions  map[string]*version.Parsed
+}
+
+func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.Agent) (*scrapeConfigLookup, error) {
+	lookup := &scrapeConfigLookup{
+		l:         l,
+		q:         q,
+		nodes:     make(map[string]*models.Node, len(agents)),
+		pmmAgents: make(map[string]*models.Agent, len(agents)),
+		versions:  make(map[string]*version.Parsed, len(agents)),
+	}
+
+	serviceIDs := make(map[string]struct{}, len(agents))
+	pmmAgentIDs := make(map[string]struct{}, len(agents))
+	nodeIDs := make(map[string]struct{}, len(agents))
+	addID := func(ids map[string]struct{}, id string) {
+		if id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+
+	for _, agent := range agents {
+		if agent.AgentType == models.PMMAgentType {
+			// pmm-agents are part of the same result set, no need to read them again.
+			lookup.pmmAgents[agent.AgentID] = agent
+		}
+		addID(serviceIDs, pointer.GetString(agent.ServiceID))
+		addID(pmmAgentIDs, pointer.GetString(agent.PMMAgentID))
+		addID(nodeIDs, pointer.GetString(agent.NodeID))
+		addID(nodeIDs, pointer.GetString(agent.RunsOnNodeID))
+	}
+
+	services, err := models.FindServicesByIDs(q, slices.Collect(maps.Keys(serviceIDs)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
+	}
+	lookup.services = services
+	for _, service := range services {
+		addID(nodeIDs, service.NodeID)
+	}
+
+	missingAgentIDs := make([]string, 0, len(pmmAgentIDs))
+	for id := range pmmAgentIDs {
+		if _, ok := lookup.pmmAgents[id]; !ok {
+			missingAgentIDs = append(missingAgentIDs, id)
+		}
+	}
+	pmmAgents, err := models.FindAgentsByIDs(q, missingAgentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find pmm-agents for scrape config: %w", err)
+	}
+	for _, pmmAgent := range pmmAgents {
+		lookup.pmmAgents[pmmAgent.AgentID] = pmmAgent
+	}
+	for _, pmmAgent := range lookup.pmmAgents {
+		addID(nodeIDs, pointer.GetString(pmmAgent.RunsOnNodeID))
+	}
+
+	nodes, err := models.FindNodesByIDs(q, slices.Collect(maps.Keys(nodeIDs)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find nodes for scrape config: %w", err)
+	}
+	for _, node := range nodes {
+		lookup.nodes[node.NodeID] = node
+	}
+
+	return lookup, nil
+}
+
+// service returns the Service with the given ID. Rows that were not prefetched - because they
+// appeared after the bulk query - are read individually, so a missing row fails exactly as before.
+func (s *scrapeConfigLookup) service(id string) (*models.Service, error) {
+	if service, ok := s.services[id]; ok {
+		return service, nil
+	}
+
+	service, err := models.FindServiceByID(s.q, id)
+	if err != nil {
+		return nil, err
+	}
+	s.services[id] = service
+
+	return service, nil
+}
+
+// node returns the Node with the given ID.
+func (s *scrapeConfigLookup) node(id string) (*models.Node, error) {
+	if node, ok := s.nodes[id]; ok {
+		return node, nil
+	}
+
+	node, err := models.FindNodeByID(s.q, id)
+	if err != nil {
+		return nil, err
+	}
+	s.nodes[id] = node
+
+	return node, nil
+}
+
+// pmmAgent returns the pmm-agent with the given ID.
+func (s *scrapeConfigLookup) pmmAgent(id string) (*models.Agent, error) {
+	if agent, ok := s.pmmAgents[id]; ok {
+		return agent, nil
+	}
+
+	agent, err := models.FindAgentByID(s.q, id)
+	if err != nil {
+		return nil, err
+	}
+	s.pmmAgents[id] = agent
+
+	return agent, nil
+}
+
+// pmmAgentVersion returns the parsed version of the given pmm-agent, or nil if it cannot be parsed.
+func (s *scrapeConfigLookup) pmmAgentVersion(agent *models.Agent) *version.Parsed {
+	if parsed, ok := s.versions[agent.AgentID]; ok {
+		return parsed
+	}
+
+	parsed, err := version.Parse(pointer.GetString(agent.Version))
+	if err != nil {
+		s.l.Warnf("couldn't parse pmm-agent version for pmm-agent %s: %s", agent.AgentID, err)
+	}
+	s.versions[agent.AgentID] = parsed
+
+	return parsed
+}
+
 // AddScrapeConfigs - adds agents scrape configuration to given scrape config,
 // pmm_agent_id and push_metrics used for filtering.
 func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //nolint:gocognit,cyclop,maintidx
@@ -35,6 +177,11 @@ func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //
 	agents, err := models.FindAgentsForScrapeConfig(q, pmmAgentID, pushMetrics)
 	if err != nil {
 		return fmt.Errorf("failed to find agent for scrape config: %w", err)
+	}
+
+	lookup, err := newScrapeConfigLookup(l, q, agents)
+	if err != nil {
+		return err
 	}
 
 	var rdsParams []*scrapeConfigParams
@@ -52,7 +199,7 @@ func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //
 		// find Service for this Agent
 		var paramsService *models.Service
 		if agent.ServiceID != nil {
-			paramsService, err = models.FindServiceByID(q, pointer.GetString(agent.ServiceID))
+			paramsService, err = lookup.service(pointer.GetString(agent.ServiceID))
 			if err != nil {
 				return err
 			}
@@ -62,9 +209,9 @@ func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //
 		var paramsNode *models.Node
 		switch {
 		case agent.NodeID != nil:
-			paramsNode, err = models.FindNodeByID(q, pointer.GetString(agent.NodeID))
+			paramsNode, err = lookup.node(pointer.GetString(agent.NodeID))
 		case paramsService != nil:
-			paramsNode, err = models.FindNodeByID(q, paramsService.NodeID)
+			paramsNode, err = lookup.node(paramsService.NodeID)
 		}
 		if err != nil {
 			return err
@@ -77,30 +224,25 @@ func AddScrapeConfigs(l *logrus.Entry, cfg *config.Config, q *reform.Querier, //
 		var pmmAgentNode *models.Node
 		if agent.PMMAgentID != nil {
 			// find a related pmm-agent to get the node address (runs_on_node_id)
-			pmmAgent, err = models.FindAgentByID(q, *agent.PMMAgentID)
+			pmmAgent, err = lookup.pmmAgent(*agent.PMMAgentID)
 			if err != nil {
 				return fmt.Errorf("failed to find pmm-agent for scrape config: %w", err)
 			}
-			paramPMMAgentVersion, err = version.Parse(pointer.GetString(pmmAgent.Version))
-			if err != nil {
-				l.Warnf("couldn't parse pmm-agent version for pmm-agent %s: %q", pmmAgent.AgentID, err)
-			}
+			paramPMMAgentVersion = lookup.pmmAgentVersion(pmmAgent)
 		}
 		switch {
 		case pushMetrics:
 			paramsHost = models.LocalhostAddr
 		case agent.PMMAgentID != nil:
-			pmmAgentNode = &models.Node{NodeID: pointer.GetString(pmmAgent.RunsOnNodeID)}
-			err = q.Reload(pmmAgentNode)
+			pmmAgentNode, err = lookup.node(pointer.GetString(pmmAgent.RunsOnNodeID))
 			if err != nil {
-				return fmt.Errorf("failed to reload Node by pmm-agent for scrape config: %w", err)
+				return fmt.Errorf("failed to find Node by pmm-agent for scrape config: %w", err)
 			}
 			paramsHost = pmmAgentNode.Address
 		case agent.RunsOnNodeID != nil:
-			externalExporterNode := &models.Node{NodeID: pointer.GetString(agent.RunsOnNodeID)}
-			err = q.Reload(externalExporterNode)
+			externalExporterNode, err := lookup.node(pointer.GetString(agent.RunsOnNodeID))
 			if err != nil {
-				return fmt.Errorf("failed to reload Node for scrape config: %w", err)
+				return fmt.Errorf("failed to find Node for scrape config: %w", err)
 			}
 			paramsHost = externalExporterNode.Address
 		default:

--- a/managed/services/victoriametrics/prometheus.go
+++ b/managed/services/victoriametrics/prometheus.go
@@ -46,6 +46,7 @@ func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.
 	lookup := &scrapeConfigLookup{
 		l:         l,
 		q:         q,
+		services:  make(map[string]*models.Service, len(agents)),
 		nodes:     make(map[string]*models.Node, len(agents)),
 		pmmAgents: make(map[string]*models.Agent, len(agents)),
 		versions:  make(map[string]*version.Parsed, len(agents)),
@@ -75,8 +76,8 @@ func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.
 	if err != nil {
 		return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
 	}
-	lookup.services = services
-	for _, service := range services {
+	for id, service := range services {
+		lookup.services[id] = service
 		addID(nodeIDs, service.NodeID)
 	}
 

--- a/managed/services/victoriametrics/prometheus.go
+++ b/managed/services/victoriametrics/prometheus.go
@@ -29,6 +29,11 @@ import (
 	"github.com/percona/pmm/version"
 )
 
+// bulkLookupChunk bounds the IN list of the lookups below: the full configuration rebuild
+// resolves every Service and Node in the inventory, and one bind parameter per ID would run
+// into PostgreSQL's 65535-parameter limit.
+const bulkLookupChunk = 1000
+
 // scrapeConfigLookup resolves the Services, Nodes and pmm-agents referenced by a set of Agents.
 // They are fetched in three bulk queries up front: a node running a dozen services used to cost
 // one Service, one Node and one pmm-agent lookup per exporter, re-reading the very same pmm-agent
@@ -72,13 +77,15 @@ func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.
 		addID(nodeIDs, pointer.GetString(agent.RunsOnNodeID))
 	}
 
-	services, err := models.FindServicesByIDs(q, slices.Collect(maps.Keys(serviceIDs)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
-	}
-	for id, service := range services {
-		lookup.services[id] = service
-		addID(nodeIDs, service.NodeID)
+	for chunk := range slices.Chunk(slices.Collect(maps.Keys(serviceIDs)), bulkLookupChunk) {
+		services, err := models.FindServicesByIDs(q, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find services for scrape config: %w", err)
+		}
+		for id, service := range services {
+			lookup.services[id] = service
+			addID(nodeIDs, service.NodeID)
+		}
 	}
 
 	missingAgentIDs := make([]string, 0, len(pmmAgentIDs))
@@ -87,23 +94,27 @@ func newScrapeConfigLookup(l *logrus.Entry, q *reform.Querier, agents []*models.
 			missingAgentIDs = append(missingAgentIDs, id)
 		}
 	}
-	pmmAgents, err := models.FindAgentsByIDs(q, missingAgentIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find pmm-agents for scrape config: %w", err)
-	}
-	for _, pmmAgent := range pmmAgents {
-		lookup.pmmAgents[pmmAgent.AgentID] = pmmAgent
+	for chunk := range slices.Chunk(missingAgentIDs, bulkLookupChunk) {
+		pmmAgents, err := models.FindAgentsByIDs(q, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find pmm-agents for scrape config: %w", err)
+		}
+		for _, pmmAgent := range pmmAgents {
+			lookup.pmmAgents[pmmAgent.AgentID] = pmmAgent
+		}
 	}
 	for _, pmmAgent := range lookup.pmmAgents {
 		addID(nodeIDs, pointer.GetString(pmmAgent.RunsOnNodeID))
 	}
 
-	nodes, err := models.FindNodesByIDs(q, slices.Collect(maps.Keys(nodeIDs)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find nodes for scrape config: %w", err)
-	}
-	for _, node := range nodes {
-		lookup.nodes[node.NodeID] = node
+	for chunk := range slices.Chunk(slices.Collect(maps.Keys(nodeIDs)), bulkLookupChunk) {
+		nodes, err := models.FindNodesByIDs(q, chunk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find nodes for scrape config: %w", err)
+		}
+		for _, node := range nodes {
+			lookup.nodes[node.NodeID] = node
+		}
 	}
 
 	return lookup, nil

--- a/managed/services/victoriametrics/prometheus_test.go
+++ b/managed/services/victoriametrics/prometheus_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2023 Percona LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package victoriametrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	config "github.com/percona/promconfig"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/reform.v1"
+	"gopkg.in/reform.v1/dialects/postgresql"
+
+	"github.com/percona/pmm/managed/models"
+	"github.com/percona/pmm/managed/utils/testdb"
+)
+
+// queryCounter counts the queries reform executes.
+type queryCounter struct {
+	queries int
+}
+
+func (c *queryCounter) Before(_ string, _ []any) {}
+
+func (c *queryCounter) After(_ string, _ []any, _ time.Duration, _ error) {
+	c.queries++
+}
+
+// addScrapeConfigsFixtures creates one Node with a pmm-agent running the given number of
+// MySQL services, each monitored by its own mysqld_exporter.
+func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string, services int) {
+	t.Helper()
+
+	nodeID := "/node_id/" + pmmAgentID
+	structs := make([]reform.Struct, 0, 2+2*services)
+	structs = append(
+		structs,
+		&models.Node{
+			NodeID:   nodeID,
+			NodeType: models.GenericNodeType,
+			NodeName: "node-" + pmmAgentID,
+			Address:  "1.2.3.4",
+		},
+		&models.Agent{
+			AgentID:      pmmAgentID,
+			AgentType:    models.PMMAgentType,
+			RunsOnNodeID: &nodeID,
+			Version:      new("3.9.0"),
+		},
+	)
+
+	for i := range services {
+		serviceID := fmt.Sprintf("/service_id/%s/%d", pmmAgentID, i)
+		structs = append(
+			structs,
+			&models.Service{
+				ServiceID:   serviceID,
+				ServiceType: models.MySQLServiceType,
+				ServiceName: fmt.Sprintf("mysql-%s-%d", pmmAgentID, i),
+				NodeID:      nodeID,
+				Address:     new("5.6.7.8"),
+				Port:        new(uint16(3306)),
+			},
+			&models.Agent{
+				AgentID:    fmt.Sprintf("/agent_id/%s/%d", pmmAgentID, i),
+				AgentType:  models.MySQLdExporterType,
+				PMMAgentID: &pmmAgentID,
+				ServiceID:  &serviceID,
+				ListenPort: new(uint16(12345)),
+			},
+		)
+	}
+
+	for _, str := range structs {
+		require.NoError(t, q.Insert(str))
+	}
+}
+
+// TestAddScrapeConfigsQueryCount pins the number of queries AddScrapeConfigs runs: it must
+// not grow with the number of monitored services. Every exporter used to cost a Service, a
+// Node and a pmm-agent lookup, which is what made a scrape config rebuild during a reconnect
+// storm hold a connection for hundreds of round trips (PMM-15228).
+func TestAddScrapeConfigsQueryCount(t *testing.T) {
+	counter := &queryCounter{}
+	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
+	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
+	db := reform.NewDB(sqlDB, postgresql.Dialect, counter)
+
+	resolutions := models.MetricsResolutions{HR: 5 * time.Second, MR: 10 * time.Second, LR: time.Minute}
+	l := logrus.WithField("component", "victoriametrics-test")
+
+	queries := make(map[int]int)
+	for _, services := range []int{1, 10} {
+		pmmAgentID := fmt.Sprintf("/agent_id/pmm-agent-%d", services)
+		addScrapeConfigsFixtures(t, db.Querier, pmmAgentID, services)
+
+		var cfg config.Config
+		counter.queries = 0
+		require.NoError(t, AddScrapeConfigs(l, &cfg, db.Querier, &resolutions, &pmmAgentID, false, false))
+		queries[services] = counter.queries
+
+		// sanity check: the exporters are actually in the generated config
+		assert.Len(t, cfg.ScrapeConfigs, services*3)
+	}
+
+	t.Logf("queries per number of services: %v", queries)
+	assert.Equal(t, queries[1], queries[10],
+		"the number of queries must not depend on the number of monitored services: %v", queries)
+	assert.LessOrEqual(t, queries[10], 5, "expected one query per entity kind: %v", queries)
+}

--- a/managed/services/victoriametrics/prometheus_test.go
+++ b/managed/services/victoriametrics/prometheus_test.go
@@ -29,20 +29,10 @@ import (
 
 	"github.com/percona/pmm/managed/models"
 	"github.com/percona/pmm/managed/utils/testdb"
+	"github.com/percona/pmm/utils/sqlmetrics"
 )
 
 const nodeAddress = "1.2.3.4"
-
-// queryCounter counts the queries reform executes.
-type queryCounter struct {
-	queries int
-}
-
-func (c *queryCounter) Before(_ string, _ []any) {}
-
-func (c *queryCounter) After(_ string, _ []any, _ time.Duration, _ error) {
-	c.queries++
-}
 
 // addScrapeConfigsFixtures creates one Node with a pmm-agent running the given number of MySQL
 // services, each monitored by its own mysqld_exporter. Every service gets a distinct address and
@@ -53,7 +43,8 @@ func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string
 
 	nodeID := "/node_id/" + pmmAgentID
 	structs := make([]reform.Struct, 0, 2+2*services)
-	structs = append(structs,
+	structs = append(
+		structs,
 		&models.Node{
 			NodeID:   nodeID,
 			NodeType: models.GenericNodeType,
@@ -105,9 +96,7 @@ func exporterPort(i int) uint16 {
 }
 
 // scrapedTargets maps every emitted target to the service_name label it carries.
-func scrapedTargets(t *testing.T, cfg *config.Config) map[string]string {
-	t.Helper()
-
+func scrapedTargets(cfg *config.Config) map[string]string {
 	res := make(map[string]string)
 	for _, scfg := range cfg.ScrapeConfigs {
 		for _, group := range scfg.ServiceDiscoveryConfig.StaticConfigs {
@@ -126,10 +115,10 @@ func scrapedTargets(t *testing.T, cfg *config.Config) map[string]string {
 // connection for hundreds of round trips (PMM-15228). The target and label assertions guard the
 // lookup keys, since a cache returning the wrong row would keep the query count flat too.
 func TestAddScrapeConfigsQueryCount(t *testing.T) {
-	counter := &queryCounter{}
+	reformL := sqlmetrics.NewReform("test", "test", t.Logf)
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
 	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
-	db := reform.NewDB(sqlDB, postgresql.Dialect, counter)
+	db := reform.NewDB(sqlDB, postgresql.Dialect, reformL)
 
 	resolutions := models.MetricsResolutions{HR: 5 * time.Second, MR: 10 * time.Second, LR: time.Minute}
 	l := logrus.WithField("component", "victoriametrics-test")
@@ -144,9 +133,9 @@ func TestAddScrapeConfigsQueryCount(t *testing.T) {
 				addScrapeConfigsFixtures(t, db.Querier, pmmAgentID, services, pushMetrics)
 
 				var cfg config.Config
-				counter.queries = 0
+				reformL.Reset()
 				require.NoError(t, AddScrapeConfigs(l, &cfg, db.Querier, &resolutions, &pmmAgentID, pushMetrics, false))
-				queries[services] = counter.queries
+				queries[services] = reformL.Requests()
 
 				// Every service must appear with its own target and its own labels: a lookup
 				// keyed by the wrong column would return another row and change these.
@@ -158,7 +147,7 @@ func TestAddScrapeConfigsQueryCount(t *testing.T) {
 				for i := range services {
 					expected[fmt.Sprintf("%s:%d", host, exporterPort(i))] = serviceName(pmmAgentID, i)
 				}
-				assert.Equal(t, expected, scrapedTargets(t, &cfg))
+				assert.Equal(t, expected, scrapedTargets(&cfg))
 				assert.Len(t, cfg.ScrapeConfigs, services*3)
 			}
 

--- a/managed/services/victoriametrics/prometheus_test.go
+++ b/managed/services/victoriametrics/prometheus_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/percona/pmm/managed/utils/testdb"
 )
 
+const nodeAddress = "1.2.3.4"
+
 // queryCounter counts the queries reform executes.
 type queryCounter struct {
 	queries int
@@ -42,20 +44,21 @@ func (c *queryCounter) After(_ string, _ []any, _ time.Duration, _ error) {
 	c.queries++
 }
 
-// addScrapeConfigsFixtures creates one Node with a pmm-agent running the given number of
-// MySQL services, each monitored by its own mysqld_exporter.
-func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string, services int) {
+// addScrapeConfigsFixtures creates one Node with a pmm-agent running the given number of MySQL
+// services, each monitored by its own mysqld_exporter. Every service gets a distinct address and
+// every exporter a distinct listen port, so a lookup that returns the wrong row shows up in the
+// generated scrape configs.
+func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string, services int, pushMetrics bool) {
 	t.Helper()
 
 	nodeID := "/node_id/" + pmmAgentID
 	structs := make([]reform.Struct, 0, 2+2*services)
-	structs = append(
-		structs,
+	structs = append(structs,
 		&models.Node{
 			NodeID:   nodeID,
 			NodeType: models.GenericNodeType,
 			NodeName: "node-" + pmmAgentID,
-			Address:  "1.2.3.4",
+			Address:  nodeAddress,
 		},
 		&models.Agent{
 			AgentID:      pmmAgentID,
@@ -72,17 +75,18 @@ func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string
 			&models.Service{
 				ServiceID:   serviceID,
 				ServiceType: models.MySQLServiceType,
-				ServiceName: fmt.Sprintf("mysql-%s-%d", pmmAgentID, i),
+				ServiceName: serviceName(pmmAgentID, i),
 				NodeID:      nodeID,
-				Address:     new("5.6.7.8"),
-				Port:        new(uint16(3306)),
+				Address:     new(fmt.Sprintf("10.0.0.%d", i+1)),
+				Port:        new(uint16(3306 + i)),
 			},
 			&models.Agent{
-				AgentID:    fmt.Sprintf("/agent_id/%s/%d", pmmAgentID, i),
-				AgentType:  models.MySQLdExporterType,
-				PMMAgentID: &pmmAgentID,
-				ServiceID:  &serviceID,
-				ListenPort: new(uint16(12345)),
+				AgentID:         fmt.Sprintf("/agent_id/%s/%d", pmmAgentID, i),
+				AgentType:       models.MySQLdExporterType,
+				PMMAgentID:      &pmmAgentID,
+				ServiceID:       &serviceID,
+				ListenPort:      new(exporterPort(i)),
+				ExporterOptions: models.ExporterOptions{PushMetrics: pushMetrics},
 			},
 		)
 	}
@@ -92,10 +96,35 @@ func addScrapeConfigsFixtures(t *testing.T, q *reform.Querier, pmmAgentID string
 	}
 }
 
-// TestAddScrapeConfigsQueryCount pins the number of queries AddScrapeConfigs runs: it must
-// not grow with the number of monitored services. Every exporter used to cost a Service, a
-// Node and a pmm-agent lookup, which is what made a scrape config rebuild during a reconnect
-// storm hold a connection for hundreds of round trips (PMM-15228).
+func serviceName(pmmAgentID string, i int) string {
+	return fmt.Sprintf("mysql-%s-%d", pmmAgentID, i)
+}
+
+func exporterPort(i int) uint16 {
+	return uint16(12345 + i)
+}
+
+// scrapedTargets maps every emitted target to the service_name label it carries.
+func scrapedTargets(t *testing.T, cfg *config.Config) map[string]string {
+	t.Helper()
+
+	res := make(map[string]string)
+	for _, scfg := range cfg.ScrapeConfigs {
+		for _, group := range scfg.ServiceDiscoveryConfig.StaticConfigs {
+			for _, target := range group.Targets {
+				res[target] = group.Labels["service_name"]
+			}
+		}
+	}
+
+	return res
+}
+
+// TestAddScrapeConfigsQueryCount pins the number of queries AddScrapeConfigs runs: it must not
+// grow with the number of monitored services. Every exporter used to cost a Service, a Node and a
+// pmm-agent lookup, which is what made a scrape config rebuild during a reconnect storm hold a
+// connection for hundreds of round trips (PMM-15228). The target and label assertions guard the
+// lookup keys, since a cache returning the wrong row would keep the query count flat too.
 func TestAddScrapeConfigsQueryCount(t *testing.T) {
 	counter := &queryCounter{}
 	sqlDB := testdb.Open(t, models.SkipFixtures, nil)
@@ -105,22 +134,38 @@ func TestAddScrapeConfigsQueryCount(t *testing.T) {
 	resolutions := models.MetricsResolutions{HR: 5 * time.Second, MR: 10 * time.Second, LR: time.Minute}
 	l := logrus.WithField("component", "victoriametrics-test")
 
-	queries := make(map[int]int)
-	for _, services := range []int{1, 10} {
-		pmmAgentID := fmt.Sprintf("/agent_id/pmm-agent-%d", services)
-		addScrapeConfigsFixtures(t, db.Querier, pmmAgentID, services)
+	// BuildScrapeConfigForVMAgent - the path a pmm-agent state update takes - passes
+	// pushMetrics=true, which resolves the host differently, so cover both.
+	for _, pushMetrics := range []bool{false, true} {
+		t.Run(fmt.Sprintf("push_metrics=%v", pushMetrics), func(t *testing.T) {
+			queries := make(map[int]int)
+			for _, services := range []int{1, 10} {
+				pmmAgentID := fmt.Sprintf("/agent_id/pmm-agent-%v-%d", pushMetrics, services)
+				addScrapeConfigsFixtures(t, db.Querier, pmmAgentID, services, pushMetrics)
 
-		var cfg config.Config
-		counter.queries = 0
-		require.NoError(t, AddScrapeConfigs(l, &cfg, db.Querier, &resolutions, &pmmAgentID, false, false))
-		queries[services] = counter.queries
+				var cfg config.Config
+				counter.queries = 0
+				require.NoError(t, AddScrapeConfigs(l, &cfg, db.Querier, &resolutions, &pmmAgentID, pushMetrics, false))
+				queries[services] = counter.queries
 
-		// sanity check: the exporters are actually in the generated config
-		assert.Len(t, cfg.ScrapeConfigs, services*3)
+				// Every service must appear with its own target and its own labels: a lookup
+				// keyed by the wrong column would return another row and change these.
+				host := nodeAddress
+				if pushMetrics {
+					host = models.LocalhostAddr
+				}
+				expected := make(map[string]string, services)
+				for i := range services {
+					expected[fmt.Sprintf("%s:%d", host, exporterPort(i))] = serviceName(pmmAgentID, i)
+				}
+				assert.Equal(t, expected, scrapedTargets(t, &cfg))
+				assert.Len(t, cfg.ScrapeConfigs, services*3)
+			}
+
+			t.Logf("queries per number of services: %v", queries)
+			assert.Equal(t, queries[1], queries[10],
+				"the number of queries must not depend on the number of monitored services: %v", queries)
+			assert.LessOrEqual(t, queries[10], 5, "expected one query per entity kind: %v", queries)
+		})
 	}
-
-	t.Logf("queries per number of services: %v", queries)
-	assert.Equal(t, queries[1], queries[10],
-		"the number of queries must not depend on the number of monitored services: %v", queries)
-	assert.LessOrEqual(t, queries[10], 5, "expected one query per entity kind: %v", queries)
 }

--- a/managed/services/victoriametrics/victoriametrics.go
+++ b/managed/services/victoriametrics/victoriametrics.go
@@ -474,21 +474,25 @@ func scrapeConfigForVMAlert(interval time.Duration, pmmServerNodeName string) *c
 }
 
 // BuildScrapeConfigForVMAgent builds scrape configuration for given pmm-agent.
-func (svc *Service) BuildScrapeConfigForVMAgent(ctx context.Context, pmmAgentID string) ([]byte, error) {
+// The querier is supplied by the caller so that the scrape config is built on the caller's
+// connection pool. The transaction this used to open bought no isolation (READ COMMITTED
+// takes a fresh snapshot per statement) and pinned a connection for the whole build.
+func (svc *Service) BuildScrapeConfigForVMAgent(q *reform.Querier, pmmAgentID string) ([]byte, error) {
 	if pmmAgentID == models.PMMServerAgentID {
 		return svc.buildVMConfig()
 	}
+
+	settings, err := models.GetSettings(q)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get settings: %w", err)
+	}
+	// In HA mode, skip ExternalExporter agents if this node is not the leader
+	skipExternalExporter := !svc.haService.IsLeader()
+
 	var cfg config.Config
-	e := svc.db.InTransactionContext(ctx, nil, func(tx *reform.TX) error {
-		settings, err := models.GetSettings(tx)
-		if err != nil {
-			return err
-		} // In HA mode, skip ExternalExporter agents if this node is not the leader
-		skipExternalExporter := !svc.haService.IsLeader()
-		return AddScrapeConfigs(svc.l, &cfg, tx.Querier, new(settings.MetricsResolutions), new(pmmAgentID), true, skipExternalExporter)
-	})
-	if e != nil {
-		return nil, e
+	err = AddScrapeConfigs(svc.l, &cfg, q, new(settings.MetricsResolutions), new(pmmAgentID), true, skipExternalExporter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build scrape config for pmm-agent '%s': %w", pmmAgentID, err)
 	}
 
 	return yaml.Marshal(cfg)

--- a/managed/services/victoriametrics/victoriametrics.go
+++ b/managed/services/victoriametrics/victoriametrics.go
@@ -477,6 +477,10 @@ func scrapeConfigForVMAlert(interval time.Duration, pmmServerNodeName string) *c
 // The querier is supplied by the caller so that the scrape config is built on the caller's
 // connection pool. The transaction this used to open bought no isolation (READ COMMITTED
 // takes a fresh snapshot per statement) and pinned a connection for the whole build.
+//
+// PMM Server's own vmagent is the exception: it scrapes the whole fleet, so it reuses the
+// service's configuration builder, which runs on the service's own handle and transaction.
+// That is one agent per server, not a per-agent cost.
 func (svc *Service) BuildScrapeConfigForVMAgent(q *reform.Querier, pmmAgentID string) ([]byte, error) {
 	if pmmAgentID == models.PMMServerAgentID {
 		return svc.buildVMConfig()


### PR DESCRIPTION
Ticket number: PMM-15228

Feature build: SUBMODULES-4537

## What

Extracts the connection-pool isolation from #5670 into a reviewable change, and fixes the issues that review found. Nothing else from #5670 is included: no new cache package, no concurrency limiter, no `automemlimit`, no auth-server metrics, no dashboard rewrite. #5670 is untouched.

8 files, +563/-89.

## Why

PMM-15228 is not "the auth path is slow", it is "PMM Server is unresponsive for 30-40 minutes after a restart, with no metrics at all". The root cause, from the ticket:

> pmm-managed hasn't finished the internal structs and configs initialisation (VM scrape config in particular) but it starts receiving a storm of `/Connect` requests from pmm-agents. Handling all such requests resulted in occupying all DB connections […] as result `/etc/victoriametrics-promscrape.yml` empty -> no metrics about pmm-server at all after restart.

pmm-managed opened **one 50-connection pool** shared by everything (`managed/models/database.go`, `SetMaxOpenConns(50)`). A reconnect storm took all 50, so `updateConfiguration` timed out after 5 minutes and left the scrape config empty, and agent state updates were rescheduled forever without converging.

This is the bulkhead for that: agent traffic can still saturate its own pool, but it can no longer take the services that keep the server alive down with it.

## Commits

**1. `Split the pmm-managed DB connection pool`**

Two independent pools against the same database:

| pool | consumers | label |
|---|---|---|
| internal | VictoriaMetrics scrape config, settings, cleanup, telemetry, checks, alerting, backups, scheduler, Nomad, dump, version cache | `db="pmm-managed/internal"` |
| api | agent connect, state updates, QAN collection, RTA, authentication, and the shared gRPC/REST deps | `db="pmm-managed/api"` |

Pool geometry moves into `models.SetupDBParams`; callers that leave it unset (tests, `pmm-encryption-rotation`) keep today's behaviour, so they stay out of the diff.

The same commit takes the transaction out of `BuildScrapeConfigForVMAgent` and passes the caller's querier instead. That transaction gave no isolation - `nil` `TxOptions` means READ COMMITTED, so every statement already took a fresh snapshot - but it pinned one connection for the whole build. It also had to go for the split to mean anything: `vmdb` holds the *internal* handle, so without it every agent state update would have pulled an internal connection. The state updater now also binds its queries to the request context, so waiting for a free connection is bounded by `stateChangeTimeout` instead of blocking.

Note the metric label rename. Nothing in the repo queries `go_sql_*` today (checked dashboards and alerting templates), and `pmm-managed/qan` already set the precedent.

**2. `Size the DB pools from the server's max_connections`** — review fix

#5670 derived the sizes from a hardcoded `postgresMaxConnections = 2000` (what PMM Server configures for its bundled PostgreSQL) and computed the budget per process. Both assumptions break in supported deployments:

- **external PostgreSQL** (`PMM_POSTGRES_ADDR`, documented) commonly has `max_connections = 100`. A 16-CPU server would ask for 240 connections and get `FATAL: sorry, too many clients already` - where it previously opened 50.
- **HA** runs N instances against one server, so the budget must be divided.

Now: read `max_connections` after migrations, reserve a quarter of it (capped at 500) for PostgreSQL internals, Grafana, telemetry and maintenance sessions, divide by the number of HA nodes, and shrink both pools to fit if the preferred sizes do not. Verified the unprivileged `pmm-managed` role can read it on the bundled PostgreSQL 14 (`SELECT current_setting('max_connections')::int` → 2000). If it cannot be read, we fall back to the minimum pool sizes and log a warning.

On PMM Server the result is unchanged: 1500 connections of budget, which the preferred sizes never reach. Unit tests cover the sizing arithmetic.

**3. `Recycle and drain idle DB connections`** — review fix

`MaxIdleConns == MaxOpenConns` with `ConnMaxIdleTime = 5m` and no `ConnMaxLifetime` meant a storm left up to 240 idle PostgreSQL backends resting for 5 minutes inside the same memory-limited container, never recycled. Idle connections are now drained after a minute and every connection is recycled twice an hour. Idle time only applies to connections nobody is using, so this adds no connect churn under load, and the lifetime bound also helps an HA node recover after a failover.

**4. `Batch the scrape config lookups`** — the remaining N+1

`AddScrapeConfigs` resolved the Service, Node and pmm-agent of every exporter one row at a time, re-reading the *same* pmm-agent row and its Node for every exporter on that node and re-parsing its version each time - **4N+1 queries**, all on one connection. That is what made a rebuild during a storm hold a connection for minutes, and the pool split alone would not have fixed it.

Everything the Agents reference is now resolved in three bulk queries up front (`FindServicesByIDs`, `FindAgentsByIDs`, `FindNodesByIDs` - all already in `models`). Rows that appear after the bulk query are still read individually, so a missing row fails exactly as before.

Measured with a query-counting reform logger:

| monitored services | before | after |
|---|---|---|
| 1 | 5 queries | 4 |
| 10 | 41 queries | 4 |

`TestAddScrapeConfigsQueryCount` pins this; it fails with `map[1:5 10:41]` on the parent commit.

## Not included from #5670, deliberately

- **HA config path ordering.** #5670 moved `migrateDB` above the `models.AgentConfigFilePath` HA override, so every HA start would read the non-HA pmm-agent config (fixtures run on every start) and either fatal after the 5-minute migration retry or adopt the wrong `PMMServerAgentID`. This branch keeps the original ordering, so there is no fix to apply.
- **The concurrency limiter.** The pools are useful without it, and as written it holds a slot - sized from the DB pool - across `SendAndWaitResponse`, which the agent only answers after synchronously starting and stopping exporter processes; rejections also increment no counter. Worth its own PR and its own discussion.
- `automemlimit`, `utils/cache`, the auth-server metrics and the PMM Health dashboard rewrite.

## Known limits, deliberately not addressed here

Surfaced by review of this branch; each would grow the diff past what one PR should carry.

- **The partition is not airtight.** `jobsService` (internal pool) is driven off the agent stream - `createJobLog` writes per streamed backup-log chunk - and the agent `StateChanged` handler calls `vmdb.ForceConfigurationUpdate`, which runs a transaction on the internal pool. Both are bounded by concurrent backups and config changes rather than fleet size, but the invariant "no agent-driven write touches the internal pool" does not hold today.
- **UI-facing services sit on the internal pool.** `server.Params.DB`, `checksService`, `alertingService`, the backup and scheduler services are all internal, so `GetSettings`/`ChangeSettings`/`readyz` share a pool that is 20 connections on a 4-CPU host - fewer than the 50 they had before. That is the bulkhead trade (isolation over headroom) and it keeps UI reads out of the way of an agent storm, but it is a real reduction in headroom for those endpoints.
- **Cross-pool nested transactions.** `managementbackup.NewRestoreService` holds an API-pool transaction open across `scheduleService.Update`, which opens a SERIALIZABLE transaction on the internal pool (same for the backup add/update/remove paths). These nested independent transactions predate the split; now they pin one connection in each pool, so the ceiling for those endpoints is the smaller pool.
- **Co-tenants are not modelled.** The reserve is a fraction of `max_connections`, but Grafana's pool is a fixed 100 (`build/ansible/roles/grafana/files/grafana.ini:16`). On a small external PostgreSQL that is the dominant consumer, and a fixed floor for it would starve pmm-managed instead. A `PMM_*` override for the pool budget is the obvious escape hatch and is not in this PR.
- **`max_connections` is not the whole truth.** `current_setting('max_connections')` does not see `ALTER ROLE ... CONNECTION LIMIT`, and behind PgBouncer or RDS Proxy it reports the backend's limit rather than the pooler's. Both would need the same override.
- **On <=4 CPUs the API pool is still 50** (`max(50, 4*12)`), identical to the single pool it replaces. The isolation is what helps there, not the size; nothing in the formula reads the fleet size, which is what actually drives demand.
- **`sendSetStateRequest` has no unit coverage in-tree**, so the batching in that function is covered by build, lint and the feature build rather than by a test.

## Open question for review

`jobsService` is wired to the internal pool (as in #5670), but its hot path is agent-driven: `createJobLog` writes a row per streamed backup-log chunk. Volume is bounded by concurrent backups rather than fleet size, so it is not a storm risk either way - but if we want the invariant "no agent-driven write touches the internal pool" to hold strictly, it belongs on the API pool.

## Testing

- `managed/services/victoriametrics` and `managed/services/agents` suites pass against a real PostgreSQL (the VM suite inside a PMM Server container, so VictoriaMetrics and the DB are both live).
- New unit tests: pool budget/fit arithmetic (`managed/cmd/pmm-managed/main_test.go`), scrape-config query count (`managed/services/victoriametrics/prometheus_test.go`).
- `go build ./...`, `go vet ./managed/...`, and `golangci-lint` clean on the touched packages (remaining findings there are pre-existing: `noctx`, which PMM-15129 covers, and one `goimports` nit that predates this branch).
- Not yet exercised on a live server under a 300/600-agent reconnect storm - that is what the feature build is for.

## Related

- #5670 - the umbrella PR this is extracted from (left as is)
- #5658 - earlier NGINX/auth work, merged into #5670's branch

