### PR TITLE
PMM-14787 Declare data retention in HA

### DIFF
--- a/api/server/v1/json/client/server_service/change_settings_responses.go
+++ b/api/server/v1/json/client/server_service/change_settings_responses.go
@@ -983,6 +983,9 @@ type ChangeSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if data retention is declared by the deployment, so ChangeSettings refuses to move it.
+	DataRetentionReadonly bool `json:"data_retention_readonly,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/client/server_service/get_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_settings_responses.go
@@ -732,6 +732,9 @@ type GetSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if data retention is declared by the deployment, so ChangeSettings refuses to move it.
+	DataRetentionReadonly bool `json:"data_retention_readonly,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *GetSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/v1.json
+++ b/api/server/v1/json/v1.json
@@ -311,6 +311,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -629,6 +634,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -1013,8 +1013,10 @@ type Settings struct {
 	DefaultRoleId uint32 `protobuf:"varint,18,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQan bool `protobuf:"varint,19,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if data retention is declared by the deployment, so ChangeSettings refuses to move it.
+	DataRetentionReadonly bool `protobuf:"varint,21,opt,name=data_retention_readonly,json=dataRetentionReadonly,proto3" json:"data_retention_readonly,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *Settings) Reset() {
@@ -1171,6 +1173,13 @@ func (x *Settings) GetDefaultRoleId() uint32 {
 func (x *Settings) GetEnableInternalPgQan() bool {
 	if x != nil {
 		return x.EnableInternalPgQan
+	}
+	return false
+}
+
+func (x *Settings) GetDataRetentionReadonly() bool {
+	if x != nil {
+		return x.DataRetentionReadonly
 	}
 	return false
 }
@@ -1703,7 +1712,7 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13AdvisorRunIntervals\x12F\n" +
 	"\x11standard_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10standardInterval\x12>\n" +
 	"\rrare_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\frareInterval\x12F\n" +
-	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xbc\a\n" +
+	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xf4\a\n" +
 	"\bSettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12N\n" +
@@ -1723,7 +1732,8 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13telemetry_summaries\x18\x10 \x03(\tR\x12telemetrySummaries\x122\n" +
 	"\x15enable_access_control\x18\x11 \x01(\bR\x13enableAccessControl\x12&\n" +
 	"\x0fdefault_role_id\x18\x12 \x01(\rR\rdefaultRoleId\x123\n" +
-	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQanJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\x8f\x03\n" +
+	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQan\x126\n" +
+	"\x17data_retention_readonly\x18\x15 \x01(\bR\x15dataRetentionReadonlyJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\x8f\x03\n" +
 	"\x10ReadOnlySettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12'\n" +

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -2283,6 +2283,8 @@ func (m *Settings) validate(all bool) error {
 
 	// no validation rules for EnableInternalPgQan
 
+	// no validation rules for DataRetentionReadonly
+
 	if len(errors) > 0 {
 		return SettingsMultiError(errors)
 	}

--- a/api/server/v1/server.proto
+++ b/api/server/v1/server.proto
@@ -176,6 +176,8 @@ message Settings {
   // Field 20 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 20;
   reserved "update_snooze_duration";
+  // True if data retention is declared by the deployment, so ChangeSettings refuses to move it.
+  bool data_retention_readonly = 21;
 }
 
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.

--- a/api/swagger/swagger-dev.json
+++ b/api/swagger/swagger-dev.json
@@ -32427,6 +32427,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -32745,6 +32750,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -31454,6 +31454,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -31772,6 +31777,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "data_retention_readonly": {
+                      "description": "True if data retention is declared by the deployment, so ChangeSettings refuses to move it.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0

--- a/documentation/docs/configure-pmm/advanced_settings.md
+++ b/documentation/docs/configure-pmm/advanced_settings.md
@@ -12,6 +12,13 @@ If you configure data retention using the [Change Settings API](https://percona-
 
 For example, to set 30-day retention: `"data_retention": "2592000s"`
 
+### When data retention is read-only
+
+The field is read-only, and the API rejects a change to it, when the deployment owns the value:
+
+- `PMM_DATA_RETENTION` is set. The environment variable wins over the stored setting.
+- PMM runs as an [HA cluster](../install-pmm/install-HA-clustered.md). Every replica enforces retention against the same stores, so the value is declared once in `values.yaml` rather than changed at runtime.
+
 ## Telemetry
 
 The **Telemetry** switch enables gathering and sending basic **anonymous** data to Percona, which helps us to determine where to focus the development and what is the uptake for each release of PMM. 

--- a/documentation/docs/install-pmm/install-HA-clustered.md
+++ b/documentation/docs/install-pmm/install-HA-clustered.md
@@ -727,6 +727,13 @@ pmmEnv:
   # Add other environment variables as needed
 ```
 
+!!! note "Data retention is declared, not clicked, in HA"
+    In an HA cluster, data retention is owned by `values.yaml`, not by the UI. Every replica enforces retention against the same VictoriaMetrics and ClickHouse but renders its own configuration at start-up, so a value that could move at runtime is a value the replicas would disagree about.
+
+    **Configuration > Settings > Advanced Settings** therefore shows **Data retention** as read-only, and `PUT /v1/server/settings` rejects a change to it. To change retention, update `PMM_DATA_RETENTION` and run `helm upgrade`; the rollout restarts every replica on the new value.
+
+    Set `victoriaMetrics.vmstorage.retentionPeriod` to the same period so metrics and Query Analytics expire together.
+
 For all available variables, see [PMM environment variables](../install-pmm/install-pmm-server/deployment-options/docker/env_var.md).
 
 #### Common customizations
@@ -1102,7 +1109,7 @@ We are aware of the following issues in this Tech Preview version and plan to fi
 | **[PMM-14706](https://perconadev.atlassian.net/browse/PMM-14706)**: Extra 'pmm-' prefix | PostgreSQL nodes show as `pmm-pmm-ha-pg-...` | Cosmetic only - no action needed |
 | **[PMM-14707](https://perconadev.atlassian.net/browse/PMM-14707)**: Wrong PostgreSQL status | Inventory shows FAILED/UNSPECIFIED despite working metrics | Check dashboards to verify metrics flow |
 | **[PMM-14734](https://perconadev.atlassian.net/browse/PMM-14734)**: Incorrect status | HA badge on PMM Home Dashboard may not reflect true cluster health | Use Inventory view or kubectl commands to check actual cluster status |                                   
-| **[PMM-14709](https://perconadev.atlassian.net/browse/PMM-14709)**: Data retention does not work on HA | Changing data retention under **Configuration > Settings > Advanced Settings** has no effect and older metrics remain available despite the new retention value. | Technical Preview only: The UI-based data retention setting does not work in HA clusters. To implement retention, configure it directly in ClickHouse using `ALTER TABLE ... TTL` instead of relying on this UI option to remove old metrics. |
+| **[PMM-14709](https://perconadev.atlassian.net/browse/PMM-14709)**: Data retention cannot be changed from the UI on HA | **Data retention** under **Configuration > Settings > Advanced Settings** is read-only, and the API rejects a change to it. | By design: retention is declared in `values.yaml`. See [Adjust data retention and other settings](#adjust-data-retention-and-other-settings). |
 
 ### Scaling limitations
 

--- a/managed/services/server/server.go
+++ b/managed/services/server/server.go
@@ -346,6 +346,42 @@ func (s *Server) UpdateStatus(ctx context.Context, _ *serverv1.UpdateStatusReque
 	}, nil
 }
 
+// dataRetentionIsDeclared reports whether data retention belongs to the deployment rather than to
+// this API. PMM_DATA_RETENTION pins it everywhere. HA pins it too: every replica enforces retention
+// against the same VictoriaMetrics and ClickHouse, but each renders its own supervisord flags at
+// start-up, so a value that can move at runtime is a value the replicas disagree about.
+//
+// Callers must hold envRW.
+func (s *Server) dataRetentionIsDeclared() bool {
+	return s.envSettings.DataRetention != 0 || s.haService.Params().Enabled
+}
+
+// validateDataRetentionInHA rejects a change to data retention on an HA cluster that has not
+// declared one. A cluster that has is already covered by the PMM_DATA_RETENTION check, which cannot
+// cover this case because telling a real change from an unchanged field needs the stored value.
+//
+// A zero newValue means the field was omitted, and the current value is always accepted, because the
+// settings form resubmits every field on save.
+//
+// Callers must hold envRW.
+func (s *Server) validateDataRetentionInHA(ctx context.Context, newValue time.Duration) error {
+	if newValue == 0 || s.envSettings.DataRetention != 0 || !s.haService.Params().Enabled {
+		return nil
+	}
+
+	settings, err := models.GetSettings(s.db.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	if newValue == settings.DataRetention {
+		return nil
+	}
+
+	return status.Error(codes.FailedPrecondition,
+		"Data retention is declared by the deployment in HA. Set PMM_DATA_RETENTION on every replica to change it.")
+}
+
 // convertSettings merges database settings and settings from environment variables into API response.
 func (s *Server) convertSettings(settings *models.Settings, disableInternalPgQan bool) *serverv1.Settings {
 	res := &serverv1.Settings{
@@ -361,13 +397,14 @@ func (s *Server) convertSettings(settings *models.Settings, disableInternalPgQan
 			StandardInterval: durationpb.New(settings.SaaS.AdvisorRunIntervals.StandardInterval),
 			FrequentInterval: durationpb.New(settings.SaaS.AdvisorRunIntervals.FrequentInterval),
 		},
-		DataRetention:        durationpb.New(settings.DataRetention),
-		SshKey:               settings.SSHKey,
-		AwsPartitions:        settings.AWSPartitions,
-		AdvisorEnabled:       settings.IsAdvisorsEnabled(),
-		AzurediscoverEnabled: settings.IsAzureDiscoverEnabled(),
-		PmmPublicAddress:     settings.PMMPublicAddress,
-		EnableInternalPgQan:  !disableInternalPgQan,
+		DataRetention:         durationpb.New(settings.DataRetention),
+		DataRetentionReadonly: s.dataRetentionIsDeclared(),
+		SshKey:                settings.SSHKey,
+		AwsPartitions:         settings.AWSPartitions,
+		AdvisorEnabled:        settings.IsAdvisorsEnabled(),
+		AzurediscoverEnabled:  settings.IsAzureDiscoverEnabled(),
+		PmmPublicAddress:      settings.PMMPublicAddress,
+		EnableInternalPgQan:   !disableInternalPgQan,
 
 		AlertingEnabled:         settings.IsAlertingEnabled(),
 		BackupManagementEnabled: settings.IsBackupManagementEnabled(),
@@ -501,7 +538,7 @@ func (s *Server) validateChangeSettingsRequest(ctx context.Context, req *serverv
 		return status.Error(codes.FailedPrecondition, "Data retention for queries is set via PMM_DATA_RETENTION environment variable.")
 	}
 
-	return nil
+	return s.validateDataRetentionInHA(ctx, req.DataRetention.AsDuration())
 }
 
 // ChangeSettings changes PMM Server settings.

--- a/managed/services/server/server_test.go
+++ b/managed/services/server/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/reform.v1"
 	"gopkg.in/reform.v1/dialects/postgresql"
 
@@ -263,6 +264,35 @@ func TestServer(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, settings.Settings.AlertingEnabled)
 		assert.True(t, settings.Settings.AzurediscoverEnabled)
+	})
+
+	t.Run("ChangeSettings data retention in HA", func(t *testing.T) {
+		server := newServer(t)
+		server.UpdateSettingsFromEnv(context.TODO(), []string{})
+
+		var ha mockHaService
+		ha.Test(t)
+		ha.On("Params").Return(&models.HAParams{Enabled: true})
+		server.haService = &ha
+
+		ctx := context.TODO()
+
+		current, err := server.GetSettings(ctx, &serverv1.GetSettingsRequest{})
+		require.NoError(t, err)
+		assert.True(t, current.Settings.DataRetentionReadonly)
+
+		// The settings form resubmits every field, so the unchanged value has to keep working.
+		_, err = server.ChangeSettings(ctx, &serverv1.ChangeSettingsRequest{
+			DataRetention: current.Settings.DataRetention,
+		})
+		require.NoError(t, err)
+
+		expected := status.New(codes.FailedPrecondition,
+			"Data retention is declared by the deployment in HA. Set PMM_DATA_RETENTION on every replica to change it.")
+		_, err = server.ChangeSettings(ctx, &serverv1.ChangeSettingsRequest{
+			DataRetention: durationpb.New(48 * time.Hour),
+		})
+		tests.AssertGRPCError(t, expected, err)
 	})
 
 	t.Run("ChangeSettings Alerting", func(t *testing.T) {

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -17,6 +17,8 @@ export const Messages = {
       'How long PMM keeps collected data. Older data is automatically deleted.',
     retentionUnits: 'days',
     retentionLink: 'https://per.co.na/data_retention',
+    retentionReadonly:
+      'Set by this deployment and cannot be changed here. Update PMM_DATA_RETENTION to change it.',
     telemetryLabel: 'Telemetry',
     telemetryLink: 'https://per.co.na/telemetry',
     telemetryDialogLink: 'What we collect',

--- a/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/advanced/AdvancedSettingsForm.tsx
@@ -76,6 +76,7 @@ export const AdvancedSettingsForm: FC<AdvancedSettingsFormProps> = ({
   };
 
   const m = Messages.advanced;
+  const retentionReadonly = settings.dataRetentionReadonly ?? false;
 
   return (
     <FormProvider {...methods}>
@@ -135,6 +136,8 @@ export const AdvancedSettingsForm: FC<AdvancedSettingsFormProps> = ({
               name="retention"
               textFieldProps={{
                 type: 'number',
+                disabled: retentionReadonly,
+                helperText: retentionReadonly ? m.retentionReadonly : undefined,
                 slotProps: {
                   htmlInput: {
                     min: MIN_DAYS,

--- a/ui/apps/pmm/src/types/settings.types.ts
+++ b/ui/apps/pmm/src/types/settings.types.ts
@@ -34,6 +34,7 @@ export interface Settings extends ReadonlySettings {
   telemetrySummaries?: string[];
   enableInternalPgQan?: boolean;
   defaultRoleId?: number;
+  dataRetentionReadonly?: boolean;
 }
 
 /** Payload for PUT /server/settings - partial updates supported */


### PR DESCRIPTION
PMM-14787

**Alternative to #5792, opened for comparison rather than to merge as-is.**

Both PRs fix the same bug: in HA, the **Data retention** setting is accepted, echoed back by `GetSettings`, displayed in the UI, and nothing downstream moves. #5792 makes retention runtime-editable by having pmm-managed patch `spec.retentionPeriod` on the `VMCluster` custom resource. This PR makes retention *declarative* instead, and leaves PMM out of the Kubernetes control plane.

## Why

VictoriaMetrics retention is a vmstorage start-up flag with no runtime endpoint. #5792's reasoning from there is sound: if retention must be editable at runtime in HA, patching the CR is the only honest mechanism. The disagreement is one step earlier — whether retention should be runtime-editable in HA at all.

The cost of saying yes shows up in the companion chart PR, which has to:

- delete `victoriaMetrics.vmstorage.retentionPeriod`,
- stop declaring `spec.retentionPeriod` in the normal case,
- and **hard-fail the helm render** if anyone sets it — because otherwise `helm upgrade` re-asserts the chart's value, PMM overwrites it back within a minute, and vmstorage rolls on every round.

A chart that must refuse to render a field it naturally owns, to stop two writers from flapping a StatefulSet, is a symptom. PMM is not a Kubernetes operator, and taking on that role is what forces the chart to abdicate.

Saying no instead is cheaper and, for a Kubernetes/GitOps deployment, arguably more correct: a UI click that mutates a CR *is* drift against the chart.

## What this does

`documentation/docs/install-pmm/install-HA-clustered.md` **already** tells users to set `PMM_DATA_RETENTION` in `pmmEnv`, and `managed/services/server/server.go` already refuses a settings change when that variable is set — a generic "env var wins" rule shared with metrics resolutions and Azure Discover. This PR finishes that existing design rather than adding a new mechanism.

1. **Extend the existing prohibition to HA.** `validateDataRetentionInHA` rejects a change on an HA cluster that has not declared a value, so a cluster running an older or hand-rolled chart cannot drift either. A cluster that *has* declared one is already covered by the `PMM_DATA_RETENTION` check. Settings are read only in that narrow HA-undeclared case, so every other deployment pays nothing; resubmitting the current value keeps working, since the settings form posts every field on save.

2. **Tell the UI, so the field can say why.** New `Settings.data_retention_readonly` (field 21, additive) is true when `PMM_DATA_RETENTION` is set or HA is on. The **Data retention** input is disabled with an explanation, instead of the user typing a value and eating a `FailedPrecondition` on save. This gap is pre-existing — the same one still applies to metrics resolutions, which have the identical guard and no UI signal.

3. **Document it.** Retention in HA is a `values.yaml` change plus a `helm upgrade`, which restarts every replica on the new value. The PMM-14709 known-issue row changes from "doesn't work, go run `ALTER TABLE ... TTL` yourself" to "by design, see values.yaml".

Every replica then boots with the same value from the same declaration, so the divergence that #5792's leader-gated reconcile exists to repair never arises.

## What that removes

| | #5792 | this PR |
|---|---|---|
| Diff | 1953 insertions, 29 files | 150 insertions, 15 files (7 generated) |
| `k8s.io/*` dependencies | 2 direct + 11 indirect (`client-go`, `apimachinery`, `klog/v2`, `kube-openapi`, `structured-merge-diff/v6`, …) | none |
| Chart RBAC | namespaced `Role` with `get`/`patch` on `vmclusters` | none |
| New packages | `managed/services/vmretention/` (~410 lines + 336 test) | none |
| `qan-api2` | leader-check client, leader-gated retention loop | unchanged |
| `supervisord` / `main.go` | `--leader-check-url` flag, `applySupervisordConfig` as a leader service | unchanged |

Dropping `applySupervisordConfig` as a leader service also drops the promotion window it introduces (a newly promoted node answers the leader health check the moment raft transitions, while its qan-api2 still holds the old `--data-retention`) and the context leak it exposes in `ha.ContextService.Start`, which never calls its cancel func on the success path.

## Chart contract

A single source of truth in `values.yaml`, rendering both `PMM_DATA_RETENTION` on the PMM StatefulSet and `spec.retentionPeriod` on the `VMCluster`. No `Role`, no `PMM_VM_CLUSTER_*` variables, and `victoriaMetrics.vmstorage.retentionPeriod` keeps working as a plain declarative field.

## Deliberately not included

`qan-api2/leader.go` from #5792. With retention pinned at boot, all replicas hold the same value, so three nodes running the same `DROP PARTITION` is redundant DDL rather than data loss. It is worth cherry-picking on top as pure efficiency — but only *together with* pinning. On its own it would make the promotion window worse, since a promoted node becomes the sole authorised deleter using a stale value.

## Trade-off

Changing retention in HA becomes a `helm upgrade` rather than a UI click. That is the real cost, and it is a product call. The UI stops lying about it either way.

## Verification

- `make gen` + `make format` clean; `go build ./managed/... ./api/...` clean.
- `golangci-lint` on `managed/services/server/...`: 10 findings on this branch, the same 10 on `main` — no new findings.
- `TestServer` passes, including the new `ChangeSettings data retention in HA` subtest.
- UI: `make lint`, `make format-check`, `tsc --noEmit`, and 365 Vitest tests pass.

No Feature Build: this is a design comparison, not a change proposed for release. Happy to spin one up if it should be evaluated on a live server.
