### PR TITLE
PMM-15281: Gate SEP's presence in the PMM UI on availability

### DIFF
--- a/ui/apps/pmm/src/contexts/navigation/navigation.provider.test.tsx
+++ b/ui/apps/pmm/src/contexts/navigation/navigation.provider.test.tsx
@@ -38,7 +38,8 @@ vi.mock('hooks/theme', () => ({
 
 const renderNavTree = (
   user: User = TEST_USER_ADMIN,
-  routerProps?: MemoryRouterProps
+  routerProps?: MemoryRouterProps,
+  settings?: { sepEnabled?: boolean; backupManagementEnabled?: boolean }
 ) => {
   const { result } = renderHook(() => useNavigation(), {
     wrapper: ({ children }) => (
@@ -50,7 +51,13 @@ const renderNavTree = (
           wrapWithUpdatesProvider(
             <NavigationProvider>{children}</NavigationProvider>
           ) as ReactElement,
-          { settings: { backupManagementEnabled: true } }
+          {
+            settings: {
+              backupManagementEnabled: true,
+              sepEnabled: true,
+              ...settings,
+            },
+          }
         )}
       </TestWrapper>
     ),
@@ -129,6 +136,14 @@ describe('NavigationProvider', () => {
 
     it('is withheld from anonymous, which has no SEP session to exchange', () => {
       const ids = renderNavTree(TEST_USER_ANONYMOUS).map((item) => item.id);
+
+      expect(ids).not.toContain('management');
+    });
+
+    it('is withheld when SEP is disabled in server settings', () => {
+      const ids = renderNavTree(TEST_USER_ADMIN, undefined, {
+        sepEnabled: false,
+      }).map((item) => item.id);
 
       expect(ids).not.toContain('management');
     });

--- a/ui/apps/pmm/src/contexts/navigation/navigation.provider.tsx
+++ b/ui/apps/pmm/src/contexts/navigation/navigation.provider.tsx
@@ -106,8 +106,9 @@ export const NavigationProvider: FC<PropsWithChildren> = ({ children }) => {
       //
       // Signed-in is the rule, so anonymous is excluded: it has no Grafana
       // session cookie to exchange for a SEP bearer, and the entry would open
-      // on SepAuthGate's failure card rather than on the app.
-      if (!user.isAnonymous) {
+      // on SepAuthGate's failure card rather than on the app. SEP navigation
+      // is also withheld when the integration is disabled (PMM_ENABLE_SEP).
+      if (!user.isAnonymous && settings?.sepEnabled) {
         items.push(...addSepApps());
       }
 

--- a/ui/apps/pmm/src/contexts/settings/settings.provider.tsx
+++ b/ui/apps/pmm/src/contexts/settings/settings.provider.tsx
@@ -38,6 +38,7 @@ export const SettingsProvider: FC<PropsWithChildren> = ({ children }) => {
         backupManagementEnabled: false,
         azurediscoverEnabled: false,
         enableAccessControl: false,
+        sepEnabled: false,
         frontend: frontendSettings.data,
         // check if pmm-compat-app plugin is enabled
         newUIEnabled: frontendSettings.data.apps['pmm-compat-app']?.preload,

--- a/ui/apps/pmm/src/sep/SepPage.test.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from '@testing-library/react';
+import { ReactElement } from 'react';
+import { SettingsContext } from 'contexts/settings';
 import { TestWrapper } from 'utils/testWrapper';
 import { wrapWithSettings } from 'utils/testUtils';
 import { TEST_USER_ADMIN, TEST_USER_VIEWER } from 'utils/testStubs';
@@ -22,7 +24,7 @@ const renderPage = (
     {
       wrapper: ({ children }) => (
         <TestWrapper userContext={{ isLoading: false, user }}>
-          {wrapWithSettings(children, { settings })}
+          {wrapWithSettings(children as ReactElement, { settings })}
         </TestWrapper>
       ),
     }
@@ -53,5 +55,61 @@ describe('SepPage', () => {
       )
     ).toBeInTheDocument();
     expect(screen.queryByTestId('sep-plugin')).not.toBeInTheDocument();
+  });
+
+  it('waits for settings instead of flashing not-enabled while they load', () => {
+    render(
+      <SepPage>
+        <div data-testid="sep-plugin" />
+      </SepPage>,
+      {
+        wrapper: ({ children }) => (
+          <TestWrapper
+            userContext={{ isLoading: false, user: TEST_USER_ADMIN }}
+          >
+            {wrapWithSettings(children as ReactElement, {
+              isLoading: true,
+              settings: { sepEnabled: true },
+            })}
+          </TestWrapper>
+        ),
+      }
+    );
+
+    expect(screen.getByTestId('sep-settings-loading')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This feature is not enabled. Contact your administrator.'
+      )
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sep-plugin')).not.toBeInTheDocument();
+  });
+
+  it('waits while settings are still null after the default context', () => {
+    render(
+      <SepPage>
+        <div data-testid="sep-plugin" />
+      </SepPage>,
+      {
+        wrapper: ({ children }) => (
+          <TestWrapper
+            userContext={{ isLoading: false, user: TEST_USER_ADMIN }}
+          >
+            <SettingsContext.Provider
+              value={{ isLoading: false, settings: null }}
+            >
+              {children}
+            </SettingsContext.Provider>
+          </TestWrapper>
+        ),
+      }
+    );
+
+    expect(screen.getByTestId('sep-settings-loading')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'This feature is not enabled. Contact your administrator.'
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/apps/pmm/src/sep/SepPage.test.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { TestWrapper } from 'utils/testWrapper';
+import { wrapWithSettings } from 'utils/testUtils';
 import { TEST_USER_ADMIN, TEST_USER_VIEWER } from 'utils/testStubs';
 import { User } from 'types/user.types';
 import { SepPage } from './SepPage';
@@ -10,7 +11,10 @@ vi.mock('./SepAuthGate', () => ({
   SepAuthGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-const renderPage = (user: User) =>
+const renderPage = (
+  user: User,
+  settings: { sepEnabled?: boolean } = { sepEnabled: true }
+) =>
   render(
     <SepPage>
       <div data-testid="sep-plugin" />
@@ -18,7 +22,7 @@ const renderPage = (user: User) =>
     {
       wrapper: ({ children }) => (
         <TestWrapper userContext={{ isLoading: false, user }}>
-          {children}
+          {wrapWithSettings(children, { settings })}
         </TestWrapper>
       ),
     }
@@ -38,5 +42,16 @@ describe('SepPage', () => {
     renderPage(TEST_USER_VIEWER);
 
     expect(screen.getByTestId('sep-plugin')).toBeInTheDocument();
+  });
+
+  it('renders an unavailable message when SEP is disabled', () => {
+    renderPage(TEST_USER_ADMIN, { sepEnabled: false });
+
+    expect(
+      screen.getByText(
+        'This feature is not enabled. Contact your administrator.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('sep-plugin')).not.toBeInTheDocument();
   });
 });

--- a/ui/apps/pmm/src/sep/SepPage.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.tsx
@@ -1,7 +1,9 @@
 import { FC, PropsWithChildren } from 'react';
+import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import { Page } from 'components/page';
+import { useSettings } from 'contexts/settings';
 import { SepAuthGate } from './SepAuthGate';
 import { SepAuthProvider } from './SepAuthProvider';
 
@@ -27,22 +29,40 @@ import { SepAuthProvider } from './SepAuthProvider';
  * component rendered while the exchange is still in flight must resolve the
  * same capability it will hold once the bearer lands, not the non-admin
  * fallback.
+ *
+ * When SEP is disabled (`sepEnabled` from server settings), direct navigation
+ * to a SEP route renders an explicit unavailable state instead of mounting the
+ * auth gate or firing SEP API requests.
  */
-export const SepPage: FC<PropsWithChildren> = ({ children }) => (
-  <Page maxWidth="full">
-    <Stack gap={3} sx={{ flex: 1 }}>
-      <SepAuthProvider>
-        <SepAuthGate>
-          {/*
-            A flex column that grows, not a plain block: it carries the height
-            handed down from Page so a plugin (or the ServiceNow setup prompt)
-            can centre itself in the page rather than in its own content box.
-          */}
-          <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-            {children}
-          </Box>
-        </SepAuthGate>
-      </SepAuthProvider>
-    </Stack>
-  </Page>
-);
+export const SepPage: FC<PropsWithChildren> = ({ children }) => {
+  const { settings } = useSettings();
+
+  if (!settings?.sepEnabled) {
+    return (
+      <Page maxWidth="full">
+        <Alert severity="info">
+          This feature is not enabled. Contact your administrator.
+        </Alert>
+      </Page>
+    );
+  }
+
+  return (
+    <Page maxWidth="full">
+      <Stack gap={3} sx={{ flex: 1 }}>
+        <SepAuthProvider>
+          <SepAuthGate>
+            {/*
+              A flex column that grows, not a plain block: it carries the height
+              handed down from Page so a plugin (or the ServiceNow setup prompt)
+              can centre itself in the page rather than in its own content box.
+            */}
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              {children}
+            </Box>
+          </SepAuthGate>
+        </SepAuthProvider>
+      </Stack>
+    </Page>
+  );
+};

--- a/ui/apps/pmm/src/sep/SepPage.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.tsx
@@ -1,6 +1,7 @@
 import { FC, PropsWithChildren } from 'react';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import { Page } from 'components/page';
 import { useSettings } from 'contexts/settings';
@@ -32,12 +33,23 @@ import { SepAuthProvider } from './SepAuthProvider';
  *
  * When SEP is disabled (`sepEnabled` from server settings), direct navigation
  * to a SEP route renders an explicit unavailable state instead of mounting the
- * auth gate or firing SEP API requests.
+ * auth gate or firing SEP API requests. Settings must resolve first — otherwise
+ * a hard refresh flashes "not enabled" while `settings` is still null.
  */
 export const SepPage: FC<PropsWithChildren> = ({ children }) => {
-  const { settings } = useSettings();
+  const { settings, isLoading } = useSettings();
 
-  if (!settings?.sepEnabled) {
+  if (isLoading || !settings) {
+    return (
+      <Page maxWidth="full">
+        <Stack alignItems="center" py={4}>
+          <CircularProgress data-testid="sep-settings-loading" />
+        </Stack>
+      </Page>
+    );
+  }
+
+  if (!settings.sepEnabled) {
     return (
       <Page maxWidth="full">
         <Alert severity="info">

--- a/ui/apps/pmm/src/types/settings.types.ts
+++ b/ui/apps/pmm/src/types/settings.types.ts
@@ -7,6 +7,7 @@ export interface ReadonlySettings {
   backupManagementEnabled: boolean;
   azurediscoverEnabled: boolean;
   enableAccessControl: boolean;
+  sepEnabled: boolean;
 }
 
 export interface MetricsResolutions {

--- a/ui/apps/pmm/src/utils/testUtils.tsx
+++ b/ui/apps/pmm/src/utils/testUtils.tsx
@@ -110,6 +110,7 @@ export const wrapWithSettings = (
         backupManagementEnabled: false,
         azurediscoverEnabled: false,
         enableAccessControl: false,
+        sepEnabled: false,
         ...props?.settings,
         frontend: {
           anonymousEnabled: false,


### PR DESCRIPTION
Ticket number: [PMM-15281](https://perconadev.atlassian.net/browse/PMM-15281)

## What

Gate SEP navigation and routes on `settings.sepEnabled` (the UI surface of `PMM_ENABLE_SEP`). When the integration is off, SEP entries stay out of the sidebar and direct navigation to a SEP route shows an explicit “not enabled” state instead of mounting the auth gate or firing SEP API requests.

SEP remains available to every signed-in user when enabled; write controls stay per-control via `canMutate` (PMM-15358), not behind `isPMMAdmin`.

## Changes

- Add `sepEnabled` to `ReadonlySettings` and default it to `false` for anonymous users / test stubs
- Push SEP Management nav only when `!user.isAnonymous && settings?.sepEnabled`
- Gate `SepPage` on settings: wait while loading/`settings` is null, then show unavailable when `sepEnabled` is false
- Cover enabled, disabled, and loading paths in nav and `SepPage` tests

## Notes

- Frontend-only. Consumes `sep_enabled` from `/v1/server/settings` and `/v1/server/settings/readonly` once the backend exposes it; until then the UI treats SEP as disabled (safe default).
- No `/health` probe — gating is env-var / settings only, matching the updated ticket direction.

If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/main/documentation/api) as well:

- [ ] API Docs updated

If this PR is related to other PRs, contributions, or ongoing work in this or other repositories, please reference them here:

- Depends on a follow-up that surfaces `PMM_ENABLE_SEP` as `sep_enabled` on Settings / ReadOnlySettings
- Related nginx / proxy work: PMM-15279 / #5759 (`PMM_ENABLE_SEP`, `/sep/` mount)


[PMM-15281]: https://perconadev.atlassian.net/browse/PMM-15281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ