### PR TITLE
PMM-15205 Sync the vendored SEP frontend to c16578dfe

### DIFF
--- a/ui/packages/plugins/atw/src/ResultsPane.tsx
+++ b/ui/packages/plugins/atw/src/ResultsPane.tsx
@@ -79,7 +79,7 @@ interface ResendContext {
  */
 const FINISHED_TASK_STATUSES: ReadonlySet<
   NonNullable<AtwIncidentExecution['task_status']>
-> = new Set(['success', 'failed', 'stopped', 'stale']);
+> = new Set(['success', 'failed', 'stopped', 'stale', 'unlaunchable']);
 
 const SEND_STATUS_COLORS = {
   success: 'success',

--- a/ui/packages/plugins/atw/src/SendDialog.tsx
+++ b/ui/packages/plugins/atw/src/SendDialog.tsx
@@ -18,6 +18,8 @@
 import { useState } from 'react';
 import {
   Alert,
+  Autocomplete,
+  Box,
   Button,
   Dialog,
   DialogActions,
@@ -32,8 +34,21 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { sendJobDetail, useAtwSendJob, useStartSendJob } from './hooks';
-import type { AtwSendLogExecution } from './types';
+import { useDebouncedValue } from '@sep/framework';
+import {
+  sendJobDetail,
+  useAtwCaseSearch,
+  useAtwConfig,
+  useAtwSendJob,
+  useStartSendJob,
+} from './hooks';
+import type { AtwCaseMatch, AtwSendLogExecution } from './types';
+
+/** Shown once a search has answered for the typed term and matched nothing. */
+const NO_MATCH_HELPER =
+  'No matching case. The reference is sent exactly as typed.';
+
+const NO_MATCHES: AtwCaseMatch[] = [];
 
 export interface SendDialogProps {
   open: boolean;
@@ -67,6 +82,28 @@ export function SendDialog({
 }: SendDialogProps) {
   const [caseRef, setCaseRef] = useState(defaultCaseRef ?? '');
   const [jobId, setJobId] = useState<string | null>(null);
+
+  const { data: config } = useAtwConfig();
+  const debouncedCaseRef = useDebouncedValue(caseRef.trim());
+  const searchQuery = useAtwCaseSearch(
+    debouncedCaseRef,
+    Boolean(config?.case_search_available)
+  );
+
+  // The query key is the *debounced* term, so for the debounce window after a
+  // keystroke the data in hand still belongs to the previous term. Rendering it
+  // would put the old term's cases under the new text; clearing the field is the
+  // same bug at its most visible. Nothing below reads the search unless the term
+  // it was issued for is the one now in the field.
+  const termIsCurrent = caseRef.trim() === debouncedCaseRef;
+  const search = termIsCurrent ? searchQuery.data : undefined;
+  const matches = search?.available ? search.matches : NO_MATCHES;
+  const isSearching = termIsCurrent && searchQuery.isFetching;
+  // An available search that matched nothing must not read as an unavailable
+  // one, which leaves the field bare. freeSolo suppresses MUI's own
+  // `noOptionsText`, so the distinction is drawn here instead.
+  const searchFoundNothing =
+    search?.available === true && !isSearching && matches.length === 0;
 
   const startMutation = useStartSendJob(incidentId);
   const { data: job, error: pollError } = useAtwSendJob(
@@ -123,15 +160,65 @@ export function SendDialog({
               bundled and attached to the support case.
             </DialogContentText>
 
-            <TextField
-              autoFocus
+            <Autocomplete<AtwCaseMatch, false, false, true>
+              freeSolo
               fullWidth
-              required
               size="small"
-              label="Support case reference"
-              value={caseRef}
-              onChange={(event) => setCaseRef(event.target.value)}
               disabled={isSending}
+              options={matches}
+              // The receiver already matched the term; re-filtering client-side
+              // would drop hits it matched on a field the label does not show.
+              filterOptions={(option) => option}
+              inputValue={caseRef}
+              onInputChange={(_event, value) => setCaseRef(value)}
+              value={caseRef}
+              onChange={(_event, value) =>
+                setCaseRef(
+                  typeof value === 'string' ? value : (value?.reference ?? '')
+                )
+              }
+              getOptionLabel={(option) =>
+                typeof option === 'string' ? option : option.reference
+              }
+              // The reference is the match's identity: the API answers at most
+              // once per reference, so no synthetic id is needed to key a row.
+              getOptionKey={(option) =>
+                typeof option === 'string' ? option : option.reference
+              }
+              loading={isSearching}
+              clearOnBlur={false}
+              // Keeps an unconfigured deployment's field visually identical to
+              // the plain text input it has always been.
+              forcePopupIcon={false}
+              renderOption={(props, option) => {
+                const { key, ...liProps } = props as typeof props & {
+                  key: string;
+                };
+                return (
+                  <Box component="li" key={key} {...liProps}>
+                    {/* MUI styles the option row as a flex row at a specificity
+                        the sx prop cannot outrank, so the two lines stack in a
+                        wrapper that rule does not reach. */}
+                    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+                      <Typography variant="body2">
+                        {option.reference}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {option.title}
+                      </Typography>
+                    </Box>
+                  </Box>
+                );
+              }}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  autoFocus
+                  required
+                  label="Support case reference"
+                  helperText={searchFoundNothing ? NO_MATCH_HELPER : undefined}
+                />
+              )}
               sx={{ mb: 2 }}
             />
 

--- a/ui/packages/plugins/atw/src/hooks.ts
+++ b/ui/packages/plugins/atw/src/hooks.ts
@@ -32,6 +32,7 @@ import {
 import type {
   AtwBatchExecuteResponse,
   AtwBatchExecuteWrite,
+  AtwCaseSearchResponse,
   AtwCategoryListing,
   AtwConfig,
   AtwIncident,
@@ -431,11 +432,51 @@ export function useAtwConfig() {
         const { data } = await apiClient.get<AtwConfig>(`${ATW_BASE}/config/`);
         return data;
       } catch {
-        return { send_disabled_reasons: [] };
+        return { send_disabled_reasons: [], case_search_available: false };
       }
     },
     staleTime: Infinity,
     retry: false,
+  });
+}
+
+/**
+ * Search the configured delivery provider for support cases matching `term`.
+ *
+ * Degrades the way `useAtwConfig` does: any error resolves to an unavailable
+ * search rather than rejecting, so a provider blip leaves the case-reference
+ * field a plain text input instead of surfacing an error beside it.
+ *
+ * `enabled` carries the deployment-level answer from `atw_config`, so a
+ * deployment that declares no case-search section issues zero requests rather
+ * than one per typing pause. Callers debounce the term; the query key is the
+ * term they pass, which lags the field by the debounce window — so a caller
+ * rendering the result must also check the term is still current.
+ *
+ * Deliberately without `placeholderData: keepPreviousData`, unlike
+ * `useAtwSnippetSearch`: opting out means react-query never serves the previous
+ * term's matches while a new term resolves.
+ */
+export function useAtwCaseSearch(term: string, enabled: boolean) {
+  const trimmed = term.trim();
+  return useQuery<AtwCaseSearchResponse>({
+    queryKey: ['atw', 'case-search', trimmed],
+    enabled: enabled && trimmed.length > 0,
+    staleTime: ATW_STALE_TIME_MS,
+    retry: false,
+    queryFn: async () => {
+      try {
+        const { data } = await apiClient.get<AtwCaseSearchResponse>(
+          `${ATW_BASE}/case-search/`,
+          {
+            params: { term: trimmed },
+          }
+        );
+        return data;
+      } catch {
+        return { available: false, matches: [] };
+      }
+    },
   });
 }
 

--- a/ui/packages/plugins/atw/src/types.ts
+++ b/ui/packages/plugins/atw/src/types.ts
@@ -107,10 +107,16 @@ export interface AtwSendLogExecution {
   snippet_filename: string;
 }
 
-/** One resolution step the delivery plan reported while the send ran. */
+/**
+ * One step the delivery plan reported while the send ran.
+ *
+ * `kind` is optional only for history: the backend writes it on every entry it
+ * records now, but rows persisted before it existed carry entries without it.
+ */
 export interface AtwSendLogStep {
   name: string;
-  status: 'running' | 'success';
+  kind?: 'resolution' | 'upload';
+  status: 'running' | 'success' | 'failed';
   outputs: Record<string, string> | null;
 }
 

--- a/ui/packages/plugins/atw/src/types.ts
+++ b/ui/packages/plugins/atw/src/types.ts
@@ -80,6 +80,8 @@ export type AtwIncidentExecution = Schemas['atw__ATWIncidentExecutionResponse'];
 export type AtwSendJobWrite = Schemas['atw__AtwSendJobWrite'];
 export type AtwSendLog = Schemas['atw__AtwSendLogResponse'];
 export type AtwConfig = Schemas['atw__AtwConfigResponse'];
+export type AtwCaseMatch = Schemas['atw__AtwCaseMatch'];
+export type AtwCaseSearchResponse = Schemas['atw__AtwCaseSearchResponse'];
 
 /** One page of a paginated list endpoint, as the API envelope carries it. */
 export interface AtwPage<T> {

--- a/ui/packages/plugins/atw/tests/SendDialog.test.tsx
+++ b/ui/packages/plugins/atw/tests/SendDialog.test.tsx
@@ -15,7 +15,14 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -51,6 +58,57 @@ function sendLog(overrides: Record<string, unknown> = {}) {
     detail: {},
     ...overrides,
   };
+}
+
+const CASE_MATCHES = [
+  { reference: 'CS0001', title: 'Slow queries on the primary' },
+  { reference: 'CS0002', title: 'Replica lag after failover' },
+];
+
+interface MockApiOptions {
+  /** What `atw_config` reports for `case_search_available`. */
+  caseSearchAvailable?: boolean;
+  /** What the case-search route answers with. */
+  search?: { available: boolean; matches: typeof CASE_MATCHES };
+  /** Answer `atw_config` without the field, as a server predating it would. */
+  omitAvailabilityField?: boolean;
+}
+
+/** Route each mocked GET by path, so config and case search answer separately. */
+function mockApis({
+  caseSearchAvailable = true,
+  search = { available: true, matches: CASE_MATCHES },
+  omitAvailabilityField = false,
+}: MockApiOptions = {}): void {
+  mockedApi.get.mockImplementation((url: string) => {
+    if (url.startsWith('/apps/atw/case-search/')) {
+      return Promise.resolve({ data: search });
+    }
+    if (url.startsWith('/apps/atw/config/')) {
+      return Promise.resolve({
+        data: omitAvailabilityField
+          ? { send_disabled_reasons: [] }
+          : {
+              send_disabled_reasons: [],
+              case_search_available: caseSearchAvailable,
+            },
+      });
+    }
+    return Promise.resolve({ data: sendLog() });
+  });
+}
+
+/** The term of every case-search request issued so far, in order. */
+function caseSearchTerms(): string[] {
+  // Indexed rather than destructured with a tuple annotation: PMM typechecks
+  // these tests where SEP does not, and mock.calls is not a fixed-length tuple.
+  return mockedApi.get.mock.calls
+    .filter((call) => String(call[0]).startsWith('/apps/atw/case-search/'))
+    .map((call) => (call[1] as { params: { term: string } }).params.term);
+}
+
+function caseRefField(): HTMLInputElement {
+  return screen.getByLabelText(/Support case reference/i) as HTMLInputElement;
 }
 
 function renderDialog(ui: ReactNode) {
@@ -322,5 +380,256 @@ describe('SendDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(onClose).toHaveBeenLastCalledWith(true);
+  });
+});
+
+describe('SendDialog case search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers the cases the provider matched for the typed term', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+
+    expect(
+      await screen.findByRole('option', { name: /CS0001/ }, { timeout: 3000 })
+    ).toBeTruthy();
+    expect(screen.getByRole('option', { name: /CS0002/ })).toBeTruthy();
+  });
+
+  it('shows the case title beneath the reference', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+
+    const option = await screen.findByRole(
+      'option',
+      { name: /CS0001/ },
+      { timeout: 3000 }
+    );
+    expect(option).toHaveTextContent('Slow queries on the primary');
+
+    const reference = within(option).getByText('CS0001');
+    const title = within(option).getByText('Slow queries on the primary');
+    expect(title.parentElement).toBe(reference.parentElement);
+
+    const stack = getComputedStyle(reference.parentElement as HTMLElement);
+    expect(stack.display).toBe('flex');
+    expect(stack.flexDirection).toBe('column');
+  });
+
+  it('puts the picked case reference in the field', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+    await userEvent.click(
+      await screen.findByRole('option', { name: /CS0002/ }, { timeout: 3000 })
+    );
+
+    expect(caseRefField().value).toBe('CS0002');
+  });
+
+  it('sends a reference the search never matched, exactly as typed', async () => {
+    mockApis({ search: { available: true, matches: [] } });
+    mockedApi.post.mockResolvedValue({ data: sendLog({ case_ref: 'CS9999' }) });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS9999');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(mockedApi.post.mock.calls[0][1].case_ref).toBe('CS9999');
+  });
+
+  it('sends the prefilled reference without the search ever answering', async () => {
+    // Every GET hangs, so nothing the search could return is in hand.
+    mockedApi.get.mockImplementation(() => new Promise(() => {}));
+    mockedApi.post.mockResolvedValue({ data: sendLog() });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        defaultCaseRef="CS0042"
+        onClose={() => {}}
+      />
+    );
+
+    const send = screen.getByRole('button', { name: 'Send' });
+    expect(send).not.toBeDisabled();
+    await userEvent.click(send);
+
+    await waitFor(() => expect(mockedApi.post).toHaveBeenCalled());
+    expect(mockedApi.post.mock.calls[0][1].case_ref).toBe('CS0042');
+  });
+
+  it('offers no options and no empty state when the search is unavailable', async () => {
+    mockApis({ search: { available: false, matches: [] } });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+    await waitFor(() => expect(caseSearchTerms()).toHaveLength(1), {
+      timeout: 3000,
+    });
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+    expect(screen.queryByText(/No matching case/i)).toBeNull();
+    expect(caseRefField()).not.toBeDisabled();
+  });
+
+  it('distinguishes a search that matched nothing from one that could not run', async () => {
+    mockApis({ search: { available: true, matches: [] } });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+
+    expect(
+      await screen.findByText(/No matching case/i, {}, { timeout: 3000 })
+    ).toBeTruthy();
+  });
+
+  it('issues one search for a term typed in one burst', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS001234');
+
+    await waitFor(() => expect(caseSearchTerms()).toHaveLength(1), {
+      timeout: 3000,
+    });
+    expect(caseSearchTerms()[0]).toBe('CS001234');
+  });
+
+  it('issues no search at all where the deployment declares none', async () => {
+    mockApis({ caseSearchAvailable: false });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(caseSearchTerms()).toHaveLength(0);
+  });
+
+  it('treats a config response without the field as no search available', async () => {
+    // A server predating this field omits it; the field must stay a plain input
+    // rather than issuing searches the deployment cannot serve.
+    mockApis({ omitAvailabilityField: true });
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    await userEvent.type(caseRefField(), 'CS00');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(caseSearchTerms()).toHaveLength(0);
+    expect(caseRefField().value).toBe('CS00');
+  });
+
+  it('drops the offered options the instant the term is typed on', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    const field = caseRefField();
+    await userEvent.type(field, 'CS00');
+    await screen.findByRole('option', { name: /CS0001/ }, { timeout: 3000 });
+
+    // Synchronous, so the assertion lands inside the debounce window while the
+    // query key — and therefore the data in hand — is still the previous term's.
+    fireEvent.change(field, { target: { value: 'CS001' } });
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+  });
+
+  it('drops the offered options the instant the field is cleared', async () => {
+    mockApis();
+    renderDialog(
+      <SendDialog
+        open
+        incidentId="inc-1"
+        executions={EXECUTIONS}
+        onClose={() => {}}
+      />
+    );
+
+    const field = caseRefField();
+    await userEvent.type(field, 'CS00');
+    await screen.findByRole('option', { name: /CS0001/ }, { timeout: 3000 });
+
+    fireEvent.change(field, { target: { value: '' } });
+
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
   });
 });

--- a/ui/packages/sep/api/specs/inventory.json
+++ b/ui/packages/sep/api/specs/inventory.json
@@ -1,6 +1,91 @@
 {
   "components": {
     "schemas": {
+      "ExternalIdentityAliasResponse": {
+        "description": "Define the external-identity alias API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the\n    current time in UTC.\n:param updated_at: The timestamp when the record is last updated.\n    Automatically updated on changes.\n:param entity_type: The inventory entity type the binding names.\n:param entity_id: The primary key of the row the upstream id resolves to.\n:param source: The upstream system the identifier belongs to.\n:param external_id: The upstream identifier being bound.\n:param valid_from: When the binding took effect.\n:param valid_to: When the binding stopped applying, or None while it stands.\n:param linkage_method: How the binding came to be recorded.\n:param principal: The caller that recorded the binding.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "entity_id": {
+            "title": "Entity Id",
+            "type": "integer"
+          },
+          "entity_type": {
+            "$ref": "#/components/schemas/RetirableEntityName"
+          },
+          "external_id": {
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "linkage_method": {
+            "$ref": "#/components/schemas/LinkageMethodEnum"
+          },
+          "principal": {
+            "minLength": 1,
+            "title": "Principal",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/SourceEnum"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "valid_from": {
+            "format": "date-time",
+            "title": "Valid From",
+            "type": "string"
+          },
+          "valid_to": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valid To"
+          }
+        },
+        "required": [
+          "entity_type",
+          "entity_id",
+          "source",
+          "external_id",
+          "valid_from",
+          "linkage_method",
+          "principal",
+          "id"
+        ],
+        "title": "ExternalIdentityAliasResponse",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -159,14 +244,105 @@
         "title": "HostSystemObservationWrite",
         "type": "object"
       },
+      "IdentityLinkDecisionEnum": {
+        "description": "Enumerate the decisions an operator may record against a candidate pairing.\n\n:cvar CONFIRMED: The pairing names one machine, and the link stands.\n:cvar REJECTED: The pairing names two machines, so stop suggesting it.\n:cvar UNLINKED: A standing confirmation was reversed.\n\nValues are spelled out for the reason given on\n:class:`LinkageMethodEnum`, and it binds harder here: this enum is also a\n*request* body field, so a rename would reject the payloads callers were\nalready sending.",
+        "enum": ["confirmed", "rejected", "unlinked"],
+        "title": "IdentityLinkDecisionEnum",
+        "type": "string"
+      },
+      "IdentityLinkDecisionWrite": {
+        "description": "Define the request body recording one operator decision over a pairing.\n\n:param successor_id: The row the addressed predecessor is being paired with.\n:param decision: What the operator decided.",
+        "properties": {
+          "decision": {
+            "$ref": "#/components/schemas/IdentityLinkDecisionEnum"
+          },
+          "successor_id": {
+            "title": "Successor Id",
+            "type": "integer"
+          }
+        },
+        "required": ["successor_id", "decision"],
+        "title": "IdentityLinkDecisionWrite",
+        "type": "object"
+      },
+      "InventoryCollectResponse": {
+        "description": "Report what a collection call deleted, or would have deleted.\n\n:param deleted: The collected ids per entity type, exhaustive for this\n    call. On a dry run these are the ids the equivalent real call would\n    delete. A type the walk stopped before reporting is empty rather than\n    absent.\n:param remaining: Whether any entity type filled its ``limit``, meaning more\n    tombstones are waiting for the next batch.",
+        "properties": {
+          "deleted": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "title": "Deleted",
+            "type": "object"
+          },
+          "remaining": {
+            "title": "Remaining",
+            "type": "boolean"
+          }
+        },
+        "required": ["deleted", "remaining"],
+        "title": "InventoryCollectResponse",
+        "type": "object"
+      },
+      "InventoryCollectWrite": {
+        "additionalProperties": false,
+        "description": "Ask the inventory service to collect the tombstones nothing resolves.\n\nUnknown fields are rejected with HTTP 422. This request deletes rows\nirreversibly, so a client typo must never be read as an omitted field: a\nmisspelled ``keep`` would otherwise arrive as an empty retained set and a\nmisspelled ``dry_run`` as a real delete.\n\n:param retired_before: The cutoff a tombstone must predate to be eligible.\n    The caller pins one value for a whole run so successive batches cannot\n    drift into collecting a tombstone that was too young a moment earlier.\n:param keep: The ids the caller knows are still referenced, per entity type.\n    Ancestors of a kept entity are retained without being listed.\n:param limit: The most entities to collect per type in this call.\n:param dry_run: Whether to report the eligible ids without deleting them.\n    Defaults to reporting: on an irreversible endpoint the mode a caller\n    reaches by omission is the one that cannot destroy anything.",
+        "properties": {
+          "dry_run": {
+            "default": true,
+            "title": "Dry Run",
+            "type": "boolean"
+          },
+          "keep": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "default": {},
+            "title": "Keep",
+            "type": "object"
+          },
+          "limit": {
+            "default": 500,
+            "exclusiveMinimum": 0.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "retired_before": {
+            "format": "date-time",
+            "title": "Retired Before",
+            "type": "string"
+          }
+        },
+        "required": ["retired_before"],
+        "title": "InventoryCollectWrite",
+        "type": "object"
+      },
       "JsonValue": {},
+      "LinkageMethodEnum": {
+        "description": "Enumerate how an external-identity binding came to be recorded.\n\nEvery member names an operator action: nothing here records a binding the\nsyncer made on its own, because ordinary sync creation writes no alias row.\n\nValues are spelled out rather than derived with ``auto()``. The column\npersists the member *name*, but the API serializes the *value*, so under\n``auto()`` the two move in opposite ways when a member is renamed: the\nstored form follows the rename while the published one silently changes\nwith it. Pinning the value holds the wire contract — this enum reaches the\ngenerated API client — and leaves a rename a database concern alone.",
+        "enum": ["operator_confirmation", "operator_unlink"],
+        "title": "LinkageMethodEnum",
+        "type": "string"
+      },
       "Node": {
-        "description": "Represent a node in the inventory.\n\n:param address: The network address of the node.\n:type address: NonEmptyStr\n:param name: The name of the node.\n:type name: NonEmptyStr\n:param external_id: An external identifier for the node. Must be unique for source,\n    as defined by composite index ix_node_external_id_source.\n:type external_id: NonEmptyStr | None\n:param source: The source from which the node information is derived. Must be unique\n    for external_id, as defined by composite index ix_node_external_id_source.\n:type source: SourceEnum | None\n:param type: The type of the node (e.g., remote, generic).\n:type type: NonEmptyStr\n:param services: A list of services associated with the node.\n:type services: list[Service]",
+        "description": "Represent a node in the inventory.\n\n:param address: The network address of the node.\n:param name: The name of the node.\n:param external_id: An external identifier for the node. Must be unique for source,\n    as defined by composite index ix_node_external_id_source.\n:param source: The source from which the node information is derived. Must be unique\n    for external_id, as defined by composite index ix_node_external_id_source.\n:param type: The type of the node (e.g., remote, generic).\n:param retired_at: When the node stopped being reported upstream, or None while\n    it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the node against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the node is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param services: A list of services associated with the node.",
         "properties": {
           "address": {
             "minLength": 1,
             "title": "Address",
             "type": "string"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -174,16 +350,9 @@
             "type": "string"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -196,20 +365,60 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
-          "source": {
+          "retired_at": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SourceEnum"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Retired At"
+          },
+          "source": {
+            "$ref": "#/components/schemas/SourceEnum"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "default": "generic",
@@ -230,17 +439,44 @@
             "title": "Updated At"
           }
         },
-        "required": ["id", "address", "name"],
+        "required": ["id", "address", "name", "external_id", "source"],
         "title": "Node",
         "type": "object"
       },
+      "NodeIdentityCandidateResponse": {
+        "description": "Pair a node with the successor a re-registration may have split it into.\n\n:param predecessor: The older row — the one every SEP reference persisted\n    before the re-registration resolves through, and so the one a\n    confirmation keeps.\n:param successor: The newer row PMM created when the node re-registered.\n:param matched_on: The signals that agreed, informational only. Detection\n    never requires an address match, because PMM discards the address on a\n    non-``--force`` re-registration.",
+        "properties": {
+          "matched_on": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Matched On",
+            "type": "array"
+          },
+          "predecessor": {
+            "$ref": "#/components/schemas/NodeResponse"
+          },
+          "successor": {
+            "$ref": "#/components/schemas/NodeResponse"
+          }
+        },
+        "required": ["predecessor", "successor", "matched_on"],
+        "title": "NodeIdentityCandidateResponse",
+        "type": "object"
+      },
       "NodeResponse": {
-        "description": "Represent a node API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param address: The network address of the node.\n:type address: NonEmptyStr\n:param name: The name of the node.\n:type name: NonEmptyStr\n:param external_id: An external identifier for the node.\n:type external_id: NonEmptyStr | None\n:param source: The source from which the node information is derived.\n:type source: SourceEnum | None\n:param type: The type of the node (e.g., remote, generic).\n:type type: NonEmptyStr\n:param services: A list of services associated with the node.\n:type services: list[Service]",
+        "description": "Represent a node API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param address: The network address of the node.\n:param name: The name of the node.\n:param external_id: An external identifier for the node.\n:param source: The source from which the node information is derived.\n:param type: The type of the node (e.g., remote, generic).\n:param retired_at: When the node stopped being reported upstream, or None while\n    it is active.\n:param last_synced_at: When a syncer last confirmed the node against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the node is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param services: A list of services associated with the node.",
         "properties": {
           "address": {
             "minLength": 1,
             "title": "Address",
             "type": "string"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -248,16 +484,9 @@
             "type": "string"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -270,10 +499,45 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
+          },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
           },
           "services": {
             "items": {
@@ -283,14 +547,19 @@
             "type": "array"
           },
           "source": {
+            "$ref": "#/components/schemas/SourceEnum"
+          },
+          "sync_failing_since": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SourceEnum"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "default": "generic",
@@ -311,12 +580,19 @@
             "title": "Updated At"
           }
         },
-        "required": ["address", "name", "id", "services"],
+        "required": [
+          "address",
+          "name",
+          "external_id",
+          "source",
+          "id",
+          "services"
+        ],
         "title": "NodeResponse",
         "type": "object"
       },
       "NodeWrite": {
-        "description": "Define the model for writing node data to the inventory.\n\n:param address: The network address of the node.\n:type address: NonEmptyStr\n:param name: The name of the node.\n:type name: NonEmptyStr\n:param external_id: An external identifier for the node, indexed for quick lookup.\n    Defaults to None.\n:type external_id: NonEmptyStr | None\n:param source: The source from which the node information is derived. Indexed for\n    quick lookup. Defaults to None.\n:type source: SourceEnum | None\n:param type: The type of the node (e.g., remote, generic). Defaults to \"generic\".\n:type type: NonEmptyStr",
+        "description": "Define the model for writing node data to the inventory.\n\n:param address: The network address of the node.\n:param name: The name of the node.\n:param external_id: An external identifier for the node, indexed for quick lookup.\n:param source: The source from which the node information is derived. Indexed for\n    quick lookup.\n:param type: The type of the node (e.g., remote, generic). Defaults to \"generic\".",
         "properties": {
           "address": {
             "minLength": 1,
@@ -324,16 +600,9 @@
             "type": "string"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "name": {
             "minLength": 1,
@@ -341,14 +610,7 @@
             "type": "string"
           },
           "source": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/SourceEnum"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/SourceEnum"
           },
           "type": {
             "default": "generic",
@@ -357,8 +619,60 @@
             "type": "string"
           }
         },
-        "required": ["address", "name"],
+        "required": ["address", "name", "external_id", "source"],
         "title": "NodeWrite",
+        "type": "object"
+      },
+      "PaginatedResponse_ExternalIdentityAliasResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ExternalIdentityAliasResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": ["items", "total", "offset", "limit"],
+        "title": "PaginatedResponse[ExternalIdentityAliasResponse]",
+        "type": "object"
+      },
+      "PaginatedResponse_NodeIdentityCandidateResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/NodeIdentityCandidateResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": ["items", "total", "offset", "limit"],
+        "title": "PaginatedResponse[NodeIdentityCandidateResponse]",
         "type": "object"
       },
       "PaginatedResponse_NodeResponse_": {
@@ -411,6 +725,32 @@
         },
         "required": ["items", "total", "offset", "limit"],
         "title": "PaginatedResponse[SchemaResponse]",
+        "type": "object"
+      },
+      "PaginatedResponse_ServiceIdentityCandidateResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ServiceIdentityCandidateResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": ["items", "total", "offset", "limit"],
+        "title": "PaginatedResponse[ServiceIdentityCandidateResponse]",
         "type": "object"
       },
       "PaginatedResponse_ServiceResponse_": {
@@ -504,9 +844,21 @@
         "title": "ReloadClassification",
         "type": "string"
       },
+      "RetirableEntityName": {
+        "description": "Name the inventory entity types that carry a retirement tombstone.\n\nValues are spelled out rather than derived, because they cross a service\nboundary: SEP names an entity type by these strings when it asks inventory\nto collect. Inventory-local on purpose — SEP's own\n``SyncInventoryEntityTypeEnum`` lives in a package this service must not\nimport.",
+        "enum": ["node", "service", "schema", "table"],
+        "title": "RetirableEntityName",
+        "type": "string"
+      },
       "Schema": {
-        "description": "Represent a database schema within a service.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the schema. Must be unique for service_id, as defined by\n    composite index ix_schema_name_service_id.\n:type name: NonEmptyStr\n:param service_id: The unique identifier of the service to which the schema belongs.\n    Must be unique for name, as defined by composite index\n    ix_schema_name_service_id.\n:type service_id: int\n:param service: The service to which the schema is associated.\n:type service: Service\n:param tables: A list of tables within the schema.\n:type tables: list[Table]",
+        "description": "Represent a database schema within a service.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the schema. Must be unique for service_id, as defined by\n    composite index ix_schema_name_service_id.\n:param service_id: The unique identifier of the service to which the schema belongs.\n    Must be unique for name, as defined by composite index\n    ix_schema_name_service_id.\n:param service: The service to which the schema is associated.\n:param retired_at: When the schema stopped being reported upstream, or None\n    while it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the schema against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the schema is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param tables: A list of tables within the schema.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -523,14 +875,61 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "service_id": {
             "title": "Service Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -550,8 +949,14 @@
         "type": "object"
       },
       "SchemaCompactResponse": {
-        "description": "Define a compact schema response without nested tables.\n\n:param id: The primary key for the schema. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the schema.\n:type name: NonEmptyStr\n:param service_id: The unique identifier of the service to which the schema belongs.\n:type service_id: int",
+        "description": "Define a compact schema response without nested tables.\n\n:param id: The primary key for the schema. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the schema.\n:param service_id: The unique identifier of the service to which the schema belongs.\n:param retired_at: When the schema stopped being reported upstream, or None while\n    it is active.\n:param last_synced_at: When a syncer last confirmed the schema against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the schema is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -568,14 +973,61 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "service_id": {
             "title": "Service Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -595,8 +1047,14 @@
         "type": "object"
       },
       "SchemaDetailResponse": {
-        "description": "Define the schema retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the schema.\n:type name: NonEmptyStr\n:param service_id: The unique identifier of the service to which the schema belongs.\n:type service_id: int\n:param service: The schema's service.\n:type service: Service",
+        "description": "Define the schema retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the schema.\n:param service_id: The unique identifier of the service to which the schema belongs.\n:param service: The schema's service.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -613,10 +1071,45 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
+          },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
           },
           "service": {
             "$ref": "#/components/schemas/Service"
@@ -624,6 +1117,18 @@
           "service_id": {
             "title": "Service Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "tables": {
             "items": {
@@ -650,8 +1155,14 @@
         "type": "object"
       },
       "SchemaResponse": {
-        "description": "Define the schema API response.\n\n:param id: The primary key for the schema. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the schema.\n:type name: NonEmptyStr\n:param service_id: The unique identifier of the service to which the schema belongs.\n:type service_id: int\n:param tables: A list of tables within the schema.\n:type tables: list[Table]",
+        "description": "Define the schema API response.\n\n:param id: The primary key for the schema. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the schema.\n:param service_id: The unique identifier of the service to which the schema belongs.\n:param retired_at: When the schema stopped being reported upstream, or None while\n    it is active.\n:param last_synced_at: When a syncer last confirmed the schema against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the schema is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param tables: A list of tables within the schema.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -668,14 +1179,61 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "service_id": {
             "title": "Service Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "tables": {
             "items": {
@@ -726,7 +1284,7 @@
         "type": "object"
       },
       "Service": {
-        "description": "Represent a service running on a node in the inventory.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param external_id: An external identifier for the service. Must be unique for\n    node_id, as defined by composite index ix_service_external_id_node_id.\n:type external_id: NonEmptyStr | None\n:param name: The name of the service.\n:type name: NonEmptyStr\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:type type: ServiceTypeEnum\n:param port: The port number on which the service is running. Must be unique for\n    node_id, as defined by composite index ix_service_port_node_id.\n:type port: int | None\n:param environment: The environment in which the service is running, if set.\n:type environment: str | None\n:param cluster: The cluster in which the service is running, if set.\n:type cluster: str | None\n:param replication_set: The replication set in which the service is running, if set.\n:type replication_set: str | None\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n    Must be unique for external_id, as defined by composite index\n    ix_service_external_id_node_id, and for port, as defined by composite index\n    ix_service_port_node_id.\n:type node_id: int\n:param node: The node to which the service is associated.\n:type node: Node\n:param schemas: A list of schemas associated with the service.\n:type schemas: list[Schema]",
+        "description": "Represent a service running on a node in the inventory.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param external_id: An external identifier for the service. Must be unique for\n    node_id, as defined by composite index ix_service_external_id_node_id.\n:param name: The name of the service.\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:param port: The port number on which the service is running.\n:param environment: The environment in which the service is running, if set.\n:param cluster: The cluster in which the service is running, if set.\n:param replication_set: The replication set in which the service is running, if set.\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n    Must be unique for external_id, as defined by composite index\n    ix_service_external_id_node_id.\n:param node: The node to which the service is associated.\n:param retired_at: When the service stopped being reported upstream, or None\n    while it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the service against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the service is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param schemas: A list of schemas associated with the service.",
         "properties": {
           "cluster": {
             "anyOf": [
@@ -738,6 +1296,12 @@
               }
             ],
             "title": "Cluster"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -768,16 +1332,9 @@
             "title": "Environment"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -789,6 +1346,29 @@
               }
             ],
             "title": "Id"
+          },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
           },
           "name": {
             "minLength": 1,
@@ -821,6 +1401,30 @@
             ],
             "title": "Replication Set"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
+          },
           "type": {
             "$ref": "#/components/schemas/ServiceTypeEnum"
           },
@@ -837,12 +1441,12 @@
             "title": "Updated At"
           }
         },
-        "required": ["name", "type", "node_id", "id"],
+        "required": ["external_id", "name", "type", "node_id", "id"],
         "title": "Service",
         "type": "object"
       },
       "ServiceDetailResponse": {
-        "description": "Define the service retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param external_id: An external identifier for the service.\n:type external_id: NonEmptyStr | None\n:param name: The name of the service.\n:type name: NonEmptyStr\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:type type: ServiceTypeEnum\n:param port: The port number on which the service is running.\n:type port: int | None\n:param environment: The environment in which the service is running, if set.\n:type environment: str | None\n:param cluster: The cluster in which the service is running, if set.\n:type cluster: str | None\n:param replication_set: The replication set in which the service is running, if set.\n:type replication_set: str | None\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:type node_id: int\n:param schemas: A list of schemas associated with the service.\n:type schemas: list[Schema]\n:param node: The service's node.\n:type node: Node",
+        "description": "Define the service retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param external_id: An external identifier for the service.\n:param name: The name of the service.\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:param port: The port number on which the service is running.\n:param environment: The environment in which the service is running, if set.\n:param cluster: The cluster in which the service is running, if set.\n:param replication_set: The replication set in which the service is running, if set.\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:param schemas: A list of schemas associated with the service.\n:param node: The service's node.",
         "properties": {
           "cluster": {
             "anyOf": [
@@ -854,6 +1458,12 @@
               }
             ],
             "title": "Cluster"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -884,16 +1494,9 @@
             "title": "Environment"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -905,6 +1508,29 @@
               }
             ],
             "title": "Id"
+          },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
           },
           "name": {
             "minLength": 1,
@@ -940,12 +1566,36 @@
             ],
             "title": "Replication Set"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schemas": {
             "items": {
               "$ref": "#/components/schemas/Schema"
             },
             "title": "Schemas",
             "type": "array"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "$ref": "#/components/schemas/ServiceTypeEnum"
@@ -963,12 +1613,41 @@
             "title": "Updated At"
           }
         },
-        "required": ["name", "type", "node_id", "id", "schemas", "node"],
+        "required": [
+          "external_id",
+          "name",
+          "type",
+          "node_id",
+          "id",
+          "schemas",
+          "node"
+        ],
         "title": "ServiceDetailResponse",
         "type": "object"
       },
+      "ServiceIdentityCandidateResponse": {
+        "description": "Pair a service with the successor a re-registration may have split it into.\n\n:param predecessor: The older row a confirmation keeps.\n:param successor: The newer row PMM created.\n:param matched_on: The signals that agreed, informational only.",
+        "properties": {
+          "matched_on": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Matched On",
+            "type": "array"
+          },
+          "predecessor": {
+            "$ref": "#/components/schemas/ServiceResponse"
+          },
+          "successor": {
+            "$ref": "#/components/schemas/ServiceResponse"
+          }
+        },
+        "required": ["predecessor", "successor", "matched_on"],
+        "title": "ServiceIdentityCandidateResponse",
+        "type": "object"
+      },
       "ServiceResponse": {
-        "description": "Define the service API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param external_id: An external identifier for the service.\n:type external_id: NonEmptyStr | None\n:param name: The name of the service.\n:type name: NonEmptyStr\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:type type: ServiceTypeEnum\n:param port: The port number on which the service is running.\n:type port: int | None\n:param environment: The environment in which the service is running, if set.\n:type environment: str | None\n:param cluster: The cluster in which the service is running, if set.\n:type cluster: str | None\n:param replication_set: The replication set in which the service is running, if set.\n:type replication_set: str | None\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:type node_id: int\n:param schemas: A list of schemas associated with the service.\n:type schemas: list[Schema]\n:param node: The node to which the service is associated.\n:type node: Node",
+        "description": "Define the service API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param external_id: An external identifier for the service.\n:param name: The name of the service.\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:param port: The port number on which the service is running.\n:param environment: The environment in which the service is running, if set.\n:param cluster: The cluster in which the service is running, if set.\n:param replication_set: The replication set in which the service is running, if set.\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:param schemas: A list of schemas associated with the service.\n:param node: The node to which the service is associated.\n:param retired_at: When the service stopped being reported upstream, or None\n    while it is active.\n:param last_synced_at: When a syncer last confirmed the service against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the service is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.",
         "properties": {
           "cluster": {
             "anyOf": [
@@ -980,6 +1659,12 @@
               }
             ],
             "title": "Cluster"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -1010,16 +1695,9 @@
             "title": "Environment"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -1031,6 +1709,29 @@
               }
             ],
             "title": "Id"
+          },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
           },
           "name": {
             "minLength": 1,
@@ -1066,12 +1767,36 @@
             ],
             "title": "Replication Set"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schemas": {
             "items": {
               "$ref": "#/components/schemas/Schema"
             },
             "title": "Schemas",
             "type": "array"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "$ref": "#/components/schemas/ServiceTypeEnum"
@@ -1089,7 +1814,15 @@
             "title": "Updated At"
           }
         },
-        "required": ["name", "type", "node_id", "id", "schemas", "node"],
+        "required": [
+          "external_id",
+          "name",
+          "type",
+          "node_id",
+          "id",
+          "schemas",
+          "node"
+        ],
         "title": "ServiceResponse",
         "type": "object"
       },
@@ -1187,7 +1920,7 @@
         "type": "string"
       },
       "ServiceWrite": {
-        "description": "Define the model for writing service data to the inventory.\n\n:param external_id: An external identifier for the service, indexed for quick\n    lookup. Defaults to None.\n:type external_id: NonEmptyStr | None\n:param name: The name of the service.\n:type name: NonEmptyStr\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:type type: ServiceTypeEnum\n:param port: The port number on which the service is running. Defaults to None.\n:type port: int | None\n:param environment: The environment in which the service is running (e.g.,\n    production, staging). Defaults to None.\n:type environment: str | None\n:param cluster: The cluster in which the service is running. Defaults to None.\n:type cluster: str | None\n:param replication_set: The replication set in which the service is running. Defaults to None.\n:type replication_set: str | None\n:param custom_labels: Custom labels associated with the service. Defaults to None.\n:param node_id: The foreign key referencing the node to which the service belongs.\n    Defaults to None.\n:type node_id: int | None",
+        "description": "Define the model for writing service data to the inventory.\n\n:param external_id: An external identifier for the service, indexed for quick\n    lookup.\n:param name: The name of the service.\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:param port: The port number on which the service is running. Defaults to None.\n:param environment: The environment in which the service is running (e.g.,\n    production, staging). Defaults to None.\n:param cluster: The cluster in which the service is running. Defaults to None.\n:param replication_set: The replication set in which the service is running. Defaults to None.\n:param custom_labels: Custom labels associated with the service. Defaults to None.\n:param node_id: The foreign key referencing the node to which the service belongs.\n    Defaults to None.",
         "properties": {
           "cluster": {
             "anyOf": [
@@ -1224,16 +1957,9 @@
             "title": "Environment"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "name": {
             "minLength": 1,
@@ -1277,28 +2003,12 @@
             "$ref": "#/components/schemas/ServiceTypeEnum"
           }
         },
-        "required": ["name", "type"],
+        "required": ["external_id", "name", "type"],
         "title": "ServiceWrite",
         "type": "object"
       },
-      "SettingClassEnum": {
-        "description": "Enumerate settings classes that may have HOT override rows.\n\nThe wired classes are ``SEPSettings``, ``TasksSettings``,\n``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,\n``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and\n``InventorySettings``.\n\nTo wire a new settings class:\n\n1. Add a member here whose value matches the Pydantic class ``__name__``.\n2. Generate an Alembic migration on every consumer track that extends the\n   ``CHECK`` constraint on ``settingoverride.setting_class``. The column\n   uses ``native_enum=False`` so the value list lives in a constraint,\n   not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.\n   Note that the column and ``CHECK`` constraint persist the enum member\n   *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member\n   *value* (the Pydantic class name, e.g. ``SEPSettings``).\n3. Wire a ``ProxyEntry`` for the new class in the relevant service's\n   lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).",
-        "enum": [
-          "SEPSettings",
-          "TasksSettings",
-          "SnippetsSettings",
-          "Settings",
-          "AlertSettings",
-          "AnonymizerSettings",
-          "AlertsSettings",
-          "HealthReportSettings",
-          "InventorySettings"
-        ],
-        "title": "SettingClassEnum",
-        "type": "string"
-      },
       "SettingClassGroup": {
-        "description": "One settings-class group in the LIST response.\n\n:param setting_class: The settings class this group represents.\n:type setting_class: SettingClassEnum\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:type settings: list[SettingResponse]\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:type is_app_owned: bool\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:type app_id: str | None\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:type app_display_name: str | None\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.\n:type app_enabled: bool | None",
+        "description": "Group one settings class's fields for the LIST response.\n\n:param setting_class: The Pydantic class ``__name__`` this group represents.\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.",
         "properties": {
           "app_display_name": {
             "anyOf": [
@@ -1339,7 +2049,8 @@
             "type": "boolean"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "settings": {
             "items": {
@@ -1369,7 +2080,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The settings class the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -1436,7 +2147,8 @@
             "$ref": "#/components/schemas/ReloadClassification"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "type": {
             "title": "Type",
@@ -1492,9 +2204,49 @@
         "title": "SourceEnum",
         "type": "string"
       },
-      "Table": {
-        "description": "Represent a table within a schema.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the table. Must be unique for schema_id, as defined by\n    composite index ix_table_name_schema_id.\n:type name: NonEmptyStr\n:param create: The SQL statement used to create the table.\n:type create: NonEmptyStr\n:param schema_id: The unique identifier of the schema to which the table belongs.\n    Must be unique for name, as defined by composite index ix_table_name_schema_id.\n:type schema_id: int\n:param database: The schema to which the table is associated.\n:type database: Schema",
+      "SyncHealthWrite": {
+        "description": "Define the body reporting one entity's sync outcome.\n\n:param outcome: Whether the attempt succeeded or failed.\n:param error: The failure's message, never empty. Required on FAILURE,\n    absent on SUCCESS.\n:param attempted_at: When the syncer began this attempt. Stamped as\n    ``last_synced_at`` on success, and compared against the row's current\n    ``last_synced_at`` so a late-arriving report from an older attempt\n    cannot overwrite a newer one. Refused when it sits further ahead of this\n    service's clock than the tolerated skew, since nothing later could then\n    supersede it.",
         "properties": {
+          "attempted_at": {
+            "format": "date-time",
+            "title": "Attempted At",
+            "type": "string"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/SyncOutcomeEnum"
+          }
+        },
+        "required": ["outcome", "attempted_at"],
+        "title": "SyncHealthWrite",
+        "type": "object"
+      },
+      "SyncOutcomeEnum": {
+        "description": "Enumerate the outcomes a syncer reports for one entity's sync attempt.\n\n:cvar SUCCESS: The entity was compared against its source and updated.\n:cvar FAILURE: The attempt raised before the comparison completed.",
+        "enum": ["success", "failure"],
+        "title": "SyncOutcomeEnum",
+        "type": "string"
+      },
+      "Table": {
+        "description": "Represent a table within a schema.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the table. Must be unique for schema_id, as defined by\n    composite index ix_table_name_schema_id.\n:param create: The SQL statement used to create the table.\n:param schema_id: The unique identifier of the schema to which the table belongs.\n    Must be unique for name, as defined by composite index ix_table_name_schema_id.\n:param retired_at: When the table stopped being reported upstream, or None while\n    it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the table against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the table is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param database: The schema to which the table is associated.",
+        "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "create": {
             "minLength": 1,
             "title": "Create",
@@ -1521,14 +2273,61 @@
             "title": "Keys",
             "type": "object"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schema_id": {
             "title": "Schema Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -1548,8 +2347,14 @@
         "type": "object"
       },
       "TableDetailResponse": {
-        "description": "Define the schema retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the table.\n:type name: NonEmptyStr\n:param create: The SQL statement used to create the table.\n:type create: NonEmptyStr\n:param schema_id: The foreign key referencing the schema to which the table belongs.\n:type schema_id: int\n:param database: The table's schema.\n:type database: Schema",
+        "description": "Define the schema retrieve API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the table.\n:param create: The SQL statement used to create the table.\n:param schema_id: The foreign key referencing the schema to which the table belongs.\n:param database: The table's schema.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "create": {
             "minLength": 1,
             "title": "Create",
@@ -1579,14 +2384,61 @@
             "title": "Keys",
             "type": "object"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schema_id": {
             "title": "Schema Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -1606,8 +2458,14 @@
         "type": "object"
       },
       "TableResponse": {
-        "description": "Define the table API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the table.\n:type name: NonEmptyStr\n:param create: The SQL statement used to create the table.\n:type create: NonEmptyStr\n:param schema_id: The foreign key referencing the schema to which the table belongs.\n:type schema_id: int",
+        "description": "Define the table API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the table.\n:param create: The SQL statement used to create the table.\n:param schema_id: The foreign key referencing the schema to which the table belongs.\n:param retired_at: When the table stopped being reported upstream, or None while\n    it is active.\n:param last_synced_at: When a syncer last confirmed the table against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the table is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "create": {
             "minLength": 1,
             "title": "Create",
@@ -1634,14 +2492,61 @@
             "title": "Keys",
             "type": "object"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schema_id": {
             "title": "Schema Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -1661,7 +2566,7 @@
         "type": "object"
       },
       "TableWrite": {
-        "description": "Define the model for writing table data to the inventory.\n\n:param name: The name of the table.\n:type name: NonEmptyStr\n:param create: The SQL statement used to create the table.\n:type create: NonEmptyStr\n:param schema_id: The foreign key referencing the schema to which the table belongs.\n:type schema_id: int | None",
+        "description": "Define the model for writing table data to the inventory.\n\n:param name: The name of the table.\n:param create: The SQL statement used to create the table.\n:param schema_id: The foreign key referencing the schema to which the table belongs.",
         "properties": {
           "create": {
             "minLength": 1,
@@ -1785,7 +2690,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           }
         ],
@@ -1844,7 +2750,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {
@@ -1889,7 +2796,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {
@@ -1933,9 +2841,54 @@
         "tags": ["settings"]
       }
     },
+    "/collection/collect": {
+      "post": {
+        "description": "Delete the tombstones the caller's retained set does not cover.\n\nEntities are walked deepest-first — table, schema, service, node — so an\ninterrupted run can only leave deleted descendants under a surviving\nancestor rather than an orphan.\n\nA type that fills its ``limit`` ends the walk. Deleting an ancestor cascades\nto descendants the cap had excluded, and those ids would then be missing from\n``deleted`` — leaving the caller unable to clear their bookkeeping and making\nthe reported set a false record of what was removed. Stopping keeps\n``deleted`` exhaustive; the ancestors are collected on the next batch, which\n``remaining`` asks for.\n\n:param session: The asynchronous database session.\n:param body: The cutoff, the retained ids, and the batch controls.\n:return: The collected ids per entity type, and whether more are waiting.",
+        "operationId": "collection_collect_retired_entities_collection_collect_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InventoryCollectWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InventoryCollectResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Collect Retired Entities",
+        "tags": ["collection"]
+      }
+    },
     "/nodes/": {
       "get": {
-        "description": "List Nodes from Inventory.",
+        "description": "List Nodes from Inventory.\n\n:param session: The async database session.\n:param pagination: Validated offset/limit query parameters.\n:param list_query: The resolved sort/search produced at the request boundary.\n:param manager: The node manager the request's retirement scope selected.\n:param external_id: Return only the node carrying this upstream identifier,\n    resolved through any identity alias recorded for it.\n:param source: Return only nodes discovered by this source.\n:param node_type: Return only nodes of this type.\n:return: A paginated response of node responses.",
         "operationId": "nodes_list_nodes_nodes__get",
         "parameters": [
           {
@@ -2041,6 +2994,16 @@
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
             }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -2117,10 +3080,70 @@
         "tags": ["nodes"]
       }
     },
+    "/nodes/identity-candidates": {
+      "get": {
+        "description": "List node pairings a PMM re-registration may have split.\n\nDeclared above ``GET /{node_id}``: FastAPI matches path operations in\ndeclaration order, so the parameterized route would claim this path first and\nanswer 422 on the unparseable identifier rather than 404.\n\nBuilt through :meth:`PaginatedResponse.from_pagination` rather than\n``list_query_paginated``, the item being a pair of rows and not a single\nmodel.\n\n:param session: The async database session.\n:param pagination: Validated offset/limit query parameters.\n:return: A paginated response of candidate pairings.",
+        "operationId": "nodes_list_node_identity_candidates_nodes_identity_candidates_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_NodeIdentityCandidateResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Node Identity Candidates",
+        "tags": ["nodes"]
+      }
+    },
     "/nodes/{node_id}": {
       "delete": {
-        "description": "Delete Node.",
-        "operationId": "nodes_delete_node_nodes__node_id__delete",
+        "description": "Retire Node and everything below it, keeping the rows resolvable.\n\n:param session: The asynchronous database session.\n:param node: The node to retire, retired or not.",
+        "operationId": "nodes_retire_node_nodes__node_id__delete",
         "parameters": [
           {
             "in": "path",
@@ -2152,11 +3175,11 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "summary": "Delete Node",
+        "summary": "Retire Node",
         "tags": ["nodes"]
       },
       "get": {
-        "description": "Retrieve Node from inventory.",
+        "description": "Retrieve Node from inventory.\n\n:param session: The async database session.\n:param node_id: The identifier of the node to retrieve.\n:param manager: The node manager the request's retirement scope selected.\n:return: The node, with its services nested.\n:raises HTTPNotFoundException: If no node in scope has the given identifier.",
         "operationId": "nodes_retrieve_node_nodes__node_id__get",
         "parameters": [
           {
@@ -2166,6 +3189,16 @@
             "schema": {
               "title": "Node Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -2200,7 +3233,7 @@
         "tags": ["nodes"]
       },
       "put": {
-        "description": "Update Node.",
+        "description": "Update Node.\n\n:param session: The async database session.\n:param existing_node: The active node addressed by the path.\n:param updated_node: The fields to write onto it.\n:return: The updated node.",
         "operationId": "nodes_update_node_nodes__node_id__put",
         "parameters": [
           {
@@ -2251,6 +3284,163 @@
           }
         ],
         "summary": "Update Node",
+        "tags": ["nodes"]
+      }
+    },
+    "/nodes/{node_id}/identity-aliases": {
+      "get": {
+        "description": "List the upstream identifiers this node has answered for, oldest first.\n\nA node no link has ever touched has no records, which is an empty page rather\nthan a 404.\n\n:param session: The async database session.\n:param node: The node addressed by the path, retired or not.\n:param pagination: Validated offset/limit query parameters.\n:return: A paginated response of the node's binding records, oldest first.",
+        "operationId": "nodes_list_node_identity_aliases_nodes__node_id__identity_aliases_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ExternalIdentityAliasResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Node Identity Aliases",
+        "tags": ["nodes"]
+      }
+    },
+    "/nodes/{node_id}/identity-link": {
+      "post": {
+        "description": "Confirm, reject or reverse a candidate node pairing.\n\nThe path names the **predecessor** — the survivor of a confirmation, and the\nrow the operator is acting on in all three decisions.\n\nCarries ``IsAuthenticatedDep`` and deliberately not ``IsServicePrincipalDep``:\nan identity link is an operator judgement, not a row the syncer owns. The\napp-wide unsafe-method gate already makes the route admin-only for a human\nwhile admitting the principal by identity.\n\n:param session: The async database session.\n:param node: The predecessor addressed by the path, retired or not.\n:param decision: What the operator decided, and about which successor.\n:param principal: The caller recorded on the resulting records.\n:raises HTTPBadRequestException: If the body names the node itself, or both\n    rows already hold one identifier.\n:raises HTTPNotFoundException: If a confirmation or rejection names a\n    successor that does not exist. A reversal reports the same absence as a\n    conflict, the pairing it would reverse no longer being reversible.\n:raises HTTPConflictException: If the decision does not apply to the pairing\n    as it currently stands.",
+        "operationId": "nodes_decide_node_identity_link_nodes__node_id__identity_link_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentityLinkDecisionWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Decide Node Identity Link",
+        "tags": ["nodes"]
+      }
+    },
+    "/nodes/{node_id}/revive": {
+      "post": {
+        "description": "Revive a retired Node, leaving the services it was retired with retired.\n\n:param session: The asynchronous database session.\n:param node: The node to revive, retired or not.\n:raises HTTPConflictException: If an active entity already holds the unique\n    key the revived node would reclaim.",
+        "operationId": "nodes_revive_node_nodes__node_id__revive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revive Node",
         "tags": ["nodes"]
       }
     },
@@ -2336,6 +3526,16 @@
               ],
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -2424,6 +3624,55 @@
         "tags": ["nodes"]
       }
     },
+    "/nodes/{node_id}/sync-health": {
+      "post": {
+        "description": "Record the outcome of one syncer attempt on a Node.\n\nAddresses the node whether retired or not: the attempt happened, and a\nconcurrent retirement must not turn bookkeeping into a failed sync item.\n\n:param session: The async database session.\n:param node: The node the outcome was observed for, retired or not.\n:param outcome: What the syncer reported.",
+        "operationId": "nodes_record_node_sync_health_nodes__node_id__sync_health_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncHealthWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record Node Sync Health",
+        "tags": ["nodes"]
+      }
+    },
     "/nodes/{node_id}/system-observation": {
       "get": {
         "description": "Retrieve host system observation for a node.",
@@ -2470,7 +3719,7 @@
         "tags": ["nodes"]
       },
       "put": {
-        "description": "Upsert host system observation for a node.",
+        "description": "Upsert host system observation for a node.\n\n:param session: The async database session.\n:param node: The active node the observation belongs to.\n:param data: The observed host facts to store.\n:return: The stored observation.",
         "operationId": "nodes_upsert_host_system_observation_nodes__node_id__system_observation_put",
         "parameters": [
           {
@@ -2526,7 +3775,7 @@
     },
     "/schemas/": {
       "get": {
-        "description": "List Schemas.",
+        "description": "List Schemas.\n\n:param session: The async database session.\n:param pagination: Validated offset/limit query parameters.\n:param list_query: The resolved sort/search produced at the request boundary.\n:param manager: The schema manager the request's retirement scope selected.\n:return: A paginated response of schema responses.",
         "operationId": "schemas_list_schemas_schemas__get",
         "parameters": [
           {
@@ -2589,6 +3838,16 @@
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
             }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -2624,8 +3883,8 @@
     },
     "/schemas/{schema_id}": {
       "delete": {
-        "description": "Delete Schema.",
-        "operationId": "schemas_delete_schema_schemas__schema_id__delete",
+        "description": "Retire Schema and its tables, keeping the rows resolvable.\n\n:param session: The asynchronous database session.\n:param schema: The schema to retire, retired or not.",
+        "operationId": "schemas_retire_schema_schemas__schema_id__delete",
         "parameters": [
           {
             "in": "path",
@@ -2657,11 +3916,11 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "summary": "Delete Schema",
+        "summary": "Retire Schema",
         "tags": ["schemas"]
       },
       "get": {
-        "description": "Retrieve Schema.",
+        "description": "Retrieve Schema.\n\n:param session: The async database session.\n:param schema_id: The identifier of the schema to retrieve.\n:param manager: The schema manager the request's retirement scope selected.\n:return: The schema, with its tables and service nested.\n:raises HTTPNotFoundException: If no schema in scope has the given identifier.",
         "operationId": "schemas_retrieve_schema_schemas__schema_id__get",
         "parameters": [
           {
@@ -2671,6 +3930,16 @@
             "schema": {
               "title": "Schema Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -2759,6 +4028,94 @@
         "tags": ["schemas"]
       }
     },
+    "/schemas/{schema_id}/revive": {
+      "post": {
+        "description": "Revive a retired Schema together with its retired ancestors.\n\n:param session: The asynchronous database session.\n:param schema: The schema to revive, retired or not.\n:raises HTTPConflictException: If an active entity already holds the unique\n    key the revived schema would reclaim.",
+        "operationId": "schemas_revive_schema_schemas__schema_id__revive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schema_id",
+            "required": true,
+            "schema": {
+              "title": "Schema Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revive Schema",
+        "tags": ["schemas"]
+      }
+    },
+    "/schemas/{schema_id}/sync-health": {
+      "post": {
+        "description": "Record the outcome of one syncer attempt on a Schema.\n\nAddresses the schema whether retired or not: the attempt happened, and a\nconcurrent retirement must not turn bookkeeping into a failed sync item.\n\n:param session: The async database session.\n:param schema: The schema the outcome was observed for, retired or not.\n:param outcome: What the syncer reported.",
+        "operationId": "schemas_record_schema_sync_health_schemas__schema_id__sync_health_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schema_id",
+            "required": true,
+            "schema": {
+              "title": "Schema Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncHealthWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record Schema Sync Health",
+        "tags": ["schemas"]
+      }
+    },
     "/schemas/{schema_id}/tables/": {
       "get": {
         "description": "List Tables by Schema.",
@@ -2832,6 +4189,16 @@
               ],
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -2922,9 +4289,26 @@
     },
     "/services/": {
       "get": {
-        "description": "List Services.",
+        "description": "List Services.\n\n:param session: The async database session.\n:param pagination: Validated offset/limit query parameters.\n:param list_query: The resolved sort/search produced at the request boundary.\n:param manager: The service manager the request's retirement scope selected.\n:param external_id: Return only the service carrying this upstream identifier,\n    resolved through any identity alias recorded for it.\n:param service_type: Return only services of this type.\n:return: A paginated response of service responses.",
         "operationId": "services_list_services_services__get",
         "parameters": [
+          {
+            "in": "query",
+            "name": "external_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "External Id"
+            }
+          },
           {
             "in": "query",
             "name": "service_type",
@@ -2994,6 +4378,16 @@
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
             }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3027,10 +4421,70 @@
         "tags": ["services"]
       }
     },
+    "/services/identity-candidates": {
+      "get": {
+        "description": "List service pairings a PMM re-registration may have split.\n\nDeclared above ``GET /{service_id}``: FastAPI matches path operations in\ndeclaration order, so the parameterized route would claim this path first and\nanswer 422 on the unparseable identifier rather than 404.\n\n:param session: The async database session.\n:param pagination: Validated offset/limit query parameters.\n:return: A paginated response of candidate pairings.",
+        "operationId": "services_list_service_identity_candidates_services_identity_candidates_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ServiceIdentityCandidateResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Service Identity Candidates",
+        "tags": ["services"]
+      }
+    },
     "/services/{service_id}": {
       "delete": {
-        "description": "Delete Service.",
-        "operationId": "services_delete_service_services__service_id__delete",
+        "description": "Retire Service and everything below it, keeping the rows resolvable.\n\n:param session: The asynchronous database session.\n:param service: The service to retire, retired or not.",
+        "operationId": "services_retire_service_services__service_id__delete",
         "parameters": [
           {
             "in": "path",
@@ -3062,7 +4516,7 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "summary": "Delete Service",
+        "summary": "Retire Service",
         "tags": ["services"]
       },
       "get": {
@@ -3076,6 +4530,16 @@
             "schema": {
               "title": "Service Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -3164,9 +4628,166 @@
         "tags": ["services"]
       }
     },
+    "/services/{service_id}/identity-aliases": {
+      "get": {
+        "description": "List the upstream identifiers this service has answered for, oldest first.\n\n:param session: The async database session.\n:param service: The service addressed by the path, retired or not.\n:param pagination: Validated offset/limit query parameters.\n:return: A paginated response of the service's binding records, oldest first.",
+        "operationId": "services_list_service_identity_aliases_services__service_id__identity_aliases_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service_id",
+            "required": true,
+            "schema": {
+              "title": "Service Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ExternalIdentityAliasResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Service Identity Aliases",
+        "tags": ["services"]
+      }
+    },
+    "/services/{service_id}/identity-link": {
+      "post": {
+        "description": "Confirm, reject or reverse a candidate service pairing.\n\nThe path names the **predecessor** — the survivor of a confirmation.\n\nCarries ``IsAuthenticatedDep`` and deliberately not ``IsServicePrincipalDep``:\nan identity link is an operator judgement, not a row the syncer owns.\n\n:param session: The async database session.\n:param service: The predecessor addressed by the path, retired or not.\n:param decision: What the operator decided, and about which successor.\n:param principal: The caller recorded on the resulting records.\n:raises HTTPBadRequestException: If the body names the service itself, or both\n    rows already hold one identifier.\n:raises HTTPNotFoundException: If a confirmation or rejection names a\n    successor that does not exist. A reversal reports the same absence as a\n    conflict, the pairing it would reverse no longer being reversible.\n:raises HTTPConflictException: If the decision does not apply to the pairing\n    as it currently stands.",
+        "operationId": "services_decide_service_identity_link_services__service_id__identity_link_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service_id",
+            "required": true,
+            "schema": {
+              "title": "Service Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IdentityLinkDecisionWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Decide Service Identity Link",
+        "tags": ["services"]
+      }
+    },
+    "/services/{service_id}/revive": {
+      "post": {
+        "description": "Revive a retired Service together with its retired ancestors.\n\n:param session: The asynchronous database session.\n:param service: The service to revive, retired or not.\n:raises HTTPConflictException: If an active entity already holds the unique\n    key the revived service would reclaim.",
+        "operationId": "services_revive_service_services__service_id__revive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service_id",
+            "required": true,
+            "schema": {
+              "title": "Service Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revive Service",
+        "tags": ["services"]
+      }
+    },
     "/services/{service_id}/schemas/": {
       "get": {
-        "description": "List Schemas by Service.\n\nReturn ``SchemaResponse`` (with nested tables) when ``include_tables``\nis set, otherwise return ``SchemaCompactResponse`` (without tables).\n\n:param session: The async database session.\n:param service: The resolved service dependency.\n:param pagination: Validated offset/limit query parameters.\n:param list_query: The resolved sort/search produced at the request\n    boundary.\n:param include_tables: Include nested tables in the response when set to\n    any non-empty value. Defaults to compact mode (no tables).\n:return: A paginated response of schema responses.",
+        "description": "List Schemas by Service.\n\nReturn ``SchemaResponse`` (with nested tables) when ``include_tables``\nis set, otherwise return ``SchemaCompactResponse`` (without tables).\n\n:param session: The async database session.\n:param service: The resolved service dependency.\n:param pagination: Validated offset/limit query parameters.\n:param list_query: The resolved sort/search produced at the request\n    boundary.\n:param manager: The schema manager the request's retirement scope selected.\n:param include_tables: Include nested tables in the response when set to\n    any non-empty value. Defaults to compact mode (no tables).\n:return: A paginated response of schema responses.",
         "operationId": "services_list_schemas_by_service_services__service_id__schemas__get",
         "parameters": [
           {
@@ -3254,6 +4875,16 @@
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
             }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3338,6 +4969,55 @@
           }
         ],
         "summary": "Create Schema For Service",
+        "tags": ["services"]
+      }
+    },
+    "/services/{service_id}/sync-health": {
+      "post": {
+        "description": "Record the outcome of one syncer attempt on a Service.\n\nAddresses the service whether retired or not: the attempt happened, and a\nconcurrent retirement must not turn bookkeeping into a failed sync item.\n\n:param session: The async database session.\n:param service: The service the outcome was observed for, retired or not.\n:param outcome: What the syncer reported.",
+        "operationId": "services_record_service_sync_health_services__service_id__sync_health_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "service_id",
+            "required": true,
+            "schema": {
+              "title": "Service Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncHealthWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record Service Sync Health",
         "tags": ["services"]
       }
     },
@@ -3535,6 +5215,16 @@
               "description": "Case-insensitive search across the searchable columns.",
               "title": "Search"
             }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -3570,8 +5260,8 @@
     },
     "/tables/{table_id}": {
       "delete": {
-        "description": "Delete Table.",
-        "operationId": "tables_delete_table_tables__table_id__delete",
+        "description": "Retire Table, keeping the row resolvable.\n\n:param session: The asynchronous database session.\n:param table: The table to retire, retired or not.",
+        "operationId": "tables_retire_table_tables__table_id__delete",
         "parameters": [
           {
             "in": "path",
@@ -3603,11 +5293,11 @@
             "OAuth2PasswordBearer": []
           }
         ],
-        "summary": "Delete Table",
+        "summary": "Retire Table",
         "tags": ["tables"]
       },
       "get": {
-        "description": "Retrieve Table.",
+        "description": "Retrieve Table.\n\n:param session: The async database session.\n:param table_id: The identifier of the table to retrieve.\n:param manager: The table manager the request's retirement scope selected.\n:return: The table, with its schema nested.\n:raises HTTPNotFoundException: If no table in scope has the given identifier.",
         "operationId": "tables_retrieve_table_tables__table_id__get",
         "parameters": [
           {
@@ -3617,6 +5307,16 @@
             "schema": {
               "title": "Table Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_retired",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Retired",
+              "type": "boolean"
             }
           }
         ],
@@ -3702,6 +5402,94 @@
           }
         ],
         "summary": "Update Table",
+        "tags": ["tables"]
+      }
+    },
+    "/tables/{table_id}/revive": {
+      "post": {
+        "description": "Revive a retired Table together with its retired ancestors.\n\n:param session: The asynchronous database session.\n:param table: The table to revive, retired or not.\n:raises HTTPConflictException: If an active entity already holds the unique\n    key the revived table would reclaim.",
+        "operationId": "tables_revive_table_tables__table_id__revive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "table_id",
+            "required": true,
+            "schema": {
+              "title": "Table Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Revive Table",
+        "tags": ["tables"]
+      }
+    },
+    "/tables/{table_id}/sync-health": {
+      "post": {
+        "description": "Record the outcome of one syncer attempt on a Table.\n\nAddresses the table whether retired or not: the attempt happened, and a\nconcurrent retirement must not turn bookkeeping into a failed sync item.\n\n:param session: The async database session.\n:param table: The table the outcome was observed for, retired or not.\n:param outcome: What the syncer reported.",
+        "operationId": "tables_record_table_sync_health_tables__table_id__sync_health_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "table_id",
+            "required": true,
+            "schema": {
+              "title": "Table Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SyncHealthWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Record Table Sync Health",
         "tags": ["tables"]
       }
     }

--- a/ui/packages/sep/api/specs/sep.json
+++ b/ui/packages/sep/api/specs/sep.json
@@ -309,7 +309,10 @@
           "error",
           "unreachable",
           "ssl_error",
-          "timeout"
+          "timeout",
+          "not_configured",
+          "inputs_drifted",
+          "probe_undeclared"
         ],
         "title": "ConnectivityStatusEnum",
         "type": "string"
@@ -444,12 +447,18 @@
         "type": "string"
       },
       "Node": {
-        "description": "Represent a node in the inventory.\n\n:param address: The network address of the node.\n:type address: NonEmptyStr\n:param name: The name of the node.\n:type name: NonEmptyStr\n:param external_id: An external identifier for the node. Must be unique for source,\n    as defined by composite index ix_node_external_id_source.\n:type external_id: NonEmptyStr | None\n:param source: The source from which the node information is derived. Must be unique\n    for external_id, as defined by composite index ix_node_external_id_source.\n:type source: SourceEnum | None\n:param type: The type of the node (e.g., remote, generic).\n:type type: NonEmptyStr\n:param services: A list of services associated with the node.\n:type services: list[Service]",
+        "description": "Represent a node in the inventory.\n\n:param address: The network address of the node.\n:param name: The name of the node.\n:param external_id: An external identifier for the node. Must be unique for source,\n    as defined by composite index ix_node_external_id_source.\n:param source: The source from which the node information is derived. Must be unique\n    for external_id, as defined by composite index ix_node_external_id_source.\n:param type: The type of the node (e.g., remote, generic).\n:param retired_at: When the node stopped being reported upstream, or None while\n    it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the node against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the node is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param services: A list of services associated with the node.",
         "properties": {
           "address": {
             "minLength": 1,
             "title": "Address",
             "type": "string"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -457,16 +466,9 @@
             "type": "string"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -479,20 +481,60 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
-          "source": {
+          "retired_at": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SourceEnum"
+                "format": "date-time",
+                "type": "string"
               },
               {
                 "type": "null"
               }
-            ]
+            ],
+            "title": "Retired At"
+          },
+          "source": {
+            "$ref": "#/components/schemas/SourceEnum"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "default": "generic",
@@ -513,7 +555,7 @@
             "title": "Updated At"
           }
         },
-        "required": ["id", "address", "name"],
+        "required": ["id", "address", "name", "external_id", "source"],
         "title": "Node",
         "type": "object"
       },
@@ -666,8 +708,14 @@
         "type": "string"
       },
       "Schema": {
-        "description": "Represent a database schema within a service.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param name: The name of the schema. Must be unique for service_id, as defined by\n    composite index ix_schema_name_service_id.\n:type name: NonEmptyStr\n:param service_id: The unique identifier of the service to which the schema belongs.\n    Must be unique for name, as defined by composite index\n    ix_schema_name_service_id.\n:type service_id: int\n:param service: The service to which the schema is associated.\n:type service: Service\n:param tables: A list of tables within the schema.\n:type tables: list[Table]",
+        "description": "Represent a database schema within a service.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param name: The name of the schema. Must be unique for service_id, as defined by\n    composite index ix_schema_name_service_id.\n:param service_id: The unique identifier of the service to which the schema belongs.\n    Must be unique for name, as defined by composite index\n    ix_schema_name_service_id.\n:param service: The service to which the schema is associated.\n:param retired_at: When the schema stopped being reported upstream, or None\n    while it is active.\n:param retirement_key: The discriminator carried inside every unique index.\n:param last_synced_at: When a syncer last confirmed the schema against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the schema is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.\n:param tables: A list of tables within the schema.",
         "properties": {
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_at": {
             "format": "date-time",
             "title": "Created At",
@@ -684,14 +732,61 @@
             ],
             "title": "Id"
           },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
+          },
           "name": {
             "minLength": 1,
             "title": "Name",
             "type": "string"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "service_id": {
             "title": "Service Id",
             "type": "integer"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "updated_at": {
             "anyOf": [
@@ -712,12 +807,12 @@
       },
       "ServiceEnum": {
         "description": "Enumerate the probeable services, used as stable ``service`` identifiers.",
-        "enum": ["pmm", "inventory", "tasks", "nomad"],
+        "enum": ["pmm", "inventory", "tasks", "nomad", "delivery"],
         "title": "ServiceEnum",
         "type": "string"
       },
       "ServiceResponse": {
-        "description": "Define the service API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:type id: int | None\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:type created_at: UTCDatetime\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:type updated_at: UTCDatetime | None\n:param external_id: An external identifier for the service.\n:type external_id: NonEmptyStr | None\n:param name: The name of the service.\n:type name: NonEmptyStr\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:type type: ServiceTypeEnum\n:param port: The port number on which the service is running.\n:type port: int | None\n:param environment: The environment in which the service is running, if set.\n:type environment: str | None\n:param cluster: The cluster in which the service is running, if set.\n:type cluster: str | None\n:param replication_set: The replication set in which the service is running, if set.\n:type replication_set: str | None\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:type node_id: int\n:param schemas: A list of schemas associated with the service.\n:type schemas: list[Schema]\n:param node: The node to which the service is associated.\n:type node: Node",
+        "description": "Define the service API response.\n\n:param id: The primary key for the table. Auto-incremented and not nullable.\n:param created_at: The timestamp when the record is created. Defaults to the current\n    time in UTC.\n:param updated_at: The timestamp when the record is last updated. Automatically\n    updated on changes.\n:param external_id: An external identifier for the service.\n:param name: The name of the service.\n:param type: The type of the service (e.g., MYSQL, POSTGRESQL).\n:param port: The port number on which the service is running.\n:param environment: The environment in which the service is running, if set.\n:param cluster: The cluster in which the service is running, if set.\n:param replication_set: The replication set in which the service is running, if set.\n:param custom_labels: Custom labels associated with the service, if set.\n:param node_id: The unique identifier of the node on which the service is running.\n:param schemas: A list of schemas associated with the service.\n:param node: The node to which the service is associated.\n:param retired_at: When the service stopped being reported upstream, or None\n    while it is active.\n:param last_synced_at: When a syncer last confirmed the service against its\n    source, or None if that has never happened.\n:param last_sync_error: The message from the most recent failed attempt, or\n    None while the service is syncing cleanly.\n:param sync_failing_since: When the current run of failures began, or None\n    while not failing.\n:param consecutive_failures: Failed attempts since the last success.",
         "properties": {
           "cluster": {
             "anyOf": [
@@ -729,6 +824,12 @@
               }
             ],
             "title": "Cluster"
+          },
+          "consecutive_failures": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Consecutive Failures",
+            "type": "integer"
           },
           "created_at": {
             "format": "date-time",
@@ -759,16 +860,9 @@
             "title": "Environment"
           },
           "external_id": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "External Id"
+            "minLength": 1,
+            "title": "External Id",
+            "type": "string"
           },
           "id": {
             "anyOf": [
@@ -780,6 +874,29 @@
               }
             ],
             "title": "Id"
+          },
+          "last_sync_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Sync Error"
+          },
+          "last_synced_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Synced At"
           },
           "name": {
             "minLength": 1,
@@ -815,12 +932,36 @@
             ],
             "title": "Replication Set"
           },
+          "retired_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          },
           "schemas": {
             "items": {
               "$ref": "#/components/schemas/Schema"
             },
             "title": "Schemas",
             "type": "array"
+          },
+          "sync_failing_since": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sync Failing Since"
           },
           "type": {
             "$ref": "#/components/schemas/ServiceTypeEnum"
@@ -838,7 +979,15 @@
             "title": "Updated At"
           }
         },
-        "required": ["name", "type", "node_id", "id", "schemas", "node"],
+        "required": [
+          "external_id",
+          "name",
+          "type",
+          "node_id",
+          "id",
+          "schemas",
+          "node"
+        ],
         "title": "ServiceResponse",
         "type": "object"
       },
@@ -856,24 +1005,8 @@
         "title": "ServiceTypeEnum",
         "type": "string"
       },
-      "SettingClassEnum": {
-        "description": "Enumerate settings classes that may have HOT override rows.\n\nThe wired classes are ``SEPSettings``, ``TasksSettings``,\n``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,\n``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and\n``InventorySettings``.\n\nTo wire a new settings class:\n\n1. Add a member here whose value matches the Pydantic class ``__name__``.\n2. Generate an Alembic migration on every consumer track that extends the\n   ``CHECK`` constraint on ``settingoverride.setting_class``. The column\n   uses ``native_enum=False`` so the value list lives in a constraint,\n   not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.\n   Note that the column and ``CHECK`` constraint persist the enum member\n   *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member\n   *value* (the Pydantic class name, e.g. ``SEPSettings``).\n3. Wire a ``ProxyEntry`` for the new class in the relevant service's\n   lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).",
-        "enum": [
-          "SEPSettings",
-          "TasksSettings",
-          "SnippetsSettings",
-          "Settings",
-          "AlertSettings",
-          "AnonymizerSettings",
-          "AlertsSettings",
-          "HealthReportSettings",
-          "InventorySettings"
-        ],
-        "title": "SettingClassEnum",
-        "type": "string"
-      },
       "SettingClassGroup": {
-        "description": "One settings-class group in the LIST response.\n\n:param setting_class: The settings class this group represents.\n:type setting_class: SettingClassEnum\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:type settings: list[SettingResponse]\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:type is_app_owned: bool\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:type app_id: str | None\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:type app_display_name: str | None\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.\n:type app_enabled: bool | None",
+        "description": "Group one settings class's fields for the LIST response.\n\n:param setting_class: The Pydantic class ``__name__`` this group represents.\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.",
         "properties": {
           "app_display_name": {
             "anyOf": [
@@ -914,7 +1047,8 @@
             "type": "boolean"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "settings": {
             "items": {
@@ -944,7 +1078,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The settings class the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -1011,7 +1145,8 @@
             "$ref": "#/components/schemas/ReloadClassification"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "type": {
             "title": "Type",
@@ -1245,6 +1380,12 @@
         "title": "SourceEnum",
         "type": "string"
       },
+      "SyncStatusEnum": {
+        "description": "Enumerate the possible statuses of a synchronization process.\n\n:cvar PENDING: The synchronization is pending.\n:vartype PENDING: str\n:cvar RUNNING: The synchronization is currently running.\n:vartype RUNNING: str\n:cvar SUCCESS: The synchronization completed successfully.\n:vartype SUCCESS: str\n:cvar FAILED: The synchronization failed.\n:vartype FAILED: str",
+        "enum": ["pending", "running", "success", "failed"],
+        "title": "SyncStatusEnum",
+        "type": "string"
+      },
       "TaskBackendEnum": {
         "description": "Control the choice of backends.\n\n:cvar NOMAD: Enum value for Nomad backend.\n:vartype NOMAD: str\n:cvar PROXY: Enum value for Proxy backend.\n:vartype PROXY: str\n:cvar CELERY: Enum value for Celery backend.\n:vartype CELERY: str",
         "enum": ["nomad", "proxy", "celery"],
@@ -1444,7 +1585,7 @@
         "type": "object"
       },
       "TaskHistoryStatusEnum": {
-        "description": "Define status codes for task executions.\n\n:cvar FAILED: Enum value for failed tasks.\n:cvar PENDING: Enum value for pending tasks.\n:cvar RUNNING: Enum value for running tasks.\n:cvar SUCCESS: Enum value for successfully completed tasks.\n:cvar STOPPED: Enum value for stopped tasks.\n:cvar LOST: Enum value for tasks that are lost.\n:cvar STALE: Enum value for tasks skipped because executor placement\n    exceeded the configured staleness threshold (for example a Nomad\n    allocation that never left the queue).",
+        "description": "Define status codes for task executions.\n\n:cvar FAILED: Enum value for failed tasks.\n:cvar PENDING: Enum value for pending tasks.\n:cvar RUNNING: Enum value for running tasks.\n:cvar SUCCESS: Enum value for successfully completed tasks.\n:cvar STOPPED: Enum value for stopped tasks.\n:cvar LOST: Enum value for tasks that are lost.\n:cvar STALE: Enum value for tasks skipped because executor placement\n    exceeded the configured staleness threshold (for example a Nomad\n    allocation that never left the queue).\n:cvar UNLAUNCHABLE: Enum value for tasks the executor node could not\n    launch at all, because some command in the invocation does not\n    resolve there. The payload never ran, so this is not a script\n    failure.",
         "enum": [
           "failed",
           "pending",
@@ -1452,7 +1593,8 @@
           "success",
           "stopped",
           "lost",
-          "stale"
+          "stale",
+          "unlaunchable"
         ],
         "title": "TaskHistoryStatusEnum",
         "type": "string"
@@ -3440,9 +3582,49 @@
         "title": "ATWSnippetSummary",
         "type": "object"
       },
-      "atw__AtwConfigResponse": {
-        "description": "Report whether the incident send action is available.\n\n:param send_disabled_reasons: Why sending is unavailable; empty when the\n    receiver is configured and the action is offered.",
+      "atw__AtwCaseMatch": {
+        "description": "Represent one support case the delivery provider matched.\n\n:param reference: The case reference to send diagnostics against.\n:param title: The case title, shown beside the reference to tell two\n    similar references apart.",
         "properties": {
+          "reference": {
+            "title": "Reference",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": ["reference", "title"],
+        "title": "AtwCaseMatch",
+        "type": "object"
+      },
+      "atw__AtwCaseSearchResponse": {
+        "description": "Report the cases matching a typed term, or that the search could not run.\n\n:param available: Whether the search ran at all. This is what keeps an\n    unavailable search distinct from an available one that matched nothing:\n    a caller must not render the first as the second.\n:param matches: The matched cases, empty when there are none and when the\n    search could not run.",
+        "properties": {
+          "available": {
+            "title": "Available",
+            "type": "boolean"
+          },
+          "matches": {
+            "items": {
+              "$ref": "#/components/schemas/atw__AtwCaseMatch"
+            },
+            "title": "Matches",
+            "type": "array"
+          }
+        },
+        "required": ["available", "matches"],
+        "title": "AtwCaseSearchResponse",
+        "type": "object"
+      },
+      "atw__AtwConfigResponse": {
+        "description": "Report whether the incident send action is available.\n\n:param send_disabled_reasons: Why sending is unavailable; empty when the\n    receiver is configured and the action is offered.\n:param case_search_available: Whether the case-reference field may query the\n    receiver for matches. Defaults to ``False`` so a client built against\n    the response before this field existed keeps validating.",
+        "properties": {
+          "case_search_available": {
+            "default": false,
+            "title": "Case Search Available",
+            "type": "boolean"
+          },
           "send_disabled_reasons": {
             "items": {
               "type": "string"
@@ -5004,10 +5186,8 @@
           "pgbackrest_incremental_cycle": {
             "anyOf": [
               {
+                "enum": ["daily", "weekly", "1", "2", "3", "4", "5", "6", "7"],
                 "type": "string"
-              },
-              {
-                "type": "integer"
               },
               {
                 "type": "null"
@@ -6010,7 +6190,7 @@
       },
       "framework__AppSchema": {
         "additionalProperties": false,
-        "description": "Represent a plugin's complete schema: form sections, list view, capabilities.\n\n:param name: The plugin identifier; must match Python identifier rules,\n    optionally with internal hyphens.\n:type name: NonEmptyStr\n:param display_name: The human-readable plugin title displayed in the UI.\n:type display_name: NonEmptyStr\n:param description: Optional helper text describing the plugin's\n    purpose. Defaults to ``None``.\n:type description: NonEmptyStr | None\n:param task_type: Optional task-type identifier used when creating tasks\n    via the shared task API. Defaults to ``None``.\n:type task_type: NonEmptyStr | None\n:param forms: Form sections for single-entity / task plugins. Defaults to\n    an empty list when ``entities`` is used instead.\n:type forms: list[FormSection]\n:param capabilities: Optional plugin-level feature flags. Defaults to\n    ``None``.\n:type capabilities: Capabilities | None\n:param list_view: List-view configuration when ``entities`` is unset\n    (single-entity / task plugins). Ignored when ``entities`` is set.\n:type list_view: ListView | None\n:param detail_view: Optional declarative layout for the task detail page's\n    section cards (task-style plugins only; ignored when ``entities`` is\n    set). Optional at the model layer for backwards compatibility. A\n    forward-looking guard refuses to load a plugin that sets\n    ``task_type`` without declaring ``detail_view``. Defaults to ``None``.\n:type detail_view: DetailView | None\n:param entities: Optional list of CRUD entities for multi-resource plugins.\n    When non-empty, the React shell renders one list/create/detail flow\n    per entity. Defaults to ``None`` (legacy single-entity mode).\n:param cardinality_rules: Optional plugin-wide cross-field cardinality\n    constraints (task-style plugins only; ignored when ``entities`` is set).\n    Defaults to ``None``.\n:type cardinality_rules: list[CardinalityRule] | None\n:param fail_when: Optional plugin-wide predicate-only invariants (task-style\n    plugins only; ignored when ``entities`` is set). Defaults to ``None``.\n:type fail_when: list[FailRule] | None\n:param derived: Optional declarative specs for sibling tasks derived from\n    the parent task on cascade. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the parent and N derived siblings. Defaults to ``None``.\n:type derived: list[DerivedTask] | None\n:param predecessors: Optional declarative specs for tasks that must run\n    before the parent. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the predecessors and the parent, including the chain wiring\n    applied at execute time. Defaults to ``None``.\n:type predecessors: list[ChainedPredecessor] | None\n:param related_apps: Optional separately registered apps the React shell\n    surfaces as sibling tabs (for example a restore app nested under a\n    backups parent). Defaults to ``None``.\n:type related_apps: list[RelatedApp] | None",
+        "description": "Represent a plugin's complete schema: form sections, list view, capabilities.\n\n:param name: The plugin identifier; must match Python identifier rules,\n    optionally with internal hyphens.\n:type name: NonEmptyStr\n:param display_name: The human-readable plugin title displayed in the UI.\n:type display_name: NonEmptyStr\n:param description: Optional helper text describing the plugin's\n    purpose. Defaults to ``None``.\n:type description: NonEmptyStr | None\n:param task_type: Optional task-type identifier used when creating tasks\n    via the shared task API. Defaults to ``None``.\n:type task_type: NonEmptyStr | None\n:param forms: Form sections for single-entity / task plugins. When\n    ``entities`` is non-empty, root ``forms`` must be empty (declare\n    forms on each entity instead); non-empty root ``forms`` are rejected\n    at construction. Defaults to an empty list.\n:type forms: list[FormSection]\n:param capabilities: Optional plugin-level feature flags. Defaults to\n    ``None``.\n:type capabilities: Capabilities | None\n:param list_view: List-view configuration when ``entities`` is unset\n    (single-entity / task plugins). Ignored when ``entities`` is set.\n:type list_view: ListView | None\n:param detail_view: Optional declarative layout for the task detail page's\n    section cards (task-style plugins only; ignored when ``entities`` is\n    set). Optional at the model layer for backwards compatibility. A\n    forward-looking guard refuses to load a plugin that sets\n    ``task_type`` without declaring ``detail_view``. Defaults to ``None``.\n:type detail_view: DetailView | None\n:param entities: Optional list of CRUD entities for multi-resource plugins.\n    When non-empty, the React shell renders one list/create/detail flow\n    per entity. Defaults to ``None`` (legacy single-entity mode).\n:param cardinality_rules: Optional plugin-wide cross-field cardinality\n    constraints (task-style plugins only). Rejected at construction when\n    ``entities`` is non-empty — declare rules on each entity instead.\n    Defaults to ``None``.\n:type cardinality_rules: list[CardinalityRule] | None\n:param fail_when: Optional plugin-wide predicate-only invariants (task-style\n    plugins only). Rejected at construction when ``entities`` is non-empty —\n    declare rules on each entity instead. Defaults to ``None``.\n:type fail_when: list[FailRule] | None\n:param derived: Optional declarative specs for sibling tasks derived from\n    the parent task on cascade. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the parent and N derived siblings. Defaults to ``None``.\n:type derived: list[DerivedTask] | None\n:param predecessors: Optional declarative specs for tasks that must run\n    before the parent. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the predecessors and the parent, including the chain wiring\n    applied at execute time. Defaults to ``None``.\n:type predecessors: list[ChainedPredecessor] | None\n:param related_apps: Optional separately registered apps the React shell\n    surfaces as sibling tabs (for example a restore app nested under a\n    backups parent). Defaults to ``None``.\n:type related_apps: list[RelatedApp] | None",
         "properties": {
           "capabilities": {
             "anyOf": [
@@ -7547,7 +7727,7 @@
       },
       "framework__HostField": {
         "additionalProperties": false,
-        "description": "Represent an executor-target (Nomad / Celery) selector field.\n\nThe React renderer loads options from ``GET /api/sep/hosts/`` (an SEP\nproxy endpoint that internally calls Tasks ``/hosts/`` and merges\nInventory display names server-side). When ``depends_on`` is set (typically\na ``ServiceField``), the renderer may auto-select an executor from the\nupstream service; when omitted every available executor is listed and no\ncascade runs.\n\n:param field_type: The discriminator literal; always ``\"host\"`` for this\n    class. Serialised as the JSON key ``\"type\"``.\n:type field_type: Literal[\"host\"]\n:param depends_on: Optional name of the field whose value drives the\n    default executor selection. ``None`` (the default) omits the key from\n    the wire so plugins that do not opt in stay byte-identical.\n:param allow_custom: When ``True``, the selector also accepts a free-typed\n    value alongside the inventory options. ``None`` (the default) omits the\n    key from the wire so plugins that do not opt in stay byte-identical.",
+        "description": "Represent an executor-target (Nomad / Celery) selector field.\n\nThe React renderer loads options from ``GET /api/sep/hosts/`` (an SEP\nproxy endpoint that internally calls Tasks ``/hosts/`` and merges\nInventory display names server-side). When ``depends_on`` is set (typically\na ``ServiceField``), the renderer may auto-select an executor from the\nupstream service; when omitted every available executor is listed and no\ncascade runs.\n\n:param field_type: The discriminator literal; always ``\"host\"`` for this\n    class. Serialised as the JSON key ``\"type\"``.\n:param depends_on: Optional name of the field whose value drives the\n    default executor selection. ``None`` (the default) omits the key from\n    the wire so plugins that do not opt in stay byte-identical.\n:param target_service: Optional service field for a non-blocking\n    co-location warning. Independent of ``depends_on`` (see\n    :class:`~app.sep.apps.framework.form_dsl.markers.HostRef`).\n    ``None`` (the default) omits the key from the wire.\n:param allow_custom: When ``True``, the selector also accepts a free-typed\n    value alongside the inventory options. ``None`` (the default) omits the\n    key from the wire so plugins that do not opt in stay byte-identical.",
         "properties": {
           "allow_custom": {
             "anyOf": [
@@ -7636,6 +7816,18 @@
               }
             ],
             "title": "Requires"
+          },
+          "target_service": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Service"
           },
           "type": {
             "const": "host",
@@ -7901,7 +8093,7 @@
       },
       "framework__MultiHostField": {
         "additionalProperties": false,
-        "description": "Represent a multi-value executor-target selector field.\n\nThe multi-value counterpart of :class:`HostField`: the renderer commits a\nlist of executor targets instead of a single one. Derived from a\n``HostRef(multiple=True)`` marker on a ``list[...]`` / ``set[...]`` field.\n\nCascade auto-select is single-host only (:class:`HostField`). ``depends_on``\nmay still be emitted when ``Ui(depends_on=...)`` is set so derivation stays\nuniform, but the multi-host renderer does not honour it today.\n\n:param field_type: The discriminator literal; always ``\"multi_host\"`` for\n    this class. Serialised as the JSON key ``\"type\"``.\n:param depends_on: Optional upstream field name mirrored from\n    ``Ui(depends_on=...)``. Emitted for wire uniformity with\n    :class:`HostField`; the current multi-host renderer ignores it (no\n    cascade). ``None`` (the default) omits the key from the wire.\n:param allow_custom: When ``True``, the selector also accepts free-typed\n    values alongside the inventory options. ``None`` (the default) omits the\n    key from the wire so plugins that do not opt in stay byte-identical.",
+        "description": "Represent a multi-value executor-target selector field.\n\nThe multi-value counterpart of :class:`HostField`: the renderer commits a\nlist of executor targets instead of a single one. Derived from a\n``HostRef(multiple=True)`` marker on a ``list[...]`` / ``set[...]`` field.\n\nCascade auto-select is single-host only (:class:`HostField`). ``depends_on``\nmay still be emitted when ``Ui(depends_on=...)`` is set so derivation stays\nuniform, but the multi-host renderer does not honour it today.\n``target_service`` is mirrored the same way; the multi-host renderer\nignores it (no co-location warning).\n\n:param field_type: The discriminator literal; always ``\"multi_host\"`` for\n    this class. Serialised as the JSON key ``\"type\"``.\n:param depends_on: Optional upstream field name mirrored from\n    ``Ui(depends_on=...)``. Emitted for wire uniformity with\n    :class:`HostField`; the current multi-host renderer ignores it (no\n    cascade). ``None`` (the default) omits the key from the wire.\n:param target_service: Optional service field name mirrored for wire\n    uniformity with :class:`HostField`; ignored by the multi-host\n    renderer. ``None`` (the default) omits the key from the wire.\n:param allow_custom: When ``True``, the selector also accepts free-typed\n    values alongside the inventory options. ``None`` (the default) omits the\n    key from the wire so plugins that do not opt in stay byte-identical.",
         "properties": {
           "allow_custom": {
             "anyOf": [
@@ -7990,6 +8182,18 @@
               }
             ],
             "title": "Requires"
+          },
+          "target_service": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Service"
           },
           "type": {
             "const": "multi_host",
@@ -9693,11 +9897,19 @@
         "type": "object"
       },
       "inventory__InventorySyncStatusResponse": {
-        "description": "Represent the inventory sync status response.\n\n:param is_running: ``True`` when an inventory-wide sync is currently\n    in progress; ``False`` otherwise.\n:type is_running: bool",
+        "description": "Represent the inventory sync status response.\n\n:param is_running: ``True`` when an inventory-wide sync is currently\n    in progress; ``False`` otherwise.\n:param last_runs: The most recently recorded synchronization runs, newest first.",
         "properties": {
           "is_running": {
             "title": "Is Running",
             "type": "boolean"
+          },
+          "last_runs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/inventory__SyncRunSummary"
+            },
+            "title": "Last Runs",
+            "type": "array"
           }
         },
         "required": ["is_running"],
@@ -9724,7 +9936,7 @@
         "type": "object"
       },
       "inventory__PluginTaskResponse": {
-        "description": "Represent a single plugin task entry returned by ``GET /api/apps/inventory/``.\n\n:param name: Machine-readable task identifier (e.g. ``\"inventory-sync\"``).\n:type name: str\n:param display_name: Human-readable label for the schedule UI.\n:type display_name: str",
+        "description": "Represent a single plugin task entry returned by ``GET /api/apps/inventory/``.\n\n:param name: Machine-readable task identifier (e.g. ``\"inventory-sync\"``).\n:param display_name: Human-readable label for the schedule UI.",
         "properties": {
           "display_name": {
             "title": "Display Name",
@@ -9739,8 +9951,58 @@
         "title": "PluginTaskResponse",
         "type": "object"
       },
+      "inventory__SyncRunSummary": {
+        "description": "Summarize one recorded synchronization run for the sync-status endpoint.\n\n:param syncer: The fully qualified name of the synchronizer that ran.\n:param started_at: When the run was recorded.\n:param finished_at: When the run last changed, or ``None`` while it is open.\n:param status: The run-level outcome.\n:param snapshot_complete: Whether the run observed a complete generation of the\n    remote inventory, or ``None`` when the syncer does not produce one.",
+        "properties": {
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "snapshot_complete": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Complete"
+          },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SyncStatusEnum"
+          },
+          "syncer": {
+            "minLength": 1,
+            "title": "Syncer",
+            "type": "string"
+          }
+        },
+        "required": [
+          "syncer",
+          "started_at",
+          "finished_at",
+          "status",
+          "snapshot_complete"
+        ],
+        "title": "SyncRunSummary",
+        "type": "object"
+      },
       "mysql_backups__BackupCreate": {
-        "description": "Declare the model-first create/update body and ``GET /schema`` source for MySQL Backups.\n\nDeclares each form field once, in section order (Task, General, Mydumper,\nXtraBackup, Binlog, Encryption, Upload), with the DSL markers driving the\nderived schema. Field declaration order is load-bearing: the derived section\norder follows each section's first field, and the within-section order follows\ndeclaration order, so the derived section and field order matches the\nhand-written schema. The conditional gating that the legacy ``schema.py`` declared\n(per-mode ``forbidden`` gates, the upload-provider ``Contains`` gates, the\nencryption gates — ``encrypt`` (in-place) and ``post_run_encrypt`` are\nindependent encryption modes that both produce an encrypted backup;\n``encrypt_using_tmpdir`` requires ``encrypt`` and is forbidden alongside\n``post_run_encrypt`` so post-run takes precedence (matching the backend at\n``mydumper_payload``), and ``encryption_recipient`` is required iff either mode\nis on — and the per-mode bool\n``FailRule``s in\n:attr:`__form_rules__`) now lives on the model; ``AppFormModel`` extracts it\ninto the conditional-rule plan at class definition, so no\n``@apply_conditional_rules`` decorator is needed. The config sub-models\n(:class:`BackupConfigAll` and friends) stay the serialization target the\npayload builder populates, not this model's base class.\n\n:cvar __form_rules__: The per-mode bool fail rules — a truthy mode-owned bool\n    outside its mode fails validation with a per-field message.",
+        "description": "Declare the model-first create/update body and ``GET /schema`` source for MySQL Backups.\n\nDeclares each form field once, in section order (Task, General, Mydumper,\nXtraBackup, Binlog, Encryption, Upload), with the DSL markers driving the\nderived schema. Field declaration order is load-bearing: the derived section\norder follows each section's first field, and the within-section order follows\ndeclaration order, so the derived section and field order matches the\nhand-written schema. The conditional gating that the legacy ``schema.py`` declared\n(per-mode ``forbidden`` gates, the upload-provider ``Contains`` gates, the\nencryption gates — ``encryption_format`` selects which encryption runs and the\nrest of the section parameterises it: the key file is required by the\nAES-bearing formats and forbidden outside them, a GPG-bearing format needs one\nof the two independent timings (``encrypt`` in place, ``post_run_encrypt``\nafter), ``encrypt_using_tmpdir`` requires ``encrypt`` and is forbidden\nalongside ``post_run_encrypt`` so post-run takes precedence (matching the\nbackend at ``mydumper_payload``), and ``encryption_recipient`` is required iff\neither timing is on — and the per-mode and encryption-format bool\n``FailRule``s in\n:attr:`__form_rules__`) now lives on the model; ``AppFormModel`` extracts it\ninto the conditional-rule plan at class definition, so no\n``@apply_conditional_rules`` decorator is needed. The config sub-models\n(:class:`BackupConfigAll` and friends) stay the serialization target the\npayload builder populates, not this model's base class.\n\n:cvar __form_rules__: The bool fail rules — a truthy mode-owned bool outside\n    its mode, or a GPG timing outside a GPG ``encryption_format``, fails\n    validation with a per-field message, as does a GPG format with no timing.",
         "properties": {
           "alert_on_fail": {
             "default": false,
@@ -9904,6 +10166,10 @@
             "default": false,
             "title": "Encrypt Using Tmpdir",
             "type": "boolean"
+          },
+          "encryption_format": {
+            "$ref": "#/components/schemas/mysql_backups__EncryptionFormat",
+            "default": "none"
           },
           "encryption_recipient": {
             "anyOf": [
@@ -10567,6 +10833,12 @@
         "description": "Enumeration for Compression Algorithms.",
         "enum": ["zstd", "lz4", "gzip", "quicklz"],
         "title": "CompressionAlgorithm",
+        "type": "string"
+      },
+      "mysql_backups__EncryptionFormat": {
+        "description": "Represent the backup-time encryption formats an operator can select.",
+        "enum": ["none", "gpg", "aes256", "dual"],
+        "title": "EncryptionFormat",
         "type": "string"
       },
       "mysql_backups__PaginatedResponse_BackupRunResponse_": {
@@ -14261,9 +14533,54 @@
         "tags": ["atw"]
       }
     },
+    "/api/apps/atw/case-search/": {
+      "get": {
+        "description": "Search the configured delivery provider for support cases matching ``term``.\n\nNo way the search itself can fail reaches the caller as an error: a\ndeployment that declares no case-search section, stored inputs that no\nlonger fit the plan, a refused credential, an unreachable receiver and a\nsearch that outran its bound all report the same unavailability, which the\ncaller renders as the plain text field rather than as a search that found\nnothing.\n\nRestricted to administrators, unlike the app's other reads. The router\nresolves a minimum role for unsafe methods only, so a safe method carries\nwhatever guard it declares itself; this one issues the deployment's own\nreceiver credential, and the dialog that calls it is already offered to\nadministrators alone.\n\n:param term: The caller's typed search term, the only input it accepts.\n    Surrounding whitespace is stripped, so a whitespace-only term is\n    refused rather than reaching the receiver as a match-everything\n    fragment.\n:return: The matched cases, or that the search could not run. At most\n    ``MAX_CASE_SEARCH_MATCHES`` are offered, so a plan that declares no\n    provider-side limit still cannot hand the dialog an unbounded list.",
+        "operationId": "atw_atw_case_search_api_apps_atw_case_search__get",
+        "parameters": [
+          {
+            "description": "The support case reference or title fragment to match.",
+            "in": "query",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "description": "The support case reference or title fragment to match.",
+              "maxLength": 128,
+              "minLength": 1,
+              "title": "Term",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/atw__AtwCaseSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Atw Case Search",
+        "tags": ["atw"]
+      }
+    },
     "/api/apps/atw/config/": {
       "get": {
-        "description": "Report whether the incident send action is available.\n\nNot gated by the send guard -- this endpoint is what reports that guard, so\nit must answer whether or not a receiver is configured.\n\n:return: The reasons the send action is withheld; empty when it is offered.",
+        "description": "Report whether the incident send action is available.\n\nNot gated by the send guard: this endpoint is what reports that guard, so\nit must answer whether or not a receiver is configured.\n\n:return: The reasons the send action is withheld, and whether the\n    case-reference field may search the receiver.",
         "operationId": "atw_atw_config_api_apps_atw_config__get",
         "responses": {
           "200": {
@@ -16500,7 +16817,7 @@
     },
     "/api/apps/inventory/": {
       "get": {
-        "description": "Return the list of periodic task names for the Inventory plugin.\n\nHard-coded because the Inventory plugin has exactly one periodic task\n(``inventory-sync``). The shape matches what the React\n``usePluginTasks('inventory')`` hook expects: a list of objects with at\nminimum a ``name`` key.",
+        "description": "Return the list of periodic task names for the Inventory plugin.\n\nHard-coded because the Inventory plugin's periodic tasks are a fixed pair\n(``inventory-sync`` and ``inventory-collection``). The shape matches what the\nReact ``usePluginTasks('inventory')`` hook expects: a list of objects with at\nminimum a ``name`` key.\n\n:return: The plugin's periodic tasks, each with its name and display name.",
         "operationId": "inventory_inventory_plugin_tasks_api_apps_inventory__get",
         "responses": {
           "200": {
@@ -16731,7 +17048,7 @@
     },
     "/api/apps/inventory/sync/status/": {
       "get": {
-        "description": "Return whether an inventory-wide sync is currently running.\n\nReplaces the server-rendered ``sync_is_running`` template variable\nused by the Jinja2 inventory page so the React control can poll the\nsame state without scraping HTML.\n\n:param session: SQLModel async session.\n:type session: SessionDep\n:return: ``{\"is_running\": <bool>}``.\n:rtype: InventorySyncStatusResponse",
+        "description": "Return whether an inventory-wide sync is running, plus recent run outcomes.\n\nReplaces the server-rendered ``sync_is_running`` template variable\nused by the Jinja2 inventory page so the React control can poll the\nsame state without scraping HTML.\n\n:param session: SQLModel async session.\n:return: The running flag and the most recent runs, newest first.",
         "operationId": "inventory_inventory_sync_status_api_apps_inventory_sync_status__get",
         "responses": {
           "200": {
@@ -16857,94 +17174,9 @@
         },
         "summary": "Inventory List Entity",
         "tags": ["inventory"]
-      },
-      "post": {
-        "description": "Create an inventory node, service, schema, or table.",
-        "operationId": "inventory_inventory_create_entity_api_apps_inventory__entity___post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "entity",
-            "required": true,
-            "schema": {
-              "title": "Entity",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Inventory Inventory Create Entity Api Apps Inventory  Entity   Post"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Create Entity",
-        "tags": ["inventory"]
       }
     },
     "/api/apps/inventory/{entity}/{item_id}": {
-      "delete": {
-        "description": "Delete an inventory node, service, schema, or table.",
-        "operationId": "inventory_inventory_delete_entity_api_apps_inventory__entity___item_id__delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "entity",
-            "required": true,
-            "schema": {
-              "title": "Entity",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "item_id",
-            "required": true,
-            "schema": {
-              "title": "Item Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Delete Entity",
-        "tags": ["inventory"]
-      },
       "get": {
         "description": "Retrieve a single inventory node, service, schema, or table.",
         "operationId": "inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get",
@@ -16991,54 +17223,6 @@
           }
         },
         "summary": "Inventory Get Entity",
-        "tags": ["inventory"]
-      },
-      "put": {
-        "description": "Update an inventory node, service, schema, or table.",
-        "operationId": "inventory_inventory_update_entity_api_apps_inventory__entity___item_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "entity",
-            "required": true,
-            "schema": {
-              "title": "Entity",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "item_id",
-            "required": true,
-            "schema": {
-              "title": "Item Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Inventory Inventory Update Entity Api Apps Inventory  Entity   Item Id  Put"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Update Entity",
         "tags": ["inventory"]
       }
     },
@@ -18998,7 +19182,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           }
         ],
@@ -19052,7 +19237,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {
@@ -19092,7 +19278,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {

--- a/ui/packages/sep/api/specs/tasks.json
+++ b/ui/packages/sep/api/specs/tasks.json
@@ -631,24 +631,8 @@
         "title": "ReloadClassification",
         "type": "string"
       },
-      "SettingClassEnum": {
-        "description": "Enumerate settings classes that may have HOT override rows.\n\nThe wired classes are ``SEPSettings``, ``TasksSettings``,\n``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,\n``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and\n``InventorySettings``.\n\nTo wire a new settings class:\n\n1. Add a member here whose value matches the Pydantic class ``__name__``.\n2. Generate an Alembic migration on every consumer track that extends the\n   ``CHECK`` constraint on ``settingoverride.setting_class``. The column\n   uses ``native_enum=False`` so the value list lives in a constraint,\n   not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.\n   Note that the column and ``CHECK`` constraint persist the enum member\n   *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member\n   *value* (the Pydantic class name, e.g. ``SEPSettings``).\n3. Wire a ``ProxyEntry`` for the new class in the relevant service's\n   lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).",
-        "enum": [
-          "SEPSettings",
-          "TasksSettings",
-          "SnippetsSettings",
-          "Settings",
-          "AlertSettings",
-          "AnonymizerSettings",
-          "AlertsSettings",
-          "HealthReportSettings",
-          "InventorySettings"
-        ],
-        "title": "SettingClassEnum",
-        "type": "string"
-      },
       "SettingClassGroup": {
-        "description": "One settings-class group in the LIST response.\n\n:param setting_class: The settings class this group represents.\n:type setting_class: SettingClassEnum\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:type settings: list[SettingResponse]\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:type is_app_owned: bool\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:type app_id: str | None\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:type app_display_name: str | None\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.\n:type app_enabled: bool | None",
+        "description": "Group one settings class's fields for the LIST response.\n\n:param setting_class: The Pydantic class ``__name__`` this group represents.\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.",
         "properties": {
           "app_display_name": {
             "anyOf": [
@@ -689,7 +673,8 @@
             "type": "boolean"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "settings": {
             "items": {
@@ -719,7 +704,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The settings class the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -786,7 +771,8 @@
             "$ref": "#/components/schemas/ReloadClassification"
           },
           "setting_class": {
-            "$ref": "#/components/schemas/SettingClassEnum"
+            "title": "Setting Class",
+            "type": "string"
           },
           "type": {
             "title": "Type",
@@ -1258,7 +1244,7 @@
         "type": "object"
       },
       "TaskHistoryStatusEnum": {
-        "description": "Define status codes for task executions.\n\n:cvar FAILED: Enum value for failed tasks.\n:cvar PENDING: Enum value for pending tasks.\n:cvar RUNNING: Enum value for running tasks.\n:cvar SUCCESS: Enum value for successfully completed tasks.\n:cvar STOPPED: Enum value for stopped tasks.\n:cvar LOST: Enum value for tasks that are lost.\n:cvar STALE: Enum value for tasks skipped because executor placement\n    exceeded the configured staleness threshold (for example a Nomad\n    allocation that never left the queue).",
+        "description": "Define status codes for task executions.\n\n:cvar FAILED: Enum value for failed tasks.\n:cvar PENDING: Enum value for pending tasks.\n:cvar RUNNING: Enum value for running tasks.\n:cvar SUCCESS: Enum value for successfully completed tasks.\n:cvar STOPPED: Enum value for stopped tasks.\n:cvar LOST: Enum value for tasks that are lost.\n:cvar STALE: Enum value for tasks skipped because executor placement\n    exceeded the configured staleness threshold (for example a Nomad\n    allocation that never left the queue).\n:cvar UNLAUNCHABLE: Enum value for tasks the executor node could not\n    launch at all, because some command in the invocation does not\n    resolve there. The payload never ran, so this is not a script\n    failure.",
         "enum": [
           "failed",
           "pending",
@@ -1266,7 +1252,8 @@
           "success",
           "stopped",
           "lost",
-          "stale"
+          "stale",
+          "unlaunchable"
         ],
         "title": "TaskHistoryStatusEnum",
         "type": "string"
@@ -1920,7 +1907,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           }
         ],
@@ -1979,7 +1967,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {
@@ -2024,7 +2013,8 @@
             "name": "setting_class",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/SettingClassEnum"
+              "title": "Setting Class",
+              "type": "string"
             }
           },
           {

--- a/ui/packages/sep/api/src/generated/inventory.ts
+++ b/ui/packages/sep/api/src/generated/inventory.ts
@@ -148,6 +148,41 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/collection/collect': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Collect Retired Entities
+     * @description Delete the tombstones the caller's retained set does not cover.
+     *
+     *     Entities are walked deepest-first — table, schema, service, node — so an
+     *     interrupted run can only leave deleted descendants under a surviving
+     *     ancestor rather than an orphan.
+     *
+     *     A type that fills its ``limit`` ends the walk. Deleting an ancestor cascades
+     *     to descendants the cap had excluded, and those ids would then be missing from
+     *     ``deleted`` — leaving the caller unable to clear their bookkeeping and making
+     *     the reported set a false record of what was removed. Stopping keeps
+     *     ``deleted`` exhaustive; the ancestors are collected on the next batch, which
+     *     ``remaining`` asks for.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param body: The cutoff, the retained ids, and the batch controls.
+     *     :return: The collected ids per entity type, and whether more are waiting.
+     */
+    post: operations['collection_collect_retired_entities_collection_collect_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/nodes/': {
     parameters: {
       query?: never;
@@ -158,6 +193,16 @@ export interface paths {
     /**
      * List Nodes
      * @description List Nodes from Inventory.
+     *
+     *     :param session: The async database session.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :param list_query: The resolved sort/search produced at the request boundary.
+     *     :param manager: The node manager the request's retirement scope selected.
+     *     :param external_id: Return only the node carrying this upstream identifier,
+     *         resolved through any identity alias recorded for it.
+     *     :param source: Return only nodes discovered by this source.
+     *     :param node_type: Return only nodes of this type.
+     *     :return: A paginated response of node responses.
      */
     get: operations['nodes_list_nodes_nodes__get'];
     put?: never;
@@ -166,6 +211,38 @@ export interface paths {
      * @description Create Node.
      */
     post: operations['nodes_create_node_nodes__post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nodes/identity-candidates': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Node Identity Candidates
+     * @description List node pairings a PMM re-registration may have split.
+     *
+     *     Declared above ``GET /{node_id}``: FastAPI matches path operations in
+     *     declaration order, so the parameterized route would claim this path first and
+     *     answer 422 on the unparseable identifier rather than 404.
+     *
+     *     Built through :meth:`PaginatedResponse.from_pagination` rather than
+     *     ``list_query_paginated``, the item being a pair of rows and not a single
+     *     model.
+     *
+     *     :param session: The async database session.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :return: A paginated response of candidate pairings.
+     */
+    get: operations['nodes_list_node_identity_candidates_nodes_identity_candidates_get'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -182,19 +259,126 @@ export interface paths {
     /**
      * Retrieve Node
      * @description Retrieve Node from inventory.
+     *
+     *     :param session: The async database session.
+     *     :param node_id: The identifier of the node to retrieve.
+     *     :param manager: The node manager the request's retirement scope selected.
+     *     :return: The node, with its services nested.
+     *     :raises HTTPNotFoundException: If no node in scope has the given identifier.
      */
     get: operations['nodes_retrieve_node_nodes__node_id__get'];
     /**
      * Update Node
      * @description Update Node.
+     *
+     *     :param session: The async database session.
+     *     :param existing_node: The active node addressed by the path.
+     *     :param updated_node: The fields to write onto it.
+     *     :return: The updated node.
      */
     put: operations['nodes_update_node_nodes__node_id__put'];
     post?: never;
     /**
-     * Delete Node
-     * @description Delete Node.
+     * Retire Node
+     * @description Retire Node and everything below it, keeping the rows resolvable.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param node: The node to retire, retired or not.
      */
-    delete: operations['nodes_delete_node_nodes__node_id__delete'];
+    delete: operations['nodes_retire_node_nodes__node_id__delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nodes/{node_id}/identity-aliases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Node Identity Aliases
+     * @description List the upstream identifiers this node has answered for, oldest first.
+     *
+     *     A node no link has ever touched has no records, which is an empty page rather
+     *     than a 404.
+     *
+     *     :param session: The async database session.
+     *     :param node: The node addressed by the path, retired or not.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :return: A paginated response of the node's binding records, oldest first.
+     */
+    get: operations['nodes_list_node_identity_aliases_nodes__node_id__identity_aliases_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nodes/{node_id}/identity-link': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Decide Node Identity Link
+     * @description Confirm, reject or reverse a candidate node pairing.
+     *
+     *     The path names the **predecessor** — the survivor of a confirmation, and the
+     *     row the operator is acting on in all three decisions.
+     *
+     *     Carries ``IsAuthenticatedDep`` and deliberately not ``IsServicePrincipalDep``:
+     *     an identity link is an operator judgement, not a row the syncer owns. The
+     *     app-wide unsafe-method gate already makes the route admin-only for a human
+     *     while admitting the principal by identity.
+     *
+     *     :param session: The async database session.
+     *     :param node: The predecessor addressed by the path, retired or not.
+     *     :param decision: What the operator decided, and about which successor.
+     *     :param principal: The caller recorded on the resulting records.
+     *     :raises HTTPBadRequestException: If the body names the node itself, or both
+     *         rows already hold one identifier.
+     *     :raises HTTPNotFoundException: If a confirmation or rejection names a
+     *         successor that does not exist. A reversal reports the same absence as a
+     *         conflict, the pairing it would reverse no longer being reversible.
+     *     :raises HTTPConflictException: If the decision does not apply to the pairing
+     *         as it currently stands.
+     */
+    post: operations['nodes_decide_node_identity_link_nodes__node_id__identity_link_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/nodes/{node_id}/revive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Revive Node
+     * @description Revive a retired Node, leaving the services it was retired with retired.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param node: The node to revive, retired or not.
+     *     :raises HTTPConflictException: If an active entity already holds the unique
+     *         key the revived node would reclaim.
+     */
+    post: operations['nodes_revive_node_nodes__node_id__revive_post'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -224,6 +408,33 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/nodes/{node_id}/sync-health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Record Node Sync Health
+     * @description Record the outcome of one syncer attempt on a Node.
+     *
+     *     Addresses the node whether retired or not: the attempt happened, and a
+     *     concurrent retirement must not turn bookkeeping into a failed sync item.
+     *
+     *     :param session: The async database session.
+     *     :param node: The node the outcome was observed for, retired or not.
+     *     :param outcome: What the syncer reported.
+     */
+    post: operations['nodes_record_node_sync_health_nodes__node_id__sync_health_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/nodes/{node_id}/system-observation': {
     parameters: {
       query?: never;
@@ -239,6 +450,11 @@ export interface paths {
     /**
      * Upsert Host System Observation
      * @description Upsert host system observation for a node.
+     *
+     *     :param session: The async database session.
+     *     :param node: The active node the observation belongs to.
+     *     :param data: The observed host facts to store.
+     *     :return: The stored observation.
      */
     put: operations['nodes_upsert_host_system_observation_nodes__node_id__system_observation_put'];
     post?: never;
@@ -258,6 +474,12 @@ export interface paths {
     /**
      * List Schemas
      * @description List Schemas.
+     *
+     *     :param session: The async database session.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :param list_query: The resolved sort/search produced at the request boundary.
+     *     :param manager: The schema manager the request's retirement scope selected.
+     *     :return: A paginated response of schema responses.
      */
     get: operations['schemas_list_schemas_schemas__get'];
     put?: never;
@@ -278,6 +500,12 @@ export interface paths {
     /**
      * Retrieve Schema
      * @description Retrieve Schema.
+     *
+     *     :param session: The async database session.
+     *     :param schema_id: The identifier of the schema to retrieve.
+     *     :param manager: The schema manager the request's retirement scope selected.
+     *     :return: The schema, with its tables and service nested.
+     *     :raises HTTPNotFoundException: If no schema in scope has the given identifier.
      */
     get: operations['schemas_retrieve_schema_schemas__schema_id__get'];
     /**
@@ -287,10 +515,65 @@ export interface paths {
     put: operations['schemas_update_schema_schemas__schema_id__put'];
     post?: never;
     /**
-     * Delete Schema
-     * @description Delete Schema.
+     * Retire Schema
+     * @description Retire Schema and its tables, keeping the rows resolvable.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param schema: The schema to retire, retired or not.
      */
-    delete: operations['schemas_delete_schema_schemas__schema_id__delete'];
+    delete: operations['schemas_retire_schema_schemas__schema_id__delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/schemas/{schema_id}/revive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Revive Schema
+     * @description Revive a retired Schema together with its retired ancestors.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param schema: The schema to revive, retired or not.
+     *     :raises HTTPConflictException: If an active entity already holds the unique
+     *         key the revived schema would reclaim.
+     */
+    post: operations['schemas_revive_schema_schemas__schema_id__revive_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/schemas/{schema_id}/sync-health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Record Schema Sync Health
+     * @description Record the outcome of one syncer attempt on a Schema.
+     *
+     *     Addresses the schema whether retired or not: the attempt happened, and a
+     *     concurrent retirement must not turn bookkeeping into a failed sync item.
+     *
+     *     :param session: The async database session.
+     *     :param schema: The schema the outcome was observed for, retired or not.
+     *     :param outcome: What the syncer reported.
+     */
+    post: operations['schemas_record_schema_sync_health_schemas__schema_id__sync_health_post'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -330,8 +613,45 @@ export interface paths {
     /**
      * List Services
      * @description List Services.
+     *
+     *     :param session: The async database session.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :param list_query: The resolved sort/search produced at the request boundary.
+     *     :param manager: The service manager the request's retirement scope selected.
+     *     :param external_id: Return only the service carrying this upstream identifier,
+     *         resolved through any identity alias recorded for it.
+     *     :param service_type: Return only services of this type.
+     *     :return: A paginated response of service responses.
      */
     get: operations['services_list_services_services__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/services/identity-candidates': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Service Identity Candidates
+     * @description List service pairings a PMM re-registration may have split.
+     *
+     *     Declared above ``GET /{service_id}``: FastAPI matches path operations in
+     *     declaration order, so the parameterized route would claim this path first and
+     *     answer 422 on the unparseable identifier rather than 404.
+     *
+     *     :param session: The async database session.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :return: A paginated response of candidate pairings.
+     */
+    get: operations['services_list_service_identity_candidates_services_identity_candidates_get'];
     put?: never;
     post?: never;
     delete?: never;
@@ -359,10 +679,100 @@ export interface paths {
     put: operations['services_update_service_services__service_id__put'];
     post?: never;
     /**
-     * Delete Service
-     * @description Delete Service.
+     * Retire Service
+     * @description Retire Service and everything below it, keeping the rows resolvable.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param service: The service to retire, retired or not.
      */
-    delete: operations['services_delete_service_services__service_id__delete'];
+    delete: operations['services_retire_service_services__service_id__delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/services/{service_id}/identity-aliases': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Service Identity Aliases
+     * @description List the upstream identifiers this service has answered for, oldest first.
+     *
+     *     :param session: The async database session.
+     *     :param service: The service addressed by the path, retired or not.
+     *     :param pagination: Validated offset/limit query parameters.
+     *     :return: A paginated response of the service's binding records, oldest first.
+     */
+    get: operations['services_list_service_identity_aliases_services__service_id__identity_aliases_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/services/{service_id}/identity-link': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Decide Service Identity Link
+     * @description Confirm, reject or reverse a candidate service pairing.
+     *
+     *     The path names the **predecessor** — the survivor of a confirmation.
+     *
+     *     Carries ``IsAuthenticatedDep`` and deliberately not ``IsServicePrincipalDep``:
+     *     an identity link is an operator judgement, not a row the syncer owns.
+     *
+     *     :param session: The async database session.
+     *     :param service: The predecessor addressed by the path, retired or not.
+     *     :param decision: What the operator decided, and about which successor.
+     *     :param principal: The caller recorded on the resulting records.
+     *     :raises HTTPBadRequestException: If the body names the service itself, or both
+     *         rows already hold one identifier.
+     *     :raises HTTPNotFoundException: If a confirmation or rejection names a
+     *         successor that does not exist. A reversal reports the same absence as a
+     *         conflict, the pairing it would reverse no longer being reversible.
+     *     :raises HTTPConflictException: If the decision does not apply to the pairing
+     *         as it currently stands.
+     */
+    post: operations['services_decide_service_identity_link_services__service_id__identity_link_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/services/{service_id}/revive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Revive Service
+     * @description Revive a retired Service together with its retired ancestors.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param service: The service to revive, retired or not.
+     *     :raises HTTPConflictException: If an active entity already holds the unique
+     *         key the revived service would reclaim.
+     */
+    post: operations['services_revive_service_services__service_id__revive_post'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -387,6 +797,7 @@ export interface paths {
      *     :param pagination: Validated offset/limit query parameters.
      *     :param list_query: The resolved sort/search produced at the request
      *         boundary.
+     *     :param manager: The schema manager the request's retirement scope selected.
      *     :param include_tables: Include nested tables in the response when set to
      *         any non-empty value. Defaults to compact mode (no tables).
      *     :return: A paginated response of schema responses.
@@ -398,6 +809,33 @@ export interface paths {
      * @description Create Schema for Service.
      */
     post: operations['services_create_schema_for_service_services__service_id__schemas__post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/services/{service_id}/sync-health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Record Service Sync Health
+     * @description Record the outcome of one syncer attempt on a Service.
+     *
+     *     Addresses the service whether retired or not: the attempt happened, and a
+     *     concurrent retirement must not turn bookkeeping into a failed sync item.
+     *
+     *     :param session: The async database session.
+     *     :param service: The service the outcome was observed for, retired or not.
+     *     :param outcome: What the syncer reported.
+     */
+    post: operations['services_record_service_sync_health_services__service_id__sync_health_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -478,6 +916,12 @@ export interface paths {
     /**
      * Retrieve Table
      * @description Retrieve Table.
+     *
+     *     :param session: The async database session.
+     *     :param table_id: The identifier of the table to retrieve.
+     *     :param manager: The table manager the request's retirement scope selected.
+     *     :return: The table, with its schema nested.
+     *     :raises HTTPNotFoundException: If no table in scope has the given identifier.
      */
     get: operations['tables_retrieve_table_tables__table_id__get'];
     /**
@@ -487,10 +931,65 @@ export interface paths {
     put: operations['tables_update_table_tables__table_id__put'];
     post?: never;
     /**
-     * Delete Table
-     * @description Delete Table.
+     * Retire Table
+     * @description Retire Table, keeping the row resolvable.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param table: The table to retire, retired or not.
      */
-    delete: operations['tables_delete_table_tables__table_id__delete'];
+    delete: operations['tables_retire_table_tables__table_id__delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tables/{table_id}/revive': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Revive Table
+     * @description Revive a retired Table together with its retired ancestors.
+     *
+     *     :param session: The asynchronous database session.
+     *     :param table: The table to revive, retired or not.
+     *     :raises HTTPConflictException: If an active entity already holds the unique
+     *         key the revived table would reclaim.
+     */
+    post: operations['tables_revive_table_tables__table_id__revive_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/tables/{table_id}/sync-health': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Record Table Sync Health
+     * @description Record the outcome of one syncer attempt on a Table.
+     *
+     *     Addresses the table whether retired or not: the attempt happened, and a
+     *     concurrent retirement must not turn bookkeeping into a failed sync item.
+     *
+     *     :param session: The async database session.
+     *     :param table: The table the outcome was observed for, retired or not.
+     *     :param outcome: What the syncer reported.
+     */
+    post: operations['tables_record_table_sync_health_tables__table_id__sync_health_post'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -500,6 +999,51 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
+    /**
+     * ExternalIdentityAliasResponse
+     * @description Define the external-identity alias API response.
+     *
+     *     :param id: The primary key for the table. Auto-incremented and not nullable.
+     *     :param created_at: The timestamp when the record is created. Defaults to the
+     *         current time in UTC.
+     *     :param updated_at: The timestamp when the record is last updated.
+     *         Automatically updated on changes.
+     *     :param entity_type: The inventory entity type the binding names.
+     *     :param entity_id: The primary key of the row the upstream id resolves to.
+     *     :param source: The upstream system the identifier belongs to.
+     *     :param external_id: The upstream identifier being bound.
+     *     :param valid_from: When the binding took effect.
+     *     :param valid_to: When the binding stopped applying, or None while it stands.
+     *     :param linkage_method: How the binding came to be recorded.
+     *     :param principal: The caller that recorded the binding.
+     */
+    ExternalIdentityAliasResponse: {
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at?: string;
+      /** Entity Id */
+      entity_id: number;
+      entity_type: components['schemas']['RetirableEntityName'];
+      /** External Id */
+      external_id: string;
+      /** Id */
+      id: number | null;
+      linkage_method: components['schemas']['LinkageMethodEnum'];
+      /** Principal */
+      principal: string;
+      source: components['schemas']['SourceEnum'];
+      /** Updated At */
+      updated_at?: string | null;
+      /**
+       * Valid From
+       * Format: date-time
+       */
+      valid_from: string;
+      /** Valid To */
+      valid_to?: string | null;
+    };
     /** HTTPValidationError */
     HTTPValidationError: {
       /** Detail */
@@ -588,41 +1132,163 @@ export interface components {
       /** Os Version */
       os_version?: string | null;
     };
+    /**
+     * IdentityLinkDecisionEnum
+     * @description Enumerate the decisions an operator may record against a candidate pairing.
+     *
+     *     :cvar CONFIRMED: The pairing names one machine, and the link stands.
+     *     :cvar REJECTED: The pairing names two machines, so stop suggesting it.
+     *     :cvar UNLINKED: A standing confirmation was reversed.
+     *
+     *     Values are spelled out for the reason given on
+     *     :class:`LinkageMethodEnum`, and it binds harder here: this enum is also a
+     *     *request* body field, so a rename would reject the payloads callers were
+     *     already sending.
+     * @enum {string}
+     */
+    IdentityLinkDecisionEnum: 'confirmed' | 'rejected' | 'unlinked';
+    /**
+     * IdentityLinkDecisionWrite
+     * @description Define the request body recording one operator decision over a pairing.
+     *
+     *     :param successor_id: The row the addressed predecessor is being paired with.
+     *     :param decision: What the operator decided.
+     */
+    IdentityLinkDecisionWrite: {
+      decision: components['schemas']['IdentityLinkDecisionEnum'];
+      /** Successor Id */
+      successor_id: number;
+    };
+    /**
+     * InventoryCollectResponse
+     * @description Report what a collection call deleted, or would have deleted.
+     *
+     *     :param deleted: The collected ids per entity type, exhaustive for this
+     *         call. On a dry run these are the ids the equivalent real call would
+     *         delete. A type the walk stopped before reporting is empty rather than
+     *         absent.
+     *     :param remaining: Whether any entity type filled its ``limit``, meaning more
+     *         tombstones are waiting for the next batch.
+     */
+    InventoryCollectResponse: {
+      /** Deleted */
+      deleted: {
+        [key: string]: number[];
+      };
+      /** Remaining */
+      remaining: boolean;
+    };
+    /**
+     * InventoryCollectWrite
+     * @description Ask the inventory service to collect the tombstones nothing resolves.
+     *
+     *     Unknown fields are rejected with HTTP 422. This request deletes rows
+     *     irreversibly, so a client typo must never be read as an omitted field: a
+     *     misspelled ``keep`` would otherwise arrive as an empty retained set and a
+     *     misspelled ``dry_run`` as a real delete.
+     *
+     *     :param retired_before: The cutoff a tombstone must predate to be eligible.
+     *         The caller pins one value for a whole run so successive batches cannot
+     *         drift into collecting a tombstone that was too young a moment earlier.
+     *     :param keep: The ids the caller knows are still referenced, per entity type.
+     *         Ancestors of a kept entity are retained without being listed.
+     *     :param limit: The most entities to collect per type in this call.
+     *     :param dry_run: Whether to report the eligible ids without deleting them.
+     *         Defaults to reporting: on an irreversible endpoint the mode a caller
+     *         reaches by omission is the one that cannot destroy anything.
+     */
+    InventoryCollectWrite: {
+      /**
+       * Dry Run
+       * @default true
+       */
+      dry_run: boolean;
+      /**
+       * Keep
+       * @default {}
+       */
+      keep: {
+        [key: string]: number[];
+      };
+      /**
+       * Limit
+       * @default 500
+       */
+      limit: number;
+      /**
+       * Retired Before
+       * Format: date-time
+       */
+      retired_before: string;
+    };
     JsonValue: unknown;
+    /**
+     * LinkageMethodEnum
+     * @description Enumerate how an external-identity binding came to be recorded.
+     *
+     *     Every member names an operator action: nothing here records a binding the
+     *     syncer made on its own, because ordinary sync creation writes no alias row.
+     *
+     *     Values are spelled out rather than derived with ``auto()``. The column
+     *     persists the member *name*, but the API serializes the *value*, so under
+     *     ``auto()`` the two move in opposite ways when a member is renamed: the
+     *     stored form follows the rename while the published one silently changes
+     *     with it. Pinning the value holds the wire contract — this enum reaches the
+     *     generated API client — and leaves a rename a database concern alone.
+     * @enum {string}
+     */
+    LinkageMethodEnum: 'operator_confirmation' | 'operator_unlink';
     /**
      * Node
      * @description Represent a node in the inventory.
      *
      *     :param address: The network address of the node.
-     *     :type address: NonEmptyStr
      *     :param name: The name of the node.
-     *     :type name: NonEmptyStr
      *     :param external_id: An external identifier for the node. Must be unique for source,
      *         as defined by composite index ix_node_external_id_source.
-     *     :type external_id: NonEmptyStr | None
      *     :param source: The source from which the node information is derived. Must be unique
      *         for external_id, as defined by composite index ix_node_external_id_source.
-     *     :type source: SourceEnum | None
      *     :param type: The type of the node (e.g., remote, generic).
-     *     :type type: NonEmptyStr
+     *     :param retired_at: When the node stopped being reported upstream, or None while
+     *         it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the node against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the node is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param services: A list of services associated with the node.
-     *     :type services: list[Service]
      */
     Node: {
       /** Address */
       address: string;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
        */
       created_at?: string;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
-      source?: components['schemas']['SourceEnum'] | null;
+      /** Retired At */
+      retired_at?: string | null;
+      source: components['schemas']['SourceEnum'];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /**
        * Type
        * @default generic
@@ -632,47 +1298,78 @@ export interface components {
       updated_at?: string | null;
     };
     /**
+     * NodeIdentityCandidateResponse
+     * @description Pair a node with the successor a re-registration may have split it into.
+     *
+     *     :param predecessor: The older row — the one every SEP reference persisted
+     *         before the re-registration resolves through, and so the one a
+     *         confirmation keeps.
+     *     :param successor: The newer row PMM created when the node re-registered.
+     *     :param matched_on: The signals that agreed, informational only. Detection
+     *         never requires an address match, because PMM discards the address on a
+     *         non-``--force`` re-registration.
+     */
+    NodeIdentityCandidateResponse: {
+      /** Matched On */
+      matched_on: string[];
+      predecessor: components['schemas']['NodeResponse'];
+      successor: components['schemas']['NodeResponse'];
+    };
+    /**
      * NodeResponse
      * @description Represent a node API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param address: The network address of the node.
-     *     :type address: NonEmptyStr
      *     :param name: The name of the node.
-     *     :type name: NonEmptyStr
      *     :param external_id: An external identifier for the node.
-     *     :type external_id: NonEmptyStr | None
      *     :param source: The source from which the node information is derived.
-     *     :type source: SourceEnum | None
      *     :param type: The type of the node (e.g., remote, generic).
-     *     :type type: NonEmptyStr
+     *     :param retired_at: When the node stopped being reported upstream, or None while
+     *         it is active.
+     *     :param last_synced_at: When a syncer last confirmed the node against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the node is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param services: A list of services associated with the node.
-     *     :type services: list[Service]
      */
     NodeResponse: {
       /** Address */
       address: string;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
        */
       created_at?: string;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Services */
       services: components['schemas']['Service'][];
-      source?: components['schemas']['SourceEnum'] | null;
+      source: components['schemas']['SourceEnum'];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /**
        * Type
        * @default generic
@@ -686,31 +1383,47 @@ export interface components {
      * @description Define the model for writing node data to the inventory.
      *
      *     :param address: The network address of the node.
-     *     :type address: NonEmptyStr
      *     :param name: The name of the node.
-     *     :type name: NonEmptyStr
      *     :param external_id: An external identifier for the node, indexed for quick lookup.
-     *         Defaults to None.
-     *     :type external_id: NonEmptyStr | None
      *     :param source: The source from which the node information is derived. Indexed for
-     *         quick lookup. Defaults to None.
-     *     :type source: SourceEnum | None
+     *         quick lookup.
      *     :param type: The type of the node (e.g., remote, generic). Defaults to "generic".
-     *     :type type: NonEmptyStr
      */
     NodeWrite: {
       /** Address */
       address: string;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Name */
       name: string;
-      source?: components['schemas']['SourceEnum'] | null;
+      source: components['schemas']['SourceEnum'];
       /**
        * Type
        * @default generic
        */
       type: string;
+    };
+    /** PaginatedResponse[ExternalIdentityAliasResponse] */
+    PaginatedResponse_ExternalIdentityAliasResponse_: {
+      /** Items */
+      items: components['schemas']['ExternalIdentityAliasResponse'][];
+      /** Limit */
+      limit: number;
+      /** Offset */
+      offset: number;
+      /** Total */
+      total: number;
+    };
+    /** PaginatedResponse[NodeIdentityCandidateResponse] */
+    PaginatedResponse_NodeIdentityCandidateResponse_: {
+      /** Items */
+      items: components['schemas']['NodeIdentityCandidateResponse'][];
+      /** Limit */
+      limit: number;
+      /** Offset */
+      offset: number;
+      /** Total */
+      total: number;
     };
     /** PaginatedResponse[NodeResponse] */
     PaginatedResponse_NodeResponse_: {
@@ -727,6 +1440,17 @@ export interface components {
     PaginatedResponse_SchemaResponse_: {
       /** Items */
       items: components['schemas']['SchemaResponse'][];
+      /** Limit */
+      limit: number;
+      /** Offset */
+      offset: number;
+      /** Total */
+      total: number;
+    };
+    /** PaginatedResponse[ServiceIdentityCandidateResponse] */
+    PaginatedResponse_ServiceIdentityCandidateResponse_: {
+      /** Items */
+      items: components['schemas']['ServiceIdentityCandidateResponse'][];
       /** Limit */
       limit: number;
       /** Offset */
@@ -791,30 +1515,50 @@ export interface components {
      */
     ReloadClassification: 'hot' | 'nested_only' | 'not_overridable';
     /**
+     * RetirableEntityName
+     * @description Name the inventory entity types that carry a retirement tombstone.
+     *
+     *     Values are spelled out rather than derived, because they cross a service
+     *     boundary: SEP names an entity type by these strings when it asks inventory
+     *     to collect. Inventory-local on purpose — SEP's own
+     *     ``SyncInventoryEntityTypeEnum`` lives in a package this service must not
+     *     import.
+     * @enum {string}
+     */
+    RetirableEntityName: 'node' | 'service' | 'schema' | 'table';
+    /**
      * Schema
      * @description Represent a database schema within a service.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the schema. Must be unique for service_id, as defined by
      *         composite index ix_schema_name_service_id.
-     *     :type name: NonEmptyStr
      *     :param service_id: The unique identifier of the service to which the schema belongs.
      *         Must be unique for name, as defined by composite index
      *         ix_schema_name_service_id.
-     *     :type service_id: int
      *     :param service: The service to which the schema is associated.
-     *     :type service: Service
+     *     :param retired_at: When the schema stopped being reported upstream, or None
+     *         while it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the schema against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the schema is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param tables: A list of tables within the schema.
-     *     :type tables: list[Table]
      */
     Schema: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -822,10 +1566,18 @@ export interface components {
       created_at?: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Service Id */
       service_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -834,19 +1586,28 @@ export interface components {
      * @description Define a compact schema response without nested tables.
      *
      *     :param id: The primary key for the schema. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the schema.
-     *     :type name: NonEmptyStr
      *     :param service_id: The unique identifier of the service to which the schema belongs.
-     *     :type service_id: int
+     *     :param retired_at: When the schema stopped being reported upstream, or None while
+     *         it is active.
+     *     :param last_synced_at: When a syncer last confirmed the schema against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the schema is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      */
     SchemaCompactResponse: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -854,10 +1615,18 @@ export interface components {
       created_at?: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Service Id */
       service_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -866,21 +1635,20 @@ export interface components {
      * @description Define the schema retrieve API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the schema.
-     *     :type name: NonEmptyStr
      *     :param service_id: The unique identifier of the service to which the schema belongs.
-     *     :type service_id: int
      *     :param service: The schema's service.
-     *     :type service: Service
      */
     SchemaDetailResponse: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -888,11 +1656,19 @@ export interface components {
       created_at?: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       service: components['schemas']['Service'];
       /** Service Id */
       service_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Tables */
       tables: components['schemas']['Table'][];
       /** Updated At */
@@ -903,21 +1679,29 @@ export interface components {
      * @description Define the schema API response.
      *
      *     :param id: The primary key for the schema. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the schema.
-     *     :type name: NonEmptyStr
      *     :param service_id: The unique identifier of the service to which the schema belongs.
-     *     :type service_id: int
+     *     :param retired_at: When the schema stopped being reported upstream, or None while
+     *         it is active.
+     *     :param last_synced_at: When a syncer last confirmed the schema against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the schema is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param tables: A list of tables within the schema.
-     *     :type tables: list[Table]
      */
     SchemaResponse: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -925,10 +1709,18 @@ export interface components {
       created_at?: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Service Id */
       service_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Tables */
       tables: components['schemas']['Table'][];
       /** Updated At */
@@ -955,43 +1747,43 @@ export interface components {
      * @description Represent a service running on a node in the inventory.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param external_id: An external identifier for the service. Must be unique for
      *         node_id, as defined by composite index ix_service_external_id_node_id.
-     *     :type external_id: NonEmptyStr | None
      *     :param name: The name of the service.
-     *     :type name: NonEmptyStr
      *     :param type: The type of the service (e.g., MYSQL, POSTGRESQL).
-     *     :type type: ServiceTypeEnum
-     *     :param port: The port number on which the service is running. Must be unique for
-     *         node_id, as defined by composite index ix_service_port_node_id.
-     *     :type port: int | None
+     *     :param port: The port number on which the service is running.
      *     :param environment: The environment in which the service is running, if set.
-     *     :type environment: str | None
      *     :param cluster: The cluster in which the service is running, if set.
-     *     :type cluster: str | None
      *     :param replication_set: The replication set in which the service is running, if set.
-     *     :type replication_set: str | None
      *     :param custom_labels: Custom labels associated with the service, if set.
      *     :param node_id: The unique identifier of the node on which the service is running.
      *         Must be unique for external_id, as defined by composite index
-     *         ix_service_external_id_node_id, and for port, as defined by composite index
-     *         ix_service_port_node_id.
-     *     :type node_id: int
+     *         ix_service_external_id_node_id.
      *     :param node: The node to which the service is associated.
-     *     :type node: Node
+     *     :param retired_at: When the service stopped being reported upstream, or None
+     *         while it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the service against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the service is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param schemas: A list of schemas associated with the service.
-     *     :type schemas: list[Schema]
      */
     Service: {
       /** Cluster */
       cluster?: string | null;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -1004,9 +1796,13 @@ export interface components {
       /** Environment */
       environment?: string | null;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
       /** Node Id */
@@ -1015,6 +1811,10 @@ export interface components {
       port?: number | null;
       /** Replication Set */
       replication_set?: string | null;
+      /** Retired At */
+      retired_at?: string | null;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       type: components['schemas']['ServiceTypeEnum'];
       /** Updated At */
       updated_at?: string | null;
@@ -1024,38 +1824,30 @@ export interface components {
      * @description Define the service retrieve API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param external_id: An external identifier for the service.
-     *     :type external_id: NonEmptyStr | None
      *     :param name: The name of the service.
-     *     :type name: NonEmptyStr
      *     :param type: The type of the service (e.g., MYSQL, POSTGRESQL).
-     *     :type type: ServiceTypeEnum
      *     :param port: The port number on which the service is running.
-     *     :type port: int | None
      *     :param environment: The environment in which the service is running, if set.
-     *     :type environment: str | None
      *     :param cluster: The cluster in which the service is running, if set.
-     *     :type cluster: str | None
      *     :param replication_set: The replication set in which the service is running, if set.
-     *     :type replication_set: str | None
      *     :param custom_labels: Custom labels associated with the service, if set.
      *     :param node_id: The unique identifier of the node on which the service is running.
-     *     :type node_id: int
      *     :param schemas: A list of schemas associated with the service.
-     *     :type schemas: list[Schema]
      *     :param node: The service's node.
-     *     :type node: Node
      */
     ServiceDetailResponse: {
       /** Cluster */
       cluster?: string | null;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -1068,9 +1860,13 @@ export interface components {
       /** Environment */
       environment?: string | null;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
       node: components['schemas']['Node'];
@@ -1080,49 +1876,68 @@ export interface components {
       port?: number | null;
       /** Replication Set */
       replication_set?: string | null;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schemas */
       schemas: components['schemas']['Schema'][];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       type: components['schemas']['ServiceTypeEnum'];
       /** Updated At */
       updated_at?: string | null;
+    };
+    /**
+     * ServiceIdentityCandidateResponse
+     * @description Pair a service with the successor a re-registration may have split it into.
+     *
+     *     :param predecessor: The older row a confirmation keeps.
+     *     :param successor: The newer row PMM created.
+     *     :param matched_on: The signals that agreed, informational only.
+     */
+    ServiceIdentityCandidateResponse: {
+      /** Matched On */
+      matched_on: string[];
+      predecessor: components['schemas']['ServiceResponse'];
+      successor: components['schemas']['ServiceResponse'];
     };
     /**
      * ServiceResponse
      * @description Define the service API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param external_id: An external identifier for the service.
-     *     :type external_id: NonEmptyStr | None
      *     :param name: The name of the service.
-     *     :type name: NonEmptyStr
      *     :param type: The type of the service (e.g., MYSQL, POSTGRESQL).
-     *     :type type: ServiceTypeEnum
      *     :param port: The port number on which the service is running.
-     *     :type port: int | None
      *     :param environment: The environment in which the service is running, if set.
-     *     :type environment: str | None
      *     :param cluster: The cluster in which the service is running, if set.
-     *     :type cluster: str | None
      *     :param replication_set: The replication set in which the service is running, if set.
-     *     :type replication_set: str | None
      *     :param custom_labels: Custom labels associated with the service, if set.
      *     :param node_id: The unique identifier of the node on which the service is running.
-     *     :type node_id: int
      *     :param schemas: A list of schemas associated with the service.
-     *     :type schemas: list[Schema]
      *     :param node: The node to which the service is associated.
-     *     :type node: Node
+     *     :param retired_at: When the service stopped being reported upstream, or None
+     *         while it is active.
+     *     :param last_synced_at: When a syncer last confirmed the service against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the service is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      */
     ServiceResponse: {
       /** Cluster */
       cluster?: string | null;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -1135,9 +1950,13 @@ export interface components {
       /** Environment */
       environment?: string | null;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
       node: components['schemas']['Node'];
@@ -1147,8 +1966,12 @@ export interface components {
       port?: number | null;
       /** Replication Set */
       replication_set?: string | null;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schemas */
       schemas: components['schemas']['Schema'][];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       type: components['schemas']['ServiceTypeEnum'];
       /** Updated At */
       updated_at?: string | null;
@@ -1245,25 +2068,17 @@ export interface components {
      * @description Define the model for writing service data to the inventory.
      *
      *     :param external_id: An external identifier for the service, indexed for quick
-     *         lookup. Defaults to None.
-     *     :type external_id: NonEmptyStr | None
+     *         lookup.
      *     :param name: The name of the service.
-     *     :type name: NonEmptyStr
      *     :param type: The type of the service (e.g., MYSQL, POSTGRESQL).
-     *     :type type: ServiceTypeEnum
      *     :param port: The port number on which the service is running. Defaults to None.
-     *     :type port: int | None
      *     :param environment: The environment in which the service is running (e.g.,
      *         production, staging). Defaults to None.
-     *     :type environment: str | None
      *     :param cluster: The cluster in which the service is running. Defaults to None.
-     *     :type cluster: str | None
      *     :param replication_set: The replication set in which the service is running. Defaults to None.
-     *     :type replication_set: str | None
      *     :param custom_labels: Custom labels associated with the service. Defaults to None.
      *     :param node_id: The foreign key referencing the node to which the service belongs.
      *         Defaults to None.
-     *     :type node_id: int | None
      */
     ServiceWrite: {
       /** Cluster */
@@ -1275,7 +2090,7 @@ export interface components {
       /** Environment */
       environment?: string | null;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Name */
       name: string;
       /** Node Id */
@@ -1287,61 +2102,22 @@ export interface components {
       type: components['schemas']['ServiceTypeEnum'];
     };
     /**
-     * SettingClassEnum
-     * @description Enumerate settings classes that may have HOT override rows.
-     *
-     *     The wired classes are ``SEPSettings``, ``TasksSettings``,
-     *     ``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,
-     *     ``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and
-     *     ``InventorySettings``.
-     *
-     *     To wire a new settings class:
-     *
-     *     1. Add a member here whose value matches the Pydantic class ``__name__``.
-     *     2. Generate an Alembic migration on every consumer track that extends the
-     *        ``CHECK`` constraint on ``settingoverride.setting_class``. The column
-     *        uses ``native_enum=False`` so the value list lives in a constraint,
-     *        not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.
-     *        Note that the column and ``CHECK`` constraint persist the enum member
-     *        *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member
-     *        *value* (the Pydantic class name, e.g. ``SEPSettings``).
-     *     3. Wire a ``ProxyEntry`` for the new class in the relevant service's
-     *        lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).
-     * @enum {string}
-     */
-    SettingClassEnum:
-      | 'SEPSettings'
-      | 'TasksSettings'
-      | 'SnippetsSettings'
-      | 'Settings'
-      | 'AlertSettings'
-      | 'AnonymizerSettings'
-      | 'AlertsSettings'
-      | 'HealthReportSettings'
-      | 'InventorySettings';
-    /**
      * SettingClassGroup
-     * @description One settings-class group in the LIST response.
+     * @description Group one settings class's fields for the LIST response.
      *
-     *     :param setting_class: The settings class this group represents.
-     *     :type setting_class: SettingClassEnum
+     *     :param setting_class: The Pydantic class ``__name__`` this group represents.
      *     :param settings: The fields declared on the settings class, with their
      *         current values and metadata.
-     *     :type settings: list[SettingResponse]
      *     :param is_app_owned: Whether this group belongs to a SEP app under
      *         ``app/sep/apps/`` rather than core SEP wiring.
-     *     :type is_app_owned: bool
      *     :param app_id: The owning app's registry key when ``is_app_owned`` is
      *         ``True``; ``None`` for core groups.
-     *     :type app_id: str | None
      *     :param app_display_name: The owning app's human-facing label when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups.
-     *     :type app_display_name: str | None
      *     :param app_enabled: Whether the owning app is currently enabled when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled
      *         apps remain listed so the frontend can hide them without a second
      *         lookup.
-     *     :type app_enabled: bool | None
      */
     SettingClassGroup: {
       /** App Display Name */
@@ -1355,7 +2131,8 @@ export interface components {
        * @default false
        */
       is_app_owned: boolean;
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Settings */
       settings: components['schemas']['SettingResponse'][];
     };
@@ -1376,7 +2153,7 @@ export interface components {
      * SettingResponse
      * @description Represent a single setting's metadata and current value.
      *
-     *     :param setting_class: The settings class the field belongs to.
+     *     :param setting_class: The Pydantic class ``__name__`` the field belongs to.
      *     :param key: The field name on the settings class.
      *     :param key_path: Carry the canonical key segments for ``key`` such that
      *         ``"__".join(key_path) == key``.
@@ -1434,7 +2211,8 @@ export interface components {
       /** Options */
       options?: components['schemas']['SettingOption'][] | null;
       reload: components['schemas']['ReloadClassification'];
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Type */
       type: string;
       /** Value */
@@ -1475,29 +2253,70 @@ export interface components {
      */
     SourceEnum: 'pmm';
     /**
+     * SyncHealthWrite
+     * @description Define the body reporting one entity's sync outcome.
+     *
+     *     :param outcome: Whether the attempt succeeded or failed.
+     *     :param error: The failure's message, never empty. Required on FAILURE,
+     *         absent on SUCCESS.
+     *     :param attempted_at: When the syncer began this attempt. Stamped as
+     *         ``last_synced_at`` on success, and compared against the row's current
+     *         ``last_synced_at`` so a late-arriving report from an older attempt
+     *         cannot overwrite a newer one. Refused when it sits further ahead of this
+     *         service's clock than the tolerated skew, since nothing later could then
+     *         supersede it.
+     */
+    SyncHealthWrite: {
+      /**
+       * Attempted At
+       * Format: date-time
+       */
+      attempted_at: string;
+      /** Error */
+      error?: string | null;
+      outcome: components['schemas']['SyncOutcomeEnum'];
+    };
+    /**
+     * SyncOutcomeEnum
+     * @description Enumerate the outcomes a syncer reports for one entity's sync attempt.
+     *
+     *     :cvar SUCCESS: The entity was compared against its source and updated.
+     *     :cvar FAILURE: The attempt raised before the comparison completed.
+     * @enum {string}
+     */
+    SyncOutcomeEnum: 'success' | 'failure';
+    /**
      * Table
      * @description Represent a table within a schema.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the table. Must be unique for schema_id, as defined by
      *         composite index ix_table_name_schema_id.
-     *     :type name: NonEmptyStr
      *     :param create: The SQL statement used to create the table.
-     *     :type create: NonEmptyStr
      *     :param schema_id: The unique identifier of the schema to which the table belongs.
      *         Must be unique for name, as defined by composite index ix_table_name_schema_id.
-     *     :type schema_id: int
+     *     :param retired_at: When the table stopped being reported upstream, or None while
+     *         it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the table against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the table is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param database: The schema to which the table is associated.
-     *     :type database: Schema
      */
     Table: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /** Create */
       create: string;
       /**
@@ -1511,10 +2330,18 @@ export interface components {
       keys: {
         [key: string]: unknown;
       };
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schema Id */
       schema_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -1523,23 +2350,21 @@ export interface components {
      * @description Define the schema retrieve API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the table.
-     *     :type name: NonEmptyStr
      *     :param create: The SQL statement used to create the table.
-     *     :type create: NonEmptyStr
      *     :param schema_id: The foreign key referencing the schema to which the table belongs.
-     *     :type schema_id: int
      *     :param database: The table's schema.
-     *     :type database: Schema
      */
     TableDetailResponse: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /** Create */
       create: string;
       /**
@@ -1554,10 +2379,18 @@ export interface components {
       keys: {
         [key: string]: unknown;
       };
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schema Id */
       schema_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -1566,21 +2399,29 @@ export interface components {
      * @description Define the table API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the table.
-     *     :type name: NonEmptyStr
      *     :param create: The SQL statement used to create the table.
-     *     :type create: NonEmptyStr
      *     :param schema_id: The foreign key referencing the schema to which the table belongs.
-     *     :type schema_id: int
+     *     :param retired_at: When the table stopped being reported upstream, or None while
+     *         it is active.
+     *     :param last_synced_at: When a syncer last confirmed the table against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the table is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      */
     TableResponse: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /** Create */
       create: string;
       /**
@@ -1594,10 +2435,18 @@ export interface components {
       keys: {
         [key: string]: unknown;
       };
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schema Id */
       schema_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -1606,11 +2455,8 @@ export interface components {
      * @description Define the model for writing table data to the inventory.
      *
      *     :param name: The name of the table.
-     *     :type name: NonEmptyStr
      *     :param create: The SQL statement used to create the table.
-     *     :type create: NonEmptyStr
      *     :param schema_id: The foreign key referencing the schema to which the table belongs.
-     *     :type schema_id: int | None
      */
     TableWrite: {
       /** Create */
@@ -1671,7 +2517,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
       };
       cookie?: never;
     };
@@ -1706,7 +2552,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;
@@ -1738,7 +2584,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;
@@ -1763,6 +2609,39 @@ export interface operations {
       };
     };
   };
+  collection_collect_retired_entities_collection_collect_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['InventoryCollectWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['InventoryCollectResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
   nodes_list_nodes_nodes__get: {
     parameters: {
       query?: {
@@ -1775,6 +2654,7 @@ export interface operations {
         sort?: 'created_at' | '-created_at' | 'name' | '-name';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path?: never;
@@ -1835,9 +2715,43 @@ export interface operations {
       };
     };
   };
+  nodes_list_node_identity_candidates_nodes_identity_candidates_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedResponse_NodeIdentityCandidateResponse_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
   nodes_retrieve_node_nodes__node_id__get: {
     parameters: {
-      query?: never;
+      query?: {
+        include_retired?: boolean;
+      };
       header?: never;
       path: {
         node_id: number;
@@ -1901,7 +2815,103 @@ export interface operations {
       };
     };
   };
-  nodes_delete_node_nodes__node_id__delete: {
+  nodes_retire_node_nodes__node_id__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        node_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  nodes_list_node_identity_aliases_nodes__node_id__identity_aliases_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        node_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedResponse_ExternalIdentityAliasResponse_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  nodes_decide_node_identity_link_nodes__node_id__identity_link_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        node_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['IdentityLinkDecisionWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  nodes_revive_node_nodes__node_id__revive_post: {
     parameters: {
       query?: never;
       header?: never;
@@ -1940,6 +2950,7 @@ export interface operations {
         sort?: 'created_at' | '-created_at' | 'name' | '-name';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path: {
@@ -1992,6 +3003,39 @@ export interface operations {
         content: {
           'application/json': components['schemas']['Service'];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  nodes_record_node_sync_health_nodes__node_id__sync_health_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        node_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SyncHealthWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       /** @description Validation Error */
       422: {
@@ -2085,6 +3129,7 @@ export interface operations {
           | '-service_id';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path?: never;
@@ -2114,7 +3159,9 @@ export interface operations {
   };
   schemas_retrieve_schema_schemas__schema_id__get: {
     parameters: {
-      query?: never;
+      query?: {
+        include_retired?: boolean;
+      };
       header?: never;
       path: {
         schema_id: number;
@@ -2178,7 +3225,7 @@ export interface operations {
       };
     };
   };
-  schemas_delete_schema_schemas__schema_id__delete: {
+  schemas_retire_schema_schemas__schema_id__delete: {
     parameters: {
       query?: never;
       header?: never;
@@ -2188,6 +3235,68 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  schemas_revive_schema_schemas__schema_id__revive_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        schema_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  schemas_record_schema_sync_health_schemas__schema_id__sync_health_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        schema_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SyncHealthWrite'];
+      };
+    };
     responses: {
       /** @description Successful Response */
       204: {
@@ -2222,6 +3331,7 @@ export interface operations {
           | '-schema_id';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path: {
@@ -2289,6 +3399,7 @@ export interface operations {
   services_list_services_services__get: {
     parameters: {
       query?: {
+        external_id?: string | null;
         service_type?: components['schemas']['ServiceTypeEnum'] | null;
         offset?: number;
         limit?: number;
@@ -2296,6 +3407,7 @@ export interface operations {
         sort?: 'created_at' | '-created_at' | 'name' | '-name';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path?: never;
@@ -2323,9 +3435,43 @@ export interface operations {
       };
     };
   };
+  services_list_service_identity_candidates_services_identity_candidates_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedResponse_ServiceIdentityCandidateResponse_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
   services_retrieve_service_services__service_id__get: {
     parameters: {
-      query?: never;
+      query?: {
+        include_retired?: boolean;
+      };
       header?: never;
       path: {
         service_id: number;
@@ -2389,7 +3535,103 @@ export interface operations {
       };
     };
   };
-  services_delete_service_services__service_id__delete: {
+  services_retire_service_services__service_id__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        service_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  services_list_service_identity_aliases_services__service_id__identity_aliases_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        service_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedResponse_ExternalIdentityAliasResponse_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  services_decide_service_identity_link_services__service_id__identity_link_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        service_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['IdentityLinkDecisionWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  services_revive_service_services__service_id__revive_post: {
     parameters: {
       query?: never;
       header?: never;
@@ -2434,6 +3676,7 @@ export interface operations {
           | '-service_id';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path: {
@@ -2486,6 +3729,39 @@ export interface operations {
         content: {
           'application/json': components['schemas']['Schema'];
         };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  services_record_service_sync_health_services__service_id__sync_health_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        service_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SyncHealthWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
       /** @description Validation Error */
       422: {
@@ -2601,6 +3877,7 @@ export interface operations {
           | '-schema_id';
         /** @description Case-insensitive search across the searchable columns. */
         search?: string | null;
+        include_retired?: boolean;
       };
       header?: never;
       path?: never;
@@ -2630,7 +3907,9 @@ export interface operations {
   };
   tables_retrieve_table_tables__table_id__get: {
     parameters: {
-      query?: never;
+      query?: {
+        include_retired?: boolean;
+      };
       header?: never;
       path: {
         table_id: number;
@@ -2694,7 +3973,7 @@ export interface operations {
       };
     };
   };
-  tables_delete_table_tables__table_id__delete: {
+  tables_retire_table_tables__table_id__delete: {
     parameters: {
       query?: never;
       header?: never;
@@ -2704,6 +3983,68 @@ export interface operations {
       cookie?: never;
     };
     requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  tables_revive_table_tables__table_id__revive_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        table_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  tables_record_table_sync_health_tables__table_id__sync_health_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        table_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SyncHealthWrite'];
+      };
+    };
     responses: {
       /** @description Successful Response */
       204: {

--- a/ui/packages/sep/api/src/generated/sep.ts
+++ b/ui/packages/sep/api/src/generated/sep.ts
@@ -656,6 +656,47 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/apps/atw/case-search/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Atw Case Search
+     * @description Search the configured delivery provider for support cases matching ``term``.
+     *
+     *     No way the search itself can fail reaches the caller as an error: a
+     *     deployment that declares no case-search section, stored inputs that no
+     *     longer fit the plan, a refused credential, an unreachable receiver and a
+     *     search that outran its bound all report the same unavailability, which the
+     *     caller renders as the plain text field rather than as a search that found
+     *     nothing.
+     *
+     *     Restricted to administrators, unlike the app's other reads. The router
+     *     resolves a minimum role for unsafe methods only, so a safe method carries
+     *     whatever guard it declares itself; this one issues the deployment's own
+     *     receiver credential, and the dialog that calls it is already offered to
+     *     administrators alone.
+     *
+     *     :param term: The caller's typed search term, the only input it accepts.
+     *         Surrounding whitespace is stripped, so a whitespace-only term is
+     *         refused rather than reaching the receiver as a match-everything
+     *         fragment.
+     *     :return: The matched cases, or that the search could not run. At most
+     *         ``MAX_CASE_SEARCH_MATCHES`` are offered, so a plan that declares no
+     *         provider-side limit still cannot hand the dialog an unbounded list.
+     */
+    get: operations['atw_atw_case_search_api_apps_atw_case_search__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/apps/atw/config/': {
     parameters: {
       query?: never;
@@ -667,10 +708,11 @@ export interface paths {
      * Atw Config
      * @description Report whether the incident send action is available.
      *
-     *     Not gated by the send guard -- this endpoint is what reports that guard, so
+     *     Not gated by the send guard: this endpoint is what reports that guard, so
      *     it must answer whether or not a receiver is configured.
      *
-     *     :return: The reasons the send action is withheld; empty when it is offered.
+     *     :return: The reasons the send action is withheld, and whether the
+     *         case-reference field may search the receiver.
      */
     get: operations['atw_atw_config_api_apps_atw_config__get'];
     put?: never;
@@ -1514,10 +1556,12 @@ export interface paths {
      * Inventory Plugin Tasks
      * @description Return the list of periodic task names for the Inventory plugin.
      *
-     *     Hard-coded because the Inventory plugin has exactly one periodic task
-     *     (``inventory-sync``). The shape matches what the React
-     *     ``usePluginTasks('inventory')`` hook expects: a list of objects with at
+     *     Hard-coded because the Inventory plugin's periodic tasks are a fixed pair
+     *     (``inventory-sync`` and ``inventory-collection``). The shape matches what the
+     *     React ``usePluginTasks('inventory')`` hook expects: a list of objects with at
      *     minimum a ``name`` key.
+     *
+     *     :return: The plugin's periodic tasks, each with its name and display name.
      */
     get: operations['inventory_inventory_plugin_tasks_api_apps_inventory__get'];
     put?: never;
@@ -1724,16 +1768,14 @@ export interface paths {
     };
     /**
      * Inventory Sync Status
-     * @description Return whether an inventory-wide sync is currently running.
+     * @description Return whether an inventory-wide sync is running, plus recent run outcomes.
      *
      *     Replaces the server-rendered ``sync_is_running`` template variable
      *     used by the Jinja2 inventory page so the React control can poll the
      *     same state without scraping HTML.
      *
      *     :param session: SQLModel async session.
-     *     :type session: SessionDep
-     *     :return: ``{"is_running": <bool>}``.
-     *     :rtype: InventorySyncStatusResponse
+     *     :return: The running flag and the most recent runs, newest first.
      */
     get: operations['inventory_inventory_sync_status_api_apps_inventory_sync_status__get'];
     put?: never;
@@ -1764,11 +1806,7 @@ export interface paths {
      */
     get: operations['inventory_inventory_list_entity_api_apps_inventory__entity___get'];
     put?: never;
-    /**
-     * Inventory Create Entity
-     * @description Create an inventory node, service, schema, or table.
-     */
-    post: operations['inventory_inventory_create_entity_api_apps_inventory__entity___post'];
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1787,17 +1825,9 @@ export interface paths {
      * @description Retrieve a single inventory node, service, schema, or table.
      */
     get: operations['inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get'];
-    /**
-     * Inventory Update Entity
-     * @description Update an inventory node, service, schema, or table.
-     */
-    put: operations['inventory_inventory_update_entity_api_apps_inventory__entity___item_id__put'];
+    put?: never;
     post?: never;
-    /**
-     * Inventory Delete Entity
-     * @description Delete an inventory node, service, schema, or table.
-     */
-    delete: operations['inventory_inventory_delete_entity_api_apps_inventory__entity___item_id__delete'];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -3689,7 +3719,10 @@ export interface components {
       | 'error'
       | 'unreachable'
       | 'ssl_error'
-      | 'timeout';
+      | 'timeout'
+      | 'not_configured'
+      | 'inputs_drifted'
+      | 'probe_undeclared';
     /**
      * DashboardStatsResponse
      * @description Represent aggregate counts for the four dashboard stat cards.
@@ -3813,35 +3846,52 @@ export interface components {
      * @description Represent a node in the inventory.
      *
      *     :param address: The network address of the node.
-     *     :type address: NonEmptyStr
      *     :param name: The name of the node.
-     *     :type name: NonEmptyStr
      *     :param external_id: An external identifier for the node. Must be unique for source,
      *         as defined by composite index ix_node_external_id_source.
-     *     :type external_id: NonEmptyStr | None
      *     :param source: The source from which the node information is derived. Must be unique
      *         for external_id, as defined by composite index ix_node_external_id_source.
-     *     :type source: SourceEnum | None
      *     :param type: The type of the node (e.g., remote, generic).
-     *     :type type: NonEmptyStr
+     *     :param retired_at: When the node stopped being reported upstream, or None while
+     *         it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the node against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the node is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param services: A list of services associated with the node.
-     *     :type services: list[Service]
      */
     Node: {
       /** Address */
       address: string;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
        */
       created_at?: string;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
-      source?: components['schemas']['SourceEnum'] | null;
+      /** Retired At */
+      retired_at?: string | null;
+      source: components['schemas']['SourceEnum'];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /**
        * Type
        * @default generic
@@ -3946,26 +3996,34 @@ export interface components {
      * @description Represent a database schema within a service.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param name: The name of the schema. Must be unique for service_id, as defined by
      *         composite index ix_schema_name_service_id.
-     *     :type name: NonEmptyStr
      *     :param service_id: The unique identifier of the service to which the schema belongs.
      *         Must be unique for name, as defined by composite index
      *         ix_schema_name_service_id.
-     *     :type service_id: int
      *     :param service: The service to which the schema is associated.
-     *     :type service: Service
+     *     :param retired_at: When the schema stopped being reported upstream, or None
+     *         while it is active.
+     *     :param retirement_key: The discriminator carried inside every unique index.
+     *     :param last_synced_at: When a syncer last confirmed the schema against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the schema is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      *     :param tables: A list of tables within the schema.
-     *     :type tables: list[Table]
      */
     Schema: {
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -3973,10 +4031,18 @@ export interface components {
       created_at?: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
+      /** Retired At */
+      retired_at?: string | null;
       /** Service Id */
       service_id: number;
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -3985,44 +4051,45 @@ export interface components {
      * @description Enumerate the probeable services, used as stable ``service`` identifiers.
      * @enum {string}
      */
-    ServiceEnum: 'pmm' | 'inventory' | 'tasks' | 'nomad';
+    ServiceEnum: 'pmm' | 'inventory' | 'tasks' | 'nomad' | 'delivery';
     /**
      * ServiceResponse
      * @description Define the service API response.
      *
      *     :param id: The primary key for the table. Auto-incremented and not nullable.
-     *     :type id: int | None
      *     :param created_at: The timestamp when the record is created. Defaults to the current
      *         time in UTC.
-     *     :type created_at: UTCDatetime
      *     :param updated_at: The timestamp when the record is last updated. Automatically
      *         updated on changes.
-     *     :type updated_at: UTCDatetime | None
      *     :param external_id: An external identifier for the service.
-     *     :type external_id: NonEmptyStr | None
      *     :param name: The name of the service.
-     *     :type name: NonEmptyStr
      *     :param type: The type of the service (e.g., MYSQL, POSTGRESQL).
-     *     :type type: ServiceTypeEnum
      *     :param port: The port number on which the service is running.
-     *     :type port: int | None
      *     :param environment: The environment in which the service is running, if set.
-     *     :type environment: str | None
      *     :param cluster: The cluster in which the service is running, if set.
-     *     :type cluster: str | None
      *     :param replication_set: The replication set in which the service is running, if set.
-     *     :type replication_set: str | None
      *     :param custom_labels: Custom labels associated with the service, if set.
      *     :param node_id: The unique identifier of the node on which the service is running.
-     *     :type node_id: int
      *     :param schemas: A list of schemas associated with the service.
-     *     :type schemas: list[Schema]
      *     :param node: The node to which the service is associated.
-     *     :type node: Node
+     *     :param retired_at: When the service stopped being reported upstream, or None
+     *         while it is active.
+     *     :param last_synced_at: When a syncer last confirmed the service against its
+     *         source, or None if that has never happened.
+     *     :param last_sync_error: The message from the most recent failed attempt, or
+     *         None while the service is syncing cleanly.
+     *     :param sync_failing_since: When the current run of failures began, or None
+     *         while not failing.
+     *     :param consecutive_failures: Failed attempts since the last success.
      */
     ServiceResponse: {
       /** Cluster */
       cluster?: string | null;
+      /**
+       * Consecutive Failures
+       * @default 0
+       */
+      consecutive_failures: number;
       /**
        * Created At
        * Format: date-time
@@ -4035,9 +4102,13 @@ export interface components {
       /** Environment */
       environment?: string | null;
       /** External Id */
-      external_id?: string | null;
+      external_id: string;
       /** Id */
       id: number | null;
+      /** Last Sync Error */
+      last_sync_error?: string | null;
+      /** Last Synced At */
+      last_synced_at?: string | null;
       /** Name */
       name: string;
       node: components['schemas']['Node'];
@@ -4047,8 +4118,12 @@ export interface components {
       port?: number | null;
       /** Replication Set */
       replication_set?: string | null;
+      /** Retired At */
+      retired_at?: string | null;
       /** Schemas */
       schemas: components['schemas']['Schema'][];
+      /** Sync Failing Since */
+      sync_failing_since?: string | null;
       type: components['schemas']['ServiceTypeEnum'];
       /** Updated At */
       updated_at?: string | null;
@@ -4082,61 +4157,22 @@ export interface components {
       | 'external'
       | 'valkey';
     /**
-     * SettingClassEnum
-     * @description Enumerate settings classes that may have HOT override rows.
-     *
-     *     The wired classes are ``SEPSettings``, ``TasksSettings``,
-     *     ``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,
-     *     ``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and
-     *     ``InventorySettings``.
-     *
-     *     To wire a new settings class:
-     *
-     *     1. Add a member here whose value matches the Pydantic class ``__name__``.
-     *     2. Generate an Alembic migration on every consumer track that extends the
-     *        ``CHECK`` constraint on ``settingoverride.setting_class``. The column
-     *        uses ``native_enum=False`` so the value list lives in a constraint,
-     *        not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.
-     *        Note that the column and ``CHECK`` constraint persist the enum member
-     *        *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member
-     *        *value* (the Pydantic class name, e.g. ``SEPSettings``).
-     *     3. Wire a ``ProxyEntry`` for the new class in the relevant service's
-     *        lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).
-     * @enum {string}
-     */
-    SettingClassEnum:
-      | 'SEPSettings'
-      | 'TasksSettings'
-      | 'SnippetsSettings'
-      | 'Settings'
-      | 'AlertSettings'
-      | 'AnonymizerSettings'
-      | 'AlertsSettings'
-      | 'HealthReportSettings'
-      | 'InventorySettings';
-    /**
      * SettingClassGroup
-     * @description One settings-class group in the LIST response.
+     * @description Group one settings class's fields for the LIST response.
      *
-     *     :param setting_class: The settings class this group represents.
-     *     :type setting_class: SettingClassEnum
+     *     :param setting_class: The Pydantic class ``__name__`` this group represents.
      *     :param settings: The fields declared on the settings class, with their
      *         current values and metadata.
-     *     :type settings: list[SettingResponse]
      *     :param is_app_owned: Whether this group belongs to a SEP app under
      *         ``app/sep/apps/`` rather than core SEP wiring.
-     *     :type is_app_owned: bool
      *     :param app_id: The owning app's registry key when ``is_app_owned`` is
      *         ``True``; ``None`` for core groups.
-     *     :type app_id: str | None
      *     :param app_display_name: The owning app's human-facing label when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups.
-     *     :type app_display_name: str | None
      *     :param app_enabled: Whether the owning app is currently enabled when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled
      *         apps remain listed so the frontend can hide them without a second
      *         lookup.
-     *     :type app_enabled: bool | None
      */
     SettingClassGroup: {
       /** App Display Name */
@@ -4150,7 +4186,8 @@ export interface components {
        * @default false
        */
       is_app_owned: boolean;
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Settings */
       settings: components['schemas']['SettingResponse'][];
     };
@@ -4171,7 +4208,7 @@ export interface components {
      * SettingResponse
      * @description Represent a single setting's metadata and current value.
      *
-     *     :param setting_class: The settings class the field belongs to.
+     *     :param setting_class: The Pydantic class ``__name__`` the field belongs to.
      *     :param key: The field name on the settings class.
      *     :param key_path: Carry the canonical key segments for ``key`` such that
      *         ``"__".join(key_path) == key``.
@@ -4229,7 +4266,8 @@ export interface components {
       /** Options */
       options?: components['schemas']['SettingOption'][] | null;
       reload: components['schemas']['ReloadClassification'];
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Type */
       type: string;
       /** Value */
@@ -4424,6 +4462,21 @@ export interface components {
      */
     SourceEnum: 'pmm';
     /**
+     * SyncStatusEnum
+     * @description Enumerate the possible statuses of a synchronization process.
+     *
+     *     :cvar PENDING: The synchronization is pending.
+     *     :vartype PENDING: str
+     *     :cvar RUNNING: The synchronization is currently running.
+     *     :vartype RUNNING: str
+     *     :cvar SUCCESS: The synchronization completed successfully.
+     *     :vartype SUCCESS: str
+     *     :cvar FAILED: The synchronization failed.
+     *     :vartype FAILED: str
+     * @enum {string}
+     */
+    SyncStatusEnum: 'pending' | 'running' | 'success' | 'failed';
+    /**
      * TaskBackendEnum
      * @description Control the choice of backends.
      *
@@ -4568,6 +4621,10 @@ export interface components {
      *     :cvar STALE: Enum value for tasks skipped because executor placement
      *         exceeded the configured staleness threshold (for example a Nomad
      *         allocation that never left the queue).
+     *     :cvar UNLAUNCHABLE: Enum value for tasks the executor node could not
+     *         launch at all, because some command in the invocation does not
+     *         resolve there. The payload never ran, so this is not a script
+     *         failure.
      * @enum {string}
      */
     TaskHistoryStatusEnum:
@@ -4577,7 +4634,8 @@ export interface components {
       | 'success'
       | 'stopped'
       | 'lost'
-      | 'stale';
+      | 'stale'
+      | 'unlaunchable';
     /**
      * TaskResponse
      * @description Represent a task API response.
@@ -5724,13 +5782,51 @@ export interface components {
       title: string;
     };
     /**
+     * AtwCaseMatch
+     * @description Represent one support case the delivery provider matched.
+     *
+     *     :param reference: The case reference to send diagnostics against.
+     *     :param title: The case title, shown beside the reference to tell two
+     *         similar references apart.
+     */
+    atw__AtwCaseMatch: {
+      /** Reference */
+      reference: string;
+      /** Title */
+      title: string;
+    };
+    /**
+     * AtwCaseSearchResponse
+     * @description Report the cases matching a typed term, or that the search could not run.
+     *
+     *     :param available: Whether the search ran at all. This is what keeps an
+     *         unavailable search distinct from an available one that matched nothing:
+     *         a caller must not render the first as the second.
+     *     :param matches: The matched cases, empty when there are none and when the
+     *         search could not run.
+     */
+    atw__AtwCaseSearchResponse: {
+      /** Available */
+      available: boolean;
+      /** Matches */
+      matches: components['schemas']['atw__AtwCaseMatch'][];
+    };
+    /**
      * AtwConfigResponse
      * @description Report whether the incident send action is available.
      *
      *     :param send_disabled_reasons: Why sending is unavailable; empty when the
      *         receiver is configured and the action is offered.
+     *     :param case_search_available: Whether the case-reference field may query the
+     *         receiver for matches. Defaults to ``False`` so a client built against
+     *         the response before this field existed keeps validating.
      */
     atw__AtwConfigResponse: {
+      /**
+       * Case Search Available
+       * @default false
+       */
+      case_search_available: boolean;
       /** Send Disabled Reasons */
       send_disabled_reasons: string[];
     };
@@ -6428,7 +6524,9 @@ export interface components {
       /** Pgbackrest Datadir */
       pgbackrest_datadir?: string | null;
       /** Pgbackrest Incremental Cycle */
-      pgbackrest_incremental_cycle?: string | number | null;
+      pgbackrest_incremental_cycle?:
+        | ('daily' | 'weekly' | '1' | '2' | '3' | '4' | '5' | '6' | '7')
+        | null;
       /** Pgbackrest Retention Archive */
       pgbackrest_retention_archive?: number | null;
       /** Pgbackrest Retention Full */
@@ -6871,8 +6969,10 @@ export interface components {
      *     :param task_type: Optional task-type identifier used when creating tasks
      *         via the shared task API. Defaults to ``None``.
      *     :type task_type: NonEmptyStr | None
-     *     :param forms: Form sections for single-entity / task plugins. Defaults to
-     *         an empty list when ``entities`` is used instead.
+     *     :param forms: Form sections for single-entity / task plugins. When
+     *         ``entities`` is non-empty, root ``forms`` must be empty (declare
+     *         forms on each entity instead); non-empty root ``forms`` are rejected
+     *         at construction. Defaults to an empty list.
      *     :type forms: list[FormSection]
      *     :param capabilities: Optional plugin-level feature flags. Defaults to
      *         ``None``.
@@ -6890,11 +6990,13 @@ export interface components {
      *         When non-empty, the React shell renders one list/create/detail flow
      *         per entity. Defaults to ``None`` (legacy single-entity mode).
      *     :param cardinality_rules: Optional plugin-wide cross-field cardinality
-     *         constraints (task-style plugins only; ignored when ``entities`` is set).
+     *         constraints (task-style plugins only). Rejected at construction when
+     *         ``entities`` is non-empty — declare rules on each entity instead.
      *         Defaults to ``None``.
      *     :type cardinality_rules: list[CardinalityRule] | None
      *     :param fail_when: Optional plugin-wide predicate-only invariants (task-style
-     *         plugins only; ignored when ``entities`` is set). Defaults to ``None``.
+     *         plugins only). Rejected at construction when ``entities`` is non-empty —
+     *         declare rules on each entity instead. Defaults to ``None``.
      *     :type fail_when: list[FailRule] | None
      *     :param derived: Optional declarative specs for sibling tasks derived from
      *         the parent task on cascade. Consumed by
@@ -7787,10 +7889,13 @@ export interface components {
      *
      *     :param field_type: The discriminator literal; always ``"host"`` for this
      *         class. Serialised as the JSON key ``"type"``.
-     *     :type field_type: Literal["host"]
      *     :param depends_on: Optional name of the field whose value drives the
      *         default executor selection. ``None`` (the default) omits the key from
      *         the wire so plugins that do not opt in stay byte-identical.
+     *     :param target_service: Optional service field for a non-blocking
+     *         co-location warning. Independent of ``depends_on`` (see
+     *         :class:`~app.sep.apps.framework.form_dsl.markers.HostRef`).
+     *         ``None`` (the default) omits the key from the wire.
      *     :param allow_custom: When ``True``, the selector also accepts a free-typed
      *         value alongside the inventory options. ``None`` (the default) omits the
      *         key from the wire so plugins that do not opt in stay byte-identical.
@@ -7817,6 +7922,8 @@ export interface components {
       required: boolean;
       /** Requires */
       requires?: components['schemas']['framework__FieldGate'][] | null;
+      /** Target Service */
+      target_service?: string | null;
       /**
        * @description discriminator enum property added by openapi-typescript
        * @enum {string}
@@ -7957,6 +8064,8 @@ export interface components {
      *     Cascade auto-select is single-host only (:class:`HostField`). ``depends_on``
      *     may still be emitted when ``Ui(depends_on=...)`` is set so derivation stays
      *     uniform, but the multi-host renderer does not honour it today.
+     *     ``target_service`` is mirrored the same way; the multi-host renderer
+     *     ignores it (no co-location warning).
      *
      *     :param field_type: The discriminator literal; always ``"multi_host"`` for
      *         this class. Serialised as the JSON key ``"type"``.
@@ -7964,6 +8073,9 @@ export interface components {
      *         ``Ui(depends_on=...)``. Emitted for wire uniformity with
      *         :class:`HostField`; the current multi-host renderer ignores it (no
      *         cascade). ``None`` (the default) omits the key from the wire.
+     *     :param target_service: Optional service field name mirrored for wire
+     *         uniformity with :class:`HostField`; ignored by the multi-host
+     *         renderer. ``None`` (the default) omits the key from the wire.
      *     :param allow_custom: When ``True``, the selector also accepts free-typed
      *         values alongside the inventory options. ``None`` (the default) omits the
      *         key from the wire so plugins that do not opt in stay byte-identical.
@@ -7990,6 +8102,8 @@ export interface components {
       required: boolean;
       /** Requires */
       requires?: components['schemas']['framework__FieldGate'][] | null;
+      /** Target Service */
+      target_service?: string | null;
       /**
        * @description discriminator enum property added by openapi-typescript
        * @enum {string}
@@ -8807,11 +8921,16 @@ export interface components {
      *
      *     :param is_running: ``True`` when an inventory-wide sync is currently
      *         in progress; ``False`` otherwise.
-     *     :type is_running: bool
+     *     :param last_runs: The most recently recorded synchronization runs, newest first.
      */
     inventory__InventorySyncStatusResponse: {
       /** Is Running */
       is_running: boolean;
+      /**
+       * Last Runs
+       * @default []
+       */
+      last_runs: components['schemas']['inventory__SyncRunSummary'][];
     };
     /**
      * InventorySyncTriggerWrite
@@ -8834,15 +8953,38 @@ export interface components {
      * @description Represent a single plugin task entry returned by ``GET /api/apps/inventory/``.
      *
      *     :param name: Machine-readable task identifier (e.g. ``"inventory-sync"``).
-     *     :type name: str
      *     :param display_name: Human-readable label for the schedule UI.
-     *     :type display_name: str
      */
     inventory__PluginTaskResponse: {
       /** Display Name */
       display_name: string;
       /** Name */
       name: string;
+    };
+    /**
+     * SyncRunSummary
+     * @description Summarize one recorded synchronization run for the sync-status endpoint.
+     *
+     *     :param syncer: The fully qualified name of the synchronizer that ran.
+     *     :param started_at: When the run was recorded.
+     *     :param finished_at: When the run last changed, or ``None`` while it is open.
+     *     :param status: The run-level outcome.
+     *     :param snapshot_complete: Whether the run observed a complete generation of the
+     *         remote inventory, or ``None`` when the syncer does not produce one.
+     */
+    inventory__SyncRunSummary: {
+      /** Finished At */
+      finished_at: string | null;
+      /** Snapshot Complete */
+      snapshot_complete: boolean | null;
+      /**
+       * Started At
+       * Format: date-time
+       */
+      started_at: string;
+      status: components['schemas']['SyncStatusEnum'];
+      /** Syncer */
+      syncer: string;
     };
     /**
      * BackupCreate
@@ -8855,12 +8997,14 @@ export interface components {
      *     declaration order, so the derived section and field order matches the
      *     hand-written schema. The conditional gating that the legacy ``schema.py`` declared
      *     (per-mode ``forbidden`` gates, the upload-provider ``Contains`` gates, the
-     *     encryption gates — ``encrypt`` (in-place) and ``post_run_encrypt`` are
-     *     independent encryption modes that both produce an encrypted backup;
-     *     ``encrypt_using_tmpdir`` requires ``encrypt`` and is forbidden alongside
-     *     ``post_run_encrypt`` so post-run takes precedence (matching the backend at
-     *     ``mydumper_payload``), and ``encryption_recipient`` is required iff either mode
-     *     is on — and the per-mode bool
+     *     encryption gates — ``encryption_format`` selects which encryption runs and the
+     *     rest of the section parameterises it: the key file is required by the
+     *     AES-bearing formats and forbidden outside them, a GPG-bearing format needs one
+     *     of the two independent timings (``encrypt`` in place, ``post_run_encrypt``
+     *     after), ``encrypt_using_tmpdir`` requires ``encrypt`` and is forbidden
+     *     alongside ``post_run_encrypt`` so post-run takes precedence (matching the
+     *     backend at ``mydumper_payload``), and ``encryption_recipient`` is required iff
+     *     either timing is on — and the per-mode and encryption-format bool
      *     ``FailRule``s in
      *     :attr:`__form_rules__`) now lives on the model; ``AppFormModel`` extracts it
      *     into the conditional-rule plan at class definition, so no
@@ -8868,8 +9012,9 @@ export interface components {
      *     (:class:`BackupConfigAll` and friends) stay the serialization target the
      *     payload builder populates, not this model's base class.
      *
-     *     :cvar __form_rules__: The per-mode bool fail rules — a truthy mode-owned bool
-     *         outside its mode fails validation with a per-field message.
+     *     :cvar __form_rules__: The bool fail rules — a truthy mode-owned bool outside
+     *         its mode, or a GPG timing outside a GPG ``encryption_format``, fails
+     *         validation with a per-field message, as does a GPG format with no timing.
      */
     mysql_backups__BackupCreate: {
       /**
@@ -8927,6 +9072,8 @@ export interface components {
        * @default false
        */
       encrypt_using_tmpdir: boolean;
+      /** @default none */
+      encryption_format: components['schemas']['mysql_backups__EncryptionFormat'];
       /** Encryption Recipient */
       encryption_recipient?: string | null;
       /** Gs Bucket */
@@ -9177,6 +9324,12 @@ export interface components {
      * @enum {string}
      */
     mysql_backups__CompressionAlgorithm: 'zstd' | 'lz4' | 'gzip' | 'quicklz';
+    /**
+     * EncryptionFormat
+     * @description Represent the backup-time encryption formats an operator can select.
+     * @enum {string}
+     */
+    mysql_backups__EncryptionFormat: 'none' | 'gpg' | 'aes256' | 'dual';
     /** PaginatedResponse[BackupRunResponse] */
     mysql_backups__PaginatedResponse_BackupRunResponse_: {
       /** Items */
@@ -11377,6 +11530,38 @@ export interface operations {
       };
     };
   };
+  atw_atw_case_search_api_apps_atw_case_search__get: {
+    parameters: {
+      query: {
+        /** @description The support case reference or title fragment to match. */
+        term: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['atw__AtwCaseSearchResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
   atw_atw_config_api_apps_atw_config__get: {
     parameters: {
       query?: never;
@@ -13161,102 +13346,7 @@ export interface operations {
       };
     };
   };
-  inventory_inventory_create_entity_api_apps_inventory__entity___post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        entity: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
   inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        entity: string;
-        item_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  inventory_inventory_update_entity_api_apps_inventory__entity___item_id__put: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        entity: string;
-        item_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  inventory_inventory_delete_entity_api_apps_inventory__entity___item_id__delete: {
     parameters: {
       query?: never;
       header?: never;
@@ -14647,7 +14737,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
       };
       cookie?: never;
     };
@@ -14682,7 +14772,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;
@@ -14714,7 +14804,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;

--- a/ui/packages/sep/api/src/generated/tasks.ts
+++ b/ui/packages/sep/api/src/generated/tasks.ts
@@ -1102,61 +1102,22 @@ export interface components {
      */
     ReloadClassification: 'hot' | 'nested_only' | 'not_overridable';
     /**
-     * SettingClassEnum
-     * @description Enumerate settings classes that may have HOT override rows.
-     *
-     *     The wired classes are ``SEPSettings``, ``TasksSettings``,
-     *     ``SnippetsSettings``, the global ``Settings``, ``AlertSettings``,
-     *     ``AlertsSettings``, ``AnonymizerSettings``, ``HealthReportSettings`` and
-     *     ``InventorySettings``.
-     *
-     *     To wire a new settings class:
-     *
-     *     1. Add a member here whose value matches the Pydantic class ``__name__``.
-     *     2. Generate an Alembic migration on every consumer track that extends the
-     *        ``CHECK`` constraint on ``settingoverride.setting_class``. The column
-     *        uses ``native_enum=False`` so the value list lives in a constraint,
-     *        not a PostgreSQL ``TYPE`` -- the migration ``ALTER``s the constraint.
-     *        Note that the column and ``CHECK`` constraint persist the enum member
-     *        *names* (e.g. ``SEP_SETTINGS``), which is distinct from the member
-     *        *value* (the Pydantic class name, e.g. ``SEPSettings``).
-     *     3. Wire a ``ProxyEntry`` for the new class in the relevant service's
-     *        lifespan (``app/sep/main.py`` or ``app/tasks/main.py``).
-     * @enum {string}
-     */
-    SettingClassEnum:
-      | 'SEPSettings'
-      | 'TasksSettings'
-      | 'SnippetsSettings'
-      | 'Settings'
-      | 'AlertSettings'
-      | 'AnonymizerSettings'
-      | 'AlertsSettings'
-      | 'HealthReportSettings'
-      | 'InventorySettings';
-    /**
      * SettingClassGroup
-     * @description One settings-class group in the LIST response.
+     * @description Group one settings class's fields for the LIST response.
      *
-     *     :param setting_class: The settings class this group represents.
-     *     :type setting_class: SettingClassEnum
+     *     :param setting_class: The Pydantic class ``__name__`` this group represents.
      *     :param settings: The fields declared on the settings class, with their
      *         current values and metadata.
-     *     :type settings: list[SettingResponse]
      *     :param is_app_owned: Whether this group belongs to a SEP app under
      *         ``app/sep/apps/`` rather than core SEP wiring.
-     *     :type is_app_owned: bool
      *     :param app_id: The owning app's registry key when ``is_app_owned`` is
      *         ``True``; ``None`` for core groups.
-     *     :type app_id: str | None
      *     :param app_display_name: The owning app's human-facing label when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups.
-     *     :type app_display_name: str | None
      *     :param app_enabled: Whether the owning app is currently enabled when
      *         ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled
      *         apps remain listed so the frontend can hide them without a second
      *         lookup.
-     *     :type app_enabled: bool | None
      */
     SettingClassGroup: {
       /** App Display Name */
@@ -1170,7 +1131,8 @@ export interface components {
        * @default false
        */
       is_app_owned: boolean;
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Settings */
       settings: components['schemas']['SettingResponse'][];
     };
@@ -1191,7 +1153,7 @@ export interface components {
      * SettingResponse
      * @description Represent a single setting's metadata and current value.
      *
-     *     :param setting_class: The settings class the field belongs to.
+     *     :param setting_class: The Pydantic class ``__name__`` the field belongs to.
      *     :param key: The field name on the settings class.
      *     :param key_path: Carry the canonical key segments for ``key`` such that
      *         ``"__".join(key_path) == key``.
@@ -1249,7 +1211,8 @@ export interface components {
       /** Options */
       options?: components['schemas']['SettingOption'][] | null;
       reload: components['schemas']['ReloadClassification'];
-      setting_class: components['schemas']['SettingClassEnum'];
+      /** Setting Class */
+      setting_class: string;
       /** Type */
       type: string;
       /** Value */
@@ -1544,6 +1507,10 @@ export interface components {
      *     :cvar STALE: Enum value for tasks skipped because executor placement
      *         exceeded the configured staleness threshold (for example a Nomad
      *         allocation that never left the queue).
+     *     :cvar UNLAUNCHABLE: Enum value for tasks the executor node could not
+     *         launch at all, because some command in the invocation does not
+     *         resolve there. The payload never ran, so this is not a script
+     *         failure.
      * @enum {string}
      */
     TaskHistoryStatusEnum:
@@ -1553,7 +1520,8 @@ export interface components {
       | 'success'
       | 'stopped'
       | 'lost'
-      | 'stale';
+      | 'stale'
+      | 'unlaunchable';
     /**
      * TaskResponse
      * @description Represent a task API response.
@@ -1918,7 +1886,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
       };
       cookie?: never;
     };
@@ -1953,7 +1921,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;
@@ -1985,7 +1953,7 @@ export interface operations {
       query?: never;
       header?: never;
       path: {
-        setting_class: components['schemas']['SettingClassEnum'];
+        setting_class: string;
         key: string;
       };
       cookie?: never;

--- a/ui/packages/sep/api/src/hooks/useSettings.ts
+++ b/ui/packages/sep/api/src/hooks/useSettings.ts
@@ -37,7 +37,9 @@ import type { components } from '../generated/sep';
 
 // The settings models are declared identically in both the `sep` and `tasks`
 // specs; we treat the `sep` copy as the canonical source for the shared shapes.
-export type SettingClass = components['schemas']['SettingClassEnum'];
+// Path params and response fields carry the Pydantic class __name__ (e.g.
+// "SEPSettings", "AlertsSettings") as a plain string, not a closed enum.
+export type SettingClass = string;
 export type ReloadClassification =
   components['schemas']['ReloadClassification'];
 export type SettingResponse = components['schemas']['SettingResponse'];

--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -194,6 +194,11 @@ export interface HostField extends BaseField {
    * not cascaded.
    */
   depends_on?: string;
+  /**
+   * Service field for a non-blocking co-location warning. Independent of
+   * `depends_on`. Omitted when unset.
+   */
+  target_service?: string;
   /** Offer free-text (free-solo) entry alongside the inventory options. */
   allow_custom?: boolean;
 }

--- a/ui/packages/sep/framework/src/components/HostSelector/HostSelector.tsx
+++ b/ui/packages/sep/framework/src/components/HostSelector/HostSelector.tsx
@@ -15,14 +15,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useRef } from 'react';
-import { get, useFormContext } from 'react-hook-form';
+import { useEffect, useRef, type ReactNode } from 'react';
+import { get, useFormContext, useWatch } from 'react-hook-form';
+import { Alert } from '@mui/material';
 import { AutoCompleteInput } from '@percona/peak-ui';
 import { useSnackbar } from 'notistack';
 import { useHosts, type HostOption } from '../../hooks/useHosts';
 import { useResolvedServiceField } from '../../hooks/useResolvedServiceField';
 import type { ServiceType } from '../../hooks/useServices';
 import { FreeSoloSelect } from '../FreeSoloSelect';
+import { isHostMismatch } from './isHostMismatch';
 import { resolveExecutorHostForService } from './resolveExecutorHostForService';
 
 const EMPTY_OPTIONS: HostOption[] = [];
@@ -51,6 +53,11 @@ export interface HostSelectorProps {
    * ``useServices()`` page-loop is intentionally not used here.
    */
   serviceTypes?: readonly ServiceType[];
+  /**
+   * Service field for the non-blocking co-location warning. Independent of
+   * `dependsOn`. Single-value only — multi-value host fields ignore this.
+   */
+  targetService?: string;
   /** Offer free-text (free-solo) entry alongside the inventory options. */
   allowCustom?: boolean;
 }
@@ -136,6 +143,64 @@ function HostServiceCascade({
   return null;
 }
 
+/**
+ * Non-blocking co-location warning for a single host field. Mounted only when
+ * `targetService` is set. Compares the selected host's network address against
+ * the resolved service's node address; stays silent whenever either side cannot
+ * be established.
+ */
+function HostMismatchWarning({
+  name,
+  targetService,
+  hosts,
+  hostsLoading,
+  hostsError,
+  fieldError,
+}: {
+  name: string;
+  targetService: string;
+  hosts: HostOption[];
+  hostsLoading: boolean;
+  hostsError: boolean;
+  fieldError?: string;
+}) {
+  const hostValue = useWatch({ name });
+  // Resolve types from the target service field, not cascade `serviceTypes`
+  // (those are scoped to `dependsOn`, which may name a different field).
+  const {
+    service,
+    isResolving,
+    isError: serviceError,
+  } = useResolvedServiceField(targetService);
+  if (fieldError) {
+    return null;
+  }
+  if (hostsLoading || hostsError || isResolving || serviceError) {
+    return null;
+  }
+  if (!service) {
+    return null;
+  }
+  const hostId = hostValueId(hostValue);
+  if (!hostId) {
+    return null;
+  }
+  const selectedHost = hosts.find((host) => host.id === hostId);
+  if (!selectedHost) {
+    return null;
+  }
+  const serviceNodeAddress = service.node?.address;
+  if (!isHostMismatch(selectedHost.address, serviceNodeAddress)) {
+    return null;
+  }
+  return (
+    <Alert severity="warning" sx={{ mt: 1 }}>
+      The selected executor host ({selectedHost.name}, {selectedHost.address})
+      is not the node where {service.name} runs ({serviceNodeAddress}).
+    </Alert>
+  );
+}
+
 export function HostSelector({
   name,
   label,
@@ -144,6 +209,7 @@ export function HostSelector({
   helperText,
   dependsOn,
   serviceTypes,
+  targetService,
   allowCustom,
 }: HostSelectorProps) {
   const {
@@ -204,6 +270,20 @@ export function HostSelector({
     />
   ) : null;
 
+  let mismatchWarning: ReactNode = null;
+  if (targetService) {
+    mismatchWarning = (
+      <HostMismatchWarning
+        name={name}
+        targetService={targetService}
+        hosts={hosts}
+        hostsLoading={isLoading}
+        hostsError={isError}
+        fieldError={fieldError}
+      />
+    );
+  }
+
   if (freeSolo) {
     return (
       <>
@@ -223,6 +303,7 @@ export function HostSelector({
             void refetch();
           }}
         />
+        {mismatchWarning}
       </>
     );
   }
@@ -249,6 +330,7 @@ export function HostSelector({
         }}
         textFieldProps={{ helperText: text, error: isError || !!fieldError }}
       />
+      {mismatchWarning}
     </>
   );
 }

--- a/ui/packages/sep/framework/src/components/HostSelector/index.ts
+++ b/ui/packages/sep/framework/src/components/HostSelector/index.ts
@@ -21,3 +21,4 @@ export { StandaloneHostSelector } from './StandaloneHostSelector';
 export type { StandaloneHostSelectorProps } from './StandaloneHostSelector';
 export { resolveExecutorHostForService } from './resolveExecutorHostForService';
 export type { ServiceHostResolveInput } from './resolveExecutorHostForService';
+export { isHostMismatch } from './isHostMismatch';

--- a/ui/packages/sep/framework/src/components/HostSelector/isHostMismatch.test.ts
+++ b/ui/packages/sep/framework/src/components/HostSelector/isHostMismatch.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isHostMismatch } from './isHostMismatch';
+
+describe('isHostMismatch', () => {
+  it('is silent when the host address is missing', () => {
+    expect(isHostMismatch(undefined, '10.0.0.1')).toBe(false);
+  });
+
+  it('is silent when the host address is empty', () => {
+    expect(isHostMismatch('', '10.0.0.1')).toBe(false);
+  });
+
+  it('is silent when the service node address is missing', () => {
+    expect(isHostMismatch('10.0.0.1', undefined)).toBe(false);
+  });
+
+  it('is silent when the service node address is empty', () => {
+    expect(isHostMismatch('10.0.0.1', '')).toBe(false);
+  });
+
+  it('is silent when both addresses are missing', () => {
+    expect(isHostMismatch(undefined, undefined)).toBe(false);
+  });
+
+  it('is silent when both addresses match', () => {
+    // Two Nomad names (or a Nomad name vs inventory display name) that
+    // share one address are the same machine — names are not compared.
+    expect(isHostMismatch('10.0.0.1', '10.0.0.1')).toBe(false);
+  });
+
+  it('warns only when the addresses differ', () => {
+    expect(isHostMismatch('10.0.0.1', '10.0.0.2')).toBe(true);
+  });
+});

--- a/ui/packages/sep/framework/src/components/HostSelector/isHostMismatch.ts
+++ b/ui/packages/sep/framework/src/components/HostSelector/isHostMismatch.ts
@@ -15,27 +15,21 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { HostSelector } from '../../HostSelector';
-import { serviceTypesForDependsOn, useFormFields } from '../formFieldsContext';
-import type { HostField as HostFieldType } from '../types';
-
-interface HostFieldProps {
-  field: HostFieldType;
-}
-
-export function HostField({ field }: HostFieldProps) {
-  const fields = useFormFields();
-  const serviceTypes = serviceTypesForDependsOn(fields, field.depends_on);
-
-  return (
-    <HostSelector
-      name={field.name}
-      label={field.label}
-      required={field.required}
-      dependsOn={field.depends_on}
-      serviceTypes={serviceTypes}
-      targetService={field.target_service}
-      allowCustom={field.allow_custom}
-    />
-  );
+/**
+ * Decide whether the selected executor host and the target service's node
+ * live at different network addresses.
+ *
+ * Co-location is address-only: Nomad node names and inventory display names
+ * are independent namespaces, so two hosts sharing one address are the same
+ * machine and must not warn. An absent or empty address is unknown, not a
+ * difference — prefer silence whenever co-location cannot be established.
+ */
+export function isHostMismatch(
+  hostAddress: string | undefined,
+  serviceNodeAddress: string | undefined
+): boolean {
+  if (!hostAddress || !serviceNodeAddress) {
+    return false;
+  }
+  return hostAddress !== serviceNodeAddress;
 }

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/hooks.ts
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/hooks.ts
@@ -40,6 +40,7 @@ const POLL_INTERVAL_MS = 30_000;
 
 interface PluginTask extends Record<string, unknown> {
   name: string;
+  display_name?: string;
 }
 
 /**

--- a/ui/packages/sep/framework/src/components/TaskHistoryTable/StatusBadge.tsx
+++ b/ui/packages/sep/framework/src/components/TaskHistoryTable/StatusBadge.tsx
@@ -19,6 +19,7 @@ import { keyframes } from '@emotion/react';
 import AutorenewIcon from '@mui/icons-material/Autorenew';
 import CancelIcon from '@mui/icons-material/Cancel';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import CloudOffIcon from '@mui/icons-material/CloudOff';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import HourglassDisabledIcon from '@mui/icons-material/HourglassDisabled';
@@ -59,6 +60,11 @@ const STATUS_MAP: Record<TaskHistoryStatus, StatusEntry> = {
   stopped: { label: 'Stopped', color: 'warning', icon: <CancelIcon /> },
   lost: { label: 'Lost', color: 'default', icon: <HelpOutlineIcon /> },
   stale: { label: 'Stale', color: 'default', icon: <HourglassDisabledIcon /> },
+  unlaunchable: {
+    label: 'Not in executor',
+    color: 'warning',
+    icon: <CloudOffIcon />,
+  },
 };
 
 /**

--- a/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.test.tsx
@@ -151,6 +151,7 @@ describe('StatusBadge', () => {
     ['stopped', 'Stopped'],
     ['lost', 'Lost'],
     ['stale', 'Stale'],
+    ['unlaunchable', 'Not in executor'],
   ] as const)('renders %s as %s label', (status, label) => {
     render(<StatusBadge status={status} />);
     expect(screen.getByText(label)).toBeInTheDocument();

--- a/ui/packages/sep/framework/src/components/TaskLogViewer/StatusBadge.tsx
+++ b/ui/packages/sep/framework/src/components/TaskLogViewer/StatusBadge.tsx
@@ -20,11 +20,18 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CloudOffIcon from '@mui/icons-material/CloudOff';
 import ErrorIcon from '@mui/icons-material/Error';
 import HelpIcon from '@mui/icons-material/Help';
+import HourglassDisabledIcon from '@mui/icons-material/HourglassDisabled';
 import ReportIcon from '@mui/icons-material/Report';
 import Chip from '@mui/material/Chip';
 import type { FinishStatus } from '../../hooks/useTaskLogs';
 
 export type BadgeStatus = FinishStatus | 'stream-error' | 'executor-gone';
+
+const NOT_IN_EXECUTOR = {
+  label: 'Not in executor',
+  color: 'warning',
+  icon: <CloudOffIcon />,
+} as const;
 
 const MAP: Record<
   BadgeStatus,
@@ -38,16 +45,20 @@ const MAP: Record<
   stopped: { label: 'Stopped', color: 'default', icon: <CancelIcon /> },
   lost: { label: 'Lost', color: 'warning', icon: <HelpIcon /> },
   failed: { label: 'Failed', color: 'error', icon: <ReportIcon /> },
+  stale: {
+    label: 'Stale',
+    color: 'default',
+    icon: <HourglassDisabledIcon />,
+  },
   'stream-error': {
     label: 'Stream error',
     color: 'error',
     icon: <ErrorIcon />,
   },
-  'executor-gone': {
-    label: 'Not in executor',
-    color: 'warning',
-    icon: <CloudOffIcon />,
-  },
+  // Shared rather than spelled twice: to the operator both mean the node could
+  // not run this, not that the script failed, so the two must stay identical.
+  unlaunchable: NOT_IN_EXECUTOR,
+  'executor-gone': NOT_IN_EXECUTOR,
 };
 
 export interface StatusBadgeProps {
@@ -55,7 +66,22 @@ export interface StatusBadgeProps {
 }
 
 export function StatusBadge({ status }: StatusBadgeProps) {
-  const entry = MAP[status];
+  // The SSE `finish` event forwards the backend's status verbatim, so a member
+  // added there before this union reaches the badge as an unmapped key however
+  // the prop is typed. Reading `.color` off the miss throws and unmounts the
+  // whole viewer, so render the raw status instead — the same degradation
+  // `LastRunStatus` applies to a status it does not recognize.
+  const entry: (typeof MAP)[BadgeStatus] | undefined = MAP[status];
+  if (!entry) {
+    return (
+      <Chip
+        size="small"
+        color="default"
+        icon={<HelpIcon />}
+        label={String(status)}
+      />
+    );
+  }
   return (
     <Chip
       size="small"

--- a/ui/packages/sep/framework/src/components/TaskLogViewer/__tests__/StatusBadge.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskLogViewer/__tests__/StatusBadge.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatusBadge } from '../StatusBadge';
+
+describe('TaskLogViewer StatusBadge', () => {
+  // The backend emits every finished status on the SSE `finish` event, so a
+  // status missing from the map indexes it to `undefined` and throws while
+  // reading `.color` -- the viewer goes blank rather than degrading.
+  it.each([
+    ['success', 'Done'],
+    ['failed', 'Failed'],
+    ['stopped', 'Stopped'],
+    ['lost', 'Lost'],
+    ['stale', 'Stale'],
+    ['unlaunchable', 'Not in executor'],
+    ['stream-error', 'Stream error'],
+    ['executor-gone', 'Not in executor'],
+  ] as const)('renders %s as %s', (status, label) => {
+    render(<StatusBadge status={status} />);
+
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('renders a status it does not recognise instead of throwing', () => {
+    // The union is a promise about the backend, not a check on it: the `finish`
+    // event carries whatever the backend sends. Completing the map fixes the
+    // statuses known today; this is what keeps the next one from blanking the
+    // viewer before the union catches up.
+    render(<StatusBadge status={'brand-new-status' as never} />);
+
+    expect(screen.getByText('brand-new-status')).toBeInTheDocument();
+  });
+});

--- a/ui/packages/sep/framework/src/hooks/index.ts
+++ b/ui/packages/sep/framework/src/hooks/index.ts
@@ -49,6 +49,7 @@ export { useTables } from './useTables';
 export type { TableOption, UseTablesOptions } from './useTables';
 export { useHosts } from './useHosts';
 export type { HostOption, UseHostsOptions } from './useHosts';
+export { useDebouncedValue, SEARCH_DEBOUNCE_MS } from './useDebouncedValue';
 export { useRemoteChoices } from './useRemoteChoices';
 export type { UseRemoteChoicesOptions } from './useRemoteChoices';
 

--- a/ui/packages/sep/framework/src/hooks/useDebouncedValue.test.tsx
+++ b/ui/packages/sep/framework/src/hooks/useDebouncedValue.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SEARCH_DEBOUNCE_MS, useDebouncedValue } from './useDebouncedValue';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Advance timers inside `act` so the resulting state update is flushed. */
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe('useDebouncedValue', () => {
+  it('publishes the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('seed'));
+
+    expect(result.current).toBe('seed');
+  });
+
+  it('withholds a new value until the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      {
+        initialProps: { value: '' },
+      }
+    );
+
+    rerender({ value: 'pg' });
+    expect(result.current).toBe('');
+
+    advance(SEARCH_DEBOUNCE_MS - 1);
+    expect(result.current).toBe('');
+
+    advance(1);
+    expect(result.current).toBe('pg');
+  });
+
+  it('publishes once per pause, not once per change', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      {
+        initialProps: { value: '' },
+      }
+    );
+
+    for (const value of ['p', 'pg', 'pgs', 'pgst']) {
+      rerender({ value });
+      advance(SEARCH_DEBOUNCE_MS - 50);
+    }
+    // Every keystroke landed inside the window, so nothing has been published.
+    expect(result.current).toBe('');
+
+    advance(50);
+    expect(result.current).toBe('pgst');
+  });
+
+  it('honours a caller-supplied delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 1000),
+      {
+        initialProps: { value: '' },
+      }
+    );
+
+    rerender({ value: 'slow' });
+    advance(SEARCH_DEBOUNCE_MS);
+    expect(result.current).toBe('');
+
+    advance(1000 - SEARCH_DEBOUNCE_MS);
+    expect(result.current).toBe('slow');
+  });
+
+  it('restarts the window when the delay itself changes', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebouncedValue(value, delay),
+      {
+        initialProps: { value: 'a', delay: SEARCH_DEBOUNCE_MS },
+      }
+    );
+
+    rerender({ value: 'b', delay: SEARCH_DEBOUNCE_MS });
+    advance(SEARCH_DEBOUNCE_MS - 100);
+
+    rerender({ value: 'b', delay: 1000 });
+    advance(100);
+    expect(result.current).toBe('a');
+
+    advance(900);
+    expect(result.current).toBe('b');
+  });
+
+  it('clears the pending timer on unmount', () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const { rerender, unmount } = renderHook(
+      ({ value }) => useDebouncedValue(value),
+      {
+        initialProps: { value: '' },
+      }
+    );
+
+    rerender({ value: 'gone' });
+    clearTimeoutSpy.mockClear();
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+
+    // The timer never fires, so no state update is attempted after unmount.
+    expect(() => advance(SEARCH_DEBOUNCE_MS)).not.toThrow();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/ui/packages/sep/framework/src/hooks/useDebouncedValue.ts
+++ b/ui/packages/sep/framework/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Default settle window for a typed input before it drives work downstream (ms).
+ *
+ * Named for its origin — the search boxes across the apps, where the work is a
+ * server refetch — and shared so they all settle on one window rather than each
+ * redeclaring it. It is the hook's default rather than its only value: a
+ * consumer wanting a different pause states that delay at the call site.
+ */
+export const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Track `value`, but only publish it once it has held still for `delayMs`.
+ *
+ * The debounced value starts at the initial `value` rather than at a blank —
+ * a list mounted with a search term already in its state queries for that term
+ * immediately instead of fetching the unfiltered page first.
+ *
+ * The pending timer is cleared on every change and on unmount, so a fast typist
+ * causes one publish per pause, and an unmounted component never publishes.
+ */
+export function useDebouncedValue<T>(
+  value: T,
+  delayMs: number = SEARCH_DEBOUNCE_MS
+): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/ui/packages/sep/framework/src/hooks/useTaskLogs.ts
+++ b/ui/packages/sep/framework/src/hooks/useTaskLogs.ts
@@ -31,7 +31,20 @@ export type LogType = 'stdout' | 'stderr';
 
 export type StepText = Record<LogType, string>;
 
-export type FinishStatus = 'success' | 'failed' | 'stopped' | 'lost';
+/**
+ * Statuses the SSE `finish` event can carry.
+ *
+ * Mirrors the backend's terminal `TaskHistoryStatusEnum` members, and must stay
+ * exhaustive: `StatusBadge` indexes a `Record` keyed on this union, so a status
+ * the backend emits but this union omits reaches the badge as an unmapped key.
+ */
+export type FinishStatus =
+  | 'success'
+  | 'failed'
+  | 'stopped'
+  | 'lost'
+  | 'stale'
+  | 'unlaunchable';
 
 export interface StreamError {
   code?: number;

--- a/ui/packages/sep/framework/src/index.ts
+++ b/ui/packages/sep/framework/src/index.ts
@@ -152,6 +152,8 @@ export {
   useHosts,
   useResolvedServiceField,
   useRemoteChoices,
+  useDebouncedValue,
+  SEARCH_DEBOUNCE_MS,
 } from './hooks';
 export type {
   ServiceOption,


### PR DESCRIPTION
Ticket number: PMM-15205 (PMM-15414, PMM-15415, PMM-15437, PMM-15438, PMM-15439, PMM-15440)

Feature build: not required — the vendored SEP frontend is compiled into PMM's own UI bundle, and every change here is exercised by `ui`'s own suite. A paired build is still wanted before the epic ships; see **What this does not cover**.

Closes the drift between PMM's vendored SEP frontend and SEP `main`. The last sync watermark was **`249f6738a`** (2026-08-25); this moves it to **`c16578dfe`**, across which 19 SEP commits touched the mirrored packages.

Targets `PMM-15205-sep-fb`, the epic's integration branch.

## The audit, before the port

The mirrored packages are `@sep/api`, `@sep/framework`, `@sep/shared` and `@sep/plugins-atw`. PMM does **not** vendor SEP's other apps — it renders them generically from the schema the side-car serves — so a change confined to `frontend/packages/apps/<other>` needs no port here.

Of the 19 commits:

| Disposition | Commits |
| --- | --- |
| Already in PMM | SEP-1845 (PMM-15359), SEP-1844 (PMM-15358) |
| Ported here | SEP-1943, SEP-1956, SEP-1942, SEP-1818, SEP-1892, SEP-1825 |
| No PMM arm | SEP-1856 — its runtime change is in the inventory app, and it drops the authoring forms from the *schema*, which PMM's generic renderer already follows |
| Spec-only | SEP-1637, SEP-1941, SEP-1859, SEP-1778, SEP-1858, SEP-1904, SEP-1854, SEP-1857, SEP-1873, SEP-1787 — carried by the regenerated client |

**The endpoint-shape audit is the part that matters**, since SEP-1759 taught us that a spec-only commit can empty a panel without failing anything. All nine bare-array `apiClient.get` call sites still receive arrays: `/api/admin/apps/`, `/api/apps/`, `/api/sep/hosts/`, `/api/sep/services/{id}/schemas`, `/api/sep/schemas/{id}/tables`, `/api/apps/atw/`, `/execution-events/{id}`, and the two that already normalise either shape. Three endpoints were **removed** — all inventory writes, from SEP-1856 — and nothing in PMM reaches them. Sixteen were added, all additive.

## What is in here

Each commit is one ticket.

- **PMM-15205** — the spec re-copy and codegen. Copied wholesale and formatted rather than hand-spliced; `main.json`'s raw diff was pure reflow and collapses to nothing under oxfmt.
- **PMM-15440** — `SettingClass` becomes a plain string. Not optional: `SettingClassEnum` is gone from the spec, so regenerating the client makes the old alias a compile error.
- **PMM-15205** — backfills `useDebouncedValue` from **SEP-1779**, which landed *before* the watermark and was missed (see below).
- **PMM-15437** — the Send dialog autocompletes support case references against the delivery provider.
- **PMM-15415** — `unlaunchable` reaches the badges and the ATW resend set, **and a live crash is fixed on the way past** (below).
- **PMM-15414** — a send log's steps carry a `kind` discriminator and a `failed` status, so a failed send names the step that ended it.
- **PMM-15439** — the scheduled tasks panel keeps the per-task `display_name`.
- **PMM-15438** — a host field may name a `target_service`, and the selector warns when the chosen executor is not the node hosting it.

## Two findings worth reading

**`'stale'` was crashing the log viewer, independently of anything SEP shipped.** `FinishStatus` never listed it while the SSE `finish` event forwards the backend's status verbatim, so `MAP['stale']` was `undefined` and reading `.color` off it threw — blanking the whole viewer for any stale task whose logs were open. `'stale'` now joins the union and the map, and the badge renders an unrecognised status as its raw text instead of indexing into nothing, so the next member added backend-side degrades rather than crashes.

**The watermark was not a reliable "everything before this is synced" marker.** SEP-1779 predates it and was never ported; the sync that set it audited spec and endpoint shape, not exports. It surfaced only because SEP-1956 imports `useDebouncedValue` and would not compile. PMM's own duplicated debounces — `CollectPane`'s `SNIPPET_SEARCH_DEBOUNCE_MS` and `ScriptPreviewField`'s `DEBOUNCE_MS` — are deliberately left alone; collapsing them onto the hook is SEP-1779's refactor and has no bearing on the drift closed here.

## Porting notes

- `SendDialog.tsx` was **byte-identical** to SEP's pre-change copy once run through PMM's formatter, so it is taken wholesale. `HostSelector.tsx` was **not** — 272 lines apart after the same treatment — so SEP-1818 is applied by hand there, with `isHostMismatch` and its test taken verbatim.
- PMM still uses the pre-rename `Plugin*` vocabulary where SEP has moved to `App*`, so `AppTask` is `PluginTask` here and `app-schema.ts` is `plugin-schema.ts`. Every sync is a translation, not a copy.
- PMM typechecks the ATW tests where SEP does not, so the ported case-search helper indexes `mock.calls` rather than destructuring it with a tuple annotation.
- Only `HostField` gains `target_service`; PMM vendors no `MultiHostField`.

## Testing

- `pnpm check-types` — clean across all six packages.
- `pnpm format:check` — clean (825 files).
- `pnpm lint` — 0 errors.
- `pnpm --filter @sep/api test` — 106 passed.
- `@sep/framework` run serially — **59 files / 748 tests, all passing**, including the new unrecognised-status guard, `isHostMismatch` and `useDebouncedValue`.

**On the framework suite's parallel run.** It is red locally — and it is red on this PR's own base branch too, 12 files / 16 tests, on a tree CI passes. testing-library's `waitFor` default is 1s and independent of vitest's per-test timeout, so a loaded machine reds out dozens of first-render tests that have nothing to do with any change. The whole suite passes with `--fileParallelism=false`, which is what establishes the failures as saturation rather than regression.

## What this does not cover

- [ ] The paired stack against a real side-car. The autocomplete, the co-location warning and the `unlaunchable` badge are all reachable only with SEP serving them, and the crash fix is best confirmed against a genuinely stale task.
- [ ] SEP-1779's refactor of PMM's two remaining duplicated debounces, deliberately out of scope.
- [ ] API Docs updated — not applicable, no PMM API endpoints added, removed or altered.

https://claude.ai/code/session_01RFUiQUpHgyaK6ozEQJ8wmT
