### PR TITLE
PMM-15460 Drop Debian 11 Bullseye support as it is already EOL.

### DIFF
--- a/build/packer/ansible/agent-aws.yml
+++ b/build/packer/ansible/agent-aws.yml
@@ -216,7 +216,6 @@
         name: "{{ item }}"
         source: pull
       loop:
-        - debian:bullseye
         - debian:bookworm
         - debian:trixie
         - ubuntu:jammy

--- a/documentation/docs/install-pmm/install-pmm-client/connect-database/linux.md
+++ b/documentation/docs/install-pmm/install-pmm-client/connect-database/linux.md
@@ -6,7 +6,7 @@ PMM Client supports collecting system metrics from various Linux distributions:
 
 - Red Hat/CentOS/Oracle Linux 8, 9 and 10
 - Amazon Linux 2023 (native support added in PMM 3.2.0)
-- Debian 11 (Bullseye), 12 (Bookworm) and 13 (Trixie)
+- Debian 12 (Bookworm) and 13 (Trixie)
 - Ubuntu 22.04 (Jammy), 24.04 (Noble) and 26.04 (Resolute)
 
 ## Add Linux monitoring

--- a/documentation/docs/install-pmm/install-pmm-client/package_manager.md
+++ b/documentation/docs/install-pmm/install-pmm-client/package_manager.md
@@ -23,7 +23,7 @@ PMM Client supports:
 - Operating systems:
 
     - Red Hat/CentOS/Oracle Linux 8, 9 and 10
-    - Debian 11 (Bullseye), 12 (Bookworm) and 13 (Trixie)
+    - Debian 12 (Bookworm) and 13 (Trixie)
     - Ubuntu 22.04 (Jammy), 24.04 (Noble) and 26.04 (Resolute)
     - Amazon Linux 2023
 


### PR DESCRIPTION
PMM-15460 Drop Debian 11 Bullseye support

Debian 11 LTS ended 31 Aug 2026, so PMM Client no longer ships packages for it.

- build/packer: stop pre-pulling debian:bullseye onto the build agents
- docs: Debian 11 removed from the supported platforms lists