### PR TITLE
PMM-15448 Render SEP pages on the paper surface

### DIFF
--- a/ui/apps/pmm/src/pages/settings/Settings.test.tsx
+++ b/ui/apps/pmm/src/pages/settings/Settings.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
 import { Settings } from './Settings';
 import { TestWrapper } from 'utils/testWrapper';
-import { wrapWithQueryProvider } from 'utils/testUtils';
+import {
+  measurePageSurface,
+  measureSurface,
+  wrapWithQueryProvider,
+} from 'utils/testUtils';
 import * as settingsApi from 'api/settings';
 import * as versionApi from 'api/version';
 import { SETTINGS_MOCK } from 'api/__mocks__/settings';
@@ -50,6 +54,28 @@ describe('Settings', () => {
     render(<TestWrapper>{wrapWithQueryProvider(<Settings />)}</TestWrapper>);
 
     expect(screen.getByTestId('settings-loading')).toBeInTheDocument();
+  });
+
+  it('shows the loading state on the paper surface the loaded page uses', () => {
+    const stage = measurePageSurface('default');
+    const paper = measurePageSurface('paper');
+
+    // Guards the assertion below: it only means anything while the two
+    // surfaces actually differ.
+    expect(paper).not.toBe(stage);
+
+    getSettingsMock.mockImplementation(() => new Promise(() => {}));
+
+    const loading = measureSurface(() => {
+      const result = render(
+        <TestWrapper>{wrapWithQueryProvider(<Settings />)}</TestWrapper>
+      );
+      expect(screen.getByTestId('settings-loading')).toBeInTheDocument();
+
+      return result;
+    });
+
+    expect(loading).toBe(paper);
   });
 
   describe('tab navigation by URL', () => {

--- a/ui/apps/pmm/src/pages/settings/Settings.tsx
+++ b/ui/apps/pmm/src/pages/settings/Settings.tsx
@@ -36,7 +36,7 @@ export const Settings: FC = () => {
 
   if (isLoading || isVersionLoading || (isEnabled && !settings)) {
     return (
-      <Page title={Messages.title}>
+      <Page title={Messages.title} surface="paper">
         <Stack alignItems="center" py={4}>
           <CircularProgress data-testid="settings-loading" />
         </Stack>

--- a/ui/apps/pmm/src/sep/SepPage.test.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.test.tsx
@@ -5,6 +5,7 @@ import { TestWrapper } from 'utils/testWrapper';
 import { wrapWithSettings } from 'utils/testUtils';
 import { TEST_USER_ADMIN, TEST_USER_VIEWER } from 'utils/testStubs';
 import { User } from 'types/user.types';
+import { Page } from 'components/page';
 import { SepPage } from './SepPage';
 
 // The gate mints a SEP bearer on mount; this suite is about who reaches it, so
@@ -13,10 +14,15 @@ vi.mock('./SepAuthGate', () => ({
   SepAuthGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-const renderPage = (
-  user: User,
-  settings: { sepEnabled?: boolean } = { sepEnabled: true }
-) =>
+const renderSepPage = ({
+  user = TEST_USER_ADMIN,
+  isLoading = false,
+  settings = { sepEnabled: true },
+}: {
+  user?: User;
+  isLoading?: boolean;
+  settings?: { sepEnabled?: boolean };
+} = {}) =>
   render(
     <SepPage>
       <div data-testid="sep-plugin" />
@@ -24,15 +30,39 @@ const renderPage = (
     {
       wrapper: ({ children }) => (
         <TestWrapper userContext={{ isLoading: false, user }}>
-          {wrapWithSettings(children as ReactElement, { settings })}
+          {wrapWithSettings(children as ReactElement, { isLoading, settings })}
         </TestWrapper>
       ),
     }
   );
 
+// `Page` paints its surface with a <GlobalStyles> rule on html/body, so the
+// resulting background is read back off the document rather than off a node.
+const bodyBackground = () => getComputedStyle(document.body).backgroundColor;
+
+// A bare `Page` on each surface, to name the two colours without hardcoding
+// them: `surface="paper"` is what Settings passes.
+const renderPlainPage = (surface: 'default' | 'paper') =>
+  render(
+    <Page maxWidth="full" surface={surface}>
+      <div />
+    </Page>,
+    {
+      wrapper: ({ children }) => <TestWrapper>{children}</TestWrapper>,
+    }
+  );
+
+const measureSurface = (renderState: () => { unmount: () => void }) => {
+  const { unmount } = renderState();
+  const background = bodyBackground();
+  unmount();
+
+  return background;
+};
+
 describe('SepPage', () => {
   it('renders the plugin for an administrator', () => {
-    renderPage(TEST_USER_ADMIN);
+    renderSepPage();
 
     expect(screen.getByTestId('sep-plugin')).toBeInTheDocument();
   });
@@ -41,13 +71,13 @@ describe('SepPage', () => {
     // SEP serves its reads to any authenticated session and holds every unsafe
     // method to administrators, so the route carries no role restriction and
     // the write controls are withheld per control instead (PMM-15358).
-    renderPage(TEST_USER_VIEWER);
+    renderSepPage({ user: TEST_USER_VIEWER });
 
     expect(screen.getByTestId('sep-plugin')).toBeInTheDocument();
   });
 
   it('renders an unavailable message when SEP is disabled', () => {
-    renderPage(TEST_USER_ADMIN, { sepEnabled: false });
+    renderSepPage({ settings: { sepEnabled: false } });
 
     expect(
       screen.getByText(
@@ -58,23 +88,7 @@ describe('SepPage', () => {
   });
 
   it('waits for settings instead of flashing not-enabled while they load', () => {
-    render(
-      <SepPage>
-        <div data-testid="sep-plugin" />
-      </SepPage>,
-      {
-        wrapper: ({ children }) => (
-          <TestWrapper
-            userContext={{ isLoading: false, user: TEST_USER_ADMIN }}
-          >
-            {wrapWithSettings(children as ReactElement, {
-              isLoading: true,
-              settings: { sepEnabled: true },
-            })}
-          </TestWrapper>
-        ),
-      }
-    );
+    renderSepPage({ isLoading: true, settings: { sepEnabled: true } });
 
     expect(screen.getByTestId('sep-settings-loading')).toBeInTheDocument();
     expect(
@@ -111,5 +125,28 @@ describe('SepPage', () => {
         'This feature is not enabled. Contact your administrator.'
       )
     ).not.toBeInTheDocument();
+  });
+
+  it('renders every state on the paper surface Settings uses', () => {
+    const stage = measureSurface(() => renderPlainPage('default'));
+    const paper = measureSurface(() => renderPlainPage('paper'));
+
+    // Guards the rest of the assertions: they only mean anything while the two
+    // surfaces actually differ.
+    expect(paper).not.toBe(stage);
+
+    const loading = measureSurface(() =>
+      renderSepPage({ isLoading: true, settings: { sepEnabled: true } })
+    );
+    const notEnabled = measureSurface(() =>
+      renderSepPage({ settings: { sepEnabled: false } })
+    );
+    const loaded = measureSurface(() =>
+      renderSepPage({ settings: { sepEnabled: true } })
+    );
+
+    expect(loading).toBe(paper);
+    expect(notEnabled).toBe(paper);
+    expect(loaded).toBe(paper);
   });
 });

--- a/ui/apps/pmm/src/sep/SepPage.test.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.test.tsx
@@ -2,10 +2,13 @@ import { render, screen } from '@testing-library/react';
 import { ReactElement } from 'react';
 import { SettingsContext } from 'contexts/settings';
 import { TestWrapper } from 'utils/testWrapper';
-import { wrapWithSettings } from 'utils/testUtils';
+import {
+  measurePageSurface,
+  measureSurface,
+  wrapWithSettings,
+} from 'utils/testUtils';
 import { TEST_USER_ADMIN, TEST_USER_VIEWER } from 'utils/testStubs';
 import { User } from 'types/user.types';
-import { Page } from 'components/page';
 import { SepPage } from './SepPage';
 
 // The gate mints a SEP bearer on mount; this suite is about who reaches it, so
@@ -35,30 +38,6 @@ const renderSepPage = ({
       ),
     }
   );
-
-// `Page` paints its surface with a <GlobalStyles> rule on html/body, so the
-// resulting background is read back off the document rather than off a node.
-const bodyBackground = () => getComputedStyle(document.body).backgroundColor;
-
-// A bare `Page` on each surface, to name the two colours without hardcoding
-// them: `surface="paper"` is what Settings passes.
-const renderPlainPage = (surface: 'default' | 'paper') =>
-  render(
-    <Page maxWidth="full" surface={surface}>
-      <div />
-    </Page>,
-    {
-      wrapper: ({ children }) => <TestWrapper>{children}</TestWrapper>,
-    }
-  );
-
-const measureSurface = (renderState: () => { unmount: () => void }) => {
-  const { unmount } = renderState();
-  const background = bodyBackground();
-  unmount();
-
-  return background;
-};
 
 describe('SepPage', () => {
   it('renders the plugin for an administrator', () => {
@@ -128,8 +107,8 @@ describe('SepPage', () => {
   });
 
   it('renders every state on the paper surface Settings uses', () => {
-    const stage = measureSurface(() => renderPlainPage('default'));
-    const paper = measureSurface(() => renderPlainPage('paper'));
+    const stage = measurePageSurface('default');
+    const paper = measurePageSurface('paper');
 
     // Guards the rest of the assertions: they only mean anything while the two
     // surfaces actually differ.

--- a/ui/apps/pmm/src/sep/SepPage.tsx
+++ b/ui/apps/pmm/src/sep/SepPage.tsx
@@ -17,6 +17,12 @@ import { SepAuthProvider } from './SepAuthProvider';
  * padding, width, auth gate, and footer. No `title` is passed: the SEP
  * plugins already render their own headings.
  *
+ * `surface="paper"` on every branch: SEP pages are form- and list-shaped like
+ * Settings, not widget-heavy like the dashboards the lighter stage surface a
+ * `Page` shows when it passes no `surface` is meant for. It has to be repeated
+ * in the loading and not-enabled branches too, or the page background shifts
+ * as settings resolve.
+ *
  * No `roles` restriction: every signed-in PMM user may open a SEP page, and
  * what they can do there is decided per control rather than per route. SEP's
  * API admits any authenticated session to its reads and holds every unsafe
@@ -41,7 +47,7 @@ export const SepPage: FC<PropsWithChildren> = ({ children }) => {
 
   if (isLoading || !settings) {
     return (
-      <Page maxWidth="full">
+      <Page maxWidth="full" surface="paper">
         <Stack alignItems="center" py={4}>
           <CircularProgress data-testid="sep-settings-loading" />
         </Stack>
@@ -51,7 +57,7 @@ export const SepPage: FC<PropsWithChildren> = ({ children }) => {
 
   if (!settings.sepEnabled) {
     return (
-      <Page maxWidth="full">
+      <Page maxWidth="full" surface="paper">
         <Alert severity="info">
           This feature is not enabled. Contact your administrator.
         </Alert>
@@ -60,7 +66,7 @@ export const SepPage: FC<PropsWithChildren> = ({ children }) => {
   }
 
   return (
-    <Page maxWidth="full">
+    <Page maxWidth="full" surface="paper">
       <Stack gap={3} sx={{ flex: 1 }}>
         <SepAuthProvider>
           <SepAuthGate>

--- a/ui/apps/pmm/src/utils/testUtils.tsx
+++ b/ui/apps/pmm/src/utils/testUtils.tsx
@@ -9,6 +9,9 @@ import { SettingsContext } from 'contexts/settings';
 import { FrontendSettings, Settings } from 'types/settings.types';
 import { GrafanaContext, GrafanaContextProps } from 'contexts/grafana';
 import { SnackbarProvider, SnackbarProviderProps } from 'notistack';
+import { render } from '@testing-library/react';
+import { Page } from 'components/page';
+import { TestWrapper } from './testWrapper';
 
 export const wrapWithUpdatesProvider = (
   children: ReactElement,
@@ -158,3 +161,32 @@ export const wrapWithSnackbarProvider = (
   children: ReactElement,
   props?: Partial<SnackbarProviderProps>
 ) => <SnackbarProvider {...props}>{children}</SnackbarProvider>;
+
+// `Page` paints its surface with a <GlobalStyles> rule on html/body, so the
+// resulting background is read back off the document rather than off a node.
+export const bodyBackground = () =>
+  getComputedStyle(document.body).backgroundColor;
+
+// Renders one state, reads the surface it painted, then unmounts so the next
+// measurement starts from a document the previous <GlobalStyles> has left.
+export const measureSurface = (renderState: () => { unmount: () => void }) => {
+  const { unmount } = renderState();
+  const background = bodyBackground();
+  unmount();
+
+  return background;
+};
+
+// The colour a bare `Page` paints for each surface, so a test can name the two
+// without hardcoding theme values.
+export const measurePageSurface = (surface: 'default' | 'paper') =>
+  measureSurface(() =>
+    render(
+      <Page maxWidth="full" surface={surface}>
+        <div />
+      </Page>,
+      {
+        wrapper: ({ children }) => <TestWrapper>{children}</TestWrapper>,
+      }
+    )
+  );


### PR DESCRIPTION
Stacked on `PMM-15205-sep-fb`. Base will need retargeting to `main` once that lands.

## What

`SepPage` rendered `<Page maxWidth="full">` in all three of its branches and never passed `surface`. `Page` only paints the paper background when `surface="paper"` is given, so the whole SEP subtree inherited the lighter *stage* surface reserved for widget-heavy pages — visibly different from the sidebar and from Settings.

Pass `surface="paper"` in all three branches: loading, not-enabled and loaded.

Settings turned out to have the same defect in its own loading branch — it rendered `<Page title>` with no `surface`, so Settings itself flashed the stage surface while settings and version resolved. Fixed in the same pass, since it is the page the criteria measure SEP against.

## Why

From Pedro Fernandes' UX pass over the MySQL Backups Tech Preview, recorded as finding **P12** on PMM-15380, under the PMM-15217 umbrella. Cosmetic, but visible on every SEP screen. Leaving it in signals the apps were not finished to PMM standards.

The not-enabled and loading branches need it too, not just the loaded one — otherwise the page background changes as settings resolve.

## Acceptance criteria

- [x] Every SEP route renders on the same background as Settings (`surface="paper"`, the same prop `pages/settings/Settings.tsx` passes).
- [x] The background does not change between the loading, not-enabled and loaded states — all three branches pass the prop, and a test asserts the three measured backgrounds are identical.

## Test plan

`SepPage.test.tsx` gains a regression test that measures `document.body`'s computed background in each of the three states and compares it against a bare `<Page surface="paper">` reference, guarded by an assertion that the paper and default surfaces actually differ. `Page` paints the surface through `GlobalStyles` on `html`/`body`, so there is no node-level style to assert on and asserting the prop would not have caught the original bug.

`Settings.test.tsx` gains the same check for its loading branch. The measuring helpers live in `utils/testUtils` so both suites share them.

The SEP suite's two near-duplicate render helpers are consolidated into one `renderSepPage`; no pre-existing assertion changes behaviour.

Verified:

- `cd ui/apps/pmm && npx vitest run` — 484 passed, 13 skipped
- `npx tsc --noEmit` — clean
- `cd ui && make lint` — 0 errors
- `cd ui && make format-check` — clean
- Confirmed both new tests fail when their `surface="paper"` is removed