### PR TITLE
chore: Add REST path naming conventions to API guidelines

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -70,6 +70,16 @@ domain/v1/
 - **`v1`** — stable API, backward-compatible changes only
 - **`v1beta1`** — beta API, may have breaking changes (e.g., `dump/v1beta1/`, `accesscontrol/v1beta1/`, `ha/v1beta1/`)
 
+## REST Path Naming
+
+PMM follows [AIP-122](https://google.aip.dev/122) and [AIP-136](https://google.aip.dev/136) for `google.api.http` paths.
+
+- **Collection identifiers are `lowerCamelCase`** — `/v1/management/enrollmentTokens`, `/v1/advisors/failedServices`. Not kebab-case, not snake_case.
+- **Custom methods use `:verb` in `lowerCamelCase`** — `/v1/inventory/services:getTypes`, `/v1/realtimeanalytics/sessions:start`.
+- **Path parameters keep the proto field name**, which is `snake_case` — `/v1/management/nodes/{node_id}`.
+
+Nothing enforces this: `buf lint` checks proto identifiers, not the path strings inside `google.api.http` annotations. Two older paths predate the convention and are kebab-case (`/v1/backups/{artifact_id}/compatible-services` and `/v1/backups/artifacts/{artifact_id}/pitr-timeranges`). Don't copy them, and don't rename them either — a released path cannot change without breaking clients.
+
 ## Patterns and Conventions
 
 ### Do
@@ -80,6 +90,7 @@ domain/v1/
 - Use `google.api.http` annotations for REST endpoint mapping
 - Use gRPC status codes (`codes.NotFound`, `codes.InvalidArgument`, etc.) not HTTP status codes
 - Follow RESTful conventions for HTTP mappings (GET for reads, POST for creates, PUT for updates, DELETE for deletes)
+- Name REST paths per [REST Path Naming](#rest-path-naming) above
 - Add comments to proto messages and fields — they become API documentation
 
 ### Don't

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -78,6 +78,11 @@ PMM follows [AIP-122](https://google.aip.dev/122) and [AIP-136](https://google.a
 - **Custom methods use `:verb` in `lowerCamelCase`** — `/v1/inventory/services:getTypes`, `/v1/realtimeanalytics/sessions:start`.
 - **Path parameters keep the proto field name**, which is `snake_case` — `/v1/management/nodes/{node_id}`.
 
+Two deliberate departures from AIP-136:
+
+- **A POST-based read keeps a `get` prefix** — `/v1/qan:getLabels`, `/v1/inventory/services:getTypes`. AIP-136 bars standard method verbs (`get`, `list`, …) from custom methods, but without the prefix `POST /v1/qan:labels` reads like a create. Marking the read intent wins over the rule here.
+- **The URI verb is chosen for HTTP readability, not to mirror the RPC name** — `ListActiveServiceTypes` is exposed as `:getTypes`. AIP-136 requires the two to match; PMM optimizes the path for REST clients instead.
+
 Nothing enforces this: `buf lint` checks proto identifiers, not the path strings inside `google.api.http` annotations. Two older paths predate the convention and are kebab-case (`/v1/backups/{artifact_id}/compatible-services` and `/v1/backups/artifacts/{artifact_id}/pitr-timeranges`). Don't copy them, and don't rename them either — a released path cannot change without breaking clients.
 
 ## Patterns and Conventions


### PR DESCRIPTION
This pull request updates the API documentation in `api/AGENTS.md` to clarify and standardize REST path naming conventions for the v1 API. The main focus is to ensure consistency with Google's AIP guidelines and to prevent future inconsistencies in REST endpoint naming.

**REST Path Naming Standardization:**

* Added a new section describing REST path naming conventions, referencing [AIP-122](https://google.aip.dev/122) and [AIP-136](https://google.aip.dev/136), including rules for collection identifiers, custom methods, and path parameters.
* Noted exceptions for two legacy endpoints that do not follow the standard and instructed not to copy or rename them.
* Updated the "Do" section to explicitly require naming REST paths according to the new conventions.