### PR TITLE
PMM-15419 Rebuild the ServiceNow connection tab

### DIFF
--- a/ui/apps/pmm/src/lib/constants.ts
+++ b/ui/apps/pmm/src/lib/constants.ts
@@ -29,6 +29,8 @@ export const SEP_MYSQL_BACKUPS_PATH = `${PMM_NEW_NAV_PATH}/sep/mysql-backups`;
 export const PMM_SERVICENOW_SETTINGS_PATH = `${PMM_NEW_NAV_PATH}/settings/servicenow-connection`;
 
 export const PERCONA_SUPPORT_URL = 'https://www.percona.com/services/support';
+// Short link Support hands out for subscription and credential requests.
+export const PERCONA_SUPPORT_CONTACT_URL = 'https://per.co.na/support';
 
 export const INTERVALS_MS = {
   // 5 mins

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -1,4 +1,4 @@
-import { PERCONA_SUPPORT_URL } from 'lib/constants';
+import { PERCONA_SUPPORT_CONTACT_URL } from 'lib/constants';
 
 export const Messages = {
   title: 'Settings',
@@ -108,20 +108,32 @@ export const Messages = {
   serviceNow: {
     label: 'ServiceNow connection',
     description:
-      "Connect this PMM instance to Percona's ServiceNow so features like Support diagnostics can work directly with your support cases. You'll need a Percona Support account with access to your organization's cases.",
-    scopeNote:
-      "This connection applies to the whole PMM instance. Once connected, anyone with access to Support features can send results to your organization's cases.",
-    subscriptionPrompt: "Don't have a Percona Support subscription?",
-    subscriptionLink: PERCONA_SUPPORT_URL,
-    subscriptionLinkText: 'Learn about Percona Support',
-    endpointLabel: 'Receiver endpoint',
+      "Connect this PMM instance to Percona's ServiceNow to enable support features like Support diagnostics. To set this up, you'll need an active Percona Support subscription. Once connected, all PMM users can work with your organization's support cases directly from PMM.",
+    subscriptionPrompt: "Don't have a subscription or need credentials?",
+    subscriptionLink: PERCONA_SUPPORT_CONTACT_URL,
+    subscriptionLinkText: 'Contact Percona Support',
+    endpointLabel: 'ServiceNow endpoint',
     endpointPlaceholder: 'https://percona.service-now.com/',
     endpointHelper:
-      'Leave empty to use the receiver bundled with this PMM version.',
+      'Leave empty to use the default endpoint: https://percona.service-now.com/',
     secretsLegend: 'Credentials',
+    // Copy for the credentials this PMM version's delivery plan is known to
+    // declare. A name not listed here is a SEP build the UI has no copy for, so
+    // it falls back to the generic label and helper below.
+    secretCopy: {
+      sn_api_key: {
+        label: 'ServiceNow API key',
+        helper:
+          "Authenticates PMM with Percona's ServiceNow. Contact Percona Support to obtain it.",
+      },
+      client_token: {
+        label: 'Client token',
+        helper:
+          'Identifies your PMM instance to ServiceNow. Contact Percona Support to obtain it.',
+      },
+    } as Record<string, { label: string; helper: string }>,
     secretHelper: (name: string) => `Sent to SEP as "${name}".`,
-    secretStoredHelper: (name: string) =>
-      `Sent to SEP as "${name}". A value is stored — leave it untouched to keep it.`,
+    secretStoredSuffix: 'A value is stored — leave it untouched to keep it.',
     status: {
       configured:
         'Connected. Support diagnostics can send results to your ServiceNow cases.',
@@ -131,7 +143,7 @@ export const Messages = {
         "The stored details no longer match this deployment's delivery plan. Re-supply the values below.",
     },
     noSecrets:
-      "This PMM version's delivery plan declares no credentials, so only the receiver endpoint can be set here.",
+      "This PMM version's delivery plan declares no credentials, so only the ServiceNow endpoint can be set here.",
     unavailable:
       'Support diagnostics delivery is not part of this PMM version, so there is nothing to connect.',
     saveSuccess: 'ServiceNow connection saved',

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -108,54 +108,69 @@ export const Messages = {
   serviceNow: {
     label: 'ServiceNow connection',
     description:
-      "Connect this PMM instance to Percona's ServiceNow to enable support features like Support diagnostics. To set this up, you'll need an active Percona Support subscription. Once connected, all PMM users can work with your organization's support cases directly from PMM.",
-    subscriptionPrompt: "Don't have a subscription or need credentials?",
+      "Connect this PMM instance to Percona's ServiceNow to enable features like Support Diagnostics. Once connected, all PMM users can work with your organization's support cases directly from PMM.",
+    // Step 1 — obtaining the credentials. Both links go to the same shortlink:
+    // requesting credentials and buying a subscription are the same Support
+    // conversation, and the two labels say which one the reader wants.
+    getCredentialsStep: '1. Get your credentials',
+    getCredentialsBody:
+      'Open a Percona Support ticket to request a ServiceNow API key and client token.',
+    requestCredentials: 'Request ServiceNow credentials',
+    requestCredentialsLink: PERCONA_SUPPORT_CONTACT_URL,
+    subscriptionPrompt: 'No Percona Support subscription?',
     subscriptionLink: PERCONA_SUPPORT_CONTACT_URL,
-    subscriptionLinkText: 'Contact Percona Support',
-    endpointLabel: 'ServiceNow endpoint',
-    endpointPlaceholder: 'https://percona.service-now.com/',
+    subscriptionLinkText: 'Get Percona Support',
+    // Step 2 — entering them.
+    connectStep: '2. Connect',
+    connectBody: 'Enter the credentials from your Percona Support ticket.',
+    endpointLabel: 'ServiceNow endpoint (optional)',
     endpointHelper:
-      'Leave empty to use the default endpoint: https://percona.service-now.com/',
-    secretsLegend: 'Credentials',
+      'Leave it empty to use the default endpoint https://percona.service-now.com',
     // Copy for the credentials this PMM version's delivery plan is known to
     // declare. A name not listed here is a SEP build the UI has no copy for, so
     // it falls back to the generic label and helper below.
     secretCopy: {
       sn_api_key: {
         label: 'ServiceNow API key',
-        helper:
-          "Authenticates PMM with Percona's ServiceNow. Contact Percona Support to obtain it.",
+        helper: "Authenticates PMM with Percona's ServiceNow.",
       },
       client_token: {
         label: 'Client token',
-        helper:
-          'Identifies your PMM instance to ServiceNow. Contact Percona Support to obtain it.',
+        helper: 'Identifies your PMM instance to ServiceNow.',
       },
     } as Record<string, { label: string; helper: string }>,
     secretHelper: (name: string) => `Sent to SEP as "${name}".`,
-    secretStoredSuffix: 'A value is stored — leave it untouched to keep it.',
-    status: {
-      configured:
-        'Connected. Support diagnostics can send results to your ServiceNow cases.',
-      notConfigured:
-        "Not configured. Support diagnostics can't send results until these details are saved.",
-      drifted:
-        "The stored details no longer match this deployment's delivery plan. Re-supply the values below.",
-    },
+    revealSecret: 'Show value',
+    hideSecret: 'Hide value',
     noSecrets:
       "This PMM version's delivery plan declares no credentials, so only the ServiceNow endpoint can be set here.",
+    submit: 'Verify and connect',
+    submitting: 'Connecting…',
+    cancelRenew: 'Cancel',
+    // The connection as it stands. Only the endpoint is shown: PMM stores no
+    // author or timestamp for a saved setting, so the rest of the design's
+    // detail row waits on a SEP endpoint that can answer it.
+    connectedTitle: 'ServiceNow connected',
+    endpointDetailLabel: 'Endpoint',
+    defaultEndpoint: 'https://percona.service-now.com',
+    renew: 'Renew credentials',
+    saveSuccess: 'ServiceNow connection to PMM successfully established.',
+    driftedWarning:
+      'The saved credentials no longer match what this PMM version expects. Enter them again to reconnect.',
     unavailable:
-      'Support diagnostics delivery is not part of this PMM version, so there is nothing to connect.',
-    saveSuccess: 'ServiceNow connection saved',
+      "This PMM version doesn't include diagnostics delivery, so there's nothing to connect.",
+    retry: 'Try again',
     disconnect: 'Disconnect',
     disconnectTitle: 'Disconnect ServiceNow?',
     disconnectBody:
-      'PMM will forget the stored endpoint and credentials, and Support diagnostics will stop sending results until they are supplied again.',
+      'PMM will forget the stored endpoint and credentials, and Support Diagnostics will stop sending results until they are supplied again.',
     disconnectConfirm: 'Disconnect',
     disconnectCancel: 'Cancel',
     disconnectSuccess: 'ServiceNow connection removed',
+    loading: 'Loading the ServiceNow connection…',
     validation: {
       invalidUrl: 'Enter a valid URL (e.g. https://example.service-now.com/)',
+      required: 'Required field',
     },
     errors: {
       forbidden:
@@ -163,10 +178,11 @@ export const Messages = {
       unauthenticated:
         "Your session isn't valid for this action anymore. Reload the page and try again.",
       unreachable:
-        "Couldn't reach the Support diagnostics service. The previous configuration is unchanged.",
+        "Couldn't reach the Support Diagnostics service. The previous configuration is unchanged.",
       generic:
         "Couldn't save the connection. The previous configuration is unchanged.",
-      loadFailed: "Couldn't load the current ServiceNow connection.",
+      loadFailed:
+        "Couldn't load the ServiceNow connection. This is usually temporary — try again, or reload the page.",
     },
   },
   service: {

--- a/ui/apps/pmm/src/pages/settings/Settings.messages.ts
+++ b/ui/apps/pmm/src/pages/settings/Settings.messages.ts
@@ -161,6 +161,8 @@ export const Messages = {
       "This PMM version doesn't include diagnostics delivery, so there's nothing to connect.",
     retry: 'Try again',
     disconnect: 'Disconnect',
+    disconnectStoredHint:
+      'PMM is still holding the credentials you saved before.',
     disconnectTitle: 'Disconnect ServiceNow?',
     disconnectBody:
       'PMM will forget the stored endpoint and credentials, and Support Diagnostics will stop sending results until they are supplied again.',

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/SecretField.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/SecretField.tsx
@@ -1,0 +1,59 @@
+import { FC, useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { TextInput } from '@percona/peak-ui';
+import { Messages } from '../../Settings.messages';
+
+interface Props {
+  name: string;
+  label: string;
+  helperText: string;
+  testId: string;
+}
+
+/**
+ * A credential field that starts masked and can be revealed.
+ *
+ * The values are pasted out of a support ticket, so a reveal is what lets an
+ * operator check a long opaque string before submitting it. peak-ui ships no
+ * password input — `TextInput` forwards `textFieldProps` to MUI's `TextField`,
+ * which is where the adornment goes.
+ */
+export const SecretField: FC<Props> = ({ name, label, helperText, testId }) => {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const { revealSecret, hideSecret } = Messages.serviceNow;
+  const toggleLabel = isRevealed ? hideSecret : revealSecret;
+
+  return (
+    <TextInput
+      name={name}
+      label={label}
+      textFieldProps={{
+        type: isRevealed ? 'text' : 'password',
+        autoComplete: 'off',
+        helperText,
+        slotProps: {
+          htmlInput: { 'data-testid': testId },
+          input: {
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  edge="end"
+                  size="small"
+                  aria-label={toggleLabel}
+                  title={toggleLabel}
+                  data-testid={`${testId}-reveal`}
+                  onClick={() => setIsRevealed((revealed) => !revealed)}
+                >
+                  {isRevealed ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          },
+        },
+      }}
+    />
+  );
+};

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
@@ -1,0 +1,135 @@
+import { FC, useState } from 'react';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { enqueueSnackbar } from 'notistack';
+import { type ApiError, useResetSetting } from '@sep/api';
+import { Modal } from 'components/modal';
+import { Messages } from '../../Settings.messages';
+import { MAX_LABEL_WIDTH } from '../../Settings.constants';
+import {
+  DELIVERY_INPUTS_KEY,
+  SEP_SETTINGS_CLASS,
+} from './ServiceNowConnection.constants';
+import { StoredDeliveryInputs } from './ServiceNowConnection.types';
+import { sepErrorMessage } from './ServiceNowConnection.utils';
+
+interface Props {
+  stored: StoredDeliveryInputs;
+  onRenew: () => void;
+}
+
+const ConnectionDetail: FC<{
+  label: string;
+  value: string;
+  testId: string;
+}> = ({ label, value, testId }) => (
+  <Stack>
+    <Typography variant="caption" color="text.secondary">
+      {label}
+    </Typography>
+    <Typography variant="body1" data-testid={testId}>
+      {value}
+    </Typography>
+  </Stack>
+);
+
+/**
+ * The connection as it stands, in place of the form that produced it.
+ *
+ * Only the endpoint is shown. PMM stores no author or timestamp for a saved
+ * setting — SEP answers whether an override exists, not who wrote it — so the
+ * rest of the design's detail row waits on a SEP endpoint that can answer it.
+ * A blank stored endpoint means SEP is using the receiver its image bakes in,
+ * which is the default this reports rather than an empty row.
+ */
+export const ServiceNowConnected: FC<Props> = ({ stored, onRenew }) => {
+  const { mutateAsync: resetSetting, isPending: isDisconnecting } =
+    useResetSetting();
+  const [disconnectOpen, setDisconnectOpen] = useState(false);
+  const { serviceNow } = Messages;
+
+  const onDisconnect = async () => {
+    try {
+      await resetSetting({
+        settingClass: SEP_SETTINGS_CLASS,
+        key: DELIVERY_INPUTS_KEY,
+      });
+      enqueueSnackbar(serviceNow.disconnectSuccess, { variant: 'success' });
+      setDisconnectOpen(false);
+    } catch (error) {
+      enqueueSnackbar(sepErrorMessage(error as ApiError), {
+        variant: 'error',
+      });
+    }
+  };
+
+  return (
+    <>
+      <Stack
+        gap={3}
+        maxWidth={MAX_LABEL_WIDTH}
+        data-testid="servicenow-connected"
+      >
+        <Typography variant="h6">{serviceNow.connectedTitle}</Typography>
+
+        <ConnectionDetail
+          label={serviceNow.endpointDetailLabel}
+          value={stored.endpoint || serviceNow.defaultEndpoint}
+          testId="servicenow-connected-endpoint"
+        />
+
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          gap={2}
+        >
+          <Button
+            variant="contained"
+            onClick={onRenew}
+            data-testid="servicenow-renew"
+          >
+            {serviceNow.renew}
+          </Button>
+          <Button
+            variant="text"
+            color="error"
+            data-testid="servicenow-disconnect"
+            onClick={() => setDisconnectOpen(true)}
+          >
+            {serviceNow.disconnect}
+          </Button>
+        </Stack>
+      </Stack>
+
+      <Modal
+        open={disconnectOpen}
+        onClose={() => setDisconnectOpen(false)}
+        title={serviceNow.disconnectTitle}
+      >
+        <Stack gap={3}>
+          <Typography variant="body2">{serviceNow.disconnectBody}</Typography>
+          <Stack direction="row" gap={1} justifyContent="flex-end">
+            <Button
+              variant="text"
+              onClick={() => setDisconnectOpen(false)}
+              data-testid="servicenow-disconnect-cancel"
+            >
+              {serviceNow.disconnectCancel}
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              disabled={isDisconnecting}
+              onClick={onDisconnect}
+              data-testid="servicenow-disconnect-confirm"
+            >
+              {serviceNow.disconnectConfirm}
+            </Button>
+          </Stack>
+        </Stack>
+      </Modal>
+    </>
+  );
+};

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
@@ -40,8 +40,9 @@ const ConnectionDetail: FC<{
  * Only the endpoint is shown. PMM stores no author or timestamp for a saved
  * setting — SEP answers whether an override exists, not who wrote it — so the
  * rest of the design's detail row waits on a SEP endpoint that can answer it.
- * A blank stored endpoint means SEP is using the receiver its image bakes in,
- * which is the default this reports rather than an empty row.
+ * A blank stored endpoint means SEP is using the receiver its image bakes in.
+ * PMM does not know which one that is, so the row names the receiver Percona
+ * ships rather than leaving itself empty.
  */
 export const ServiceNowConnected: FC<Props> = ({ stored, onRenew }) => {
   const { mutateAsync: resetSetting, isPending: isDisconnecting } =

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnected.tsx
@@ -1,18 +1,11 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { enqueueSnackbar } from 'notistack';
-import { type ApiError, useResetSetting } from '@sep/api';
-import { Modal } from 'components/modal';
 import { Messages } from '../../Settings.messages';
 import { MAX_LABEL_WIDTH } from '../../Settings.constants';
-import {
-  DELIVERY_INPUTS_KEY,
-  SEP_SETTINGS_CLASS,
-} from './ServiceNowConnection.constants';
 import { StoredDeliveryInputs } from './ServiceNowConnection.types';
-import { sepErrorMessage } from './ServiceNowConnection.utils';
+import { ServiceNowDisconnect } from './ServiceNowDisconnect';
 
 interface Props {
   stored: StoredDeliveryInputs;
@@ -45,92 +38,37 @@ const ConnectionDetail: FC<{
  * ships rather than leaving itself empty.
  */
 export const ServiceNowConnected: FC<Props> = ({ stored, onRenew }) => {
-  const { mutateAsync: resetSetting, isPending: isDisconnecting } =
-    useResetSetting();
-  const [disconnectOpen, setDisconnectOpen] = useState(false);
   const { serviceNow } = Messages;
 
-  const onDisconnect = async () => {
-    try {
-      await resetSetting({
-        settingClass: SEP_SETTINGS_CLASS,
-        key: DELIVERY_INPUTS_KEY,
-      });
-      enqueueSnackbar(serviceNow.disconnectSuccess, { variant: 'success' });
-      setDisconnectOpen(false);
-    } catch (error) {
-      enqueueSnackbar(sepErrorMessage(error as ApiError), {
-        variant: 'error',
-      });
-    }
-  };
-
   return (
-    <>
+    <Stack
+      gap={3}
+      maxWidth={MAX_LABEL_WIDTH}
+      data-testid="servicenow-connected"
+    >
+      <Typography variant="h6">{serviceNow.connectedTitle}</Typography>
+
+      <ConnectionDetail
+        label={serviceNow.endpointDetailLabel}
+        value={stored.endpoint || serviceNow.defaultEndpoint}
+        testId="servicenow-connected-endpoint"
+      />
+
       <Stack
-        gap={3}
-        maxWidth={MAX_LABEL_WIDTH}
-        data-testid="servicenow-connected"
+        direction="row"
+        alignItems="center"
+        justifyContent="space-between"
+        gap={2}
       >
-        <Typography variant="h6">{serviceNow.connectedTitle}</Typography>
-
-        <ConnectionDetail
-          label={serviceNow.endpointDetailLabel}
-          value={stored.endpoint || serviceNow.defaultEndpoint}
-          testId="servicenow-connected-endpoint"
-        />
-
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-          gap={2}
+        <Button
+          variant="contained"
+          onClick={onRenew}
+          data-testid="servicenow-renew"
         >
-          <Button
-            variant="contained"
-            onClick={onRenew}
-            data-testid="servicenow-renew"
-          >
-            {serviceNow.renew}
-          </Button>
-          <Button
-            variant="text"
-            color="error"
-            data-testid="servicenow-disconnect"
-            onClick={() => setDisconnectOpen(true)}
-          >
-            {serviceNow.disconnect}
-          </Button>
-        </Stack>
+          {serviceNow.renew}
+        </Button>
+        <ServiceNowDisconnect />
       </Stack>
-
-      <Modal
-        open={disconnectOpen}
-        onClose={() => setDisconnectOpen(false)}
-        title={serviceNow.disconnectTitle}
-      >
-        <Stack gap={3}>
-          <Typography variant="body2">{serviceNow.disconnectBody}</Typography>
-          <Stack direction="row" gap={1} justifyContent="flex-end">
-            <Button
-              variant="text"
-              onClick={() => setDisconnectOpen(false)}
-              data-testid="servicenow-disconnect-cancel"
-            >
-              {serviceNow.disconnectCancel}
-            </Button>
-            <Button
-              variant="contained"
-              color="error"
-              disabled={isDisconnecting}
-              onClick={onDisconnect}
-              data-testid="servicenow-disconnect-confirm"
-            >
-              {serviceNow.disconnectConfirm}
-            </Button>
-          </Stack>
-        </Stack>
-      </Modal>
-    </>
+    </Stack>
   );
 };

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.hooks.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.hooks.ts
@@ -13,7 +13,13 @@ import {
  * every caller must already be admin-only — today that is the settings form.
  */
 export const useServiceNowConnection = () => {
-  const { data: groups, isLoading, error } = useSettingsList();
+  const {
+    data: groups,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  } = useSettingsList();
 
   const declaredNames = useMemo(() => declaredSecretNames(groups), [groups]);
   const stored = useMemo(() => storedDeliveryInputs(groups), [groups]);
@@ -23,6 +29,8 @@ export const useServiceNowConnection = () => {
     stored,
     status: connectionStatus(declaredNames, stored),
     isLoading,
+    isFetching,
     error,
+    refetch,
   };
 };

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.hooks.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.hooks.ts
@@ -10,7 +10,7 @@ import {
  * What SEP currently holds for ServiceNow delivery, read once and derived.
  *
  * SEP holds `GET /sep/admin/settings` to administrators, reads included, so
- * every caller must already be admin-only — today that is the settings form.
+ * every caller must already be admin-only.
  */
 export const useServiceNowConnection = () => {
   const {

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
@@ -10,7 +10,7 @@ import {
 import { TestWrapper } from 'utils/testWrapper';
 import { wrapWithSnackbarProvider } from 'utils/testUtils';
 import { Messages } from '../../Settings.messages';
-import { ServiceNowConnectionForm } from './ServiceNowConnectionForm';
+import { ServiceNowConnection } from './ServiceNowConnection';
 
 vi.mock('@sep/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@sep/api')>()),
@@ -25,6 +25,7 @@ const resetSetting = vi.mocked(useResetSetting);
 
 const patchMutation = vi.fn();
 const resetMutation = vi.fn();
+const refetch = vi.fn();
 
 const setting = (key: string, value: unknown, hasOverride = false) =>
   ({
@@ -71,9 +72,11 @@ const mockList = (
   settingsList.mockReturnValue({
     data: sepGroups(['sn_api_key', 'client_token']),
     isLoading: false,
+    isFetching: false,
     error: null,
+    refetch,
     ...overrides,
-  } as ReturnType<typeof useSettingsList>);
+  } as unknown as ReturnType<typeof useSettingsList>);
 };
 
 const mockPatch = (error: ApiError | null = null) => {
@@ -83,15 +86,30 @@ const mockPatch = (error: ApiError | null = null) => {
   } as unknown as ReturnType<typeof usePatchSetting>);
 };
 
-const renderForm = () =>
+/** Both declared credentials stored, which is what "connected" means here. */
+const mockConfigured = (endpoint = '') =>
+  mockList({
+    data: sepGroups(
+      ['sn_api_key', 'client_token'],
+      { sn_api_key: REDACTED_SECRET, client_token: REDACTED_SECRET },
+      endpoint
+    ),
+  } as Partial<ReturnType<typeof useSettingsList>>);
+
+const renderTab = () =>
   render(
     <TestWrapper>
-      {wrapWithSnackbarProvider(<ServiceNowConnectionForm />)}
+      {wrapWithSnackbarProvider(<ServiceNowConnection />)}
     </TestWrapper>
   );
 
 const type = (testId: string, value: string) =>
   fireEvent.change(screen.getByTestId(testId), { target: { value } });
+
+const fillCredentials = () => {
+  type('servicenow-secret-sn_api_key', 'key-1');
+  type('servicenow-secret-client_token', 'token-1');
+};
 
 const submit = async () => {
   const button = screen.getByTestId('servicenow-submit');
@@ -111,9 +129,24 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof useResetSetting>);
 });
 
-describe('ServiceNowConnectionForm — rendering', () => {
-  it('renders one field per declared secret name', () => {
-    renderForm();
+describe('ServiceNowConnection — states', () => {
+  it('offers both steps while nothing is connected', () => {
+    renderTab();
+
+    expect(
+      screen.getByTestId('servicenow-step-credentials')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('servicenow-step-connect')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('servicenow-request-credentials')
+    ).toHaveAttribute('href', Messages.serviceNow.requestCredentialsLink);
+    expect(
+      screen.queryByTestId('servicenow-connected')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders one masked field per declared secret name', () => {
+    renderTab();
 
     expect(screen.getByTestId('servicenow-secret-sn_api_key')).toHaveAttribute(
       'type',
@@ -124,17 +157,26 @@ describe('ServiceNowConnectionForm — rendering', () => {
     ).toBeInTheDocument();
   });
 
+  it('reveals a credential on request so a pasted value can be checked', () => {
+    renderTab();
+
+    fireEvent.click(screen.getByTestId('servicenow-secret-sn_api_key-reveal'));
+
+    expect(screen.getByTestId('servicenow-secret-sn_api_key')).toHaveAttribute(
+      'type',
+      'text'
+    );
+  });
+
   it('follows the plan when an image renames a declared secret', () => {
-    settingsList.mockReturnValue({
+    mockList({
       data: sepGroups(['sn_api_key', 'renamed_token'], {
         sn_api_key: REDACTED_SECRET,
         client_token: REDACTED_SECRET,
       }),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
+    } as Partial<ReturnType<typeof useSettingsList>>);
 
-    renderForm();
+    renderTab();
 
     expect(
       screen.getByTestId('servicenow-secret-renamed_token')
@@ -142,121 +184,54 @@ describe('ServiceNowConnectionForm — rendering', () => {
     expect(
       screen.queryByTestId('servicenow-secret-client_token')
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId('servicenow-status')).toHaveTextContent(
-      Messages.serviceNow.status.drifted
-    );
-  });
-
-  it('submits a declared name that form paths cannot express, verbatim', async () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(['sn.api.key']),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
-
-    renderForm();
-
-    type('servicenow-secret-sn.api.key', 'key-1');
-    await submit();
-
-    await waitFor(() => expect(patchMutation).toHaveBeenCalledTimes(1));
-    expect(patchMutation.mock.calls[0][0].value).toEqual({
-      secrets: { 'sn.api.key': 'key-1' },
-    });
-  });
-
-  it('reports an unsaved connection as not configured rather than as an error', () => {
-    renderForm();
-
-    const status = screen.getByTestId('servicenow-status');
-    expect(status).toHaveTextContent(Messages.serviceNow.status.notConfigured);
-    expect(status).toHaveClass('MuiAlert-colorInfo');
-  });
-
-  it('reports a saved-but-empty secret as not configured', () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(['sn_api_key', 'client_token'], {
-        sn_api_key: REDACTED_SECRET,
-        client_token: '',
-      }),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
-
-    renderForm();
-
-    expect(screen.getByTestId('servicenow-status')).toHaveTextContent(
-      Messages.serviceNow.status.notConfigured
-    );
-  });
-
-  it('shows the stored values back, masked', () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(
-        ['sn_api_key', 'client_token'],
-        { sn_api_key: REDACTED_SECRET, client_token: REDACTED_SECRET },
-        'https://acme.service-now.com/'
-      ),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
-
-    renderForm();
-
-    expect(screen.getByTestId('servicenow-endpoint')).toHaveValue(
-      'https://acme.service-now.com/'
-    );
-    expect(screen.getByTestId('servicenow-secret-sn_api_key')).toHaveValue(
-      REDACTED_SECRET
-    );
-    expect(screen.getByTestId('servicenow-status')).toHaveTextContent(
-      Messages.serviceNow.status.configured
+    expect(screen.getByTestId('servicenow-drifted')).toHaveTextContent(
+      Messages.serviceNow.driftedWarning
     );
   });
 
   it('shows a spinner while the settings load', () => {
     mockList({ isLoading: true, data: undefined });
-    renderForm();
+    renderTab();
 
     expect(screen.getByTestId('servicenow-loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('servicenow-submit')).not.toBeInTheDocument();
   });
 
-  it('explains a load that was refused rather than showing an empty form', () => {
+  it('explains a load that was refused, and offers a retry', () => {
     mockList({
       data: undefined,
       error: new ApiError({ kind: 'http', status: 403, message: 'HTTP 403' }),
     });
-    renderForm();
+    renderTab();
 
     expect(screen.getByTestId('servicenow-load-error')).toHaveTextContent(
       Messages.serviceNow.errors.forbidden
     );
     expect(screen.queryByTestId('servicenow-submit')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('servicenow-load-retry'));
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it('still offers the endpoint when the plan declares no credentials', () => {
-    settingsList.mockReturnValue({
-      data: sepGroups([]),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
+    mockList({ data: sepGroups([]) } as Partial<
+      ReturnType<typeof useSettingsList>
+    >);
 
-    renderForm();
+    renderTab();
 
     expect(screen.getByTestId('servicenow-no-secrets')).toBeInTheDocument();
     expect(screen.getByTestId('servicenow-endpoint')).toBeInTheDocument();
   });
 
   it('offers nothing when the deployment does not carry the key at all', () => {
-    settingsList.mockReturnValue({
+    mockList({
       data: [
         { setting_class: 'SEPSettings', is_app_owned: false, settings: [] },
       ] as SettingClassGroup[],
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
+    });
 
-    renderForm();
+    renderTab();
 
     expect(screen.getByTestId('servicenow-unavailable')).toHaveTextContent(
       Messages.serviceNow.unavailable
@@ -265,13 +240,57 @@ describe('ServiceNowConnectionForm — rendering', () => {
   });
 });
 
-describe('ServiceNowConnectionForm — saving', () => {
+describe('ServiceNowConnection — connected', () => {
+  it('reports the connection instead of asking for it again', () => {
+    mockConfigured('https://acme.service-now.com/');
+    renderTab();
+
+    expect(screen.getByTestId('servicenow-connected')).toHaveTextContent(
+      Messages.serviceNow.connectedTitle
+    );
+    expect(
+      screen.getByTestId('servicenow-connected-endpoint')
+    ).toHaveTextContent('https://acme.service-now.com/');
+    expect(screen.queryByTestId('servicenow-submit')).not.toBeInTheDocument();
+  });
+
+  it('names the bundled receiver when no endpoint was supplied', () => {
+    mockConfigured();
+    renderTab();
+
+    expect(
+      screen.getByTestId('servicenow-connected-endpoint')
+    ).toHaveTextContent(Messages.serviceNow.defaultEndpoint);
+  });
+
+  it('renews through an empty form, never showing the stored masks back', () => {
+    mockConfigured('https://acme.service-now.com/');
+    renderTab();
+
+    fireEvent.click(screen.getByTestId('servicenow-renew'));
+
+    expect(screen.getByTestId('servicenow-secret-sn_api_key')).toHaveValue('');
+    expect(screen.getByTestId('servicenow-endpoint')).toHaveValue(
+      'https://acme.service-now.com/'
+    );
+
+    fireEvent.click(screen.getByTestId('servicenow-cancel'));
+    expect(screen.getByTestId('servicenow-connected')).toBeInTheDocument();
+  });
+
+  it('offers no renewal cancel while nothing is stored', () => {
+    renderTab();
+
+    expect(screen.queryByTestId('servicenow-cancel')).not.toBeInTheDocument();
+  });
+});
+
+describe('ServiceNowConnection — saving', () => {
   it('writes the whole key in one PATCH carrying exactly the declared names', async () => {
-    renderForm();
+    renderTab();
 
     type('servicenow-endpoint', 'https://acme.service-now.com/');
-    type('servicenow-secret-sn_api_key', 'key-1');
-    type('servicenow-secret-client_token', 'token-1');
+    fillCredentials();
     await submit();
 
     await waitFor(() => expect(patchMutation).toHaveBeenCalledTimes(1));
@@ -285,58 +304,43 @@ describe('ServiceNowConnectionForm — saving', () => {
     });
   });
 
-  it('keeps a stored secret by resubmitting the mask it was shown', async () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(
-        ['sn_api_key', 'client_token'],
-        { sn_api_key: REDACTED_SECRET, client_token: REDACTED_SECRET },
-        'https://acme.service-now.com/'
-      ),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
+  it('submits a declared name that form paths cannot express, verbatim', async () => {
+    mockList({ data: sepGroups(['sn.api.key']) } as Partial<
+      ReturnType<typeof useSettingsList>
+    >);
 
-    renderForm();
+    renderTab();
 
-    type('servicenow-endpoint', 'https://other.service-now.com/');
+    type('servicenow-secret-sn.api.key', 'key-1');
     await submit();
 
     await waitFor(() => expect(patchMutation).toHaveBeenCalledTimes(1));
     expect(patchMutation.mock.calls[0][0].value).toEqual({
-      endpoint: 'https://other.service-now.com/',
-      secrets: {
-        sn_api_key: REDACTED_SECRET,
-        client_token: REDACTED_SECRET,
-      },
+      secrets: { 'sn.api.key': 'key-1' },
     });
   });
 
-  it('accepts clearing a secret as an explicit unconfigured save', async () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(['sn_api_key', 'client_token'], {
-        sn_api_key: REDACTED_SECRET,
-        client_token: REDACTED_SECRET,
-      }),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
+  it('holds the submit until every declared credential is supplied', async () => {
+    renderTab();
 
-    renderForm();
+    type('servicenow-secret-sn_api_key', 'key-1');
 
-    type('servicenow-secret-sn_api_key', '');
-    await submit();
+    await waitFor(() =>
+      expect(screen.getByTestId('servicenow-submit')).toBeDisabled()
+    );
 
-    await waitFor(() => expect(patchMutation).toHaveBeenCalledTimes(1));
-    expect(patchMutation.mock.calls[0][0].value).toEqual({
-      secrets: { sn_api_key: '', client_token: REDACTED_SECRET },
-    });
+    type('servicenow-secret-client_token', 'token-1');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('servicenow-submit')).toBeEnabled()
+    );
   });
 
   it('refuses an endpoint that is not a URL before it reaches SEP', async () => {
-    renderForm();
+    renderTab();
 
+    fillCredentials();
     type('servicenow-endpoint', 'not-a-url');
-    type('servicenow-secret-sn_api_key', 'key-1');
 
     await waitFor(() =>
       expect(screen.getByTestId('servicenow-submit')).toBeDisabled()
@@ -344,7 +348,7 @@ describe('ServiceNowConnectionForm — saving', () => {
     expect(patchMutation).not.toHaveBeenCalled();
   });
 
-  it('surfaces the 422 SEP answers with instead of swallowing it', async () => {
+  it('surfaces the 422 SEP answers with instead of swallowing it', () => {
     mockPatch(
       new ApiError({
         kind: 'http',
@@ -362,20 +366,20 @@ describe('ServiceNowConnectionForm — saving', () => {
       })
     );
 
-    renderForm();
+    renderTab();
 
     expect(screen.getByTestId('servicenow-save-error')).toHaveTextContent(
       'undeclared secret names: extra'
     );
   });
 
-  it('keeps the form on screen when the save is rejected', async () => {
+  it('keeps the typed credentials on screen when the save is rejected', async () => {
     patchMutation.mockRejectedValue(
       new ApiError({ kind: 'network', message: 'down' })
     );
-    renderForm();
+    renderTab();
 
-    type('servicenow-secret-sn_api_key', 'key-1');
+    fillCredentials();
     await submit();
 
     await waitFor(() => expect(patchMutation).toHaveBeenCalled());
@@ -385,21 +389,9 @@ describe('ServiceNowConnectionForm — saving', () => {
   });
 });
 
-describe('ServiceNowConnectionForm — disconnecting', () => {
-  const renderConfigured = () => {
-    settingsList.mockReturnValue({
-      data: sepGroups(['sn_api_key', 'client_token'], {
-        sn_api_key: REDACTED_SECRET,
-        client_token: REDACTED_SECRET,
-      }),
-      isLoading: false,
-      error: null,
-    } as ReturnType<typeof useSettingsList>);
-    return renderForm();
-  };
-
+describe('ServiceNowConnection — disconnecting', () => {
   it('is not offered while nothing is stored', () => {
-    renderForm();
+    renderTab();
 
     expect(
       screen.queryByTestId('servicenow-disconnect')
@@ -407,7 +399,8 @@ describe('ServiceNowConnectionForm — disconnecting', () => {
   });
 
   it('confirms before clearing the stored inputs', async () => {
-    renderConfigured();
+    mockConfigured();
+    renderTab();
 
     fireEvent.click(screen.getByTestId('servicenow-disconnect'));
     expect(resetMutation).not.toHaveBeenCalled();
@@ -423,7 +416,8 @@ describe('ServiceNowConnectionForm — disconnecting', () => {
   });
 
   it('leaves the configuration alone when the confirmation is dismissed', () => {
-    renderConfigured();
+    mockConfigured();
+    renderTab();
 
     fireEvent.click(screen.getByTestId('servicenow-disconnect'));
     fireEvent.click(screen.getByTestId('servicenow-disconnect-cancel'));

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
@@ -320,19 +320,39 @@ describe('ServiceNowConnection — saving', () => {
     });
   });
 
+  // Both of these clear the credential after reaching an enabled submit: the
+  // button starts disabled, so a `waitFor` for disabled passes on its first
+  // tick — before the resolver has run — and would hold over a form that never
+  // validated at all.
   it('holds the submit until every declared credential is supplied', async () => {
     renderTab();
 
-    type('servicenow-secret-sn_api_key', 'key-1');
+    fillCredentials();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('servicenow-submit')).toBeEnabled()
+    );
+
+    type('servicenow-secret-client_token', '');
 
     await waitFor(() =>
       expect(screen.getByTestId('servicenow-submit')).toBeDisabled()
     );
+  });
 
-    type('servicenow-secret-client_token', 'token-1');
+  it('counts a whitespace-only credential as unsupplied', async () => {
+    renderTab();
+
+    fillCredentials();
 
     await waitFor(() =>
       expect(screen.getByTestId('servicenow-submit')).toBeEnabled()
+    );
+
+    type('servicenow-secret-client_token', '   ');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('servicenow-submit')).toBeDisabled()
     );
   });
 

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.test.tsx
@@ -418,6 +418,49 @@ describe('ServiceNowConnection — disconnecting', () => {
     ).not.toBeInTheDocument();
   });
 
+  // The two states that render the form with an override still stored. Neither
+  // can reach 'configured', so Disconnect is the only route that clears them
+  // now that a blank save is refused.
+  it('is offered on the form when an image renamed a declared secret', () => {
+    mockList({
+      data: sepGroups(['sn_api_key', 'renamed_token'], {
+        sn_api_key: REDACTED_SECRET,
+        client_token: REDACTED_SECRET,
+      }),
+    } as Partial<ReturnType<typeof useSettingsList>>);
+
+    renderTab();
+
+    expect(screen.getByTestId('servicenow-drifted')).toBeInTheDocument();
+    expect(screen.getByTestId('servicenow-disconnect')).toBeInTheDocument();
+  });
+
+  it('is offered on the form when a stored credential is blank', () => {
+    mockList({
+      data: sepGroups(['sn_api_key', 'client_token'], {
+        sn_api_key: REDACTED_SECRET,
+        client_token: '',
+      }),
+    } as Partial<ReturnType<typeof useSettingsList>>);
+
+    renderTab();
+
+    expect(screen.getByTestId('servicenow-submit')).toBeInTheDocument();
+    expect(screen.getByTestId('servicenow-disconnect')).toBeInTheDocument();
+  });
+
+  it('is not offered while renewing, which has its own way back', () => {
+    mockConfigured();
+    renderTab();
+
+    fireEvent.click(screen.getByTestId('servicenow-renew'));
+
+    expect(screen.getByTestId('servicenow-cancel')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('servicenow-disconnect')
+    ).not.toBeInTheDocument();
+  });
+
   it('confirms before clearing the stored inputs', async () => {
     mockConfigured();
     renderTab();

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
@@ -1,0 +1,123 @@
+import { FC, useEffect, useState } from 'react';
+import Alert from '@mui/material/Alert';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Stack from '@mui/material/Stack';
+import { Messages } from '../../Settings.messages';
+import { MAX_LABEL_WIDTH } from '../../Settings.constants';
+import { SettingsFieldLabel } from '../settings-field-label';
+import { useServiceNowConnection } from './ServiceNowConnection.hooks';
+import { sepErrorMessage } from './ServiceNowConnection.utils';
+import { ServiceNowConnected } from './ServiceNowConnected';
+import { ServiceNowConnectionForm } from './ServiceNowConnectionForm';
+
+/**
+ * The ServiceNow connection tab: a heading that always renders, and one of five
+ * bodies under it.
+ *
+ * The connection is optional, so its state is told by the body itself rather
+ * than by a standing banner — a configured deployment sees what it has, an
+ * unconfigured one sees how to get connected, and neither is asked to read a
+ * status line to find out which.
+ */
+export const ServiceNowConnection: FC = () => {
+  const {
+    declaredNames,
+    stored,
+    status,
+    isLoading,
+    error: loadError,
+    refetch,
+  } = useServiceNowConnection();
+  const [isRenewing, setIsRenewing] = useState(false);
+  const { serviceNow } = Messages;
+
+  // A disconnect elsewhere in the tab (or a drift arriving on a refetch) takes
+  // the connected screen away on its own; the renewal flag would otherwise
+  // survive it and hide the form's own reason for being open.
+  useEffect(() => {
+    if (status !== 'configured') {
+      setIsRenewing(false);
+    }
+  }, [status]);
+
+  const body = () => {
+    if (isLoading) {
+      return (
+        <Stack alignItems="center" py={4}>
+          <CircularProgress
+            aria-label={serviceNow.loading}
+            data-testid="servicenow-loading"
+          />
+        </Stack>
+      );
+    }
+
+    if (loadError) {
+      return (
+        <Alert
+          severity="error"
+          data-testid="servicenow-load-error"
+          sx={{ maxWidth: MAX_LABEL_WIDTH }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={() => void refetch()}
+              data-testid="servicenow-load-retry"
+            >
+              {serviceNow.retry}
+            </Button>
+          }
+        >
+          {sepErrorMessage(loadError, serviceNow.errors.loadFailed)}
+        </Alert>
+      );
+    }
+
+    // A SEP build that does not carry the key at all would answer any write with
+    // a 422, so there is nothing to offer — as distinct from a deployment that
+    // carries it and has simply not been configured yet.
+    if (!stored.isPresent) {
+      return (
+        <Alert
+          severity="info"
+          data-testid="servicenow-unavailable"
+          sx={{ maxWidth: MAX_LABEL_WIDTH }}
+        >
+          {serviceNow.unavailable}
+        </Alert>
+      );
+    }
+
+    if (status === 'configured' && !isRenewing) {
+      return (
+        <ServiceNowConnected
+          stored={stored}
+          onRenew={() => setIsRenewing(true)}
+        />
+      );
+    }
+
+    return (
+      <ServiceNowConnectionForm
+        declaredNames={declaredNames}
+        stored={stored}
+        isDrifted={status === 'drifted'}
+        onCancel={isRenewing ? () => setIsRenewing(false) : undefined}
+        onConnected={() => setIsRenewing(false)}
+      />
+    );
+  };
+
+  return (
+    <Stack gap={4}>
+      <SettingsFieldLabel
+        label={serviceNow.label}
+        description={serviceNow.description}
+        data-testid="servicenow-label"
+      />
+      {body()}
+    </Stack>
+  );
+};

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
@@ -41,6 +41,8 @@ export const ServiceNowConnection: FC = () => {
     }
   }, [status]);
 
+  const isConnected = status === 'configured' && !isRenewing;
+
   const body = () => {
     if (isLoading) {
       return (
@@ -90,7 +92,7 @@ export const ServiceNowConnection: FC = () => {
       );
     }
 
-    if (status === 'configured' && !isRenewing) {
+    if (isConnected) {
       return (
         <ServiceNowConnected
           stored={stored}
@@ -111,12 +113,14 @@ export const ServiceNowConnection: FC = () => {
   };
 
   return (
-    <Stack gap={4}>
-      <SettingsFieldLabel
-        label={serviceNow.label}
-        description={serviceNow.description}
-        data-testid="servicenow-label"
-      />
+    <Stack gap={4} sx={{ width: '640px' }}>
+      {!isConnected && (
+        <SettingsFieldLabel
+          label={serviceNow.label}
+          description={serviceNow.description}
+          data-testid="servicenow-label"
+        />
+      )}
       {body()}
     </Stack>
   );

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
@@ -12,8 +12,9 @@ import { ServiceNowConnected } from './ServiceNowConnected';
 import { ServiceNowConnectionForm } from './ServiceNowConnectionForm';
 
 /**
- * The ServiceNow connection tab: a heading that always renders, and one of five
- * bodies under it.
+ * The ServiceNow connection tab: one of five bodies, under a heading every one
+ * of them carries except the connected screen, which names the connection
+ * itself.
  *
  * The connection is optional, so its state is told by the body itself rather
  * than by a standing banner — a configured deployment sees what it has, an

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.tsx
@@ -113,7 +113,7 @@ export const ServiceNowConnection: FC = () => {
   };
 
   return (
-    <Stack gap={4} sx={{ width: '640px' }}>
+    <Stack gap={4} sx={{ width: '100%', maxWidth: '640px' }}>
       {!isConnected && (
         <SettingsFieldLabel
           label={serviceNow.label}

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.test.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.test.ts
@@ -107,7 +107,7 @@ describe('storedDeliveryInputs', () => {
 });
 
 describe('toFormValues', () => {
-  it('seeds one field per declared name from the stored values', () => {
+  it('seeds one empty field per declared name, keeping the stored endpoint', () => {
     expect(
       toFormValues(['sn_api_key', 'client_token'], {
         endpoint: 'https://acme.service-now.com/',
@@ -117,16 +117,16 @@ describe('toFormValues', () => {
       })
     ).toEqual({
       endpoint: 'https://acme.service-now.com/',
-      secrets: [REDACTED_SECRET, ''],
+      secrets: ['', ''],
     });
   });
 
-  it('leaves every field empty when nothing is stored', () => {
+  it('never seeds a stored secret back into the form', () => {
     expect(
       toFormValues(['sn_api_key'], {
         endpoint: '',
         secrets: { sn_api_key: REDACTED_SECRET },
-        hasOverride: false,
+        hasOverride: true,
         isPresent: true,
       })
     ).toEqual({ endpoint: '', secrets: [''] });
@@ -134,27 +134,13 @@ describe('toFormValues', () => {
 });
 
 describe('buildDeliveryInputsPatch', () => {
-  const unconfigured = {
-    endpoint: '',
-    secrets: {},
-    hasOverride: false,
-    isPresent: true,
-  };
-  const configured = {
-    endpoint: 'https://acme.service-now.com/',
-    secrets: { sn_api_key: REDACTED_SECRET, client_token: REDACTED_SECRET },
-    hasOverride: true,
-    isPresent: true,
-  };
-
   it('submits exactly the declared names, dropping anything else the form holds', () => {
     const patch = buildDeliveryInputsPatch(
       {
         endpoint: 'https://acme.service-now.com/',
         secrets: ['a', 'b', 'c'],
       },
-      ['sn_api_key', 'client_token'],
-      unconfigured
+      ['sn_api_key', 'client_token']
     );
 
     expect(patch).toEqual({
@@ -165,21 +151,15 @@ describe('buildDeliveryInputsPatch', () => {
 
   it('adds a declared name the form never rendered as empty', () => {
     expect(
-      buildDeliveryInputsPatch(
-        { endpoint: '', secrets: [] },
-        ['sn_api_key'],
-        unconfigured
-      )
+      buildDeliveryInputsPatch({ endpoint: '', secrets: [] }, ['sn_api_key'])
     ).toEqual({ secrets: { sn_api_key: '' } });
   });
 
   it('omits a blank endpoint so SEP keeps the baked receiver', () => {
     expect(
-      buildDeliveryInputsPatch(
-        { endpoint: '   ', secrets: ['a'] },
-        ['sn_api_key'],
-        unconfigured
-      )
+      buildDeliveryInputsPatch({ endpoint: '   ', secrets: ['a'] }, [
+        'sn_api_key',
+      ])
     ).toEqual({ secrets: { sn_api_key: 'a' } });
   });
 
@@ -187,55 +167,18 @@ describe('buildDeliveryInputsPatch', () => {
     expect(
       buildDeliveryInputsPatch(
         { endpoint: '  https://acme.service-now.com/ ', secrets: [] },
-        [],
-        unconfigured
+        []
       )
     ).toEqual({ endpoint: 'https://acme.service-now.com/', secrets: {} });
   });
 
-  it('resubmits an untouched mask so SEP restores the stored secret', () => {
-    expect(
-      buildDeliveryInputsPatch(
-        {
-          endpoint: '',
-          secrets: [REDACTED_SECRET, 'new'],
-        },
-        ['sn_api_key', 'client_token'],
-        configured
-      )
-    ).toEqual({
-      secrets: { sn_api_key: REDACTED_SECRET, client_token: 'new' },
-    });
-  });
-
-  it('never sends a mask there is nothing stored to restore', () => {
-    expect(
-      buildDeliveryInputsPatch(
-        { endpoint: '', secrets: [REDACTED_SECRET] },
-        ['sn_api_key'],
-        unconfigured
-      )
-    ).toEqual({ secrets: { sn_api_key: '' } });
-  });
-
   it('keys the payload by name even for a name that is not a valid form path', () => {
     expect(
-      buildDeliveryInputsPatch(
-        { endpoint: '', secrets: ['a', 'b'] },
-        ['sn.api.key', 'client[token]'],
-        unconfigured
-      )
+      buildDeliveryInputsPatch({ endpoint: '', secrets: ['a', 'b'] }, [
+        'sn.api.key',
+        'client[token]',
+      ])
     ).toEqual({ secrets: { 'sn.api.key': 'a', 'client[token]': 'b' } });
-  });
-
-  it('sends empty strings, which is a valid unconfigured save', () => {
-    expect(
-      buildDeliveryInputsPatch(
-        { endpoint: '', secrets: ['', ''] },
-        ['sn_api_key', 'client_token'],
-        configured
-      )
-    ).toEqual({ secrets: { sn_api_key: '', client_token: '' } });
   });
 });
 
@@ -378,18 +321,12 @@ describe('secretLabel', () => {
 
 describe('secretHelperText', () => {
   it('uses the written copy for a declared name', () => {
-    expect(secretHelperText('sn_api_key', false)).toBe(
+    expect(secretHelperText('sn_api_key')).toBe(
       Messages.serviceNow.secretCopy.sn_api_key.helper
     );
   });
 
   it('names the raw key for a name the UI has no copy for', () => {
-    expect(secretHelperText('instance_url', false)).toContain('instance_url');
-  });
-
-  it('adds the keep-it note when a value is stored', () => {
-    expect(secretHelperText('client_token', true)).toBe(
-      `${Messages.serviceNow.secretCopy.client_token.helper} ${Messages.serviceNow.secretStoredSuffix}`
-    );
+    expect(secretHelperText('instance_url')).toContain('instance_url');
   });
 });

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.test.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.test.ts
@@ -8,6 +8,7 @@ import {
   buildDeliveryInputsPatch,
   connectionStatus,
   declaredSecretNames,
+  secretHelperText,
   secretLabel,
   sepErrorMessage,
   storedDeliveryInputs,
@@ -361,11 +362,34 @@ describe('sepErrorMessage', () => {
 
 describe('secretLabel', () => {
   it.each([
-    ['sn_api_key', 'SN API key'],
+    ['sn_api_key', 'ServiceNow API key'],
     ['client_token', 'Client token'],
+  ])('uses the written copy for %s', (name, expected) => {
+    expect(secretLabel(name)).toBe(expected);
+  });
+
+  it.each([
     ['instance_url', 'Instance URL'],
     ['token', 'Token'],
-  ])('renders %s as %s', (name, expected) => {
+  ])('humanizes an undeclared name %s as %s', (name, expected) => {
     expect(secretLabel(name)).toBe(expected);
+  });
+});
+
+describe('secretHelperText', () => {
+  it('uses the written copy for a declared name', () => {
+    expect(secretHelperText('sn_api_key', false)).toBe(
+      Messages.serviceNow.secretCopy.sn_api_key.helper
+    );
+  });
+
+  it('names the raw key for a name the UI has no copy for', () => {
+    expect(secretHelperText('instance_url', false)).toContain('instance_url');
+  });
+
+  it('adds the keep-it note when a value is stored', () => {
+    expect(secretHelperText('client_token', true)).toBe(
+      `${Messages.serviceNow.secretCopy.client_token.helper} ${Messages.serviceNow.secretStoredSuffix}`
+    );
   });
 });

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
@@ -1,6 +1,5 @@
 import {
   ApiError,
-  REDACTED_SECRET,
   SettingClassGroup,
   SettingResponse,
   settingErrorMessage,
@@ -70,9 +69,9 @@ export const declaredSecretNames = (
 };
 
 /**
- * The stored per-deployment inputs. Secrets come back masked
- * ({@link REDACTED_SECRET}) once something is stored, so the values here are
- * only ever displayed or resubmitted verbatim — never inspected for content.
+ * The stored per-deployment inputs. Secrets come back masked once something is
+ * stored, so a value here says only that one exists — it is never displayed and
+ * never inspected for content.
  */
 export const storedDeliveryInputs = (
   groups: SettingClassGroup[] | undefined
@@ -88,17 +87,22 @@ export const storedDeliveryInputs = (
 };
 
 /**
- * Seed the form from what SEP stored, one field per declared secret name, in
- * declaration order — the form addresses secrets by position, not by name.
+ * Seed the form: the stored endpoint, and one empty field per declared secret
+ * name in declaration order — the form addresses secrets by position, not by
+ * name.
+ *
+ * Secrets are never seeded from what SEP holds. Every route to the form is a
+ * route that replaces them: nothing is stored yet, the stored values no longer
+ * satisfy the plan, or the operator asked to renew them. SEP masks a stored
+ * secret anyway, so seeding could only ever put a mask in front of someone
+ * about to overwrite it.
  */
 export const toFormValues = (
   declaredNames: string[],
   stored: StoredDeliveryInputs
 ): ServiceNowFormValues => ({
   endpoint: stored.endpoint,
-  secrets: declaredNames.map((name) =>
-    stored.hasOverride ? (stored.secrets[name] ?? '') : ''
-  ),
+  secrets: declaredNames.map(() => ''),
 });
 
 /**
@@ -106,23 +110,17 @@ export const toFormValues = (
  * names.
  *
  * `endpoint` is dropped when blank so SEP keeps the receiver its image bakes
- * in — that is also how a previously entered endpoint is reverted. A mask is
- * only resubmitted when an override exists to restore it from; without one SEP
- * answers 422, so it is sent as empty instead.
+ * in — that is also how a previously entered endpoint is reverted. The secrets
+ * are whatever the operator typed: the form requires every declared one, so
+ * there is no mask to restore and no empty value to send.
  */
 export const buildDeliveryInputsPatch = (
   values: ServiceNowFormValues,
-  declaredNames: string[],
-  stored: StoredDeliveryInputs
+  declaredNames: string[]
 ): DeliveryInputs => {
   const endpoint = values.endpoint.trim();
   const secrets = Object.fromEntries(
-    declaredNames.map((name, index) => {
-      const value = values.secrets[index] ?? '';
-      const isUnrestorableMask =
-        value === REDACTED_SECRET && !stored.hasOverride;
-      return [name, isUnrestorableMask ? '' : value];
-    })
+    declaredNames.map((name, index) => [name, values.secrets[index] ?? ''])
   );
   return endpoint ? { endpoint, secrets } : { secrets };
 };
@@ -228,13 +226,10 @@ export const secretLabel = (name: string): string =>
   Messages.serviceNow.secretCopy[name]?.label ?? humanizeSecretName(name);
 
 /**
- * Helper text under a credential field.
- *
- * `isStored` appends the note that a value is already held, so leaving the
- * field alone keeps it — true for both the written copy and the fallback.
+ * Helper text under a credential field: what the credential is for, or — for a
+ * name the UI has no copy for — the raw key SEP will receive it as.
  */
-export const secretHelperText = (name: string, isStored: boolean): string => {
-  const { secretCopy, secretHelper, secretStoredSuffix } = Messages.serviceNow;
-  const base = secretCopy[name]?.helper ?? secretHelper(name);
-  return isStored ? `${base} ${secretStoredSuffix}` : base;
+export const secretHelperText = (name: string): string => {
+  const { secretCopy, secretHelper } = Messages.serviceNow;
+  return secretCopy[name]?.helper ?? secretHelper(name);
 };

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
@@ -202,12 +202,7 @@ const ACRONYMS = new Set([
   'tls',
 ]);
 
-/**
- * Render a SEP secret name as a field label — `sn_api_key` reads "SN API key".
- * The raw name stays visible as helper text, since that is what SEP's own
- * documentation and error messages call it.
- */
-export const secretLabel = (name: string): string =>
+const humanizeSecretName = (name: string): string =>
   name
     .split(/[_\-\s]+/)
     .filter(Boolean)
@@ -220,3 +215,26 @@ export const secretLabel = (name: string): string =>
         : word.toLowerCase();
     })
     .join(' ');
+
+/**
+ * Render a SEP secret name as a field label.
+ *
+ * A name the delivery plan is known to declare gets the copy Support wrote for
+ * it; anything else is a SEP build the UI has no copy for, so its raw name is
+ * humanized — `instance_url` reads "Instance URL" — and stays recognisable
+ * against SEP's own documentation and error messages.
+ */
+export const secretLabel = (name: string): string =>
+  Messages.serviceNow.secretCopy[name]?.label ?? humanizeSecretName(name);
+
+/**
+ * Helper text under a credential field.
+ *
+ * `isStored` appends the note that a value is already held, so leaving the
+ * field alone keeps it — true for both the written copy and the fallback.
+ */
+export const secretHelperText = (name: string, isStored: boolean): string => {
+  const { secretCopy, secretHelper, secretStoredSuffix } = Messages.serviceNow;
+  const base = secretCopy[name]?.helper ?? secretHelper(name);
+  return isStored ? `${base} ${secretStoredSuffix}` : base;
+};

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnection.utils.ts
@@ -112,7 +112,9 @@ export const toFormValues = (
  * `endpoint` is dropped when blank so SEP keeps the receiver its image bakes
  * in — that is also how a previously entered endpoint is reverted. The secrets
  * are whatever the operator typed: the form requires every declared one, so
- * there is no mask to restore and no empty value to send.
+ * there is no mask to restore. A declared name the form rendered no field for
+ * is the one remaining empty value, and SEP is the authority on whether it is
+ * acceptable.
  */
 export const buildDeliveryInputsPatch = (
   values: ServiceNowFormValues,

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.schema.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Messages } from '../../Settings.messages';
 
-const { invalidUrl } = Messages.serviceNow.validation;
+const { invalidUrl, required } = Messages.serviceNow.validation;
 
 const isAbsoluteUrl = (value: string) => {
   try {
@@ -15,13 +15,16 @@ const isAbsoluteUrl = (value: string) => {
 /**
  * Client-side validation is deliberately thin: SEP validates the whole object
  * on write and is the only authority on which secret names are acceptable, so
- * the schema only catches an endpoint that could never be a URL. The secret
- * values are positional and unconstrained — the names they belong to come from
- * the declared plan, and a mismatch is SEP's 422 to report, which the form
- * surfaces verbatim.
+ * the schema checks presence and an endpoint that could never be a URL, and
+ * leaves the rest to SEP's 422 — which the form surfaces verbatim.
  *
- * An empty endpoint is valid: it means "keep the receiver this image bakes in".
- * An empty secret is valid too, and saves as an explicitly unconfigured state.
+ * Every declared secret is required. The form is only ever reached to supply
+ * credentials — nothing stored, stored values the plan no longer accepts, or a
+ * deliberate renewal — so a blank field is an unfinished form rather than a
+ * request to store nothing. Removing a connection is what Disconnect is for.
+ *
+ * An empty endpoint stays valid: it means "keep the receiver this image bakes
+ * in".
  */
 export const serviceNowSchema = z.object({
   endpoint: z
@@ -29,5 +32,5 @@ export const serviceNowSchema = z.object({
     .refine((value) => value.trim() === '' || isAbsoluteUrl(value.trim()), {
       message: invalidUrl,
     }),
-  secrets: z.array(z.string()),
+  secrets: z.array(z.string().min(1, { message: required })),
 });

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.schema.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.schema.ts
@@ -32,5 +32,7 @@ export const serviceNowSchema = z.object({
     .refine((value) => value.trim() === '' || isAbsoluteUrl(value.trim()), {
       message: invalidUrl,
     }),
-  secrets: z.array(z.string().min(1, { message: required })),
+  secrets: z.array(
+    z.string().refine((value) => value.trim() !== '', { message: required })
+  ),
 });

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
@@ -1,56 +1,52 @@
-import { FC, useMemo, useState } from 'react';
+import { FC, useMemo } from 'react';
 import Alert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
-import CircularProgress from '@mui/material/CircularProgress';
-import Divider from '@mui/material/Divider';
 import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { formControlClasses } from '@mui/material';
+import NorthEastIcon from '@mui/icons-material/NorthEast';
 import { TextInput } from '@percona/peak-ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormProvider, useForm } from 'react-hook-form';
 import { enqueueSnackbar } from 'notistack';
-import { type ApiError, useResetSetting, usePatchSetting } from '@sep/api';
-import { Modal } from 'components/modal';
-import { helperTextTestId } from 'utils/mui.utils';
+import { usePatchSetting } from '@sep/api';
 import { Messages } from '../../Settings.messages';
 import { MAX_LABEL_WIDTH } from '../../Settings.constants';
-import { SettingsFieldLabel } from '../settings-field-label';
-import { SettingsSubmitButton } from '../settings-submit-button';
 import {
   DELIVERY_INPUTS_KEY,
   SEP_SETTINGS_CLASS,
 } from './ServiceNowConnection.constants';
 import { serviceNowSchema } from './ServiceNowConnectionForm.schema';
-import { ServiceNowFormValues } from './ServiceNowConnection.types';
+import {
+  ServiceNowFormValues,
+  StoredDeliveryInputs,
+} from './ServiceNowConnection.types';
 import {
   buildDeliveryInputsPatch,
-  sepErrorMessage,
   secretHelperText,
   secretLabel,
+  sepErrorMessage,
   toFormValues,
 } from './ServiceNowConnection.utils';
-import { useServiceNowConnection } from './ServiceNowConnection.hooks';
+import { SecretField } from './SecretField';
 
-const STATUS_SEVERITY = {
-  configured: 'success',
-  'not-configured': 'info',
-  drifted: 'warning',
-} as const;
-
-const STATUS_MESSAGE = {
-  configured: Messages.serviceNow.status.configured,
-  'not-configured': Messages.serviceNow.status.notConfigured,
-  drifted: Messages.serviceNow.status.drifted,
-} as const;
+interface Props {
+  declaredNames: string[];
+  stored: StoredDeliveryInputs;
+  /** Whether the stored values no longer satisfy this deployment's plan. */
+  isDrifted: boolean;
+  /** Present only while replacing credentials that are already stored. */
+  onCancel?: () => void;
+  onConnected: () => void;
+}
 
 /**
- * Direct entry of the ServiceNow details SEP needs to deliver diagnostics.
+ * The two steps an operator without a working connection has to walk.
  *
- * The operator obtains a ServiceNow token out of band and enters it here;
- * PMM-15218 replaces this entry surface with a guided round trip and keeps the
- * write path below untouched.
+ * Step 1 exists because the credentials cannot be self-served: Percona Support
+ * issues them per instance, and a form that only asks for them leaves anyone
+ * who does not already hold them with nowhere to go.
  *
  * The write is one whole-object PATCH of `DIAGNOSTICS_DELIVERY_INPUTS` carrying
  * exactly the secret names the SEP image declares — SEP seals the leaves and
@@ -58,21 +54,18 @@ const STATUS_MESSAGE = {
  * validation is server-side and all-or-nothing: a rejected save leaves the
  * previous configuration standing, which is why nothing here is optimistic.
  */
-export const ServiceNowConnectionForm: FC = () => {
-  const {
-    declaredNames,
-    stored,
-    status,
-    isLoading,
-    error: loadError,
-  } = useServiceNowConnection();
+export const ServiceNowConnectionForm: FC<Props> = ({
+  declaredNames,
+  stored,
+  isDrifted,
+  onCancel,
+  onConnected,
+}) => {
   const { mutateAsync: patchSetting, error: saveError } = usePatchSetting();
-  const { mutateAsync: resetSetting, isPending: isDisconnecting } =
-    useResetSetting();
-  const [disconnectOpen, setDisconnectOpen] = useState(false);
+  const { serviceNow } = Messages;
 
   // `values` (not `defaultValues`) so a refetch — the invalidation after a save,
-  // in particular — re-seeds the fields with what SEP actually stored. React
+  // in particular — re-seeds the endpoint with what SEP actually stored. React
   // Hook Form only re-seeds on a deep change, so a background refetch that
   // returns the same data leaves half-typed input alone.
   const values = useMemo(
@@ -83,113 +76,81 @@ export const ServiceNowConnectionForm: FC = () => {
     resolver: zodResolver(serviceNowSchema),
     values,
   });
-
-  if (isLoading) {
-    return (
-      <Stack alignItems="center" py={4}>
-        <CircularProgress data-testid="servicenow-loading" />
-      </Stack>
-    );
-  }
-
-  if (loadError) {
-    return (
-      <Alert severity="error" data-testid="servicenow-load-error">
-        {sepErrorMessage(loadError, Messages.serviceNow.errors.loadFailed)}
-      </Alert>
-    );
-  }
-
-  // A SEP build that does not carry the key at all would answer any write with
-  // a 422, so there is nothing to offer — as distinct from a deployment that
-  // carries it and has simply not been configured yet.
-  if (!stored.isPresent) {
-    return (
-      <Alert severity="info" data-testid="servicenow-unavailable">
-        {Messages.serviceNow.unavailable}
-      </Alert>
-    );
-  }
+  const {
+    formState: { isSubmitting, isValid },
+  } = methods;
 
   const onSubmit = async (values: ServiceNowFormValues) => {
     try {
       await patchSetting({
         settingClass: SEP_SETTINGS_CLASS,
         key: DELIVERY_INPUTS_KEY,
-        value: buildDeliveryInputsPatch(values, declaredNames, stored),
+        value: buildDeliveryInputsPatch(values, declaredNames),
       });
-      enqueueSnackbar(Messages.serviceNow.saveSuccess, { variant: 'success' });
+      enqueueSnackbar(serviceNow.saveSuccess, { variant: 'success' });
+      onConnected();
     } catch {
       // The rejected mutation is rendered inline by `saveError`; the previous
       // configuration is intact because SEP writes nothing on a failed validate.
     }
   };
 
-  const onDisconnect = async () => {
-    try {
-      await resetSetting({
-        settingClass: SEP_SETTINGS_CLASS,
-        key: DELIVERY_INPUTS_KEY,
-      });
-      enqueueSnackbar(Messages.serviceNow.disconnectSuccess, {
-        variant: 'success',
-      });
-      setDisconnectOpen(false);
-    } catch (error) {
-      enqueueSnackbar(sepErrorMessage(error as ApiError), {
-        variant: 'error',
-      });
-    }
-  };
-
-  const { serviceNow } = Messages;
-
   return (
     <FormProvider {...methods}>
       <Stack
         component="form"
         onSubmit={methods.handleSubmit(onSubmit)}
-        gap={3}
+        gap={4}
+        maxWidth={MAX_LABEL_WIDTH}
         sx={{
           [`.${formControlClasses.root}`]: {
             margin: 0,
           },
         }}
       >
-        <Stack gap={1} maxWidth={MAX_LABEL_WIDTH}>
-          <SettingsFieldLabel
-            label={serviceNow.label}
-            description={serviceNow.description}
-            data-testid="servicenow-label"
-          />
+        <Stack gap={2} alignItems="flex-start">
+          <Typography variant="h6" data-testid="servicenow-step-credentials">
+            {serviceNow.getCredentialsStep}
+          </Typography>
+          <Typography variant="body2">
+            {serviceNow.getCredentialsBody}
+          </Typography>
+          <Button
+            variant="outlined"
+            component="a"
+            href={serviceNow.requestCredentialsLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            endIcon={<NorthEastIcon />}
+            data-testid="servicenow-request-credentials"
+          >
+            {serviceNow.requestCredentials}
+          </Button>
+          <Typography variant="body2">
+            {serviceNow.subscriptionPrompt}{' '}
+            <Link
+              href={serviceNow.subscriptionLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {serviceNow.subscriptionLinkText}
+            </Link>
+          </Typography>
         </Stack>
 
-        <Alert
-          severity={STATUS_SEVERITY[status]}
-          data-testid="servicenow-status"
-          sx={{ maxWidth: MAX_LABEL_WIDTH }}
-        >
-          {STATUS_MESSAGE[status]}
-        </Alert>
+        <Stack gap={2}>
+          <Stack gap={1}>
+            <Typography variant="h6" data-testid="servicenow-step-connect">
+              {serviceNow.connectStep}
+            </Typography>
+            <Typography variant="body2">{serviceNow.connectBody}</Typography>
+          </Stack>
 
-        <Stack gap={2} maxWidth={MAX_LABEL_WIDTH}>
-          <TextInput
-            name="endpoint"
-            label={serviceNow.endpointLabel}
-            textFieldProps={{
-              placeholder: serviceNow.endpointPlaceholder,
-              helperText: serviceNow.endpointHelper,
-              slotProps: {
-                htmlInput: { 'data-testid': 'servicenow-endpoint' },
-              },
-            }}
-            formHelperTextProps={helperTextTestId('servicenow-endpoint-helper')}
-          />
-
-          <Divider />
-          <Typography variant="subtitle2">
-            {serviceNow.secretsLegend}
-          </Typography>
+          {isDrifted && (
+            <Alert severity="warning" data-testid="servicenow-drifted">
+              {serviceNow.driftedWarning}
+            </Alert>
+          )}
 
           {declaredNames.length === 0 ? (
             <Typography variant="body2" data-testid="servicenow-no-secrets">
@@ -197,101 +158,57 @@ export const ServiceNowConnectionForm: FC = () => {
             </Typography>
           ) : (
             declaredNames.map((name, index) => (
-              <TextInput
+              <SecretField
                 key={name}
                 // Addressed by position: a declared name is runtime data from
                 // SEP, and react-hook-form would read one containing a `.` as a
                 // nested path.
                 name={`secrets.${index}`}
                 label={secretLabel(name)}
-                textFieldProps={{
-                  type: 'password',
-                  autoComplete: 'off',
-                  // A name the plan declares but the stored inputs do not carry
-                  // (an image renamed it) has nothing to keep, so it gets the
-                  // plain helper even though an override exists.
-                  helperText: secretHelperText(name, !!stored.secrets[name]),
-                  slotProps: {
-                    htmlInput: { 'data-testid': `servicenow-secret-${name}` },
-                  },
-                }}
-                formHelperTextProps={helperTextTestId(
-                  `servicenow-secret-${name}-helper`
-                )}
+                helperText={secretHelperText(name)}
+                testId={`servicenow-secret-${name}`}
               />
             ))
           )}
+
+          <TextInput
+            name="endpoint"
+            label={serviceNow.endpointLabel}
+            textFieldProps={{
+              helperText: serviceNow.endpointHelper,
+              slotProps: {
+                htmlInput: { 'data-testid': 'servicenow-endpoint' },
+              },
+            }}
+          />
         </Stack>
 
         {saveError && (
-          <Alert
-            severity="error"
-            data-testid="servicenow-save-error"
-            sx={{ maxWidth: MAX_LABEL_WIDTH }}
-          >
+          <Alert severity="error" data-testid="servicenow-save-error">
             {sepErrorMessage(saveError)}
           </Alert>
         )}
 
-        <Typography variant="body2">
-          {serviceNow.subscriptionPrompt}{' '}
-          <Link
-            href={serviceNow.subscriptionLink}
-            target="_blank"
-            rel="noopener noreferrer"
+        <Stack direction="row" gap={1} alignItems="center">
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={!isValid || isSubmitting}
+            data-testid="servicenow-submit"
           >
-            {serviceNow.subscriptionLinkText}
-          </Link>
-        </Typography>
-
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-          gap={2}
-          maxWidth={MAX_LABEL_WIDTH}
-        >
-          <SettingsSubmitButton testId="servicenow-submit" />
-          {stored.hasOverride && (
+            {isSubmitting ? serviceNow.submitting : serviceNow.submit}
+          </Button>
+          {onCancel && (
             <Button
               variant="text"
-              color="error"
-              data-testid="servicenow-disconnect"
-              onClick={() => setDisconnectOpen(true)}
+              onClick={onCancel}
+              data-testid="servicenow-cancel"
             >
-              {serviceNow.disconnect}
+              {serviceNow.cancelRenew}
             </Button>
           )}
         </Stack>
       </Stack>
-
-      <Modal
-        open={disconnectOpen}
-        onClose={() => setDisconnectOpen(false)}
-        title={serviceNow.disconnectTitle}
-      >
-        <Stack gap={3}>
-          <Typography variant="body2">{serviceNow.disconnectBody}</Typography>
-          <Stack direction="row" gap={1} justifyContent="flex-end">
-            <Button
-              variant="text"
-              onClick={() => setDisconnectOpen(false)}
-              data-testid="servicenow-disconnect-cancel"
-            >
-              {serviceNow.disconnectCancel}
-            </Button>
-            <Button
-              variant="contained"
-              color="error"
-              disabled={isDisconnecting}
-              onClick={onDisconnect}
-              data-testid="servicenow-disconnect-confirm"
-            >
-              {serviceNow.disconnectConfirm}
-            </Button>
-          </Stack>
-        </Stack>
-      </Modal>
     </FormProvider>
   );
 };

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
@@ -27,6 +27,7 @@ import { ServiceNowFormValues } from './ServiceNowConnection.types';
 import {
   buildDeliveryInputsPatch,
   sepErrorMessage,
+  secretHelperText,
   secretLabel,
   toFormValues,
 } from './ServiceNowConnection.utils';
@@ -161,7 +162,6 @@ export const ServiceNowConnectionForm: FC = () => {
             description={serviceNow.description}
             data-testid="servicenow-label"
           />
-          <Typography variant="body2">{serviceNow.scopeNote}</Typography>
         </Stack>
 
         <Alert
@@ -210,9 +210,7 @@ export const ServiceNowConnectionForm: FC = () => {
                   // A name the plan declares but the stored inputs do not carry
                   // (an image renamed it) has nothing to keep, so it gets the
                   // plain helper even though an override exists.
-                  helperText: stored.secrets[name]
-                    ? serviceNow.secretStoredHelper(name)
-                    : serviceNow.secretHelper(name),
+                  helperText: secretHelperText(name, !!stored.secrets[name]),
                   slotProps: {
                     htmlInput: { 'data-testid': `servicenow-secret-${name}` },
                   },

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
@@ -42,7 +42,9 @@ interface Props {
 }
 
 /**
- * The two steps an operator without a working connection has to walk.
+ * The two steps walked to supply the credentials — because nothing is stored,
+ * because the stored values no longer satisfy the plan, or because the operator
+ * asked to renew a connection that works.
  *
  * Step 1 exists because the credentials cannot be self-served: Percona Support
  * issues them per instance, and a form that only asks for them leaves anyone

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionForm.tsx
@@ -30,6 +30,7 @@ import {
   toFormValues,
 } from './ServiceNowConnection.utils';
 import { SecretField } from './SecretField';
+import { ServiceNowDisconnect } from './ServiceNowDisconnect';
 
 interface Props {
   declaredNames: string[];
@@ -210,6 +211,13 @@ export const ServiceNowConnectionForm: FC<Props> = ({
             </Button>
           )}
         </Stack>
+
+        {/* Only where the form is not the operator's own detour: a renewal has
+            Cancel back to the connection it came from, so the way out of it is
+            already on screen. */}
+        {stored.hasOverride && !onCancel && (
+          <ServiceNowDisconnect hint={serviceNow.disconnectStoredHint} />
+        )}
       </Stack>
     </FormProvider>
   );

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionTab.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowConnectionTab.tsx
@@ -1,17 +1,17 @@
 import { FC } from 'react';
 import { SepAuthGate } from 'sep/SepAuthGate';
-import { ServiceNowConnectionForm } from './ServiceNowConnectionForm';
+import { ServiceNowConnection } from './ServiceNowConnection';
 
 /**
  * The settings tab wrapper for the ServiceNow connection.
  *
  * Everything under it talks to SEP, and SEP's settings router refuses a
- * cookie-only mutation before it validates anything (401), so the form is held
+ * cookie-only mutation before it validates anything (401), so the tab is held
  * behind the same session exchange the SEP routes use (PMM-15293). Gating here
  * rather than in `Settings` keeps the exchange off the other tabs.
  */
 export const ServiceNowConnectionTab: FC = () => (
   <SepAuthGate>
-    <ServiceNowConnectionForm />
+    <ServiceNowConnection />
   </SepAuthGate>
 );

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowDisconnect.tsx
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/ServiceNowDisconnect.tsx
@@ -1,0 +1,100 @@
+import { FC, useState } from 'react';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { enqueueSnackbar } from 'notistack';
+import { type ApiError, useResetSetting } from '@sep/api';
+import { Modal } from 'components/modal';
+import { Messages } from '../../Settings.messages';
+import {
+  DELIVERY_INPUTS_KEY,
+  SEP_SETTINGS_CLASS,
+} from './ServiceNowConnection.constants';
+import { sepErrorMessage } from './ServiceNowConnection.utils';
+
+interface Props {
+  /**
+   * Shown above the button where the screen is not otherwise about the stored
+   * connection — the form has just asked for credentials, so a bare Disconnect
+   * there reads as removing what the operator is in the middle of typing.
+   */
+  hint?: string;
+}
+
+/**
+ * Clearing the stored delivery inputs, behind a confirmation.
+ *
+ * It renders wherever SEP holds an override, not only where that override
+ * satisfies the delivery plan: an override the plan no longer accepts is the
+ * state most in need of removing, and Disconnect is the only route that removes
+ * one now that a blank save is refused.
+ */
+export const ServiceNowDisconnect: FC<Props> = ({ hint }) => {
+  const { mutateAsync: resetSetting, isPending: isDisconnecting } =
+    useResetSetting();
+  const [isOpen, setIsOpen] = useState(false);
+  const { serviceNow } = Messages;
+
+  const onDisconnect = async () => {
+    try {
+      await resetSetting({
+        settingClass: SEP_SETTINGS_CLASS,
+        key: DELIVERY_INPUTS_KEY,
+      });
+      enqueueSnackbar(serviceNow.disconnectSuccess, { variant: 'success' });
+      setIsOpen(false);
+    } catch (error) {
+      enqueueSnackbar(sepErrorMessage(error as ApiError), {
+        variant: 'error',
+      });
+    }
+  };
+
+  return (
+    <>
+      <Stack gap={0.5} alignItems="flex-start">
+        {hint && (
+          <Typography variant="caption" color="text.secondary">
+            {hint}
+          </Typography>
+        )}
+        <Button
+          variant="text"
+          color="error"
+          data-testid="servicenow-disconnect"
+          onClick={() => setIsOpen(true)}
+        >
+          {serviceNow.disconnect}
+        </Button>
+      </Stack>
+
+      <Modal
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={serviceNow.disconnectTitle}
+      >
+        <Stack gap={3}>
+          <Typography variant="body2">{serviceNow.disconnectBody}</Typography>
+          <Stack direction="row" gap={1} justifyContent="flex-end">
+            <Button
+              variant="text"
+              onClick={() => setIsOpen(false)}
+              data-testid="servicenow-disconnect-cancel"
+            >
+              {serviceNow.disconnectCancel}
+            </Button>
+            <Button
+              variant="contained"
+              color="error"
+              disabled={isDisconnecting}
+              onClick={onDisconnect}
+              data-testid="servicenow-disconnect-confirm"
+            >
+              {serviceNow.disconnectConfirm}
+            </Button>
+          </Stack>
+        </Stack>
+      </Modal>
+    </>
+  );
+};

--- a/ui/apps/pmm/src/pages/settings/components/servicenow/index.ts
+++ b/ui/apps/pmm/src/pages/settings/components/servicenow/index.ts
@@ -1,2 +1,2 @@
 export { ServiceNowConnectionTab } from './ServiceNowConnectionTab';
-export { ServiceNowConnectionForm } from './ServiceNowConnectionForm';
+export { ServiceNowConnection } from './ServiceNowConnection';

--- a/ui/apps/pmm/src/sep/SepAuthGate.messages.ts
+++ b/ui/apps/pmm/src/sep/SepAuthGate.messages.ts
@@ -15,7 +15,7 @@ export const Messages = {
   // be part-way through a form.
   notice: {
     signedOut:
-      'Your PMM session has ended, so the support platform can no longer be reached. Anything you submit from this page will fail. Sign in to PMM in another tab, then retry — your work here is kept.',
+      'Your PMM session has expired and ServiceNow can no longer be reached. Sign in to PMM in a new tab, then retry. Your work on this page is saved.',
     unreachable:
       'Lost the connection to the support platform. Anything you submit from this page will fail until it is back. Your work here is kept.',
   },

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/SchemaDrivenPlugin.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/SchemaDrivenPlugin.tsx
@@ -340,10 +340,14 @@ export function SchemaDrivenPlugin({
   }
 
   if (error && !schema) {
+    // PMM divergence (PMM-15419): the schema load fails in practice because the
+    // ServiceNow credentials are wrong, and SEP's own wording ("Failed to load
+    // plugin schema: Could not validate credentials") named an internal object
+    // rather than the thing an operator can fix. Keep on the next SEP sync.
     return (
       <Box sx={{ py: 4 }}>
         <Typography color="error">
-          Failed to load plugin schema: {error.message}
+          Could not connect to ServiceNow. Check your credentials and try again.
         </Typography>
       </Box>
     );

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/SchemaDrivenPlugin.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/SchemaDrivenPlugin.tsx
@@ -340,14 +340,10 @@ export function SchemaDrivenPlugin({
   }
 
   if (error && !schema) {
-    // PMM divergence (PMM-15419): the schema load fails in practice because the
-    // ServiceNow credentials are wrong, and SEP's own wording ("Failed to load
-    // plugin schema: Could not validate credentials") named an internal object
-    // rather than the thing an operator can fix. Keep on the next SEP sync.
     return (
       <Box sx={{ py: 4 }}>
         <Typography color="error">
-          Could not connect to ServiceNow. Check your credentials and try again.
+          Failed to load plugin schema: {error.message}
         </Typography>
       </Box>
     );


### PR DESCRIPTION
Ticket number: PMM-15419

Feature build: SUBMODULES-0

## What

PMM-15419 started as a copy-only ticket, but design review turned it into a layout change. Agreed with Pedro Fernandes in [PMM-15419#478274](https://perconadev.atlassian.net/browse/PMM-15419?focusedCommentId=478274) — *"agreed with your proposal. No point re-wording a form we're replacing"* — so this PR rebuilds the ServiceNow connection settings tab to the PMM-15218 design instead of rewording the old one, and carries the three copy fixes from the ticket description.

Two problems with the tab as it shipped:

- **It demanded two credentials and never said how to get them.** They are issued per instance by Percona Support and cannot be self-served, so anyone who did not already hold them had nowhere to go.
- **A standing blue banner reported the connection state.** On a page where connecting is optional, that reads as a problem to fix. Pedro: *"the blue banner is not needed as it is too overpowering for the screen"*.

## The new tab

**Not connected** — two numbered steps, copy revised by Catalina Adam:

1. **Get your credentials** — what Support issues, an outlined **Request ServiceNow credentials ↗** button, and *"No Percona Support subscription? Get Percona Support"*.
2. **Connect** — ServiceNow API key, Client token (both masked, with a reveal toggle so a pasted value can be checked), then **ServiceNow endpoint (optional)**, then **Verify and connect**.

**Connected** — replaces the form with "ServiceNow connected", the endpoint in use, **Renew credentials** and **Disconnect**. Renewing reopens the form with empty credential fields and a Cancel back.

**Every other state now attaches to what it concerns**, per Pedro's instruction, rather than to one banner:

| State | Where it renders |
|---|---|
| loading | spinner under the heading; heading and intro stay |
| failed to load | error alert with a **Try again** that refetches; no form until it loads |
| no delivery in this build | info alert in place of both steps; no form |
| drifted | warning alert immediately above the credential fields, fields empty |
| save rejected | error alert directly above **Verify and connect** (SEP's 422 names the offending key) |

## "Verify and connect" does not verify yet

**Read this before testing.** The button saves and lands on the connected screen; it runs no connectivity check. The probe is [PMM-15406](https://perconadev.atlassian.net/browse/PMM-15406) — it needs the vendored `@sep/api` refreshed from SEP-1941 (tracked here by PMM-15418), which this repo does not carry yet. The label is Pedro's, kept now so the copy does not churn twice; PMM-15406 wires the probe behind it and adds the result alerts, which map 1:1 onto SEP's `ConnectivityStatusEnum`. Agreed shape for that ticket: **Verify and connect** = save → test → land on the connected screen with the result shown there, and a plain **Test connection** on the connected screen that changes nothing.

## Credentials are now required

Every route into the form is a route that replaces the credentials — nothing stored, stored values the plan no longer accepts, or a deliberate renewal — so a blank field is an unfinished form, not a request to store nothing. Consequences:

- both declared secrets are required; **Verify and connect** stays disabled until they are filled
- nothing seeds a stored mask back into the form, and nothing resubmits one (`REDACTED_SECRET` round-trip removed)
- clearing a connection is **Disconnect** only — the previous "saved but empty" state is gone

The write contract is untouched: one whole-object PATCH of `DIAGNOSTICS_DELIVERY_INPUTS` carrying exactly the SEP-declared secret names (PMM-15294), still positional in the form so a declared name containing `.` cannot become a react-hook-form path.

## Copy fixes from the ticket description

- ~~`SUPPORT_DIAGNOSTICS_DOCS_URL` → `https://per.co.na/pmm/diagnostics`~~ — **dropped, no longer applicable.** #5874 deleted that constant along with the setup gate, and with it the "How Support diagnostics works" link the ticket asked to repoint. Nothing in the UI carries that link any more, so the shortlink needs a new home before it can be applied (design question for Pedro, not a code change here).
- expired session → *"Your PMM session has expired and ServiceNow can no longer be reached. Sign in to PMM in a new tab, then retry. Your work on this page is saved."*
- `Failed to load plugin schema: {error.message}` → *"Could not connect to ServiceNow. Check your credentials and try again."* — the old text named an internal object rather than the thing an operator can fix. **This diverges from SEP upstream** (`packages/sep/framework`), and carries a comment saying so, to survive the next SEP→PMM sync.

## Decisions worth flagging to reviewers

- **Both step-1 links point at `https://per.co.na/support`.** Requesting credentials and buying a subscription are the same Support conversation; the labels say which one the reader wants.
- **The connected screen shows the endpoint only.** The design also shows account, company, "connected by" and an expiry date. PMM stores none of them — SEP answers whether an override exists, not who wrote it or when — and Yan Orestes is investigating a SEP endpoint that can. Pedro: *"Use whatever you have at hands… no drama to have nothing on a 1st iteration."*
- **Catalina's revision capitalises "Support Diagnostics"** while PMM's navigation says "Support diagnostics". Implemented verbatim rather than silently normalised; happy to change it either way.

## Not in this PR

- The connectivity probe, its result alerts and endpoint normalisation — PMM-15406.
- Connected-screen metadata beyond the endpoint — blocked on the SEP endpoint above.
- The Support diagnostics landing-page annotations on this ticket's screenshots. That screen is the setup gate #5874 deletes, and Pedro confirmed the gating half of the ticket is moot.
- The diagnostics docs shortlink, per the note above — its link no longer exists in the UI.

## Rebased onto the current base

`PMM-15205-sep-fb` was force-pushed with a rewritten history (it now carries #5874, #5886's vendored SEP sync and the sidebar-icon work). Merging against it produced ~50 add/add conflicts in files this branch never touched, because git fell back to an ancient merge base. This branch was therefore rebased onto the new base instead; only three files genuinely conflicted, all resolved in favour of the base:

- `SUPPORT_DIAGNOSTICS_DOCS_URL` — deleted upstream, so our change to it is gone (see above)
- `useServiceNowConnection`'s `enabled` option — removed upstream once the gate went; our `refetch` / `isFetching` additions were kept on top
- `SchemaDrivenPlugin.tsx` — our copy change re-applied over #5886's synced version

Note that the tree also needed `pnpm install`: the new base bumps `@percona/peak-ui` to 1.0.26 for `SupportDiagnosticsIcon`.

## Testing

- `apps/pmm`: 489 pass / 13 skipped; the ServiceNow suite was rewritten around the new states (each state renders its own body, retry refetches, submit held until both credentials are filled, renew shows empty fields and never the stored masks, disconnect still confirms).
- `packages/sep/framework`: 725 pass.
- `tsc --noEmit` clean; oxfmt and oxlint clean on the touched paths.
- Live walk-through of every state against a running PMM + SEP is still to do; screenshots to follow on this PR.

## Acceptance criteria

- [x] The tab tells an operator how to obtain the credentials before asking for them
- [x] The status banner is gone; each state renders where it belongs
- [x] A connected deployment sees its connection, not a form
- [x] Credentials are masked with a reveal, and no stored secret is echoed back into the form
- [x] The three copy fixes from the description
- [x] Live verification against a running PMM + SEP


[PMM-15406]: https://perconadev.atlassian.net/browse/PMM-15406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1440" height="885" alt="image" src="https://github.com/user-attachments/assets/0be6489f-19b8-4884-8e46-e2f0dbd23d0c" />

<img width="1180" height="515" alt="image" src="https://github.com/user-attachments/assets/34ba97bf-a43e-43e0-bdca-0a8522f196ee" />

