### PR TITLE
PMM-14989 Fix the Kubernetes PMM Client persistence example

### DIFF
--- a/documentation/docs/install-pmm/install-pmm-client/docker.md
+++ b/documentation/docs/install-pmm/install-pmm-client/docker.md
@@ -184,5 +184,6 @@ When running PMM Client in Docker, use the `PMM_AGENT_PRERUN_SCRIPT` argument to
 
 ## Tips for Docker configuration
 
+- The examples above register the Node on every start, because `PMM_AGENT_SETUP_FORCE=1` replaces the Node together with the Services on it, and the prerun script adds them again. To keep the Node and its Services across containers instead, mount a volume at `/usr/local/percona/pmm/config`, drop `PMM_AGENT_SETUP_FORCE`, and set `PMM_AGENT_SETUP_NODE_NAME`: the Node name defaults to the hostname, which a new container does not keep, and `pmm-agent setup` stops when PMM Server has the pmm-agent registered under another name. Requires PMM Client 3.10.0 or later.
 - Ensure your host's firewall and routing rules are configured to allow Docker communications. This is crucial for Docker containers to communicate properly. For more details, see the [troubleshooting checklist](../../troubleshoot/checklist.md).
 - To view available pmm-agent command-line options, run: `docker run --rm percona/pmm-client:3 --help`

--- a/documentation/docs/install-pmm/install-pmm-client/docker.md
+++ b/documentation/docs/install-pmm/install-pmm-client/docker.md
@@ -32,6 +32,11 @@ Set up PMM Client by deploying it as a Docker container and registering it with 
 
 Deploy and register PMM Client to start monitoring your node. 
 
+PMM identifies a Node by name, and the identity that PMM Server issues to the pmm-agent is stored in its configuration file. Keep both stable, a fixed `PMM_AGENT_SETUP_NODE_NAME` and a volume for the configuration, and the Node together with the Services you add survives a restart, a re-created container, or an image upgrade.
+
+!!! caution alert alert-warning "Requires PMM Client 3.10.0 or later"
+    Earlier versions register the Node again on every container start, and PMM Server answers a re-registration by removing the Node together with every Service configured on it. On those versions the Services you add to a restarted container are lost regardless of the volume you give it.
+
 Registration gives PMM Server permission to collect metrics from your infrastructure and display them in monitoring dashboards. PMM supports two authentication methods: service account tokens (recommended) and username/password credentials. 
 
 To deploy and register PMM Client using Docker:
@@ -78,21 +83,19 @@ To deploy and register PMM Client using Docker:
             -e PMM_AGENT_SERVER_INSECURE_TLS=1 \
             -e PMM_AGENT_SETUP=1 \
             -e PMM_AGENT_CONFIG_FILE=config/pmm-agent.yaml \
-            -e PMM_AGENT_SETUP_FORCE=1 \
-            -e PMM_AGENT_PRERUN_SCRIPT=/opt/percona/pmm-prerun.sh \
-            -v ./pmm-prerun.sh:/opt/percona/pmm-prerun.sh \
+            -v pmm-client-config:/usr/local/percona/pmm/config \
             percona/pmm-client:3
             ```
     
             **Parameters explained:**
     
-            - `PMM_AGENT_SETUP_NODE_NAME` - (Optional) Descriptive name for the node
+            - `PMM_AGENT_SETUP_NODE_NAME` - Name of the Node in PMM. Keep it fixed: it defaults to the hostname, which a re-created container does not keep, and `pmm-agent setup` stops when PMM Server has the pmm-agent registered under another name
+            - `pmm-client-config` - Named volume holding `pmm-agent.yaml` with the identity PMM Server issued to the pmm-agent. Without it a re-created container has nothing to keep, and registering the same Node name again fails
             - `PMM_AGENT_SETUP_NODE_TYPE` - (Optional) Node type: generic, container, etc.
             - `PMM_AGENT_SERVER_ADDRESS` - Your PMM Server’s IP address or hostname
             - `service_token` - Use this exact string as the username (not a placeholder!)
             - `YOUR_GLSA_TOKEN` - The token you copied (starts with `glsa_`)
             - `PMM_AGENT_SERVER_INSECURE_TLS` - Skip certificate validation (remove for production with valid certificates)
-            - `PMM_AGENT_PRERUN_SCRIPT` - (Optional) Path to a script inside the container that runs after registration. Mount your script using `-v ./your-script.sh:/opt/percona/pmm-prerun.sh`. See [Monitoring services](#add-monitoring-services). 
 
             You can find a complete list of compatible environment variables [here](../../use/commands/pmm-agent.md).
     
@@ -111,19 +114,17 @@ To deploy and register PMM Client using Docker:
         -e PMM_AGENT_SERVER_INSECURE_TLS=1 \
         -e PMM_AGENT_SETUP=1 \
         -e PMM_AGENT_CONFIG_FILE=config/pmm-agent.yaml \
-        -e PMM_AGENT_SETUP_FORCE=1 \
-        -e PMM_AGENT_PRERUN_SCRIPT=/opt/percona/pmm-prerun.sh \
-        -v ./pmm-prerun.sh:/opt/percona/pmm-prerun.sh \
+        -v pmm-client-config:/usr/local/percona/pmm/config \
         percona/pmm-client:3
         ```
     
         **Parameters explained:**
    
-        - `PMM_AGENT_SETUP_NODE_NAME` - (Optional) Descriptive name for the node
+        - `PMM_AGENT_SETUP_NODE_NAME` - Name of the Node in PMM. Keep it fixed: it defaults to the hostname, which a re-created container does not keep, and `pmm-agent setup` stops when PMM Server has the pmm-agent registered under another name
+        - `pmm-client-config` - Named volume holding `pmm-agent.yaml` with the identity PMM Server issued to the pmm-agent. Without it a re-created container has nothing to keep, and registering the same Node name again fails
         - `PMM_AGENT_SETUP_NODE_TYPE` - (Optional) Node type: generic, container, etc.
         - `PMM_AGENT_SERVER_ADDRESS` - Your PMM Server’s IP address or hostname
         - `admin`/`admin` - Default PMM Server username and password (change this immediately after first login)
-        - `PMM_AGENT_PRERUN_SCRIPT` - (Optional) See [Monitoring services](#add-monitoring-services)
         
         You can find a complete list of compatible environment variables [here](../../use/commands/pmm-agent.md).
 
@@ -138,6 +139,9 @@ To deploy and register PMM Client using Docker:
 
 !!! hint alert-success "Important"
     If you get `Failed to register pmm-agent on PMM Server: connection refused`, this typically means that the IP address is incorrect or the PMM Server is unreachable.
+
+!!! caution alert alert-warning "Recovering a Node after losing the volume"
+    If the volume is deleted while the Node still exists in PMM, the Client cannot register that Node name again and the container exits. Add `-e PMM_AGENT_SETUP_FORCE=1` for one start to take the name over. PMM Server then removes the old Node together with every Service on it, so drop the variable again afterwards.
     
 ## Verify the connection
 
@@ -161,9 +165,13 @@ To confirm your node is being monitored:
 
 ## Add monitoring services
 
-After installing PMM Client, you add database services to monitor with the [`pmm-admin`](../../use/commands/pmm-admin/pmm-admin.md) command. 
+After installing PMM Client, you add database services to monitor with the [`pmm-admin`](../../use/commands/pmm-admin/pmm-admin.md) command. Run it in the container once; the Node keeps the Services you add across restarts:
 
-When running PMM Client in Docker, use the `PMM_AGENT_PRERUN_SCRIPT` argument to pass a script containing any required `pmm-admin add DATABASE [FLAGS] [NAME] [ADDRESS]` commands. The `pmm-agent` runs the script automatically after registering with PMM Server. For example:
+```bash
+docker exec -t pmm-client pmm-admin add mysql --username=pmm --password=pass --query-source=perfschema --host=mysql-host
+```
+
+If you would rather declare the Services together with the container, use the `PMM_AGENT_PRERUN_SCRIPT` argument to pass a script with the `pmm-admin add DATABASE [FLAGS] [NAME] [ADDRESS]` commands. The pmm-agent runs the script on every start, after setup. `pmm-admin add` reports a Service which exists already as an error, and a failing script stops the container, so make the script tolerate the Services it added on an earlier start, for example by appending `|| true` to each command. For example:
 
 ```bash
  docker run \
@@ -176,7 +184,7 @@ When running PMM Client in Docker, use the `PMM_AGENT_PRERUN_SCRIPT` argument to
  -e PMM_AGENT_SERVER_INSECURE_TLS=1 \
  -e PMM_AGENT_SETUP=1 \
  -e PMM_AGENT_CONFIG_FILE=config/pmm-agent.yaml \
- -e PMM_AGENT_SETUP_FORCE=1 \
+ -v pmm-client-config:/usr/local/percona/pmm/config \
  -e PMM_AGENT_PRERUN_SCRIPT=/opt/percona/pmm-prerun.sh \
  -v ./pmm-prerun.sh:/opt/percona/pmm-prerun.sh \
  percona/pmm-client:3
@@ -184,6 +192,5 @@ When running PMM Client in Docker, use the `PMM_AGENT_PRERUN_SCRIPT` argument to
 
 ## Tips for Docker configuration
 
-- The examples above register the Node on every start, because `PMM_AGENT_SETUP_FORCE=1` replaces the Node together with the Services on it, and the prerun script adds them again. To keep the Node and its Services across containers instead, mount a volume at `/usr/local/percona/pmm/config`, drop `PMM_AGENT_SETUP_FORCE`, and set `PMM_AGENT_SETUP_NODE_NAME`: the Node name defaults to the hostname, which a new container does not keep, and `pmm-agent setup` stops when PMM Server has the pmm-agent registered under another name. Requires PMM Client 3.10.0 or later.
 - Ensure your host's firewall and routing rules are configured to allow Docker communications. This is crucial for Docker containers to communicate properly. For more details, see the [troubleshooting checklist](../../troubleshoot/checklist.md).
 - To view available pmm-agent command-line options, run: `docker run --rm percona/pmm-client:3 --help`

--- a/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
+++ b/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
@@ -34,6 +34,16 @@ Choose your deployment approach:
 - **Sidecar**: Deploy PMM Client alongside a database in the same pod 
 
 === "Deploy PMM Client as a Standalone container"
+    Deploy PMM Client as a StatefulSet, so that the pod keeps its name when it restarts. PMM
+    identifies a Node by name, and the Agent identity that PMM Server issues is stored in a file on
+    the pod's volume, so both the name and the volume have to be stable for the Services you add to
+    survive a restart or an image upgrade.
+
+    !!! caution alert alert-warning "Requires PMM Client 3.10.0 or later"
+        Earlier versions register the Node again on every container start, and PMM Server answers a
+        re-registration by removing the Node together with every Service configured on it. On those
+        versions the Services you add to a restarted pod are lost regardless of the storage you give it.
+
     Follow these steps to deploy PMM Client using `kubectl`:
     {.power-number}
 
@@ -44,44 +54,7 @@ Choose your deployment approach:
         kubectl config set-context --current --namespace=pmm-client-test
         ```
 
-    2. Create `pmm-client-volume.yaml` to define persistent storage for PMM Client data between pod restarts:
-
-        ```yaml
-        apiVersion: v1
-        kind: PersistentVolume
-        metadata:
-          name: pmm-client-pv
-          labels:
-            type: local
-        spec:
-          storageClassName: manual
-          capacity:
-            storage: 10Gi
-          accessModes:
-            - ReadWriteOnce
-          hostPath:
-            path: "/mnt/data"
-        ---
-        apiVersion: v1
-        kind: PersistentVolumeClaim
-        metadata:
-          name: pmm-client-pvc
-        spec:
-          storageClassName: manual
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10Gi
-        ```
-
-    3. Create the resources defined in `pmm-client-volume.yaml`
-
-        ```sh
-        kubectl apply -f pmm-client-volume.yaml
-        ```
-
-    4. Create a Secret to store PMM Server credentials. Replace `admin` password if you changed it during PMM Server setup:
+    2. Create a Secret to store PMM Server credentials. Replace `admin` password if you changed it during PMM Server setup:
 
         ```sh
         kubectl create secret generic pmm-secret \
@@ -89,39 +62,39 @@ Choose your deployment approach:
         --from-literal=PMM_AGENT_SERVER_PASSWORD=admin
         ```
 
-    5. Create `pmm-client-pod.yaml` to define a Pod running PMM Client. Replace `X.X.X.X` with the IP address of your PMM Server:
+    3. Create `pmm-client.yaml` to define the StatefulSet and its volume. Replace `X.X.X.X` with the IP address of your PMM Server:
 
         ```yaml
         apiVersion: apps/v1
-        kind: Deployment
+        kind: StatefulSet
         metadata:
           name: pmm-client
         spec:
+          serviceName: pmm-client
+          replicas: 1
           selector:
             matchLabels:
               app: pmm-client
-          strategy:
-            type: Recreate
           template:
             metadata:
               labels:
                 app: pmm-client
             spec:
-              initContainers:
-                - name: set-tmp-permissions
-                  image: busybox
-                  command: ["sh", "-c", "chown -R 1002:0 /usr/local/percona/pmm/tmp"]
-                  securityContext:
-                    runAsUser: 0
-                  volumeMounts:
-                    - name: pmm-client-storage
-                      mountPath: /usr/local/percona/pmm/tmp            
+              securityContext:
+                # The PMM Client image runs as this user, which has to own the volume to write to it.
+                fsGroup: 1002
               containers:
                 - name: pmm-client
                   image: percona/pmm-client:3
                   volumeMounts:
-                    - name: pmm-client-storage
+                    # Holds the Agent identity, so the pod keeps its Node and the Services on it.
+                    - name: pmm-agent
+                      mountPath: /usr/local/percona/pmm/config
+                      subPath: config
+                    # Holds the metrics buffered on disk while PMM Server is unreachable.
+                    - name: pmm-agent
                       mountPath: /usr/local/percona/pmm/tmp
+                      subPath: tmp
                   env:
                     - name: PMM_AGENT_SERVER_ADDRESS
                       value: X.X.X.X:443
@@ -137,17 +110,37 @@ Choose your deployment approach:
                           key: PMM_AGENT_SERVER_PASSWORD
                     - name: PMM_AGENT_SERVER_INSECURE_TLS
                       value: "1"
+                    # An absolute path, so that it resolves to the mounted volume whatever the
+                    # container's working directory is.
                     - name: PMM_AGENT_CONFIG_FILE
-                      value: config/pmm-agent.yaml
+                      value: /usr/local/percona/pmm/config/pmm-agent.yaml
                     - name: PMM_AGENT_SETUP
                       value: "1"
-                    - name: PMM_AGENT_SETUP_FORCE
-                      value: "1"
-              volumes:
-                - name: pmm-client-storage
-                  persistentVolumeClaim:
-                    claimName: pmm-client-pvc
+                    - name: PMM_AGENT_SETUP_NODE_TYPE
+                      value: container
+                    # The pod name of a StatefulSet replica does not change when the pod restarts,
+                    # which is what lets PMM Server recognise it as the same Node.
+                    - name: PMM_AGENT_SETUP_NODE_NAME
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.name
+          volumeClaimTemplates:
+            - metadata:
+                name: pmm-agent
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi
         ```
+
+        !!! note alert alert-primary "Storage"
+            The volume is claimed from your cluster's default StorageClass. Add `storageClassName` to
+            the claim template to choose a different one. Keep the size above 1Gi: that is the
+            on-disk queue the Client fills with metrics it cannot deliver while PMM Server is
+            unreachable.
+
         !!! warning alert alert-warning "Security and configuration"
             - The `PMM_AGENT_SERVER_INSECURE_TLS=1` setting disables TLS certificate verification. For production environments, configure proper TLS certificates and remove this setting.
             - If disk metrics appear missing or incorrect, your container may not expose `/proc/mounts` at the default path. Add `PMM_AGENT_SETUP_PROC_MOUNTS_PATH` to the `env` section to point PMM Client to the correct location:
@@ -157,14 +150,31 @@ Choose your deployment approach:
               value: /path/to/proc/mounts
             ```
 
-    6. Deploy PMM Client pod and configure the [pmm-agent](../../use/commands/pmm-agent.md) in Setup mode to connect to PMM Server:
+    4. Deploy PMM Client and configure the [pmm-agent](../../use/commands/pmm-agent.md) in Setup mode to connect to PMM Server:
 
         ```sh
-        kubectl apply -f pmm-client-pod.yaml
+        kubectl apply -f pmm-client.yaml
         ```
 
-    !!! hint alert-success "Important"
-        You can set the container environment variable `PMM_AGENT_PRERUN_SCRIPT` to a shell script to automatically add services to PMM for monitoring.
+    5. Check that the Node registered, and that a restart keeps it:
+
+        ```sh
+        kubectl logs pmm-client-0
+        kubectl delete pod pmm-client-0
+        kubectl logs pmm-client-0
+        ```
+
+        On the first start the Client registers the Node. After the restart it reports that the Node
+        is registered already and keeps its identity, so any Services you added remain.
+
+    !!! hint alert-success "Adding services automatically"
+        You can set the container environment variable `PMM_AGENT_PRERUN_SCRIPT` to a shell script to automatically add services to PMM for monitoring. Because this deployment keeps the Services you add, a prerun script is only needed if you would rather declare them in the manifest than add them once.
+
+    !!! caution alert alert-warning "Recovering a Node after losing the volume"
+        If the volume is deleted while the Node still exists in PMM, the Client cannot register that
+        Node name again and the pod fails to start. Add `PMM_AGENT_SETUP_FORCE=1` to the `env`
+        section for one start to take the name over. PMM Server then removes the old Node together
+        with every Service on it, so remove the variable again afterwards.
 
 
 === "Deploy PMM Client as a Sidecar container"
@@ -366,13 +376,16 @@ If you get `Failed to register pmm-agent on PMM Server: connection refused`, thi
 - Firewall rules allow traffic on port `443`
 
 ### Pod stuck in Pending state
-Check if the `PersistentVolume` was created successfully:
+Check that the volume was bound. The standalone StatefulSet claims it through its volume claim
+template, which names the claim after the template and the pod:
 
 ```sh
-kubectl get pv
 kubectl get pvc
-kubectl describe pvc pmm-client-pvc
+kubectl describe pvc pmm-agent-pmm-client-0
 ```
+
+A claim left `Pending` usually means the cluster has no default StorageClass. List the available
+classes with `kubectl get storageclass` and set `storageClassName` in the claim template.
 
 ### View PMM Client logs
 

--- a/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
+++ b/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
@@ -168,7 +168,7 @@ Choose your deployment approach:
         is registered already and keeps its identity, so any Services you added remain.
 
     !!! hint alert-success "Adding services automatically"
-        You can set the container environment variable `PMM_AGENT_PRERUN_SCRIPT` to a shell script to automatically add services to PMM for monitoring. Because this deployment keeps the Services you add, a prerun script is only needed if you would rather declare them in the manifest than add them once.
+        You can set the container environment variable `PMM_AGENT_PRERUN_SCRIPT` to a shell script to automatically add services to PMM for monitoring. Because this deployment keeps the Services you add, a prerun script is only needed if you would rather declare them in the manifest than add them once. The script runs on every start of the pod, after setup. `pmm-admin add` reports a Service which exists already as an error, and a failing script stops the container, so make the script tolerate the Services it added on an earlier start, for example by appending `|| true` to each command.
 
     !!! caution alert alert-warning "Recovering a Node after losing the volume"
         If the volume is deleted while the Node still exists in PMM, the Client cannot register that

--- a/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
+++ b/documentation/docs/install-pmm/install-pmm-client/kubernetes.md
@@ -188,36 +188,13 @@ Choose your deployment approach:
         kubectl config set-context --current --namespace=pmm-client-test
         ```
 
-    2. Create `mysql-pmm-client-volume.yaml` to define persistent storage for storing PMM Client and MySQL data between pod restarts:
+    2. Create `mysql-pmm-client-volume.yaml` to define persistent storage for MySQL data between pod restarts:
+
+        The PMM Client sidecar deliberately gets no volume of its own. It keeps its configuration in
+        the container, registers with `PMM_AGENT_SETUP_FORCE=1` and re-adds the database service from
+        `PMM_AGENT_PRERUN_SCRIPT` on every start, so it rebuilds its state instead of persisting it.
 
         ```yaml
-        apiVersion: v1
-        kind: PersistentVolume
-        metadata:
-          name: pmm-client-pv
-          labels:
-            type: local
-        spec:
-          storageClassName: manual
-          capacity:
-            storage: 10Gi
-          accessModes:
-            - ReadWriteOnce
-          hostPath:
-            path: "/mnt/data/pmm-client"
-        ---
-        apiVersion: v1
-        kind: PersistentVolumeClaim
-        metadata:
-          name: pmm-client-pvc
-        spec:
-          storageClassName: manual
-          accessModes:
-            - ReadWriteOnce
-          resources:
-            requests:
-              storage: 10Gi
-        ---
         apiVersion: v1
         kind: PersistentVolume
         metadata:
@@ -337,9 +314,6 @@ Choose your deployment approach:
                 - name: mysql-persistent-storage
                   persistentVolumeClaim:
                     claimName: mysql-pv-claim
-                - name: pmm-client-storage
-                  persistentVolumeClaim:
-                    claimName: pmm-client-pvc
         ```
 
         !!! warning alert alert-warning "Security note"

--- a/documentation/docs/use/commands/pmm-admin/config.md
+++ b/documentation/docs/use/commands/pmm-admin/config.md
@@ -22,7 +22,7 @@ Set the PMM Server URL and credentials that pmm-agent uses to communicate with t
 
 Run this after installing PMM Client or when changing server connection details.
 
-Running it again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. Settings which describe the Node, such as `--custom-labels`, only take effect when the Node is registered. The credentials in `--server-url` only serve to register the Node; a registered pmm-agent keeps its service token.
+Running it again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. If PMM Server has the pmm-agent on a Node with another name, the command stops: re-run it with that name to keep the Node, or with `--force` to replace it. Settings which describe the Node, such as `--custom-labels`, only take effect when the Node is registered. The credentials in `--server-url` only serve to register the Node; a registered pmm-agent keeps its service token.
 
 ### Syntax
 

--- a/documentation/docs/use/commands/pmm-admin/config.md
+++ b/documentation/docs/use/commands/pmm-admin/config.md
@@ -22,6 +22,8 @@ Set the PMM Server URL and credentials that pmm-agent uses to communicate with t
 
 Run this after installing PMM Client or when changing server connection details.
 
+Running it again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. Settings which describe the Node, such as `--custom-labels`, only take effect when the Node is registered. The credentials in `--server-url` only serve to register the Node; a registered pmm-agent keeps its service token.
+
 ### Syntax
 
 ```bash
@@ -47,6 +49,8 @@ pmm-admin config [<node-address> [<node-type> [<node-name>]]] [FLAGS]
 - `--paths-base=dir`:   Base path for PMM client binaries, tools, and collectors
 
 - `--agent-password=password`:   Custom agent password
+
+- `--force`:   Register the Node even if this pmm-agent is registered already, removing the Node with that name together with all dependent Services and Agents
 
 ### Examples
 

--- a/documentation/docs/use/commands/pmm-admin/config.md
+++ b/documentation/docs/use/commands/pmm-admin/config.md
@@ -22,7 +22,15 @@ Set the PMM Server URL and credentials that pmm-agent uses to communicate with t
 
 Run this after installing PMM Client or when changing server connection details.
 
-Running it again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. If PMM Server has the pmm-agent on a Node with another name, the command stops: re-run it with that name to keep the Node, or with `--force` to replace it. Settings which describe the Node, such as `--custom-labels`, only take effect when the Node is registered. The credentials in `--server-url` only serve to register the Node; a registered pmm-agent keeps its service token.
+Running it again for a registered pmm-agent keeps its registration, along with the Node and every Service on it:
+
+- The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`.
+- If PMM Server has the pmm-agent on a Node with another name, the command stops. Re-run it with that name as the Node name argument to keep that Node together with its Services, or use `--force` to register the name you gave as a new Node instead, which leaves the other Node and its Services on PMM Server with nothing monitoring them.
+- Settings which describe the Node, such as `--custom-labels` or the Node type, only take effect when the Node is registered. The command lists the ones it did not apply, and reports a registered Node address or type which differs from the one you gave.
+- The credentials in `--server-url` only serve to register the Node. A registered pmm-agent keeps its service token, and the command says so when the credentials you gave were not the ones used.
+- The configuration file is left unchanged, so settings it holds which have no `pmm-admin config` flag, such as the ports range or the path to `/proc/mounts`, are kept.
+- If PMM Server cannot be reached, or answers something pmm-agent cannot interpret, the registration is kept, a warning is written to standard error and the command still succeeds, so that a Client can be configured while PMM Server is unavailable.
+- If the configuration file is encrypted, set `PMM_AGENT_CONFIG_FILE_KEY_FILE` in the environment. Without the key the command cannot tell whether the pmm-agent is registered, and stops instead of guessing. See [Encrypt the PMM Client configuration file](../../../admin/security/client_config_encryption.md).
 
 ### Syntax
 

--- a/documentation/docs/use/commands/pmm-agent.md
+++ b/documentation/docs/use/commands/pmm-agent.md
@@ -24,7 +24,7 @@ You typically don't interact with pmm-agent directly, `pmm-admin` communicates w
 `pmm-agent setup [node-address] [node-type] [node-name]`
 : Configure local pmm-agent (requires root permissions)
 
-    Running `setup` again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. Settings which describe the Node, such as `--custom-labels` or `--disable-collectors`, only take effect when the Node is registered. The credentials given to `setup` only serve to register the Node; a registered pmm-agent keeps its service token.
+    Running `setup` again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. If PMM Server has the pmm-agent on a Node with another name, `setup` stops: re-run it with that name to keep the Node, or with `--force` to replace it. Settings which describe the Node, such as `--custom-labels` or `--disable-collectors`, only take effect when the Node is registered. The credentials given to `setup` only serve to register the Node; a registered pmm-agent keeps its service token.
 
 `pmm-agent help [command]`
 : Show help (for command) and exit.

--- a/documentation/docs/use/commands/pmm-agent.md
+++ b/documentation/docs/use/commands/pmm-agent.md
@@ -24,7 +24,16 @@ You typically don't interact with pmm-agent directly, `pmm-admin` communicates w
 `pmm-agent setup [node-address] [node-type] [node-name]`
 : Configure local pmm-agent (requires root permissions)
 
-    Running `setup` again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. If PMM Server has the pmm-agent on a Node with another name, `setup` stops: re-run it with that name to keep the Node, or with `--force` to replace it. Settings which describe the Node, such as `--custom-labels` or `--disable-collectors`, only take effect when the Node is registered. The credentials given to `setup` only serve to register the Node; a registered pmm-agent keeps its service token.
+    Running `setup` again for a registered pmm-agent keeps its registration, along with the Node and every Service on it:
+
+    - The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`.
+    - If PMM Server has the pmm-agent on a Node with another name, `setup` stops. Re-run it with that name as the `node-name` argument to keep that Node together with its Services, or use `--force` to register the name you gave as a new Node instead, which leaves the other Node and its Services on PMM Server with nothing monitoring them.
+    - Settings which describe the Node, such as `--custom-labels`, `--disable-collectors` or the `node-type` argument, only take effect when the Node is registered. `setup` lists the ones it did not apply, and reports a registered Node address or type which differs from the one you gave.
+    - The credentials given to `setup` only serve to register the Node. A registered pmm-agent keeps its service token, and `setup` says so when the credentials you gave were not the ones used.
+    - Without `--config-file`, as when `pmm-admin config` runs `setup`, the configuration file is left unchanged, so settings it holds beyond the flags given are kept.
+    - If PMM Server cannot be reached, or answers something pmm-agent cannot interpret, the registration is kept, a warning is written to standard error and `setup` still succeeds, so that a Client can be set up while PMM Server is unavailable.
+    - If the configuration file is encrypted, pass `--config-file-key-file`. Without the key `setup` cannot tell whether the pmm-agent is registered, and stops instead of guessing.
+    - `--skip-registration` needs an Agent ID already in hand, from `--id`, `PMM_AGENT_ID`, or a configuration file given with `--config-file`. It stops when nothing supplied one, rather than adopting the ID of a configuration file it only located through the running pmm-agent.
 
 `pmm-agent help [command]`
 : Show help (for command) and exit.
@@ -47,7 +56,7 @@ Most options can be set via environment variables (shown in parentheses).
 | `--container-name=CONTAINER-NAME`      | `PMM_AGENT_SETUP_CONTAINER_NAME`    | Container name.
 | `--debug`                              | `PMM_AGENT_DEBUG`                   | Enable debug output.
 | `--distro=distro`                      | `PMM_AGENT_SETUP_DISTRO`            | Node OS distribution (default is auto-detected).
-| `--force`                              | `PMM_AGENT_SETUP_FORCE`             | Register the Node even if this pmm-agent is registered already, removing the Node with that name together with all dependent Services and Agents (if existing).
+| `--force`                              | `PMM_AGENT_SETUP_FORCE`             | Register the Node even if this pmm-agent is registered, removing any existing Node with that name and its Services and Agents.
 | `--id=...`                             | `PMM_AGENT_ID`                      | ID of this pmm-agent.
 | `--listen-address=LISTEN-ADDRESS`      | `PMM_AGENT_LISTEN_ADDRESS`          | Agent local API address.
 | `--listen-port=LISTEN-PORT`            | `PMM_AGENT_LISTEN_PORT`             | Agent local API port.

--- a/documentation/docs/use/commands/pmm-agent.md
+++ b/documentation/docs/use/commands/pmm-agent.md
@@ -24,6 +24,8 @@ You typically don't interact with pmm-agent directly, `pmm-admin` communicates w
 `pmm-agent setup [node-address] [node-type] [node-name]`
 : Configure local pmm-agent (requires root permissions)
 
+    Running `setup` again for a registered pmm-agent keeps its registration. The Node is registered again only when the PMM Server address changed, when PMM Server no longer knows the pmm-agent on that Node, or with `--force`. Settings which describe the Node, such as `--custom-labels` or `--disable-collectors`, only take effect when the Node is registered. The credentials given to `setup` only serve to register the Node; a registered pmm-agent keeps its service token.
+
 `pmm-agent help [command]`
 : Show help (for command) and exit.
 
@@ -45,7 +47,7 @@ Most options can be set via environment variables (shown in parentheses).
 | `--container-name=CONTAINER-NAME`      | `PMM_AGENT_SETUP_CONTAINER_NAME`    | Container name.
 | `--debug`                              | `PMM_AGENT_DEBUG`                   | Enable debug output.
 | `--distro=distro`                      | `PMM_AGENT_SETUP_DISTRO`            | Node OS distribution (default is auto-detected).
-| `--force`                              | `PMM_AGENT_SETUP_FORCE`             | Remove Node with that name and all dependent Services and Agents (if existing).
+| `--force`                              | `PMM_AGENT_SETUP_FORCE`             | Register the Node even if this pmm-agent is registered already, removing the Node with that name together with all dependent Services and Agents (if existing).
 | `--id=...`                             | `PMM_AGENT_ID`                      | ID of this pmm-agent.
 | `--listen-address=LISTEN-ADDRESS`      | `PMM_AGENT_LISTEN_ADDRESS`          | Agent local API address.
 | `--listen-port=LISTEN-PORT`            | `PMM_AGENT_LISTEN_PORT`             | Agent local API port.


### PR DESCRIPTION
Ticket number: PMM-14989

Feature build: N/A - documentation only.

Based on `doc-3.10.0`, not `main`.

## The problem

This is the user-facing half of PMM-14989. The reporter followed the Kubernetes page exactly,
created the PV and PVC it asks for, and still lost every database Service they had added whenever
the pod restarted or the client image was upgraded. The page was wrong in four ways at once:

- The volume was introduced as "persistent storage for PMM Client data between pod restarts" and
  then mounted at `/usr/local/percona/pmm/tmp`, never at `config`, where the Agent identity lives.
- `PMM_AGENT_CONFIG_FILE` was the relative `config/pmm-agent.yaml`, resolving under the image's
  `WORKDIR` and so onto the container's ephemeral layer rather than the volume.
- The workload was a `Deployment`, so the pod hostname, and with it the Node name, changed on every
  rollout.
- `PMM_AGENT_SETUP_FORCE=1` was set, which makes PMM Server remove the Node together with every
  Service configured on it.

The first two mean nothing was ever persisted; the last two mean the Node would have been replaced
even if it had been.

## The example now

A `StatefulSet`, whose pod name is stable and is passed to `PMM_AGENT_SETUP_NODE_NAME`, with the
volume claimed from a `volumeClaimTemplates` entry and mounted at both directories that have to
survive a restart: `config` for the identity, `tmp` for the metrics the Client buffers on disk while
PMM Server is unreachable. `PMM_AGENT_CONFIG_FILE` is absolute so it cannot drift from the mount,
and `fsGroup: 1002` replaces the chown init container.

The force flag is gone from the manifest and documented instead as the one-off recovery for a volume
lost while its Node still exists in PMM, with the consequence spelled out.

Setup still runs on every start. That is only safe from **3.10.0**, where PMM-15260 (percona/pmm#5890)
makes `pmm-agent setup` idempotent, so the page states the requirement up front - on earlier
versions this manifest still loses Services, and quietly.

Also adds a step that deletes the pod to show the identity surviving the restart, and fixes the
troubleshooting section, which pointed at `pmm-client-pvc`, a claim the flow no longer creates.

## The sidecar example

Its deployment pattern is unchanged and correct: an ephemeral configuration file, a forced setup and
a prerun script that re-adds the database service on every start. A sidecar's lifecycle is the
database's, so it rebuilds its state rather than keeping it, which is what the Percona database
operators do too.

What it did carry was the same false promise as the standalone example. It created a 10Gi
PersistentVolume and claim for the PMM Client and declared a pod volume for them, none of which any
container ever mounted, and step 2 introduced that storage as being "for storing PMM Client and
MySQL data between pod restarts". Second commit removes the volume, the claim and the pod volume
entry, says the remaining storage is for MySQL, and states why the Client gets none - so the
removal does not read later as an omission to correct. Every volume the example declares is now
mounted by a container.

## The command pages

`pmm-agent setup` and `pmm-admin config` are what the manifests on the install pages actually run, so
the pages describing them carry the same promise. They described the idempotent registration as it
stood when they were written, and one sentence had since become wrong: `--force` does not *replace*
the Node PMM Server holds the pmm-agent on when the names differ. It registers the name you gave as a
new Node and leaves the other one, with its Services, behind. That is the state the install examples
exist to avoid, so the wording is corrected on both pages.

Both now list what a re-run does rather than running it together in one paragraph, and cover what was
missing from it:

- the configuration file being left unchanged when setup did not read it, which is the `pmm-admin config` path
- an unverifiable PMM Server keeping the registration, warning on standard error, and still succeeding
- an encrypted configuration file needing its key before setup can tell whether the Node is registered
- a registered Node address or type being reported rather than quietly ignored
- the Agent ID `--skip-registration` expects, and where it may come from

The `--force` row in the options table matches the flag's own help text again.

## Verification

No local mkdocs build - the change is confined to one page and adds no new links, so `linkspector`
in CI covers what a build would. The manifest itself was checked, since it is hand-written and
readers copy it verbatim:

- every manifest on the page parses as YAML, and `kubectl apply --dry-run=client` accepts each one
- `PMM_AGENT_CONFIG_FILE` resolves inside a mounted path, which is the specific defect being fixed
- no `PMM_AGENT_SETUP_FORCE` in the manifest
- code fences balanced across the page, and the admonition classes match those already used in
  `documentation/docs`

## Related

- percona/pmm#5890 - PMM-15260, the pmm-agent change this page depends on.
- percona/percona-helm-charts#954 - the pmm-ha chart, which already deploys its Client pods this
  way and will drop its own registration gate once 3.10.0 is out.

A release note for PMM-15260 is not yet in `documentation/docs/release-notes/3.10.0.md`; its ticket
asks for one, and it is not part of this PR.


