### PR TITLE
PMM-15071 Group MongoDB unused index panels by node

### DIFF
--- a/dashboards/dashboards/MongoDB/MongoDB_Unused_Indexes.json
+++ b/dashboards/dashboards/MongoDB/MongoDB_Unused_Indexes.json
@@ -476,6 +476,7 @@
                                 "collection",
                                 "key_name",
                                 "service_name",
+                                "node_name",
                                 "Value"
                             ]
                         }
@@ -487,11 +488,12 @@
                         "excludeByName": {},
                         "includeByName": {},
                         "indexByName": {
-                            "Value": 5,
+                            "Value": 6,
                             "cluster": 0,
                             "collection": 2,
                             "database": 1,
                             "key_name": 3,
+                            "node_name": 5,
                             "service_name": 4
                         },
                         "renameByName": {}
@@ -770,6 +772,7 @@
                                 "collection",
                                 "key_name",
                                 "service_name",
+                                "node_name",
                                 "Value"
                             ]
                         }
@@ -781,11 +784,12 @@
                         "excludeByName": {},
                         "includeByName": {},
                         "indexByName": {
-                            "Value": 5,
+                            "Value": 6,
                             "cluster": 0,
                             "collection": 2,
                             "database": 1,
                             "key_name": 3,
+                            "node_name": 5,
                             "service_name": 4
                         },
                         "renameByName": {}

--- a/dashboards/dashboards/MongoDB/MongoDB_Unused_Indexes.json
+++ b/dashboards/dashboards/MongoDB/MongoDB_Unused_Indexes.json
@@ -222,7 +222,7 @@
                 {
                     "datasource": "Metrics",
                     "editorMode": "code",
-                    "expr": "count(avg by (cluster, collection, database, key_name, service_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}) == 0)",
+                    "expr": "count(avg by (cluster, collection, database, key_name, service_name, node_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}) == 0)",
                     "instant": true,
                     "refId": "A"
                 }
@@ -289,7 +289,7 @@
             "pluginVersion": "11.6.4",
             "targets": [
                 {
-                    "expr": "count(avg by (cluster, collection, database, key_name, service_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}))",
+                    "expr": "count(avg by (cluster, collection, database, key_name, service_name, node_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}))",
                     "refId": "A"
                 }
             ],
@@ -400,6 +400,18 @@
                     {
                         "matcher": {
                             "id": "byName",
+                            "options": "node_name"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "Node"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
                             "options": "Value"
                         },
                         "properties": [
@@ -446,7 +458,7 @@
                     "datasource": "Metrics",
                     "editorMode": "code",
                     "exemplar": false,
-                    "expr": "avg by (cluster, collection, database, key_name, service_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}) == 0",
+                    "expr": "avg by (cluster, collection, database, key_name, service_name, node_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}) == 0",
                     "format": "table",
                     "instant": true,
                     "refId": "A"
@@ -585,9 +597,9 @@
                 {
                     "datasource": "Metrics",
                     "editorMode": "code",
-                    "expr": "avg by (cluster, database, collection, key_name, service_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"})",
+                    "expr": "avg by (cluster, database, collection, key_name, service_name, node_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"})",
                     "interval": "$interval",
-                    "legendFormat": "{{cluster}} | {{service_name}} | {{database}}.{{collection}} | {{key_name}}",
+                    "legendFormat": "{{cluster}} | {{service_name}} | {{node_name}} | {{database}}.{{collection}} | {{key_name}}",
                     "range": true,
                     "refId": "A"
                 }
@@ -686,6 +698,18 @@
                     {
                         "matcher": {
                             "id": "byName",
+                            "options": "node_name"
+                        },
+                        "properties": [
+                            {
+                                "id": "displayName",
+                                "value": "Node"
+                            }
+                        ]
+                    },
+                    {
+                        "matcher": {
+                            "id": "byName",
                             "options": "Value"
                         },
                         "properties": [
@@ -728,7 +752,7 @@
                     "datasource": "Metrics",
                     "editorMode": "code",
                     "exemplar": false,
-                    "expr": "bottomk(20, avg by (cluster, database, collection, key_name, service_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}))",
+                    "expr": "bottomk(20, avg by (cluster, database, collection, key_name, service_name, node_name) (mongodb_indexstats_accesses_ops{environment=~\"$environment\", cluster=~\"$cluster\", service_name=~\"$service_name\", database=~\"$database\", node_name=~\"$node_name\", key_name!=\"_id_\"}))",
                     "format": "table",
                     "instant": true,
                     "refId": "A"


### PR DESCRIPTION
## Summary
- Follow-up to #5827 / CodeRabbit's review comment on that PR.
- Panels **Unused Indexes** (4), **Indexes Monitored** (5), **Unused Indexes by Collection** (7), **Index Accesses Since Restart** (9), and **Least Used Indexes** (10) in `MongoDB_Unused_Indexes.json` aggregated `mongodb_indexstats_accesses_ops` with `avg by(...)` but did not include `node_name` in the grouping.
- `node_name` is a multi-select template variable that defaults to **All** replica set members, so by default these panels averaged index access counts across every node.
- Index usage is tracked per node (MongoDB records it on whichever member executes the query), so an index unused on one member but active on another was hidden behind a blended average — and could be excluded entirely from the "unused"/"least used" panels via `== 0` / `bottomk()`.
- Fix: add `node_name` to each panel's `by(...)` clause so results are broken out per node, matching the "check every replica set member" guidance already in the dashboard's tooltips. Added a "Node" column/legend segment for readability on the two table panels and the timeseries panel.