### PR TITLE
PMM-15407 Add SEP enablement telemetry

### DIFF
--- a/managed/services/telemetry/config.default.yml
+++ b/managed/services/telemetry/config.default.yml
@@ -973,6 +973,13 @@ telemetry:
       - metric_name: "pmm_server_builtin_postgres_disable"
         column: "PMM_DISABLE_BUILTIN_POSTGRES"
 
+  - id: PMMServerSEPEnabled
+    source: ENV_VARS
+    summary: "Use of SEP integration"
+    data:
+      - metric_name: "pmm_server_sep_enabled"
+        column: "PMM_ENABLE_SEP"
+
   - id: PMMServerHAUseOfDBs
     source: ENV_VARS
     transform:


### PR DESCRIPTION
Ticket number: PMM-15407

Feature build: SUBMODULES-4500 — the SEP integration feature build for this epic. This PR adds no user-visible surface of its own (telemetry only), so it needs no separate FB.

## What

Adds one telemetry item, `pmm_server_sep_enabled`, reporting whether the SEP integration is switched on.

```yaml
  - id: PMMServerSEPEnabled
    source: ENV_VARS
    summary: "Use of SEP integration"
    data:
      - metric_name: "pmm_server_sep_enabled"
        column: "PMM_ENABLE_SEP"
```

## Why

The SEP integration ships as Tech Preview in 3.10.0 and is entirely opt-in behind `PMM_ENABLE_SEP`. See https://github.com/percona/SEP/tree/pmm/sidecar/pmm-fb Nothing reports whether anyone turns it on, and the GA scope (PMM-15254) depends on knowing whether it is being used at all.

## How

Structurally identical to the existing `PMMServerHAEnabled` — same `ENV_VARS` datasource, same shape, no Go changes and no new machinery. Placed next to `PMMServerBuiltinDatabaseDisabled`, the flag SEP's enablement is actually coupled to in the entrypoint.

`PMM_ENABLE_SEP` reaches pmm-managed's process environment along the whole chain: `docker-compose.yml` passes it into the container, `entrypoint.sh` reads it at top level rather than in a subshell, and `[program:pmm-managed]` in `pmm.ini` sets no `environment =` directive so it inherits supervisord's environment. (`managed/utils/envvars/parser.go` explicitly *skips* it, but that only keeps it out of PMM Settings and out of the `pmm-managed-init` log — it does not remove it from the process environment, and the telemetry datasource reads `os.LookupEnv` directly.)

## Semantics — please read before building a dashboard

| `PMM_ENABLE_SEP` | Metric emitted | Value |
|---|---|---|
| `1` | yes | `"1"` |
| `true` | yes | `"true"` |
| `0` / `false` | yes | `"0"` / `"false"` |
| **unset or empty** | **no metric at all** | — |

Two consequences, both deliberate:

1. **Absence encodes "not enabled", not a literal `0`.** The `ENV_VARS` datasource emits a metric only when `os.LookupEnv` returns `ok && value != ""`, and passes the raw string through unmodified. This is the established encoding for exactly this question in PMM — `pmm_server_ha_enable` and `pmm_server_builtin_postgres_disable`, the only other `ENV_VARS` boolean flags, behave identically. Emitting a literal `0` would require adding a default-value field to `ConfigData` plus value normalization in the datasource; that was considered and rejected as disproportionate for one metric.

2. **This reports intent, not effective state.** The entrypoint *ignores* `PMM_ENABLE_SEP` when `PMM_HA_ENABLE` or `PMM_DISABLE_BUILTIN_POSTGRES` is set, logging `WARNING: ignoring PMM_ENABLE_SEP, the embedded PostgreSQL is not in use.` Such a deployment will report SEP as enabled while SEP cannot run. Both of those flags are already reported, so the consumer can correct for it: treat `pmm_server_sep_enabled` as truthy **and** neither of the other two as truthy.


## Related

- Depends on PMM-15238 (`PMM_ENABLE_SEP`), already merged.
- Not touched: documenting `PMM_ENABLE_SEP` in `documentation/docs/.../preview_env_var.md` alongside `PMM_HA_ENABLE` is a real gap, but user docs belong to PMM-15251 / #5850.
- Not touched: `pmm_server_ha_enable` shares both limitations above; changing it is a wider decision.

- [ ] API Docs updated — n/a, no API endpoints added, removed or altered.
