### PR TITLE
PMM-15360: Add the OpenManager settings flag

### DIFF
--- a/api/server/v1/json/client/server_service/change_settings_responses.go
+++ b/api/server/v1/json/client/server_service/change_settings_responses.go
@@ -222,6 +222,9 @@ type ChangeSettingsBody struct {
 	// Enable Query Analytics for PMM's internal PG database.
 	EnableInternalPgQAN *bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// Enable OpenManager.
+	EnableOm *bool `json:"enable_om,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsParamsBodyAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 
@@ -982,6 +985,9 @@ type ChangeSettingsOKBodySettings struct {
 
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
+
+	// True if OpenManager is enabled.
+	OmEnabled bool `json:"om_enabled,omitempty"`
 
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`

--- a/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
@@ -707,6 +707,9 @@ type GetReadOnlySettingsOKBodySettings struct {
 
 	// True if Access Control is enabled.
 	EnableAccessControl bool `json:"enable_access_control,omitempty"`
+
+	// True if OpenManager is enabled.
+	OmEnabled bool `json:"om_enabled,omitempty"`
 }
 
 // Validate validates this get read only settings OK body settings

--- a/api/server/v1/json/client/server_service/get_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_settings_responses.go
@@ -732,6 +732,9 @@ type GetSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if OpenManager is enabled.
+	OmEnabled bool `json:"om_enabled,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *GetSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/v1.json
+++ b/api/server/v1/json/v1.json
@@ -311,6 +311,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -488,6 +493,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -629,6 +640,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -729,6 +745,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -7,16 +7,18 @@
 package serverv1
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
-	common "github.com/percona/pmm/api/common"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
+
+	common "github.com/percona/pmm/api/common"
 )
 
 const (
@@ -1693,36 +1695,39 @@ func file_server_v1_server_proto_rawDescGZIP() []byte {
 	return file_server_v1_server_proto_rawDescData
 }
 
-var file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_server_v1_server_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
-var file_server_v1_server_proto_goTypes = []any{
-	(DistributionMethod)(0),             // 0: server.v1.DistributionMethod
-	(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
-	(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
-	(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
-	(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
-	(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
-	(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
-	(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
-	(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
-	(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
-	(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
-	(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
-	(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
-	(*MetricsResolutions)(nil),          // 13: server.v1.MetricsResolutions
-	(*AdvisorRunIntervals)(nil),         // 14: server.v1.AdvisorRunIntervals
-	(*Settings)(nil),                    // 15: server.v1.Settings
-	(*ReadOnlySettings)(nil),            // 16: server.v1.ReadOnlySettings
-	(*GetSettingsRequest)(nil),          // 17: server.v1.GetSettingsRequest
-	(*GetReadOnlySettingsRequest)(nil),  // 18: server.v1.GetReadOnlySettingsRequest
-	(*GetSettingsResponse)(nil),         // 19: server.v1.GetSettingsResponse
-	(*GetReadOnlySettingsResponse)(nil), // 20: server.v1.GetReadOnlySettingsResponse
-	(*ChangeSettingsRequest)(nil),       // 21: server.v1.ChangeSettingsRequest
-	(*ChangeSettingsResponse)(nil),      // 22: server.v1.ChangeSettingsResponse
-	(*timestamppb.Timestamp)(nil),       // 23: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),         // 24: google.protobuf.Duration
-	(*common.StringArray)(nil),          // 25: common.StringArray
-}
+var (
+	file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+	file_server_v1_server_proto_msgTypes  = make([]protoimpl.MessageInfo, 22)
+	file_server_v1_server_proto_goTypes   = []any{
+		DistributionMethod(0),               // 0: server.v1.DistributionMethod
+		(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
+		(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
+		(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
+		(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
+		(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
+		(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
+		(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
+		(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
+		(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
+		(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
+		(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
+		(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
+		(*MetricsResolutions)(nil),          // 13: server.v1.MetricsResolutions
+		(*AdvisorRunIntervals)(nil),         // 14: server.v1.AdvisorRunIntervals
+		(*Settings)(nil),                    // 15: server.v1.Settings
+		(*ReadOnlySettings)(nil),            // 16: server.v1.ReadOnlySettings
+		(*GetSettingsRequest)(nil),          // 17: server.v1.GetSettingsRequest
+		(*GetReadOnlySettingsRequest)(nil),  // 18: server.v1.GetReadOnlySettingsRequest
+		(*GetSettingsResponse)(nil),         // 19: server.v1.GetSettingsResponse
+		(*GetReadOnlySettingsResponse)(nil), // 20: server.v1.GetReadOnlySettingsResponse
+		(*ChangeSettingsRequest)(nil),       // 21: server.v1.ChangeSettingsRequest
+		(*ChangeSettingsResponse)(nil),      // 22: server.v1.ChangeSettingsResponse
+		(*timestamppb.Timestamp)(nil),       // 23: google.protobuf.Timestamp
+		(*durationpb.Duration)(nil),         // 24: google.protobuf.Duration
+		(*common.StringArray)(nil),          // 25: common.StringArray
+	}
+)
+
 var file_server_v1_server_proto_depIdxs = []int32{
 	23, // 0: server.v1.VersionInfo.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 1: server.v1.VersionResponse.server:type_name -> server.v1.VersionInfo

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -7,18 +7,16 @@
 package serverv1
 
 import (
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
-
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
+	common "github.com/percona/pmm/api/common"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-
-	common "github.com/percona/pmm/api/common"
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
 )
 
 const (
@@ -883,8 +881,10 @@ type Settings struct {
 	DefaultRoleId uint32 `protobuf:"varint,18,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQan bool `protobuf:"varint,19,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if OpenManager is enabled.
+	OmEnabled     bool `protobuf:"varint,21,opt,name=om_enabled,json=omEnabled,proto3" json:"om_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Settings) Reset() {
@@ -1045,6 +1045,13 @@ func (x *Settings) GetEnableInternalPgQan() bool {
 	return false
 }
 
+func (x *Settings) GetOmEnabled() bool {
+	if x != nil {
+		return x.OmEnabled
+	}
+	return false
+}
+
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.
 type ReadOnlySettings struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1064,8 +1071,10 @@ type ReadOnlySettings struct {
 	AzurediscoverEnabled bool `protobuf:"varint,7,opt,name=azurediscover_enabled,json=azurediscoverEnabled,proto3" json:"azurediscover_enabled,omitempty"`
 	// True if Access Control is enabled.
 	EnableAccessControl bool `protobuf:"varint,8,opt,name=enable_access_control,json=enableAccessControl,proto3" json:"enable_access_control,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if OpenManager is enabled.
+	OmEnabled     bool `protobuf:"varint,9,opt,name=om_enabled,json=omEnabled,proto3" json:"om_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ReadOnlySettings) Reset() {
@@ -1150,6 +1159,13 @@ func (x *ReadOnlySettings) GetAzurediscoverEnabled() bool {
 func (x *ReadOnlySettings) GetEnableAccessControl() bool {
 	if x != nil {
 		return x.EnableAccessControl
+	}
+	return false
+}
+
+func (x *ReadOnlySettings) GetOmEnabled() bool {
+	if x != nil {
+		return x.OmEnabled
 	}
 	return false
 }
@@ -1339,8 +1355,10 @@ type ChangeSettingsRequest struct {
 	EnableAccessControl *bool `protobuf:"varint,13,opt,name=enable_access_control,json=enableAccessControl,proto3,oneof" json:"enable_access_control,omitempty"`
 	// Enable Query Analytics for PMM's internal PG database.
 	EnableInternalPgQan *bool `protobuf:"varint,14,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3,oneof" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Enable OpenManager.
+	EnableOm      *bool `protobuf:"varint,16,opt,name=enable_om,json=enableOm,proto3,oneof" json:"enable_om,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ChangeSettingsRequest) Reset() {
@@ -1471,6 +1489,13 @@ func (x *ChangeSettingsRequest) GetEnableInternalPgQan() bool {
 	return false
 }
 
+func (x *ChangeSettingsRequest) GetEnableOm() bool {
+	if x != nil && x.EnableOm != nil {
+		return *x.EnableOm
+	}
+	return false
+}
+
 type ChangeSettingsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Settings      *Settings              `protobuf:"bytes,1,opt,name=settings,proto3" json:"settings,omitempty"`
@@ -1563,7 +1588,7 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13AdvisorRunIntervals\x12F\n" +
 	"\x11standard_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10standardInterval\x12>\n" +
 	"\rrare_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\frareInterval\x12F\n" +
-	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xbc\a\n" +
+	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xdb\a\n" +
 	"\bSettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12N\n" +
@@ -1583,7 +1608,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13telemetry_summaries\x18\x10 \x03(\tR\x12telemetrySummaries\x122\n" +
 	"\x15enable_access_control\x18\x11 \x01(\bR\x13enableAccessControl\x12&\n" +
 	"\x0fdefault_role_id\x18\x12 \x01(\rR\rdefaultRoleId\x123\n" +
-	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQanJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\x8f\x03\n" +
+	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQan\x12\x1d\n" +
+	"\n" +
+	"om_enabled\x18\x15 \x01(\bR\tomEnabledJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\xae\x03\n" +
 	"\x10ReadOnlySettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12'\n" +
@@ -1592,13 +1619,15 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x12pmm_public_address\x18\x05 \x01(\tR\x10pmmPublicAddress\x12:\n" +
 	"\x19backup_management_enabled\x18\x06 \x01(\bR\x17backupManagementEnabled\x123\n" +
 	"\x15azurediscover_enabled\x18\a \x01(\bR\x14azurediscoverEnabled\x122\n" +
-	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\"\x14\n" +
+	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\x12\x1d\n" +
+	"\n" +
+	"om_enabled\x18\t \x01(\bR\tomEnabled\"\x14\n" +
 	"\x12GetSettingsRequest\"\x1c\n" +
 	"\x1aGetReadOnlySettingsRequest\"F\n" +
 	"\x13GetSettingsResponse\x12/\n" +
 	"\bsettings\x18\x01 \x01(\v2\x13.server.v1.SettingsR\bsettings\"V\n" +
 	"\x1bGetReadOnlySettingsResponse\x127\n" +
-	"\bsettings\x18\x01 \x01(\v2\x1b.server.v1.ReadOnlySettingsR\bsettings\"\xbd\b\n" +
+	"\bsettings\x18\x01 \x01(\v2\x1b.server.v1.ReadOnlySettingsR\bsettings\"\xed\b\n" +
 	"\x15ChangeSettingsRequest\x12*\n" +
 	"\x0eenable_updates\x18\x01 \x01(\bH\x00R\renableUpdates\x88\x01\x01\x12.\n" +
 	"\x10enable_telemetry\x18\x02 \x01(\bH\x01R\x0fenableTelemetry\x88\x01\x01\x12N\n" +
@@ -1615,7 +1644,8 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x18enable_backup_management\x18\f \x01(\bH\bR\x16enableBackupManagement\x88\x01\x01\x127\n" +
 	"\x15enable_access_control\x18\r \x01(\bH\tR\x13enableAccessControl\x88\x01\x01\x128\n" +
 	"\x16enable_internal_pg_qan\x18\x0e \x01(\bH\n" +
-	"R\x13enableInternalPgQan\x88\x01\x01B\x11\n" +
+	"R\x13enableInternalPgQan\x88\x01\x01\x12 \n" +
+	"\tenable_om\x18\x10 \x01(\bH\vR\benableOm\x88\x01\x01B\x11\n" +
 	"\x0f_enable_updatesB\x13\n" +
 	"\x11_enable_telemetryB\n" +
 	"\n" +
@@ -1627,7 +1657,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x15_enable_azurediscoverB\x1b\n" +
 	"\x19_enable_backup_managementB\x18\n" +
 	"\x16_enable_access_controlB\x19\n" +
-	"\x17_enable_internal_pg_qanJ\x04\b\x0f\x10\x10R\x16update_snooze_duration\"I\n" +
+	"\x17_enable_internal_pg_qanB\f\n" +
+	"\n" +
+	"_enable_omJ\x04\b\x0f\x10\x10R\x16update_snooze_duration\"I\n" +
 	"\x16ChangeSettingsResponse\x12/\n" +
 	"\bsettings\x18\x01 \x01(\v2\x13.server.v1.SettingsR\bsettings*\xce\x01\n" +
 	"\x12DistributionMethod\x12#\n" +
@@ -1661,39 +1693,36 @@ func file_server_v1_server_proto_rawDescGZIP() []byte {
 	return file_server_v1_server_proto_rawDescData
 }
 
-var (
-	file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_server_v1_server_proto_msgTypes  = make([]protoimpl.MessageInfo, 22)
-	file_server_v1_server_proto_goTypes   = []any{
-		DistributionMethod(0),               // 0: server.v1.DistributionMethod
-		(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
-		(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
-		(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
-		(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
-		(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
-		(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
-		(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
-		(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
-		(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
-		(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
-		(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
-		(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
-		(*MetricsResolutions)(nil),          // 13: server.v1.MetricsResolutions
-		(*AdvisorRunIntervals)(nil),         // 14: server.v1.AdvisorRunIntervals
-		(*Settings)(nil),                    // 15: server.v1.Settings
-		(*ReadOnlySettings)(nil),            // 16: server.v1.ReadOnlySettings
-		(*GetSettingsRequest)(nil),          // 17: server.v1.GetSettingsRequest
-		(*GetReadOnlySettingsRequest)(nil),  // 18: server.v1.GetReadOnlySettingsRequest
-		(*GetSettingsResponse)(nil),         // 19: server.v1.GetSettingsResponse
-		(*GetReadOnlySettingsResponse)(nil), // 20: server.v1.GetReadOnlySettingsResponse
-		(*ChangeSettingsRequest)(nil),       // 21: server.v1.ChangeSettingsRequest
-		(*ChangeSettingsResponse)(nil),      // 22: server.v1.ChangeSettingsResponse
-		(*timestamppb.Timestamp)(nil),       // 23: google.protobuf.Timestamp
-		(*durationpb.Duration)(nil),         // 24: google.protobuf.Duration
-		(*common.StringArray)(nil),          // 25: common.StringArray
-	}
-)
-
+var file_server_v1_server_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_server_v1_server_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_server_v1_server_proto_goTypes = []any{
+	(DistributionMethod)(0),             // 0: server.v1.DistributionMethod
+	(*VersionInfo)(nil),                 // 1: server.v1.VersionInfo
+	(*VersionRequest)(nil),              // 2: server.v1.VersionRequest
+	(*VersionResponse)(nil),             // 3: server.v1.VersionResponse
+	(*ReadinessRequest)(nil),            // 4: server.v1.ReadinessRequest
+	(*ReadinessResponse)(nil),           // 5: server.v1.ReadinessResponse
+	(*LeaderHealthCheckRequest)(nil),    // 6: server.v1.LeaderHealthCheckRequest
+	(*LeaderHealthCheckResponse)(nil),   // 7: server.v1.LeaderHealthCheckResponse
+	(*CheckUpdatesRequest)(nil),         // 8: server.v1.CheckUpdatesRequest
+	(*DockerVersionInfo)(nil),           // 9: server.v1.DockerVersionInfo
+	(*CheckUpdatesResponse)(nil),        // 10: server.v1.CheckUpdatesResponse
+	(*ListChangeLogsRequest)(nil),       // 11: server.v1.ListChangeLogsRequest
+	(*ListChangeLogsResponse)(nil),      // 12: server.v1.ListChangeLogsResponse
+	(*MetricsResolutions)(nil),          // 13: server.v1.MetricsResolutions
+	(*AdvisorRunIntervals)(nil),         // 14: server.v1.AdvisorRunIntervals
+	(*Settings)(nil),                    // 15: server.v1.Settings
+	(*ReadOnlySettings)(nil),            // 16: server.v1.ReadOnlySettings
+	(*GetSettingsRequest)(nil),          // 17: server.v1.GetSettingsRequest
+	(*GetReadOnlySettingsRequest)(nil),  // 18: server.v1.GetReadOnlySettingsRequest
+	(*GetSettingsResponse)(nil),         // 19: server.v1.GetSettingsResponse
+	(*GetReadOnlySettingsResponse)(nil), // 20: server.v1.GetReadOnlySettingsResponse
+	(*ChangeSettingsRequest)(nil),       // 21: server.v1.ChangeSettingsRequest
+	(*ChangeSettingsResponse)(nil),      // 22: server.v1.ChangeSettingsResponse
+	(*timestamppb.Timestamp)(nil),       // 23: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),         // 24: google.protobuf.Duration
+	(*common.StringArray)(nil),          // 25: common.StringArray
+}
 var file_server_v1_server_proto_depIdxs = []int32{
 	23, // 0: server.v1.VersionInfo.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 1: server.v1.VersionResponse.server:type_name -> server.v1.VersionInfo

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -154,7 +154,8 @@ func (e VersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionInfoValidationError{}
@@ -256,7 +257,8 @@ func (e VersionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionRequestValidationError{}
@@ -418,7 +420,8 @@ func (e VersionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionResponseValidationError{}
@@ -518,7 +521,8 @@ func (e ReadinessRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadinessRequestValidationError{}
@@ -620,7 +624,8 @@ func (e ReadinessResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadinessResponseValidationError{}
@@ -722,7 +727,8 @@ func (e LeaderHealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = LeaderHealthCheckRequestValidationError{}
@@ -824,7 +830,8 @@ func (e LeaderHealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = LeaderHealthCheckResponseValidationError{}
@@ -930,7 +937,8 @@ func (e CheckUpdatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = CheckUpdatesRequestValidationError{}
@@ -1069,7 +1077,8 @@ func (e DockerVersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = DockerVersionInfoValidationError{}
@@ -1262,7 +1271,8 @@ func (e CheckUpdatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = CheckUpdatesResponseValidationError{}
@@ -1364,7 +1374,8 @@ func (e ListChangeLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ListChangeLogsRequestValidationError{}
@@ -1529,7 +1540,8 @@ func (e ListChangeLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ListChangeLogsResponseValidationError{}
@@ -1718,7 +1730,8 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = MetricsResolutionsValidationError{}
@@ -1907,7 +1920,8 @@ func (e AdvisorRunIntervalsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = AdvisorRunIntervalsValidationError{}
@@ -2121,7 +2135,8 @@ func (e SettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = SettingsValidationError{}
@@ -2239,7 +2254,8 @@ func (e ReadOnlySettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadOnlySettingsValidationError{}
@@ -2341,7 +2357,8 @@ func (e GetSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetSettingsRequestValidationError{}
@@ -2443,7 +2460,8 @@ func (e GetReadOnlySettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetReadOnlySettingsRequestValidationError{}
@@ -2574,7 +2592,8 @@ func (e GetSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetSettingsResponseValidationError{}
@@ -2706,7 +2725,8 @@ func (e GetReadOnlySettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetReadOnlySettingsResponseValidationError{}
@@ -2841,7 +2861,6 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 	}
 
 	if m.AwsPartitions != nil {
-
 		if all {
 			switch v := interface{}(m.GetAwsPartitions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -2870,7 +2889,6 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 				}
 			}
 		}
-
 	}
 
 	if m.EnableAdvisor != nil {
@@ -2972,7 +2990,8 @@ func (e ChangeSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ChangeSettingsRequestValidationError{}
@@ -3103,7 +3122,8 @@ func (e ChangeSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ChangeSettingsResponseValidationError{}

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -154,8 +154,7 @@ func (e VersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionInfoValidationError{}
@@ -257,8 +256,7 @@ func (e VersionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionRequestValidationError{}
@@ -420,8 +418,7 @@ func (e VersionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionResponseValidationError{}
@@ -521,8 +518,7 @@ func (e ReadinessRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessRequestValidationError{}
@@ -624,8 +620,7 @@ func (e ReadinessResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessResponseValidationError{}
@@ -727,8 +722,7 @@ func (e LeaderHealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckRequestValidationError{}
@@ -830,8 +824,7 @@ func (e LeaderHealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckResponseValidationError{}
@@ -937,8 +930,7 @@ func (e CheckUpdatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesRequestValidationError{}
@@ -1077,8 +1069,7 @@ func (e DockerVersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DockerVersionInfoValidationError{}
@@ -1271,8 +1262,7 @@ func (e CheckUpdatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesResponseValidationError{}
@@ -1374,8 +1364,7 @@ func (e ListChangeLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsRequestValidationError{}
@@ -1540,8 +1529,7 @@ func (e ListChangeLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsResponseValidationError{}
@@ -1730,8 +1718,7 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsResolutionsValidationError{}
@@ -1920,8 +1907,7 @@ func (e AdvisorRunIntervalsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorRunIntervalsValidationError{}
@@ -2069,6 +2055,8 @@ func (m *Settings) validate(all bool) error {
 
 	// no validation rules for EnableInternalPgQan
 
+	// no validation rules for OmEnabled
+
 	if len(errors) > 0 {
 		return SettingsMultiError(errors)
 	}
@@ -2133,8 +2121,7 @@ func (e SettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SettingsValidationError{}
@@ -2184,6 +2171,8 @@ func (m *ReadOnlySettings) validate(all bool) error {
 	// no validation rules for AzurediscoverEnabled
 
 	// no validation rules for EnableAccessControl
+
+	// no validation rules for OmEnabled
 
 	if len(errors) > 0 {
 		return ReadOnlySettingsMultiError(errors)
@@ -2250,8 +2239,7 @@ func (e ReadOnlySettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadOnlySettingsValidationError{}
@@ -2353,8 +2341,7 @@ func (e GetSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsRequestValidationError{}
@@ -2456,8 +2443,7 @@ func (e GetReadOnlySettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsRequestValidationError{}
@@ -2588,8 +2574,7 @@ func (e GetSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsResponseValidationError{}
@@ -2721,8 +2706,7 @@ func (e GetReadOnlySettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsResponseValidationError{}
@@ -2857,6 +2841,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 	}
 
 	if m.AwsPartitions != nil {
+
 		if all {
 			switch v := interface{}(m.GetAwsPartitions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -2885,6 +2870,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnableAdvisor != nil {
@@ -2913,6 +2899,10 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 
 	if m.EnableInternalPgQan != nil {
 		// no validation rules for EnableInternalPgQan
+	}
+
+	if m.EnableOm != nil {
+		// no validation rules for EnableOm
 	}
 
 	if len(errors) > 0 {
@@ -2982,8 +2972,7 @@ func (e ChangeSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsRequestValidationError{}
@@ -3114,8 +3103,7 @@ func (e ChangeSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsResponseValidationError{}

--- a/api/server/v1/server.proto
+++ b/api/server/v1/server.proto
@@ -156,6 +156,8 @@ message Settings {
   // Field 20 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 20;
   reserved "update_snooze_duration";
+  // True if OpenManager is enabled.
+  bool om_enabled = 21;
 }
 
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.
@@ -176,6 +178,8 @@ message ReadOnlySettings {
   bool azurediscover_enabled = 7;
   // True if Access Control is enabled.
   bool enable_access_control = 8;
+  // True if OpenManager is enabled.
+  bool om_enabled = 9;
 }
 
 message GetSettingsRequest {}
@@ -217,6 +221,8 @@ message ChangeSettingsRequest {
   // Field 15 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 15;
   reserved "update_snooze_duration";
+  // Enable OpenManager.
+  optional bool enable_om = 16;
 }
 
 message ChangeSettingsResponse {

--- a/api/swagger/swagger-dev.json
+++ b/api/swagger/swagger-dev.json
@@ -32427,6 +32427,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -32604,6 +32609,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -32745,6 +32756,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -32845,6 +32861,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -31454,6 +31454,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -31631,6 +31636,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -31772,6 +31783,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -31872,6 +31888,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/managed/models/settings.go
+++ b/managed/models/settings.go
@@ -33,6 +33,7 @@ const (
 	AzureDiscoverEnabledDefault        = false
 	AccessControlEnabledDefault        = false
 	InternalPgQANEnabledDefault        = false
+	OMEnabledDefault                   = false
 	awsPartitionID                     = "aws"
 )
 
@@ -118,6 +119,12 @@ type Settings struct {
 
 	// Contains all encrypted tables in format 'db.table.column'.
 	EncryptedItems []string `json:"encrypted_items"`
+
+	// OM holds OpenManager's settings.
+	OM struct {
+		// Enabled is true if OpenManager is enabled.
+		Enabled *bool `json:"enabled"`
+	} `json:"om"`
 }
 
 // IsAlertingEnabled returns true if alerting is enabled.
@@ -180,6 +187,14 @@ func (s *Settings) IsAccessControlEnabled() bool {
 		return *s.AccessControl.Enabled
 	}
 	return AccessControlEnabledDefault
+}
+
+// IsOMEnabled returns true if OpenManager is enabled.
+func (s *Settings) IsOMEnabled() bool {
+	if s.OM.Enabled != nil {
+		return *s.OM.Enabled
+	}
+	return OMEnabledDefault
 }
 
 // IsVictoriaMetricsCacheEnabled returns true if VictoriaMetrics cache is enabled.

--- a/managed/models/settings_helpers.go
+++ b/managed/models/settings_helpers.go
@@ -97,6 +97,9 @@ type ChangeSettingsParams struct {
 	// EnableInternalPgQAN enables Query Analytics for PMM's internal PG database.
 	EnableInternalPgQAN *bool
 
+	// EnableOM enables OpenManager.
+	EnableOM *bool
+
 	// DefaultRoleID sets a default role to be assigned to new users.
 	DefaultRoleID *int
 
@@ -233,6 +236,10 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 
 	if params.EnableBackupManagement != nil {
 		settings.BackupManagement.Enabled = params.EnableBackupManagement
+	}
+
+	if params.EnableOM != nil {
+		settings.OM.Enabled = params.EnableOM
 	}
 
 	if params.DefaultRoleID != nil {

--- a/managed/models/settings_helpers_test.go
+++ b/managed/models/settings_helpers_test.go
@@ -299,6 +299,16 @@ func TestSettings(t *testing.T) {
 			assert.True(t, *ns.Alerting.Enabled)
 		})
 
+		t.Run("enable OpenManager", func(t *testing.T) {
+			s, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableOM: new(false)})
+			require.NoError(t, err)
+			assert.False(t, s.IsOMEnabled())
+
+			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableOM: new(true)})
+			require.NoError(t, err)
+			assert.True(t, ns.IsOMEnabled())
+		})
+
 		t.Run("Set PMM server ID", func(t *testing.T) {
 			t.Run("not set", func(t *testing.T) {
 				settings, err := models.GetSettings(sqlDB)

--- a/managed/services/server/server.go
+++ b/managed/services/server/server.go
@@ -362,6 +362,7 @@ func (s *Server) convertSettings(settings *models.Settings, disableInternalPgQan
 
 		EnableAccessControl: settings.IsAccessControlEnabled(),
 		DefaultRoleId:       convertDefaultRoleID(settings.DefaultRoleID),
+		OmEnabled:           settings.IsOMEnabled(),
 	}
 
 	return res
@@ -386,6 +387,7 @@ func (s *Server) convertReadOnlySettings(settings *models.Settings) *serverv1.Re
 		BackupManagementEnabled: settings.IsBackupManagementEnabled(),
 		AzurediscoverEnabled:    settings.IsAzureDiscoverEnabled(),
 		EnableAccessControl:     settings.IsAccessControlEnabled(),
+		OmEnabled:               settings.IsOMEnabled(),
 	}
 
 	return res

--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -65,6 +65,7 @@ func (e InvalidDurationError) Error() string { return string(e) }
 //   - PMM_DATA_RETENTION is the duration of how long keep time-series data in ClickHouse;
 //   - PMM_ENABLE_AZURE_DISCOVER enables Azure Discover;
 //   - PMM_ENABLE_ACCESS_CONTROL enables Access control;
+//   - PMM_ENABLE_OM enables OpenManager;
 //   - the environment variables prefixed with GF_ passed as related to Grafana.
 //   - the environment variables relating to proxies
 //   - the environment variable set by podman
@@ -204,6 +205,14 @@ func ParseEnvVars(envs []string) (*models.ChangeSettingsParams, []error, []strin
 				continue
 			}
 			envSettings.EnableBackupManagement = &b
+
+		case "PMM_ENABLE_OM":
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("invalid value %q for environment variable %q", v, k))
+				continue
+			}
+			envSettings.EnableOM = &b
 
 		case "PMM_ENABLE_NOMAD":
 			b, err := strconv.ParseBool(v)

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -45,6 +45,10 @@ export const Messages = {
     accessControlTooltip:
       'Restrict data visibility based on user roles and labels.',
     accessControlLink: 'https://per.co.na/roles_permissions',
+    openManagerLabel: 'OpenManager',
+    openManagerTooltip:
+      'Option to enable/disable OpenManager, PMM periodic collection and the OpenManager Inventory app.',
+    openManagerLink: 'https://per.co.na/pmm-feature-status',
     publicAddressLabel: 'Public address',
     publicAddressTooltip:
       'The address or hostname PMM Server will be accessible at.',

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.schema.ts
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.schema.ts
@@ -40,6 +40,7 @@ export const advancedSettingsSchema = z
     frequentInterval: z.string(),
     azureDiscover: z.boolean(),
     accessControl: z.boolean(),
+    openManager: z.boolean(),
   })
   .superRefine((data, ctx) => {
     if (!data.stt) return;

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
@@ -406,6 +406,36 @@ export const AdvancedSettingsForm: FC<AdvancedSettingsFormProps> = ({
                 </IconButton>
               </Tooltip>
             </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              data-testid="advanced-open-manager"
+            >
+              <SwitchInput name="openManager" label={m.openManagerLabel} />
+              <Tooltip
+                title={
+                  <Box data-testid="info-tooltip">
+                    <Typography variant="caption">
+                      {m.openManagerTooltip}{' '}
+                      <Link
+                        href={m.openManagerLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        color="inherit"
+                        sx={{ textDecorationColor: 'inherit' }}
+                      >
+                        {Messages.tooltipLinkText}
+                      </Link>
+                    </Typography>
+                  </Box>
+                }
+                arrow
+              >
+                <IconButton size="small" data-testid="info-icon">
+                  <InfoOutlinedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
           </Stack>
         </Stack>
 

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.utils.ts
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.utils.ts
@@ -24,6 +24,7 @@ export const toFormValues = (
   ...convertCheckIntervalsToHours(settings.advisorRunIntervals),
   azureDiscover: settings.azurediscoverEnabled,
   accessControl: settings.enableAccessControl,
+  openManager: settings.omEnabled,
 });
 
 export const toPayload = (
@@ -50,5 +51,6 @@ export const toPayload = (
     advisorRunIntervals,
     enableAzurediscover: values.azureDiscover,
     enableAccessControl: values.accessControl,
+    enableOm: values.openManager,
   };
 };

--- a/ui/apps/pmm/src/types/settings.types.ts
+++ b/ui/apps/pmm/src/types/settings.types.ts
@@ -7,6 +7,7 @@ export interface ReadonlySettings {
   backupManagementEnabled: boolean;
   azurediscoverEnabled: boolean;
   enableAccessControl: boolean;
+  omEnabled: boolean;
 }
 
 export interface MetricsResolutions {
@@ -52,6 +53,7 @@ export interface UpdateSettingsPayload {
   enableAccessControl?: boolean;
   enableInternalPgQan?: boolean;
   awsPartitions?: string[];
+  enableOm?: boolean;
 }
 
 export interface FrontendSettings extends GetFrontendSettingsResponse {}

--- a/ui/apps/pmm/src/utils/testUtils.tsx
+++ b/ui/apps/pmm/src/utils/testUtils.tsx
@@ -110,6 +110,7 @@ export const wrapWithSettings = (
         backupManagementEnabled: false,
         azurediscoverEnabled: false,
         enableAccessControl: false,
+        omEnabled: false,
         ...props?.settings,
         frontend: {
           anonymousEnabled: false,


### PR DESCRIPTION
## What

Adds `Settings.OpenManager.Enabled` to pmm-managed and an Advanced Settings toggle for it, default off like every other technical-preview flag (Azure Discover, Access Control). `PMM_ENABLE_OM` seeds it the same way `PMM_ENABLE_NOMAD`/`PMM_ENABLE_AZURE_DISCOVER` do, and reuses `validateChangeSettingsRequest`'s existing env-var-wins precedence check rather than adding a new mechanism.

This only exposes and stores the flag; nothing reads it yet to gate OpenManager's own behavior. That's the follow-up PR (#TBD), once this and PMM-15326-om-backend / PMM-15326-om-ui-nav are all available to stack on.

Ticket: [PMM-15360](https://perconadev.atlassian.net/browse/PMM-15360)

## First of three PRs for PMM-15360

1. **This one** — the flag itself (base: this branch, the epic)
2. Gate OpenManager's service on the switch — base: `PMM-15326-om-backend` (#5816)
3. Gate OpenManager's nav and page on the switch — base: `PMM-15326-om-ui-nav` (#5818)

PRs 2 and 3 both merge this branch in (rather than depending on the non-PR `PMM-15326-om-integration` branch), so their diffs will show this PR's changes inline until it merges.

Feature build: N/A on its own — this only adds a setting nothing reads yet.

[PMM-15360]: https://perconadev.atlassian.net/browse/PMM-15360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ