### PR TITLE
PMM-15360: Add the OpenManager settings flag

### DIFF
--- a/api/server/v1/json/client/server_service/change_settings_responses.go
+++ b/api/server/v1/json/client/server_service/change_settings_responses.go
@@ -222,6 +222,9 @@ type ChangeSettingsBody struct {
 	// Enable Query Analytics for PMM's internal PG database.
 	EnableInternalPgQAN *bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// Enable OpenManager.
+	EnableOM *bool `json:"enable_om,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsParamsBodyAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 
@@ -982,6 +985,9 @@ type ChangeSettingsOKBodySettings struct {
 
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
+
+	// True if OpenManager is enabled.
+	OMEnabled bool `json:"om_enabled,omitempty"`
 
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`

--- a/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
@@ -707,6 +707,9 @@ type GetReadOnlySettingsOKBodySettings struct {
 
 	// True if Access Control is enabled.
 	EnableAccessControl bool `json:"enable_access_control,omitempty"`
+
+	// True if OpenManager is enabled.
+	OMEnabled bool `json:"om_enabled,omitempty"`
 }
 
 // Validate validates this get read only settings OK body settings

--- a/api/server/v1/json/client/server_service/get_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_settings_responses.go
@@ -732,6 +732,9 @@ type GetSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if OpenManager is enabled.
+	OMEnabled bool `json:"om_enabled,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *GetSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/v1.json
+++ b/api/server/v1/json/v1.json
@@ -311,6 +311,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -488,6 +493,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -629,6 +640,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -729,6 +745,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -1013,8 +1013,10 @@ type Settings struct {
 	DefaultRoleId uint32 `protobuf:"varint,18,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQan bool `protobuf:"varint,19,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if OpenManager is enabled.
+	OmEnabled     bool `protobuf:"varint,21,opt,name=om_enabled,json=omEnabled,proto3" json:"om_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Settings) Reset() {
@@ -1175,6 +1177,13 @@ func (x *Settings) GetEnableInternalPgQan() bool {
 	return false
 }
 
+func (x *Settings) GetOmEnabled() bool {
+	if x != nil {
+		return x.OmEnabled
+	}
+	return false
+}
+
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.
 type ReadOnlySettings struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1194,8 +1203,10 @@ type ReadOnlySettings struct {
 	AzurediscoverEnabled bool `protobuf:"varint,7,opt,name=azurediscover_enabled,json=azurediscoverEnabled,proto3" json:"azurediscover_enabled,omitempty"`
 	// True if Access Control is enabled.
 	EnableAccessControl bool `protobuf:"varint,8,opt,name=enable_access_control,json=enableAccessControl,proto3" json:"enable_access_control,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if OpenManager is enabled.
+	OmEnabled     bool `protobuf:"varint,9,opt,name=om_enabled,json=omEnabled,proto3" json:"om_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ReadOnlySettings) Reset() {
@@ -1280,6 +1291,13 @@ func (x *ReadOnlySettings) GetAzurediscoverEnabled() bool {
 func (x *ReadOnlySettings) GetEnableAccessControl() bool {
 	if x != nil {
 		return x.EnableAccessControl
+	}
+	return false
+}
+
+func (x *ReadOnlySettings) GetOmEnabled() bool {
+	if x != nil {
+		return x.OmEnabled
 	}
 	return false
 }
@@ -1469,8 +1487,10 @@ type ChangeSettingsRequest struct {
 	EnableAccessControl *bool `protobuf:"varint,13,opt,name=enable_access_control,json=enableAccessControl,proto3,oneof" json:"enable_access_control,omitempty"`
 	// Enable Query Analytics for PMM's internal PG database.
 	EnableInternalPgQan *bool `protobuf:"varint,14,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3,oneof" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Enable OpenManager.
+	EnableOm      *bool `protobuf:"varint,16,opt,name=enable_om,json=enableOm,proto3,oneof" json:"enable_om,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ChangeSettingsRequest) Reset() {
@@ -1601,6 +1621,13 @@ func (x *ChangeSettingsRequest) GetEnableInternalPgQan() bool {
 	return false
 }
 
+func (x *ChangeSettingsRequest) GetEnableOm() bool {
+	if x != nil && x.EnableOm != nil {
+		return *x.EnableOm
+	}
+	return false
+}
+
 type ChangeSettingsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Settings      *Settings              `protobuf:"bytes,1,opt,name=settings,proto3" json:"settings,omitempty"`
@@ -1703,7 +1730,7 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13AdvisorRunIntervals\x12F\n" +
 	"\x11standard_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10standardInterval\x12>\n" +
 	"\rrare_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\frareInterval\x12F\n" +
-	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xbc\a\n" +
+	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xdb\a\n" +
 	"\bSettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12N\n" +
@@ -1723,7 +1750,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13telemetry_summaries\x18\x10 \x03(\tR\x12telemetrySummaries\x122\n" +
 	"\x15enable_access_control\x18\x11 \x01(\bR\x13enableAccessControl\x12&\n" +
 	"\x0fdefault_role_id\x18\x12 \x01(\rR\rdefaultRoleId\x123\n" +
-	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQanJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\x8f\x03\n" +
+	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQan\x12\x1d\n" +
+	"\n" +
+	"om_enabled\x18\x15 \x01(\bR\tomEnabledJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\xae\x03\n" +
 	"\x10ReadOnlySettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12'\n" +
@@ -1732,13 +1761,15 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x12pmm_public_address\x18\x05 \x01(\tR\x10pmmPublicAddress\x12:\n" +
 	"\x19backup_management_enabled\x18\x06 \x01(\bR\x17backupManagementEnabled\x123\n" +
 	"\x15azurediscover_enabled\x18\a \x01(\bR\x14azurediscoverEnabled\x122\n" +
-	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\"\x14\n" +
+	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\x12\x1d\n" +
+	"\n" +
+	"om_enabled\x18\t \x01(\bR\tomEnabled\"\x14\n" +
 	"\x12GetSettingsRequest\"\x1c\n" +
 	"\x1aGetReadOnlySettingsRequest\"F\n" +
 	"\x13GetSettingsResponse\x12/\n" +
 	"\bsettings\x18\x01 \x01(\v2\x13.server.v1.SettingsR\bsettings\"V\n" +
 	"\x1bGetReadOnlySettingsResponse\x127\n" +
-	"\bsettings\x18\x01 \x01(\v2\x1b.server.v1.ReadOnlySettingsR\bsettings\"\xbd\b\n" +
+	"\bsettings\x18\x01 \x01(\v2\x1b.server.v1.ReadOnlySettingsR\bsettings\"\xed\b\n" +
 	"\x15ChangeSettingsRequest\x12*\n" +
 	"\x0eenable_updates\x18\x01 \x01(\bH\x00R\renableUpdates\x88\x01\x01\x12.\n" +
 	"\x10enable_telemetry\x18\x02 \x01(\bH\x01R\x0fenableTelemetry\x88\x01\x01\x12N\n" +
@@ -1755,7 +1786,8 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x18enable_backup_management\x18\f \x01(\bH\bR\x16enableBackupManagement\x88\x01\x01\x127\n" +
 	"\x15enable_access_control\x18\r \x01(\bH\tR\x13enableAccessControl\x88\x01\x01\x128\n" +
 	"\x16enable_internal_pg_qan\x18\x0e \x01(\bH\n" +
-	"R\x13enableInternalPgQan\x88\x01\x01B\x11\n" +
+	"R\x13enableInternalPgQan\x88\x01\x01\x12 \n" +
+	"\tenable_om\x18\x10 \x01(\bH\vR\benableOm\x88\x01\x01B\x11\n" +
 	"\x0f_enable_updatesB\x13\n" +
 	"\x11_enable_telemetryB\n" +
 	"\n" +
@@ -1767,7 +1799,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x15_enable_azurediscoverB\x1b\n" +
 	"\x19_enable_backup_managementB\x18\n" +
 	"\x16_enable_access_controlB\x19\n" +
-	"\x17_enable_internal_pg_qanJ\x04\b\x0f\x10\x10R\x16update_snooze_duration\"I\n" +
+	"\x17_enable_internal_pg_qanB\f\n" +
+	"\n" +
+	"_enable_omJ\x04\b\x0f\x10\x10R\x16update_snooze_duration\"I\n" +
 	"\x16ChangeSettingsResponse\x12/\n" +
 	"\bsettings\x18\x01 \x01(\v2\x13.server.v1.SettingsR\bsettings*\xce\x01\n" +
 	"\x12DistributionMethod\x12#\n" +

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -154,7 +154,8 @@ func (e VersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionInfoValidationError{}
@@ -256,7 +257,8 @@ func (e VersionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionRequestValidationError{}
@@ -418,7 +420,8 @@ func (e VersionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = VersionResponseValidationError{}
@@ -518,7 +521,8 @@ func (e ReadinessRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadinessRequestValidationError{}
@@ -620,7 +624,8 @@ func (e ReadinessResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadinessResponseValidationError{}
@@ -722,7 +727,8 @@ func (e LeaderHealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = LeaderHealthCheckRequestValidationError{}
@@ -824,7 +830,8 @@ func (e LeaderHealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = LeaderHealthCheckResponseValidationError{}
@@ -930,7 +937,8 @@ func (e CheckUpdatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = CheckUpdatesRequestValidationError{}
@@ -1069,7 +1077,8 @@ func (e DockerVersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = DockerVersionInfoValidationError{}
@@ -1262,7 +1271,8 @@ func (e CheckUpdatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = CheckUpdatesResponseValidationError{}
@@ -1364,7 +1374,8 @@ func (e ListChangeLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ListChangeLogsRequestValidationError{}
@@ -1529,7 +1540,8 @@ func (e ListChangeLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ListChangeLogsResponseValidationError{}
@@ -1932,7 +1944,8 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = MetricsResolutionsValidationError{}
@@ -2121,7 +2134,8 @@ func (e AdvisorRunIntervalsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = AdvisorRunIntervalsValidationError{}
@@ -2335,7 +2349,8 @@ func (e SettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = SettingsValidationError{}
@@ -2453,7 +2468,8 @@ func (e ReadOnlySettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ReadOnlySettingsValidationError{}
@@ -2555,7 +2571,8 @@ func (e GetSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetSettingsRequestValidationError{}
@@ -2657,7 +2674,8 @@ func (e GetReadOnlySettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetReadOnlySettingsRequestValidationError{}
@@ -2788,7 +2806,8 @@ func (e GetSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetSettingsResponseValidationError{}
@@ -2920,7 +2939,8 @@ func (e GetReadOnlySettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = GetReadOnlySettingsResponseValidationError{}
@@ -3055,7 +3075,6 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 	}
 
 	if m.AwsPartitions != nil {
-
 		if all {
 			switch v := interface{}(m.GetAwsPartitions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -3084,7 +3103,6 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 				}
 			}
 		}
-
 	}
 
 	if m.EnableAdvisor != nil {
@@ -3186,7 +3204,8 @@ func (e ChangeSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ChangeSettingsRequestValidationError{}
@@ -3317,7 +3336,8 @@ func (e ChangeSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause)
+		cause,
+	)
 }
 
 var _ error = ChangeSettingsResponseValidationError{}

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -154,8 +154,7 @@ func (e VersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionInfoValidationError{}
@@ -257,8 +256,7 @@ func (e VersionRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionRequestValidationError{}
@@ -420,8 +418,7 @@ func (e VersionResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = VersionResponseValidationError{}
@@ -521,8 +518,7 @@ func (e ReadinessRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessRequestValidationError{}
@@ -624,8 +620,7 @@ func (e ReadinessResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadinessResponseValidationError{}
@@ -727,8 +722,7 @@ func (e LeaderHealthCheckRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckRequestValidationError{}
@@ -830,8 +824,7 @@ func (e LeaderHealthCheckResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = LeaderHealthCheckResponseValidationError{}
@@ -937,8 +930,7 @@ func (e CheckUpdatesRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesRequestValidationError{}
@@ -1077,8 +1069,7 @@ func (e DockerVersionInfoValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = DockerVersionInfoValidationError{}
@@ -1271,8 +1262,7 @@ func (e CheckUpdatesResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = CheckUpdatesResponseValidationError{}
@@ -1374,8 +1364,7 @@ func (e ListChangeLogsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsRequestValidationError{}
@@ -1540,8 +1529,7 @@ func (e ListChangeLogsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ListChangeLogsResponseValidationError{}
@@ -1944,8 +1932,7 @@ func (e MetricsResolutionsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = MetricsResolutionsValidationError{}
@@ -2134,8 +2121,7 @@ func (e AdvisorRunIntervalsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = AdvisorRunIntervalsValidationError{}
@@ -2283,6 +2269,8 @@ func (m *Settings) validate(all bool) error {
 
 	// no validation rules for EnableInternalPgQan
 
+	// no validation rules for OmEnabled
+
 	if len(errors) > 0 {
 		return SettingsMultiError(errors)
 	}
@@ -2347,8 +2335,7 @@ func (e SettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = SettingsValidationError{}
@@ -2398,6 +2385,8 @@ func (m *ReadOnlySettings) validate(all bool) error {
 	// no validation rules for AzurediscoverEnabled
 
 	// no validation rules for EnableAccessControl
+
+	// no validation rules for OmEnabled
 
 	if len(errors) > 0 {
 		return ReadOnlySettingsMultiError(errors)
@@ -2464,8 +2453,7 @@ func (e ReadOnlySettingsValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ReadOnlySettingsValidationError{}
@@ -2567,8 +2555,7 @@ func (e GetSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsRequestValidationError{}
@@ -2670,8 +2657,7 @@ func (e GetReadOnlySettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsRequestValidationError{}
@@ -2802,8 +2788,7 @@ func (e GetSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetSettingsResponseValidationError{}
@@ -2935,8 +2920,7 @@ func (e GetReadOnlySettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = GetReadOnlySettingsResponseValidationError{}
@@ -3071,6 +3055,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 	}
 
 	if m.AwsPartitions != nil {
+
 		if all {
 			switch v := interface{}(m.GetAwsPartitions()).(type) {
 			case interface{ ValidateAll() error }:
@@ -3099,6 +3084,7 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 				}
 			}
 		}
+
 	}
 
 	if m.EnableAdvisor != nil {
@@ -3127,6 +3113,10 @@ func (m *ChangeSettingsRequest) validate(all bool) error {
 
 	if m.EnableInternalPgQan != nil {
 		// no validation rules for EnableInternalPgQan
+	}
+
+	if m.EnableOm != nil {
+		// no validation rules for EnableOm
 	}
 
 	if len(errors) > 0 {
@@ -3196,8 +3186,7 @@ func (e ChangeSettingsRequestValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsRequestValidationError{}
@@ -3328,8 +3317,7 @@ func (e ChangeSettingsResponseValidationError) Error() string {
 		key,
 		e.field,
 		e.reason,
-		cause,
-	)
+		cause)
 }
 
 var _ error = ChangeSettingsResponseValidationError{}

--- a/api/server/v1/server.proto
+++ b/api/server/v1/server.proto
@@ -176,6 +176,8 @@ message Settings {
   // Field 20 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 20;
   reserved "update_snooze_duration";
+  // True if OpenManager is enabled.
+  bool om_enabled = 21;
 }
 
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.
@@ -196,6 +198,8 @@ message ReadOnlySettings {
   bool azurediscover_enabled = 7;
   // True if Access Control is enabled.
   bool enable_access_control = 8;
+  // True if OpenManager is enabled.
+  bool om_enabled = 9;
 }
 
 message GetSettingsRequest {}
@@ -237,6 +241,8 @@ message ChangeSettingsRequest {
   // Field 15 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 15;
   reserved "update_snooze_duration";
+  // Enable OpenManager.
+  optional bool enable_om = 16;
 }
 
 message ChangeSettingsResponse {

--- a/api/swagger/swagger-dev.json
+++ b/api/swagger/swagger-dev.json
@@ -35381,6 +35381,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -35558,6 +35563,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -35699,6 +35710,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -35799,6 +35815,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -34408,6 +34408,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -34585,6 +34590,12 @@
                   "type": "boolean",
                   "x-nullable": true,
                   "x-order": 13
+                },
+                "enable_om": {
+                  "description": "Enable OpenManager.",
+                  "type": "boolean",
+                  "x-nullable": true,
+                  "x-order": 14
                 }
               }
             }
@@ -34726,6 +34737,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -34826,6 +34842,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "om_enabled": {
+                      "description": "True if OpenManager is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/managed/models/settings.go
+++ b/managed/models/settings.go
@@ -33,6 +33,7 @@ const (
 	AzureDiscoverEnabledDefault        = false
 	AccessControlEnabledDefault        = false
 	InternalPgQANEnabledDefault        = false
+	OMEnabledDefault                   = false
 	awsPartitionID                     = "aws"
 )
 
@@ -118,6 +119,12 @@ type Settings struct {
 
 	// Contains all encrypted tables in format 'db.table.column'.
 	EncryptedItems []string `json:"encrypted_items"`
+
+	// OM holds OpenManager's settings.
+	OM struct {
+		// Enabled is true if OpenManager is enabled.
+		Enabled *bool `json:"enabled"`
+	} `json:"om"`
 }
 
 // IsAlertingEnabled returns true if alerting is enabled.
@@ -180,6 +187,14 @@ func (s *Settings) IsAccessControlEnabled() bool {
 		return *s.AccessControl.Enabled
 	}
 	return AccessControlEnabledDefault
+}
+
+// IsOMEnabled returns true if OpenManager is enabled.
+func (s *Settings) IsOMEnabled() bool {
+	if s.OM.Enabled != nil {
+		return *s.OM.Enabled
+	}
+	return OMEnabledDefault
 }
 
 // IsVictoriaMetricsCacheEnabled returns true if VictoriaMetrics cache is enabled.

--- a/managed/models/settings_helpers.go
+++ b/managed/models/settings_helpers.go
@@ -97,6 +97,9 @@ type ChangeSettingsParams struct {
 	// EnableInternalPgQAN enables Query Analytics for PMM's internal PG database.
 	EnableInternalPgQAN *bool
 
+	// EnableOM enables OpenManager.
+	EnableOM *bool
+
 	// DefaultRoleID sets a default role to be assigned to new users.
 	DefaultRoleID *int
 
@@ -233,6 +236,10 @@ func UpdateSettings(q reform.DBTX, params *ChangeSettingsParams) (*Settings, err
 
 	if params.EnableBackupManagement != nil {
 		settings.BackupManagement.Enabled = params.EnableBackupManagement
+	}
+
+	if params.EnableOM != nil {
+		settings.OM.Enabled = params.EnableOM
 	}
 
 	if params.DefaultRoleID != nil {

--- a/managed/models/settings_helpers_test.go
+++ b/managed/models/settings_helpers_test.go
@@ -299,6 +299,16 @@ func TestSettings(t *testing.T) {
 			assert.True(t, *ns.Alerting.Enabled)
 		})
 
+		t.Run("enable OpenManager", func(t *testing.T) {
+			s, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableOM: new(false)})
+			require.NoError(t, err)
+			assert.False(t, s.IsOMEnabled())
+
+			ns, err := models.UpdateSettings(sqlDB, &models.ChangeSettingsParams{EnableOM: new(true)})
+			require.NoError(t, err)
+			assert.True(t, ns.IsOMEnabled())
+		})
+
 		t.Run("Set PMM server ID", func(t *testing.T) {
 			t.Run("not set", func(t *testing.T) {
 				settings, err := models.GetSettings(sqlDB)

--- a/managed/services/server/server.go
+++ b/managed/services/server/server.go
@@ -376,6 +376,7 @@ func (s *Server) convertSettings(settings *models.Settings, disableInternalPgQan
 
 		EnableAccessControl: settings.IsAccessControlEnabled(),
 		DefaultRoleId:       convertDefaultRoleID(settings.DefaultRoleID),
+		OmEnabled:           settings.IsOMEnabled(),
 	}
 
 	return res
@@ -400,6 +401,7 @@ func (s *Server) convertReadOnlySettings(settings *models.Settings) *serverv1.Re
 		BackupManagementEnabled: settings.IsBackupManagementEnabled(),
 		AzurediscoverEnabled:    settings.IsAzureDiscoverEnabled(),
 		EnableAccessControl:     settings.IsAccessControlEnabled(),
+		OmEnabled:               settings.IsOMEnabled(),
 	}
 
 	return res

--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -65,6 +65,7 @@ func (e InvalidDurationError) Error() string { return string(e) }
 //   - PMM_DATA_RETENTION is the duration of how long keep time-series data in ClickHouse;
 //   - PMM_ENABLE_AZURE_DISCOVER enables Azure Discover;
 //   - PMM_ENABLE_ACCESS_CONTROL enables Access control;
+//   - PMM_ENABLE_OM enables OpenManager;
 //   - the environment variables prefixed with GF_ are related to Grafana.
 //   - the environment variables related to proxies
 //   - the environment variable set by podman
@@ -208,6 +209,14 @@ func ParseEnvVars(envs []string) (*models.ChangeSettingsParams, []error, []strin
 				continue
 			}
 			envSettings.EnableBackupManagement = &b
+
+		case "PMM_ENABLE_OM":
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("invalid value %q for environment variable %q", v, k))
+				continue
+			}
+			envSettings.EnableOM = &b
 
 		case "PMM_ENABLE_NOMAD":
 			b, err := strconv.ParseBool(v)

--- a/ui/apps/pmm/src/api/__mocks__/settings.ts
+++ b/ui/apps/pmm/src/api/__mocks__/settings.ts
@@ -15,6 +15,7 @@ export const READONLY_SETTINGS_MOCK: ReadonlySettings = {
   backupManagementEnabled: true,
   azurediscoverEnabled: false,
   enableAccessControl: false,
+  omEnabled: false,
 };
 
 export const SETTINGS_MOCK: Settings = {

--- a/ui/apps/pmm/src/contexts/settings/settings.provider.tsx
+++ b/ui/apps/pmm/src/contexts/settings/settings.provider.tsx
@@ -38,6 +38,7 @@ export const SettingsProvider: FC<PropsWithChildren> = ({ children }) => {
         backupManagementEnabled: false,
         azurediscoverEnabled: false,
         enableAccessControl: false,
+        omEnabled: false,
         frontend: frontendSettings.data,
         // check if pmm-compat-app plugin is enabled
         newUIEnabled: frontendSettings.data.apps['pmm-compat-app']?.preload,

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -45,6 +45,10 @@ export const Messages = {
     accessControlTooltip:
       'Restrict data visibility based on user roles and labels.',
     accessControlLink: 'https://per.co.na/roles_permissions',
+    openManagerLabel: 'OpenManager',
+    openManagerTooltip:
+      'Option to enable/disable OpenManager, PMM periodic collection and the OpenManager Inventory app.',
+    openManagerLink: 'https://per.co.na/pmm-feature-status',
     publicAddressLabel: 'Public address',
     publicAddressTooltip:
       'The address or hostname PMM Server will be accessible at.',

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.schema.ts
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.schema.ts
@@ -40,6 +40,7 @@ export const advancedSettingsSchema = z
     frequentInterval: z.string(),
     azureDiscover: z.boolean(),
     accessControl: z.boolean(),
+    openManager: z.boolean(),
   })
   .superRefine((data, ctx) => {
     if (!data.stt) return;

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
@@ -406,6 +406,36 @@ export const AdvancedSettingsForm: FC<AdvancedSettingsFormProps> = ({
                 </IconButton>
               </Tooltip>
             </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              data-testid="advanced-open-manager"
+            >
+              <SwitchInput name="openManager" label={m.openManagerLabel} />
+              <Tooltip
+                title={
+                  <Box data-testid="info-tooltip">
+                    <Typography variant="caption">
+                      {m.openManagerTooltip}{' '}
+                      <Link
+                        href={m.openManagerLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        color="inherit"
+                        sx={{ textDecorationColor: 'inherit' }}
+                      >
+                        {Messages.tooltipLinkText}
+                      </Link>
+                    </Typography>
+                  </Box>
+                }
+                arrow
+              >
+                <IconButton size="small" data-testid="info-icon">
+                  <InfoOutlinedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </Stack>
           </Stack>
         </Stack>
 

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
@@ -431,7 +431,11 @@ export const AdvancedSettingsForm: FC<AdvancedSettingsFormProps> = ({
                 }
                 arrow
               >
-                <IconButton size="small" data-testid="info-icon">
+                <IconButton
+                  aria-label={m.openManagerLabel}
+                  size="small"
+                  data-testid="info-icon"
+                >
                   <InfoOutlinedIcon fontSize="small" />
                 </IconButton>
               </Tooltip>

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.utils.ts
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.utils.ts
@@ -24,6 +24,7 @@ export const toFormValues = (
   ...convertCheckIntervalsToHours(settings.advisorRunIntervals),
   azureDiscover: settings.azurediscoverEnabled,
   accessControl: settings.enableAccessControl,
+  openManager: settings.omEnabled,
 });
 
 export const toPayload = (
@@ -50,5 +51,6 @@ export const toPayload = (
     advisorRunIntervals,
     enableAzurediscover: values.azureDiscover,
     enableAccessControl: values.accessControl,
+    enableOm: values.openManager,
   };
 };

--- a/ui/apps/pmm/src/types/settings.types.ts
+++ b/ui/apps/pmm/src/types/settings.types.ts
@@ -7,6 +7,7 @@ export interface ReadonlySettings {
   backupManagementEnabled: boolean;
   azurediscoverEnabled: boolean;
   enableAccessControl: boolean;
+  omEnabled: boolean;
 }
 
 export interface MetricsResolutions {
@@ -52,6 +53,7 @@ export interface UpdateSettingsPayload {
   enableAccessControl?: boolean;
   enableInternalPgQan?: boolean;
   awsPartitions?: string[];
+  enableOm?: boolean;
 }
 
 export interface FrontendSettings extends GetFrontendSettingsResponse {}

--- a/ui/apps/pmm/src/utils/testUtils.tsx
+++ b/ui/apps/pmm/src/utils/testUtils.tsx
@@ -110,6 +110,7 @@ export const wrapWithSettings = (
         backupManagementEnabled: false,
         azurediscoverEnabled: false,
         enableAccessControl: false,
+        omEnabled: false,
         ...props?.settings,
         frontend: {
           anonymousEnabled: false,


### PR DESCRIPTION
Recreated after #5851 was merged by mistake and reverted on `PMM-15299-open-manager` (see #5851 for the original description and discussion).

Same two commits as the original PR, unchanged:
- Add the OpenManager settings flag
- Regenerate the server/v1 swagger and JSON client for om_enabled