### PR TITLE
PMM-15449 Surface run progress and failure reason for a backup run

### DIFF
--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/LastRunStatus.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/LastRunStatus.tsx
@@ -33,6 +33,13 @@ export interface LastRunStatusProps {
    * "ran, but the result could not be resolved" when `status` is absent.
    */
   lastRunAt: PeriodicTaskResponse['last_run_at'];
+  /**
+   * Makes a recognized outcome open that run's execution detail.
+   *
+   * Only the badge branch is clickable: the "Not yet run" and "Unknown"
+   * branches describe the absence of a run, so there is nothing to open.
+   */
+  onOpenRun?: () => void;
 }
 
 const mutedChipSx = { color: 'text.disabled', borderColor: 'divider' } as const;
@@ -53,9 +60,19 @@ const mutedChipSx = { color: 'text.disabled', borderColor: 'divider' } as const;
  * status is shown verbatim rather than dropped, matching the fallback used by
  * the list/detail status columns.
  */
-export function LastRunStatus({ status, lastRunAt }: LastRunStatusProps) {
+export function LastRunStatus({
+  status,
+  lastRunAt,
+  onOpenRun,
+}: LastRunStatusProps) {
   if (isTaskHistoryStatus(status)) {
-    return <TaskHistoryStatusBadge status={status} />;
+    return (
+      <TaskHistoryStatusBadge
+        status={status}
+        onClick={onOpenRun}
+        title={onOpenRun ? 'View the last run' : undefined}
+      />
+    );
   }
 
   if (status !== null && status !== undefined) {

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTaskRow.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTaskRow.tsx
@@ -63,6 +63,15 @@ export interface ScheduledTaskRowProps {
    * schedule readable. Set for sessions that may not mutate.
    */
   readOnly?: boolean;
+  /**
+   * Open the execution detail for this schedule's last run. Omit to leave the
+   * last-run cell inert, as it was before.
+   *
+   * Carries `last_run_at` as well as the name: the periodic-task API reports no
+   * `task_history_id`, so the timestamp is the only thing that identifies which
+   * run this row is describing.
+   */
+  onOpenLastRun?: (taskName: string, lastRunAt: string | null) => void;
 }
 
 export function ScheduledTaskRow({
@@ -78,6 +87,7 @@ export function ScheduledTaskRow({
   toggling,
   errorMessage,
   readOnly = false,
+  onOpenLastRun,
 }: ScheduledTaskRowProps) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const period = describePeriod(task);
@@ -120,6 +130,11 @@ export function ScheduledTaskRow({
             <LastRunStatus
               status={task.last_run_status}
               lastRunAt={task.last_run_at}
+              onOpenRun={
+                onOpenLastRun
+                  ? () => onOpenLastRun(task.task, task.last_run_at)
+                  : undefined
+              }
             />
             {task.last_run_at && (
               <Typography variant="body2" color="text.secondary">

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.test.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.test.tsx
@@ -517,4 +517,29 @@ describe('ScheduledTasksPanel — write access', () => {
       within(screen.getByTestId('scheduled-task-row-1')).getByText('Enabled')
     ).toBeInTheDocument();
   });
+
+  it('opens the execution detail from the last-run cell', async () => {
+    // The periodic-task API reports a last-run status but no task history id,
+    // so the cell has to open the run by task name. It was inert before, which
+    // left the schedules table as much of a dead end as the history row.
+    setup([
+      makePeriodic({
+        id: 1,
+        task: 'plugin-task',
+        last_run_status: 'failed',
+        last_run_at: '2026-09-07T02:00:00Z',
+      }),
+    ]);
+
+    renderPanel(<ScheduledTasksPanel pluginName="myplugin" />);
+
+    const chip = await waitFor(() =>
+      screen.getByRole('button', { name: /Failed/ })
+    );
+    await userEvent.click(chip);
+
+    expect(
+      await screen.findByRole('button', { name: 'Close run details' })
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.tsx
@@ -33,6 +33,7 @@ import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 import { useAuth } from '@sep/api';
 import { ScheduledTaskForm } from './ScheduledTaskForm';
+import { TaskRunDetailDrawer } from '../TaskRunDetailDrawer';
 import { ScheduledTaskRow } from './ScheduledTaskRow';
 import {
   useCreateScheduledTask,
@@ -80,6 +81,12 @@ export function ScheduledTasksPanel({
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formError, setFormError] = useState<string | undefined>(undefined);
   const [actionError, setActionError] = useState<string | undefined>(undefined);
+  // The periodic-task API reports a last-run status and time but no task
+  // history id, so the cell identifies its run by name plus that timestamp.
+  const [openedRun, setOpenedRun] = useState<{
+    taskName: string;
+    lastRunAt: string | null;
+  } | null>(null);
 
   const availableTasks = useMemo(
     () => pluginTasks.map((t) => ({ name: t.name })),
@@ -258,6 +265,9 @@ export function ScheduledTasksPanel({
                   toggling={updateMut.isPending}
                   errorMessage={editingId === task.id ? formError : undefined}
                   readOnly={!canMutate}
+                  onOpenLastRun={(taskName, lastRunAt) =>
+                    setOpenedRun({ taskName, lastRunAt })
+                  }
                 />
               ))}
             </TableBody>
@@ -294,6 +304,16 @@ export function ScheduledTasksPanel({
             Add new
           </Button>
         </Stack>
+      )}
+
+      {openedRun !== null && (
+        <TaskRunDetailDrawer
+          open
+          onClose={() => setOpenedRun(null)}
+          taskNames={openedRun.taskName}
+          at={openedRun.lastRunAt}
+          taskLabel={openedRun.taskName}
+        />
       )}
     </Paper>
   );

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginDetailPage.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginDetailPage.test.tsx
@@ -65,6 +65,8 @@ let mockCanMutate = true;
 // Manual factory keeps axios out of the resolution graph.
 vi.mock('@sep/api', () => ({
   useAuth: () => ({ isAdmin: mockCanMutate, canMutate: mockCanMutate }),
+  // Mirrors the real module: the embedded log viewer probes this set.
+  RUNNING_STATUSES: new Set(['running', 'pending']),
   usePluginTask: (...args: unknown[]) => mockUsePluginTask(...args),
   // Consumed by ScheduleSummary (via useScheduledTasksForPlugin) and by
   // ActionBar when capabilities.chaining is set. Default empty list keeps the

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginDetailPage.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginDetailPage.tsx
@@ -77,7 +77,11 @@ import {
   isTaskHistoryStatus,
   type TaskHistoryEntry,
 } from '../TaskHistoryTable';
-import { TaskLogViewer } from '../TaskLogViewer';
+import {
+  LastRunCard,
+  resolveOpenedRun,
+  TaskRunDetailDrawer,
+} from '../TaskRunDetailDrawer';
 import { ScheduleSummary } from '../ScheduleSummary';
 import { ChainBuilder, type ChainValue } from '../ChainBuilder';
 import {
@@ -418,9 +422,13 @@ function ConnectivityWarningAlert({
         sx={{ mb: 3, whiteSpace: 'pre-wrap' }}
         action={
           taskHistoryId !== null ? (
+            // An outlined button, not the inherit-coloured text button this
+            // replaces: on the warning Alert's tinted ground that rendered as
+            // low-contrast body text rather than something to click.
             <Button
               color="inherit"
               size="small"
+              variant="outlined"
               data-testid="connectivity-log-button"
               onClick={() => setLogOpen(true)}
             >
@@ -432,17 +440,12 @@ function ConnectivityWarningAlert({
         {message}
       </Alert>
       {taskHistoryId !== null && (
-        <Dialog
+        <TaskRunDetailDrawer
           open={logOpen}
           onClose={() => setLogOpen(false)}
-          fullWidth
-          maxWidth="lg"
-        >
-          <DialogTitle>Connectivity check log — #{taskHistoryId}</DialogTitle>
-          <DialogContent dividers sx={{ p: 0 }}>
-            <TaskLogViewer taskHistoryId={taskHistoryId} height={520} />
-          </DialogContent>
-        </Dialog>
+          taskHistoryId={taskHistoryId}
+          taskLabel="Connectivity check"
+        />
       )}
     </>
   );
@@ -465,6 +468,7 @@ function OverviewTab({
   } | null;
   const connectivityWarning =
     task.connectivity_warning ?? navState?.connectivityWarning;
+  const [lastRunOpen, setLastRunOpen] = useState(false);
   const taskName =
     typeof task.name === 'string' && task.name.trim()
       ? task.name.trim()
@@ -527,6 +531,30 @@ function OverviewTab({
             }
           />
         )}
+
+      {/* The last run sits above everything else on the Overview: when a
+          nightly backup fails, why it failed is the first thing the page owes
+          the reader. Before this the Overview said nothing about any run, and
+          the only failure signal was a banner riding router state that was
+          gone after a reload. */}
+      {taskName && (
+        <LastRunCard
+          taskNames={taskName}
+          onOpenRun={() => setLastRunOpen(true)}
+        />
+      )}
+
+      {/* Opened by name, not with the row the card is holding: the drawer then
+          keeps following the run, so one watched from here reaches its terminal
+          status in place. */}
+      {lastRunOpen && taskName && (
+        <TaskRunDetailDrawer
+          open
+          onClose={() => setLastRunOpen(false)}
+          taskNames={taskName}
+          taskLabel={taskName}
+        />
+      )}
 
       {/* Schedule / next-run sits first so it is visible without scrolling
           past the Task information card. Gate unchanged: plugins without the
@@ -618,7 +646,17 @@ interface LogsTabProps {
 function LogsTab({ taskNames }: LogsTabProps) {
   const historyQuery = useTaskHistoryByNames(taskNames);
   const stop = useStopTaskHistory();
-  const [logsEntry, setLogsEntry] = useState<TaskHistoryEntry | null>(null);
+  const [openedRow, setOpenedRow] = useState<TaskHistoryEntry | null>(null);
+  // Re-read the opened run out of the live query rather than showing the row as
+  // it looked when it was clicked: this query already polls while anything is
+  // running, so a backup watched from here flips to failed in place instead of
+  // counting elapsed time forever behind a drawer that has to be reopened.
+  // Falls back to the clicked row for a run with no id, and for one that has
+  // since paged out of the list.
+  const logsEntry = useMemo(
+    () => resolveOpenedRun(openedRow, historyQuery.data?.items),
+    [openedRow, historyQuery.data]
+  );
   const logsTaskName = logsEntry?.task?.name ?? taskNames[0] ?? 'task';
 
   return (
@@ -633,7 +671,7 @@ function LogsTab({ taskNames }: LogsTabProps) {
             data={historyQuery.data?.items ?? []}
             isLoading={historyQuery.isLoading}
             hideTaskNameColumn={taskNames.length <= 1}
-            onViewLogs={setLogsEntry}
+            onViewLogs={setOpenedRow}
             onStopTask={(entry) => {
               if (entry.id !== null && entry.id !== undefined) {
                 stop.mutate(entry.id);
@@ -646,28 +684,14 @@ function LogsTab({ taskNames }: LogsTabProps) {
         </Paper>
       )}
 
-      <Dialog
-        open={logsEntry !== null}
-        onClose={() => setLogsEntry(null)}
-        fullWidth
-        maxWidth="lg"
-      >
-        <DialogTitle>
-          Logs — {logsTaskName}
-          {logsEntry?.id !== null && logsEntry?.id !== undefined
-            ? ` #${logsEntry.id}`
-            : ''}
-        </DialogTitle>
-        <DialogContent dividers sx={{ p: 0 }}>
-          {logsEntry?.id !== null && logsEntry?.id !== undefined && (
-            <TaskLogViewer
-              taskHistoryId={logsEntry.id}
-              taskStatus={logsEntry.status}
-              height={520}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {logsEntry !== null && (
+        <TaskRunDetailDrawer
+          open
+          onClose={() => setOpenedRow(null)}
+          entry={logsEntry}
+          taskLabel={logsTaskName}
+        />
+      )}
     </>
   );
 }

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
@@ -18,6 +18,8 @@
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { SnackbarProvider } from 'notistack';
 import type { PluginSchema } from '@sep/api';
@@ -112,6 +114,112 @@ describe('PluginListPage — generic Schedules button', () => {
     expect(
       screen.queryByTestId('plugin-schedule-link')
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('PluginListPage — status column opens the last run', () => {
+  const renderWithClient = (ui: ReactNode) =>
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: { queries: { retry: false, gcTime: 0 } },
+          })
+        }
+      >
+        <SnackbarProvider>
+          <MemoryRouter>{ui}</MemoryRouter>
+        </SnackbarProvider>
+      </QueryClientProvider>
+    );
+
+  const statusSchema: PluginSchema = {
+    name: 'sched',
+    display_name: 'Sched',
+    list_view: {
+      columns: [
+        { key: 'name', label: 'Name' },
+        { key: 'status', label: 'Status', format: 'status' },
+      ],
+    },
+  } as unknown as PluginSchema;
+
+  const statusCell = (row: Record<string, unknown> = { name: 'backup' }) => {
+    const render = schemaListViewMock.mock.calls.at(-1)?.[0]
+      .renderListColumn as (context: {
+      columnKey: string;
+      value: unknown;
+      row: Record<string, unknown>;
+    }) => ReactNode | undefined;
+
+    return render({ columnKey: 'status', value: 'failed', row });
+  };
+
+  it('opens the run without also following the row', async () => {
+    // The row navigates to the task detail. Both handlers see the same native
+    // click, so without a stopPropagation one click would open the run and
+    // leave the page at the same time.
+    renderWithClient(
+      <PluginListPage schema={statusSchema} pluginName="sched" />
+    );
+
+    const onRowClick = vi.fn();
+    render(<div onClick={onRowClick}>{statusCell()}</div>);
+
+    await userEvent.click(screen.getByRole('button', { name: /Failed/ }));
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('leaves the chip inert on a multi-entity list', () => {
+    // A row there is an entity, so `name` is not a task name and there is no
+    // run to resolve from it.
+    render(
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={['/apps/sched/inventory']}>
+          <Routes>
+            <Route
+              path="/apps/:plugin/:entityName"
+              element={
+                <PluginListPage
+                  schema={
+                    {
+                      ...statusSchema,
+                      entities: [
+                        {
+                          name: 'inventory',
+                          display_name: 'Inventory',
+                          list_view: statusSchema.list_view,
+                        },
+                      ],
+                    } as unknown as PluginSchema
+                  }
+                  pluginName="sched"
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </SnackbarProvider>
+    );
+
+    expect(statusCell()).toBeUndefined();
+  });
+
+  it('defers to a plugin-supplied override for the same column', () => {
+    const renderListColumn = vi.fn(() => <span>custom</span>);
+    renderWithClient(
+      <PluginListPage
+        schema={statusSchema}
+        pluginName="sched"
+        renderListColumn={renderListColumn}
+      />
+    );
+
+    render(<div>{statusCell()}</div>);
+
+    expect(screen.getByText('custom')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Failed/ })).toBeNull();
   });
 });
 

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.tsx
@@ -15,7 +15,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -43,6 +43,11 @@ import {
   SchemaListView,
   type RenderListColumnOverride,
 } from '../SchemaListView';
+import {
+  TaskHistoryStatusBadge,
+  isTaskHistoryStatus,
+} from '../TaskHistoryTable';
+import { TaskRunDetailDrawer } from '../TaskRunDetailDrawer';
 import { DeleteConfirmDialog } from './DeleteConfirmDialog';
 
 interface PluginListPageProps {
@@ -103,6 +108,7 @@ export function PluginListPage({
     id: string;
     name?: string;
   } | null>(null);
+  const [runTaskName, setRunTaskName] = useState<string | null>(null);
   const { entityName: entityNameParam } = useParams<{ entityName?: string }>();
   const entityName = entityNameOverride ?? entityNameParam;
   const entitySchema = useMemo(
@@ -172,6 +178,59 @@ export function PluginListPage({
   const listView = multi ? entitySchema!.list_view : schema.list_view;
   const title = multi ? entitySchema!.display_name : schema.display_name;
   const description = multi ? entitySchema?.description : schema.description;
+
+  // Which columns render a task status, so the chip in them can become the way
+  // into that task's last run. Read off the schema because the per-cell
+  // override is keyed by column name and carries no format.
+  const statusColumnKeys = useMemo(
+    () =>
+      new Set(
+        (listView?.columns ?? [])
+          .filter((col) => col.format === 'status')
+          .map((col) => col.key)
+      ),
+    [listView]
+  );
+
+  /**
+   * Makes a list row's status chip open that task's most recent run.
+   *
+   * Wraps rather than replaces a plugin-supplied override, which keeps first
+   * refusal. Single-task plugins only: on a multi-entity list a row is an
+   * entity and `name` is not a task name, so there is nothing to resolve a run
+   * from and the chip is left as it was.
+   */
+  const renderListColumnWithRunAccess = useCallback<RenderListColumnOverride>(
+    (context) => {
+      const overridden = renderListColumn?.(context);
+      if (overridden !== undefined) {
+        return overridden;
+      }
+      if (multi || !statusColumnKeys.has(context.columnKey)) {
+        return undefined;
+      }
+
+      const status = String(context.value);
+      const name = context.row.name;
+      if (!isTaskHistoryStatus(status) || typeof name !== 'string' || !name) {
+        return undefined;
+      }
+
+      return (
+        <TaskHistoryStatusBadge
+          status={status}
+          title="View the last run"
+          onClick={(event) => {
+            // The row navigates to the task detail; without this, one click on
+            // the chip both opens the run and leaves the page.
+            event.stopPropagation();
+            setRunTaskName(name);
+          }}
+        />
+      );
+    },
+    [multi, renderListColumn, statusColumnKeys]
+  );
 
   const hasActionsColumn =
     listView?.columns.some((c) => c.format === 'actions') ?? false;
@@ -362,8 +421,20 @@ export function PluginListPage({
         }
         onDeleteRow={onDeleteRow}
         deletingRowId={deleteEntity.isPending ? deleteEntity.variables : null}
-        renderListColumn={renderListColumn}
+        renderListColumn={renderListColumnWithRunAccess}
       />
+
+      {/* Mounted only while open: the drawer resolves the run it shows with a
+          query, and a list has no reason to hold one open for a row nobody
+          clicked. */}
+      {runTaskName !== null && (
+        <TaskRunDetailDrawer
+          open
+          onClose={() => setRunTaskName(null)}
+          taskNames={runTaskName}
+          taskLabel={runTaskName}
+        />
+      )}
     </Box>
   );
 }

--- a/ui/packages/sep/framework/src/components/TaskHistoryTable/StatusBadge.tsx
+++ b/ui/packages/sep/framework/src/components/TaskHistoryTable/StatusBadge.tsx
@@ -24,6 +24,7 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import HourglassDisabledIcon from '@mui/icons-material/HourglassDisabled';
 import ReportIcon from '@mui/icons-material/Report';
+import type { MouseEvent } from 'react';
 import Chip from '@mui/material/Chip';
 import type { TaskHistoryStatus } from '../../hooks/useTaskHistory';
 
@@ -87,9 +88,24 @@ export function isTaskHistoryStatus(
 
 export interface StatusBadgeProps {
   status: TaskHistoryStatus;
+  /**
+   * Makes the badge open that run's execution detail.
+   *
+   * Passed through to `Chip`, which gives a clicked badge a button role, focus
+   * ring and keyboard activation on its own — so the surfaces that turn a
+   * status into a way into the run (the list status column, a schedule's
+   * last-run cell) do not each hand-roll an affordance.
+   *
+   * The event is handed on: a badge inside a clickable row has to stop the
+   * click reaching the row, or one click both opens the run and follows the
+   * row somewhere else.
+   */
+  onClick?: (event: MouseEvent<HTMLDivElement>) => void;
+  /** Tooltip/label text for a clickable badge. */
+  title?: string;
 }
 
-export function StatusBadge({ status }: StatusBadgeProps) {
+export function StatusBadge({ status, onClick, title }: StatusBadgeProps) {
   const entry = STATUS_MAP[status];
   return (
     <Chip
@@ -99,6 +115,8 @@ export function StatusBadge({ status }: StatusBadgeProps) {
       label={entry.label}
       data-status={status}
       sx={entry.spin ? spinningIconSx : undefined}
+      onClick={onClick}
+      title={title}
     />
   );
 }

--- a/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.test.tsx
@@ -229,7 +229,7 @@ describe('TaskHistoryTable actions', () => {
     expect(stopButtons).toHaveLength(1);
   });
 
-  it('calls onViewLogs when view-logs clicked', async () => {
+  it('calls onViewLogs when the run-details control is clicked', async () => {
     const onViewLogs = vi.fn();
     const data = [makeEntry(1, 'success')];
     render(
@@ -237,9 +237,123 @@ describe('TaskHistoryTable actions', () => {
         <TaskHistoryTable data={data} disablePolling onViewLogs={onViewLogs} />
       </Wrapper>
     );
-    await userEvent.click(screen.getByRole('button', { name: 'View logs' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'View run details' })
+    );
     expect(onViewLogs).toHaveBeenCalledOnce();
     expect(onViewLogs.mock.calls[0][0].id).toBe(1);
+  });
+
+  it('opens the run from a click anywhere on the row', async () => {
+    // The row was inert before, which read as a dead end to anyone who
+    // clicked it rather than hunting for the icon.
+    const onViewLogs = vi.fn();
+    render(
+      <Wrapper client={client}>
+        <TaskHistoryTable
+          data={[makeEntry(4, 'failed')]}
+          disablePolling
+          onViewLogs={onViewLogs}
+        />
+      </Wrapper>
+    );
+
+    await userEvent.click(screen.getByText('host-4'));
+
+    expect(onViewLogs).toHaveBeenCalledOnce();
+    expect(onViewLogs.mock.calls[0][0].id).toBe(4);
+  });
+
+  it('reports the run once when the control inside the row is clicked', async () => {
+    const onViewLogs = vi.fn();
+    render(
+      <Wrapper client={client}>
+        <TaskHistoryTable
+          data={[makeEntry(5, 'success')]}
+          disablePolling
+          onViewLogs={onViewLogs}
+        />
+      </Wrapper>
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'View run details' })
+    );
+
+    // The row handler would otherwise fire on the same click.
+    expect(onViewLogs).toHaveBeenCalledOnce();
+  });
+
+  it('does not open the run when a control in the row is used instead', async () => {
+    // Every control in the actions cell acts on the run without opening it;
+    // the row handler must not fire underneath them.
+    const onViewLogs = vi.fn();
+    const onStopTask = vi.fn();
+    render(
+      <Wrapper client={client}>
+        <TaskHistoryTable
+          data={[makeEntry(7, 'running')]}
+          disablePolling
+          onViewLogs={onViewLogs}
+          onStopTask={onStopTask}
+          actionError={null}
+        />
+      </Wrapper>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Stop task' }));
+
+    expect(onViewLogs).not.toHaveBeenCalled();
+  });
+
+  it('does not open the run when a chain link is followed', async () => {
+    const onViewLogs = vi.fn();
+    const onChainItemClick = vi.fn();
+    render(
+      <Wrapper client={client}>
+        <TaskHistoryTable
+          data={[
+            makeEntry(8, 'success', {
+              execution_request: {
+                task: 'task-8',
+                target: 'host-8',
+                meta: { _chain_task_names: ['next-task'], _chain_depth: 1 },
+                tracking: {},
+              } as TaskHistoryEntry['execution_request'],
+            }),
+          ]}
+          disablePolling
+          onViewLogs={onViewLogs}
+          onChainItemClick={onChainItemClick}
+        />
+      </Wrapper>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'next-task' }));
+
+    expect(onChainItemClick).toHaveBeenCalledOnce();
+    expect(onViewLogs).not.toHaveBeenCalled();
+  });
+
+  it('offers the run of a terminal execution that recorded no log', async () => {
+    // The detail carries status, timing and failure reason as well as the log,
+    // so a log-less run is exactly the one a reader needs to open — it used to
+    // be the one case the control was greyed out for.
+    const onViewLogs = vi.fn();
+    render(
+      <Wrapper client={client}>
+        <TaskHistoryTable
+          data={[makeEntry(6, 'success', { has_logs: false })]}
+          disablePolling
+          onViewLogs={onViewLogs}
+        />
+      </Wrapper>
+    );
+
+    const control = screen.getByRole('button', { name: 'View run details' });
+    expect(control).toBeEnabled();
+    await userEvent.click(control);
+    expect(onViewLogs).toHaveBeenCalledOnce();
   });
 
   it('opens confirm dialog and invokes onStopTask on Stop click', async () => {
@@ -721,9 +835,9 @@ describe('TaskHistoryTable — write access', () => {
     expect(
       screen.queryByRole('button', { name: 'Stop task' })
     ).not.toBeInTheDocument();
-    // Reads stay: the row and its log viewer remain available.
+    // Reads stay: the row and its execution detail remain available.
     expect(
-      screen.getByRole('button', { name: 'View logs' })
+      screen.getByRole('button', { name: 'View run details' })
     ).toBeInTheDocument();
   });
 });

--- a/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.tsx
+++ b/ui/packages/sep/framework/src/components/TaskHistoryTable/TaskHistoryTable.tsx
@@ -42,6 +42,8 @@ import { useTaskHistoryFiles } from '../../hooks/useTaskHistoryFiles';
 import { SEP_TABLE_CLASS } from '../../constants';
 import { ChainDisplay } from './ChainDisplay';
 import { StatusBadge } from './StatusBadge';
+import Box from '@mui/material/Box';
+import { formatDuration } from '../../utils/formatDuration';
 import { TaskFilesDialog } from './TaskFilesDialog';
 import type {
   TaskHistoryEntry,
@@ -59,19 +61,6 @@ function formatDateTime(value?: string | null): string {
   }
   const d = new Date(value);
   return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
-}
-
-function formatDuration(seconds: number | null | undefined): string {
-  if (seconds === null || seconds === undefined) {
-    return '—';
-  }
-  if (seconds < 60) {
-    return `${seconds.toFixed(1)}s`;
-  }
-  const total = Math.round(seconds);
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m}m ${s}s`;
 }
 
 interface MetaShape {
@@ -237,15 +226,20 @@ function TaskHistoryTableView({
         Cell: ({ row }) => {
           const meta = readMeta(row.original);
           return (
-            <ChainDisplay
-              chainNames={meta._chain_task_names}
-              chainDepth={meta._chain_depth}
-              onChainItemClick={
-                onChainItemClick
-                  ? (name, index) => onChainItemClick(name, index, row.original)
-                  : undefined
-              }
-            />
+            // A chain chip navigates to another task, so it must not also open
+            // this run's detail.
+            <Box component="span" onClick={(event) => event.stopPropagation()}>
+              <ChainDisplay
+                chainNames={meta._chain_task_names}
+                chainDepth={meta._chain_depth}
+                onChainItemClick={
+                  onChainItemClick
+                    ? (name, index) =>
+                        onChainItemClick(name, index, row.original)
+                    : undefined
+                }
+              />
+            </Box>
           );
         },
       },
@@ -291,13 +285,27 @@ function TaskHistoryTableView({
           const entry = row.original;
           const running = isRunningStatus(entry.status);
           return (
-            <Stack direction="row" spacing={0.5}>
-              <Tooltip title="View logs">
+            // Every control in this cell acts on the run without opening it, so
+            // the cell swallows the click rather than each button repeating a
+            // stopPropagation the next one added would forget.
+            <Stack
+              direction="row"
+              spacing={0.5}
+              onClick={(event) => event.stopPropagation()}
+            >
+              {/*
+                Enabled whenever a handler exists, including for a run with no
+                log: the execution detail also carries the status, timing and
+                failure reason, which is the only way to establish that a run
+                marked Done produced nothing. It used to be greyed out for
+                exactly the log-less runs a reader most needs to inspect.
+              */}
+              <Tooltip title="View run details">
                 <span>
                   <IconButton
                     size="small"
-                    aria-label="View logs"
-                    disabled={!onViewLogs || (!entry.has_logs && !running)}
+                    aria-label="View run details"
+                    disabled={!onViewLogs}
                     onClick={() => onViewLogs?.(entry)}
                   >
                     <VisibilityIcon fontSize="small" />
@@ -375,14 +383,25 @@ function TaskHistoryTableView({
             row.id ?? `${row.task?.name ?? 'row'}-${row.started_at ?? index}`
           )
         }
-        muiTableBodyRowProps={({ row }) =>
-          isRunningStatus(row.original.status)
+        muiTableBodyRowProps={({ row }) => {
+          const running = isRunningStatus(row.original.status);
+          // The whole row opens the run, not just the icon: the row was inert
+          // before, which read as a dead end to anyone who clicked it.
+          const clickable = onViewLogs
             ? {
-                'data-running': 'true',
-                sx: { backgroundColor: 'action.hover' },
+                onClick: () => onViewLogs(row.original),
+                sx: { cursor: 'pointer' },
               }
-            : {}
-        }
+            : {};
+
+          return running
+            ? {
+                ...clickable,
+                'data-running': 'true',
+                sx: { ...clickable.sx, backgroundColor: 'action.hover' },
+              }
+            : clickable;
+        }}
         renderEmptyRowsFallback={() => (
           <Typography
             variant="body2"

--- a/ui/packages/sep/framework/src/components/TaskLogViewer/TaskLogViewer.tsx
+++ b/ui/packages/sep/framework/src/components/TaskLogViewer/TaskLogViewer.tsx
@@ -32,6 +32,7 @@ import Tabs from '@mui/material/Tabs';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { RUNNING_STATUSES, type TaskHistoryStatus } from '@sep/api';
 import { useExecutionEvents } from '../../hooks/useExecutionEvents';
 import { useLogDownload } from '../../hooks/useLogDownload';
 import {
@@ -103,8 +104,24 @@ export interface TaskLogViewerProps {
   height?: number | string;
 }
 
+/**
+ * Whether a loosely-typed status means the run is still going.
+ *
+ * `taskStatus` arrives as a bare string, so the canonical set from `@sep/api`
+ * is probed rather than compared against a literal. That set counts `pending`
+ * as running, which the local comparison this replaces did not: a run in the
+ * seconds between launch and first output was treated as finished, so its
+ * execution events came over one-shot REST and its log never streamed —
+ * exactly the window someone watching a backup start is looking at.
+ *
+ * The case fold is kept from that comparison. The enum is lower-case on the
+ * wire, but the prop is typed as a bare string and callers outside the
+ * generated client have passed other casings.
+ */
 function isRunningStatus(status?: string): boolean {
-  return (status ?? '').toLowerCase() === 'running';
+  return RUNNING_STATUSES.has(
+    (status ?? '').toLowerCase() as TaskHistoryStatus
+  );
 }
 
 /**

--- a/ui/packages/sep/framework/src/components/TaskLogViewer/__tests__/TaskLogViewer.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskLogViewer/__tests__/TaskLogViewer.test.tsx
@@ -52,6 +52,9 @@ vi.mock('@sep/api', () => ({
   emitUnauthorized: vi.fn(),
   apiClient: { get: vi.fn(), defaults: {} },
   SEP_BASE_PATH: '/sep',
+  // Mirrors the real module: the viewer probes this set to decide whether a run
+  // is still going, and `pending` counts as running.
+  RUNNING_STATUSES: new Set(['running', 'pending']),
 }));
 
 describe('TaskLogViewer', () => {

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/LastRunCard.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/LastRunCard.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TaskHistoryEntry, TaskHistoryStatus } from '../../hooks';
+import { LastRunCard } from './LastRunCard';
+
+vi.mock('@sep/api', () => ({
+  apiClient: { get: vi.fn() },
+  SEP_BASE_PATH: '/sep',
+  RUNNING_STATUSES: new Set(['running', 'pending']),
+  isRunningStatus: (status: string) =>
+    status === 'running' || status === 'pending',
+}));
+
+import { apiClient } from '@sep/api';
+
+const mockedGet = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+function makeEntry(
+  id: number,
+  status: TaskHistoryStatus,
+  overrides: Partial<TaskHistoryEntry> = {}
+): TaskHistoryEntry {
+  const terminal = status !== 'running' && status !== 'pending';
+  return {
+    id,
+    status,
+    display_name: `backup-${id}`,
+    started_at: '2026-09-07T10:00:00Z',
+    finished_at: terminal ? '2026-09-07T10:02:07Z' : null,
+    duration: terminal ? 127 : null,
+    executed_by: 'admin',
+    has_logs: true,
+    log_capture: 'complete',
+    task: { id, name: `backup-${id}` } as TaskHistoryEntry['task'],
+    execution_request: {
+      task: `backup-${id}`,
+      target: 'host-1',
+      meta: {},
+      tracking: {},
+    } as TaskHistoryEntry['execution_request'],
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const renderCard = (onOpenRun = vi.fn()) => {
+  render(<LastRunCard taskNames="backup-1" onOpenRun={onOpenRun} />, {
+    wrapper: Wrapper,
+  });
+  return onOpenRun;
+};
+
+describe('LastRunCard', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+    mockedGet.mockResolvedValue({ data: { items: [] } });
+  });
+
+  it('reports a failed run at error severity, with its reason', async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        items: [
+          makeEntry(9, 'failed', {
+            execution_request: {
+              task: 'backup-1',
+              target: 'host-1',
+              meta: {},
+              tracking: {
+                error_message:
+                  'xtrabackup: no space left on device\n  at /var/backups',
+              },
+            } as TaskHistoryEntry['execution_request'],
+          }),
+        ],
+      },
+    });
+
+    renderCard();
+
+    const failure = await screen.findByTestId('last-run-card-failure');
+    expect(failure).toHaveClass('MuiAlert-colorError');
+    // One line here; the traceback's remainder lives in the execution detail,
+    // so the card keeps its height whatever the backend sends.
+    expect(failure).toHaveTextContent('xtrabackup: no space left on device');
+    expect(failure).not.toHaveTextContent('/var/backups');
+  });
+
+  it('survives a reload by fetching the run rather than being handed it', async () => {
+    // The Overview's only failure signal used to be a banner riding router
+    // state, which was gone after a refresh. This asks the server instead.
+    mockedGet.mockResolvedValue({ data: { items: [makeEntry(9, 'failed')] } });
+
+    renderCard();
+
+    await waitFor(() => expect(mockedGet).toHaveBeenCalledOnce());
+    expect(
+      await screen.findByTestId('last-run-card-failure')
+    ).toHaveTextContent(/open the log/);
+  });
+
+  it('shows the duration of a finished run', async () => {
+    mockedGet.mockResolvedValue({ data: { items: [makeEntry(8, 'success')] } });
+
+    renderCard();
+
+    expect(await screen.findByText('2m 7s')).toBeInTheDocument();
+    expect(screen.getByText('Duration')).toBeInTheDocument();
+  });
+
+  it('labels an in-flight run as elapsed rather than showing no duration', async () => {
+    // The wire leaves `duration` null until a run finishes, so the card
+    // derives the number from `started_at` instead of rendering an em-dash.
+    // The tick itself is covered by useElapsedSeconds and the drawer suite.
+    mockedGet.mockResolvedValue({
+      data: {
+        items: [
+          makeEntry(7, 'running', {
+            started_at: new Date(Date.now() - 45_000).toISOString(),
+          }),
+        ],
+      },
+    });
+
+    renderCard();
+
+    expect(await screen.findByText('Elapsed')).toBeInTheDocument();
+    expect(screen.queryByText('Duration')).not.toBeInTheDocument();
+    expect(screen.getByText(/^4[45]\.\ds$/)).toBeInTheDocument();
+  });
+
+  it('says the task has not run yet rather than showing an empty run', async () => {
+    renderCard();
+
+    expect(await screen.findByTestId('last-run-card-empty')).toHaveTextContent(
+      'This task has not run yet.'
+    );
+  });
+
+  it('reports a failed lookup', async () => {
+    mockedGet.mockRejectedValue(new Error('history unreachable'));
+
+    renderCard();
+
+    expect(await screen.findByTestId('last-run-card-error')).toHaveTextContent(
+      'history unreachable'
+    );
+  });
+
+  it('asks the caller to open the run in one click', async () => {
+    // No run is handed back: the caller opens the detail by task name so it
+    // keeps following the newest run rather than freezing this row.
+    mockedGet.mockResolvedValue({ data: { items: [makeEntry(6, 'success')] } });
+    const onOpenRun = renderCard();
+
+    await userEvent.click(await screen.findByTestId('last-run-card-view'));
+
+    expect(onOpenRun).toHaveBeenCalledOnce();
+    expect(onOpenRun).toHaveBeenCalledWith();
+  });
+});

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/LastRunCard.tsx
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/LastRunCard.tsx
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import Skeleton from '@mui/material/Skeleton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { isRunningStatus, useLatestTaskRun } from '../../hooks/useTaskHistory';
+import { useElapsedSeconds } from '../../hooks/useElapsedSeconds';
+import { formatDuration } from '../../utils/formatDuration';
+import { TaskHistoryStatusBadge } from '../TaskHistoryTable';
+import { formatAbsoluteTime } from '../ScheduledTasksPanel/periods';
+import { firstLine, runFailureReason } from './runFailureReason';
+
+export interface LastRunCardProps {
+  /** Task name(s) whose most recent run this block describes. */
+  taskNames: string | string[];
+  /**
+   * Open the execution detail for the run this block describes.
+   *
+   * Takes no argument on purpose: the caller opens the detail by task name so
+   * it keeps resolving the newest run, rather than freezing the row this card
+   * happened to be holding when the button was pressed.
+   */
+  onOpenRun: () => void;
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" component="div">
+        {label}
+      </Typography>
+      <Typography variant="body2" component="div">
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * A persistent summary of a task's most recent run, for the detail Overview.
+ *
+ * The Overview used to say nothing at all about the last run: the only failure
+ * signal was a banner riding router state, which vanished on reload and left
+ * no error text anywhere on the page. This block is fetched, not passed in, so
+ * it survives a reload and a DBA arriving the morning after a failed nightly
+ * backup still sees that it failed and when.
+ *
+ * A failed run renders at error severity with the first line of its reason;
+ * multi-line reasons and everything else live one click away in the execution
+ * detail. While a run is in flight the duration reads as a live elapsed time.
+ */
+export function LastRunCard({ taskNames, onOpenRun }: LastRunCardProps) {
+  const { entry, isLoading, error } = useLatestTaskRun(taskNames);
+
+  const running = entry ? isRunningStatus(entry.status) : false;
+  const elapsed = useElapsedSeconds(entry?.started_at, running);
+  const reason = firstLine(runFailureReason(entry));
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }} data-testid="last-run-card">
+      <Stack
+        direction="row"
+        alignItems="center"
+        gap={1}
+        sx={{ mb: entry || isLoading || error ? 1.5 : 0 }}
+      >
+        <Typography variant="h6" sx={{ flex: 1 }}>
+          Last run
+        </Typography>
+        {entry && <TaskHistoryStatusBadge status={entry.status} />}
+      </Stack>
+
+      {isLoading && <Skeleton variant="rounded" height={56} />}
+
+      {!isLoading && error && (
+        <Alert severity="error" data-testid="last-run-card-error">
+          Failed to load the last run: {error.message}
+        </Alert>
+      )}
+
+      {!isLoading && !error && !entry && (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          data-testid="last-run-card-empty"
+        >
+          This task has not run yet.
+        </Typography>
+      )}
+
+      {entry && (
+        <Stack gap={1.5}>
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 2,
+              gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(3, 1fr)' },
+            }}
+          >
+            <Field
+              label="Started"
+              value={formatAbsoluteTime(entry.started_at)}
+            />
+            <Field
+              label={running ? 'Elapsed' : 'Duration'}
+              value={formatDuration(running ? elapsed : entry.duration)}
+            />
+            <Field
+              label="Finished"
+              value={formatAbsoluteTime(entry.finished_at)}
+            />
+          </Box>
+
+          {entry.status === 'failed' && (
+            <Alert severity="error" data-testid="last-run-card-failure">
+              {reason ??
+                'The reason is not reported with the run — open the log to see what went wrong.'}
+            </Alert>
+          )}
+
+          <Box>
+            <Button
+              size="small"
+              variant="outlined"
+              // Called with no argument, not handed the click event: the
+              // prop is typed as taking none.
+              onClick={() => onOpenRun()}
+              data-testid="last-run-card-view"
+            >
+              {entry.has_logs || running ? 'View log' : 'View run details'}
+            </Button>
+          </Box>
+        </Stack>
+      )}
+    </Paper>
+  );
+}

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/TaskRunDetailDrawer.test.tsx
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/TaskRunDetailDrawer.test.tsx
@@ -1,0 +1,303 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TaskHistoryEntry, TaskHistoryStatus } from '../../hooks';
+import { TaskRunDetailDrawer } from './TaskRunDetailDrawer';
+
+// Manual factory rather than `importOriginal`: it keeps axios out of the graph,
+// and the running-status set and predicate mirror the real module.
+vi.mock('@sep/api', () => ({
+  apiClient: { get: vi.fn() },
+  SEP_BASE_PATH: '/sep',
+  RUNNING_STATUSES: new Set(['running', 'pending']),
+  isRunningStatus: (status: string) =>
+    status === 'running' || status === 'pending',
+}));
+
+// The viewer holds an SSE connection and is covered by its own suite; this one
+// is about what the drawer puts around it, and which run it hands over.
+vi.mock('../TaskLogViewer', () => ({
+  TaskLogViewer: ({
+    taskHistoryId,
+    taskStatus,
+  }: {
+    taskHistoryId: number | string;
+    taskStatus?: string;
+  }) => (
+    <div
+      data-testid="log-viewer"
+      data-history-id={String(taskHistoryId)}
+      data-task-status={taskStatus ?? ''}
+    />
+  ),
+}));
+
+import { apiClient } from '@sep/api';
+
+const mockedGet = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+function makeEntry(
+  id: number,
+  status: TaskHistoryStatus,
+  overrides: Partial<TaskHistoryEntry> = {}
+): TaskHistoryEntry {
+  const terminal = status !== 'running' && status !== 'pending';
+  return {
+    id,
+    status,
+    display_name: `backup-${id}`,
+    started_at: '2026-09-07T10:00:00Z',
+    finished_at: terminal ? '2026-09-07T10:02:07Z' : null,
+    duration: terminal ? 127 : null,
+    executed_by: 'admin',
+    has_logs: true,
+    log_capture: 'complete',
+    task: { id, name: `backup-${id}` } as TaskHistoryEntry['task'],
+    execution_request: {
+      task: `backup-${id}`,
+      target: 'host-1',
+      meta: {},
+      tracking: {},
+    } as TaskHistoryEntry['execution_request'],
+    ...overrides,
+  };
+}
+
+function Wrapper({ children }: PropsWithChildren) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const renderDrawer = (
+  props: Partial<Parameters<typeof TaskRunDetailDrawer>[0]>
+) =>
+  render(<TaskRunDetailDrawer open onClose={() => {}} {...props} />, {
+    wrapper: Wrapper,
+  });
+
+describe('TaskRunDetailDrawer', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+    mockedGet.mockResolvedValue({ data: { items: [] } });
+  });
+
+  it('is announced as a dialog named by its heading', () => {
+    renderDrawer({ entry: makeEntry(11, 'success') });
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAccessibleName(/backup-11 #11/);
+  });
+
+  describe('a run handed in directly', () => {
+    it('shows the run status, its duration and its log', () => {
+      renderDrawer({ entry: makeEntry(12, 'success') });
+
+      expect(screen.getByText(/backup-12 #12/)).toBeInTheDocument();
+      expect(screen.getByText('Duration')).toBeInTheDocument();
+      expect(screen.getByTestId('run-detail-duration')).toHaveTextContent(
+        '2m 7s'
+      );
+      expect(screen.getByTestId('log-viewer')).toHaveAttribute(
+        'data-history-id',
+        '12'
+      );
+      // Nothing failed, so no failure block.
+      expect(
+        screen.queryByTestId('run-detail-failure')
+      ).not.toBeInTheDocument();
+      // It resolves nothing by name when the row is already in hand.
+      expect(mockedGet).not.toHaveBeenCalled();
+    });
+
+    it('renders a failed run at error severity', () => {
+      renderDrawer({ entry: makeEntry(13, 'failed') });
+
+      const failure = screen.getByTestId('run-detail-failure');
+      expect(failure).toHaveClass('MuiAlert-colorError');
+      // No reason on the wire yet (SEP-2000), so it points at the log instead
+      // of rendering an empty error.
+      expect(failure).toHaveTextContent(/only record of what went wrong/);
+    });
+
+    it('shows the failure reason once the wire carries one', () => {
+      // The seam SEP-2000 lands on: a reason on the row, or in the tracking
+      // bag it is likely to arrive in first.
+      renderDrawer({
+        entry: makeEntry(14, 'failed', {
+          execution_request: {
+            task: 'backup-14',
+            target: 'host-1',
+            meta: {},
+            tracking: { error_message: 'xtrabackup: no space left on device' },
+          } as TaskHistoryEntry['execution_request'],
+        }),
+      });
+
+      expect(screen.getByTestId('run-detail-failure')).toHaveTextContent(
+        'xtrabackup: no space left on device'
+      );
+    });
+
+    it('explains a terminal run that produced no readable log', () => {
+      renderDrawer({
+        entry: makeEntry(15, 'success', {
+          has_logs: false,
+          log_capture: 'incomplete',
+        }),
+      });
+
+      // `log_capture` tells "produced nothing" apart from "output was lost",
+      // which is the difference between a usable backup and an unknown one.
+      expect(screen.getByTestId('run-detail-no-log')).toHaveTextContent(
+        /lost before it could be stored/
+      );
+      expect(screen.queryByTestId('log-viewer')).not.toBeInTheDocument();
+    });
+
+    it('says a run was not a script failure when the executor could not launch it', () => {
+      renderDrawer({ entry: makeEntry(16, 'unlaunchable') });
+
+      expect(screen.getByTestId('run-detail-note')).toHaveTextContent(
+        /not a script failure/
+      );
+      expect(
+        screen.queryByTestId('run-detail-failure')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('a run in flight', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-09-07T10:00:45Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('counts elapsed time up and streams the log', () => {
+      renderDrawer({ entry: makeEntry(20, 'running') });
+
+      // The wire carries no duration for a run in flight, so the number is
+      // derived from `started_at` and labelled as elapsed, not duration.
+      expect(screen.getByText('Elapsed')).toBeInTheDocument();
+      expect(screen.getByTestId('run-detail-duration')).toHaveTextContent(
+        '45.0s'
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(screen.getByTestId('run-detail-duration')).toHaveTextContent(
+        '48.0s'
+      );
+      // The viewer is told the run is live, which is what makes it stream.
+      expect(screen.getByTestId('log-viewer')).toHaveAttribute(
+        'data-task-status',
+        'running'
+      );
+    });
+
+    it('offers the log for a running run that has none recorded yet', () => {
+      renderDrawer({ entry: makeEntry(21, 'running', { has_logs: false }) });
+
+      expect(screen.getByTestId('log-viewer')).toBeInTheDocument();
+    });
+  });
+
+  describe('a run resolved by task name', () => {
+    it('shows the newest run for the task', async () => {
+      mockedGet.mockResolvedValue({
+        data: {
+          items: [
+            makeEntry(30, 'success', { started_at: '2026-09-07T08:00:00Z' }),
+            makeEntry(31, 'failed', { started_at: '2026-09-07T09:00:00Z' }),
+          ],
+        },
+      });
+
+      renderDrawer({ taskNames: 'backup-30' });
+
+      // Ordering is not trusted from the response: the newest of the page wins.
+      await waitFor(() => expect(screen.getByText(/#31/)).toBeInTheDocument());
+      expect(screen.getByTestId('run-detail-failure')).toBeInTheDocument();
+      expect(mockedGet).toHaveBeenCalledOnce();
+    });
+
+    it('opens the run that started at a given time, not the newest', async () => {
+      // A schedule knows when its own last run fired but not which history row
+      // that was, and a task that also runs manually will have newer rows.
+      mockedGet.mockResolvedValue({
+        data: {
+          items: [
+            makeEntry(40, 'failed', { started_at: '2026-09-07T02:00:04Z' }),
+            makeEntry(41, 'success', { started_at: '2026-09-07T11:30:00Z' }),
+          ],
+        },
+      });
+
+      renderDrawer({ taskNames: 'backup-40', at: '2026-09-07T02:00:00Z' });
+
+      // Nearest, not exact: `last_run_at` is when the scheduler fired, which is
+      // near but not identical to the row's `started_at`.
+      await waitFor(() => expect(screen.getByText(/#40/)).toBeInTheDocument());
+      expect(screen.queryByText(/#41/)).not.toBeInTheDocument();
+    });
+
+    it('falls back to the newest run when the given time is unusable', async () => {
+      mockedGet.mockResolvedValue({
+        data: {
+          items: [
+            makeEntry(50, 'success', { started_at: '2026-09-07T08:00:00Z' }),
+            makeEntry(51, 'success', { started_at: '2026-09-07T09:00:00Z' }),
+          ],
+        },
+      });
+
+      renderDrawer({ taskNames: 'backup-50', at: 'not-a-date' });
+
+      await waitFor(() => expect(screen.getByText(/#51/)).toBeInTheDocument());
+    });
+
+    it('says so when the task has never run', async () => {
+      renderDrawer({ taskNames: 'backup-99' });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('run-detail-empty')).toBeInTheDocument()
+      );
+    });
+
+    it('reports a failed lookup instead of rendering an empty run', async () => {
+      mockedGet.mockRejectedValue(new Error('history unreachable'));
+
+      renderDrawer({ taskNames: 'backup-98' });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('run-detail-error')).toHaveTextContent(
+          'history unreachable'
+        )
+      );
+    });
+  });
+
+  describe('a run known only by id', () => {
+    it('shows the log without a summary it cannot fill in', () => {
+      // The post-create connectivity check reports a task_history_id and
+      // nothing else, so there is no status, timing or reason to show.
+      renderDrawer({ taskHistoryId: 555, taskLabel: 'Connectivity check' });
+
+      expect(screen.getByText(/Connectivity check #555/)).toBeInTheDocument();
+      expect(screen.getByTestId('log-viewer')).toHaveAttribute(
+        'data-history-id',
+        '555'
+      );
+      expect(screen.queryByText('Duration')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('run-detail-empty')).not.toBeInTheDocument();
+      expect(mockedGet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/TaskRunDetailDrawer.tsx
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/TaskRunDetailDrawer.tsx
@@ -1,0 +1,325 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import CloseIcon from '@mui/icons-material/Close';
+import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import {
+  isRunningStatus,
+  type TaskHistoryEntry,
+  useLatestTaskRun,
+} from '../../hooks/useTaskHistory';
+import { useElapsedSeconds } from '../../hooks/useElapsedSeconds';
+import { formatDuration } from '../../utils/formatDuration';
+import { TaskHistoryStatusBadge } from '../TaskHistoryTable';
+import { TaskLogViewer } from '../TaskLogViewer';
+import { formatAbsoluteTime } from '../ScheduledTasksPanel/periods';
+import { runFailureReason } from './runFailureReason';
+
+/**
+ * Height handed to the embedded log viewer.
+ *
+ * A CSS `clamp` rather than a measured pixel value: the viewer applies its
+ * height to an inner box, so a percentage would resolve against an
+ * indefinite-height parent and collapse the pane to nothing. This keeps the
+ * log the tallest element the drawer can afford without a resize observer.
+ */
+const LOG_HEIGHT = 'clamp(240px, calc(100vh - 460px), 900px)';
+
+const DRAWER_WIDTH = { xs: '100%', sm: 560, md: 760 } as const;
+
+/**
+ * Id linking the drawer's heading to its dialog role.
+ *
+ * A constant rather than a generated id: only one run detail is open at a
+ * time — each call site mounts the drawer only while it is showing something.
+ */
+const HEADING_ID = 'run-detail-heading';
+
+/**
+ * Why a terminal run that did not succeed ended, for the statuses whose
+ * meaning is not self-evident from the badge alone.
+ *
+ * `failed` is deliberately absent: it renders at error severity with the
+ * backend's own reason (or a pointer to the log), rather than a fixed sentence.
+ */
+const NON_FAILURE_TERMINAL_NOTES: Partial<Record<string, string>> = {
+  stopped: 'This run was stopped before it finished.',
+  lost: 'The executor stopped reporting on this run, so its outcome is unknown.',
+  stale:
+    'This run was skipped because the executor could not place it before the staleness threshold.',
+  unlaunchable:
+    'The executor node could not launch this run, so the payload never executed. This is not a script failure.',
+};
+
+/**
+ * Explanation for a run that finished with no readable log.
+ *
+ * Uses `log_capture`, which distinguishes a run that genuinely produced nothing
+ * from one whose output was lost before SEP could read it — a difference that
+ * matters when the reader is trying to establish whether a backup did anything.
+ */
+const NO_LOG_NOTES: Record<string, string> = {
+  incomplete:
+    'This run produced log output, but it was lost before it could be stored.',
+  unknown: 'No log was recorded for this run.',
+  complete: 'This run produced no log output.',
+};
+
+function SummaryField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" component="div">
+        {label}
+      </Typography>
+      <Typography variant="body2" component="div">
+        {children}
+      </Typography>
+    </Box>
+  );
+}
+
+export interface TaskRunDetailDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * A run already in hand. Supplied by execution history, whose rows carry a
+   * `task_history_id`; takes precedence over `taskNames`.
+   *
+   * Rendered exactly as given — the drawer does not re-read it. A caller that
+   * shows a run still in flight must therefore pass a row it keeps fresh
+   * (execution history re-reads the opened row out of its own polling query),
+   * or the status here freezes at whatever it was when the drawer opened.
+   */
+  entry?: TaskHistoryEntry | null;
+  /**
+   * Task name(s) whose most recent run should be shown, for the surfaces that
+   * hold a name and no run id — the list status chip, the detail Overview and
+   * the schedules "Last Run" cell. Resolved only while the drawer is open, so
+   * a table of rows costs one request on click rather than one per row.
+   */
+  taskNames?: string | string[];
+  /**
+   * With `taskNames`, the run that started at this time rather than the newest
+   * one. The schedules cell passes its own `last_run_at`: a task that also runs
+   * manually would otherwise open a newer, unrelated run.
+   */
+  at?: string | null;
+  /**
+   * A run known only by id, with no history row to describe it — the
+   * post-create connectivity check, which reports a `task_history_id` and
+   * nothing else. The log is shown without the summary, because there is no
+   * status, timing or reason to show. Ignored when `entry` or `taskNames` is
+   * given.
+   */
+  taskHistoryId?: number | string;
+  /** Heading fallback for a run whose own payload does not name its task. */
+  taskLabel?: string;
+}
+
+/**
+ * The execution detail for a single task run: status, timing, why it failed,
+ * and its log.
+ *
+ * One view behind every entry point, so a run opened from a status chip, the
+ * Overview, execution history or a schedule's last-run cell shows the same
+ * thing. It replaces the two log dialogs the detail page used to own, which
+ * showed the log and nothing around it.
+ *
+ * A run in flight gets a live elapsed time and a streaming log: the viewer
+ * holds an SSE connection open, so neither needs a reload. Whether the run's
+ * *status* keeps up depends on how it was opened — by name it is re-resolved
+ * on the poll, and `entry` is only as fresh as the caller keeps it.
+ */
+export function TaskRunDetailDrawer({
+  open,
+  onClose,
+  entry,
+  taskNames,
+  at,
+  taskHistoryId,
+  taskLabel,
+}: TaskRunDetailDrawerProps) {
+  // Resolve by name only when no row was handed in, and only while open.
+  const shouldResolve = open && !entry && taskNames !== undefined;
+  const latest = useLatestTaskRun(taskNames, { at, enabled: shouldResolve });
+
+  const run = entry ?? (shouldResolve ? latest.entry : null);
+  const isLoading = shouldResolve && latest.isLoading;
+
+  const running = run ? isRunningStatus(run.status) : false;
+  const elapsed = useElapsedSeconds(run?.started_at, running);
+
+  const heading =
+    run?.display_name || run?.task?.name || taskLabel || 'Task run';
+  const failureReason = runFailureReason(run);
+  const nonFailureNote = run
+    ? NON_FAILURE_TERMINAL_NOTES[run.status]
+    : undefined;
+  // With no history row there is nothing to gate on, so an id on its own is
+  // taken at face value and the log is attempted.
+  const logId = run?.id ?? (run ? null : (taskHistoryId ?? null));
+  const showLog =
+    logId !== null && logId !== undefined && (!run || run.has_logs || running);
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      slotProps={{
+        paper: {
+          sx: { width: DRAWER_WIDTH },
+          // The drawer is a modal detail view, so it is announced as a dialog
+          // named by its own heading rather than as an unlabelled region.
+          role: 'dialog',
+          'aria-modal': true,
+          'aria-labelledby': HEADING_ID,
+        },
+      }}
+      data-testid="run-detail-drawer"
+    >
+      <Stack sx={{ height: '100%' }}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          gap={1}
+          sx={{ p: 2, borderBottom: 1, borderColor: 'divider' }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography variant="h6" noWrap title={heading} id={HEADING_ID}>
+              {heading}
+              {logId !== null && logId !== undefined ? ` #${logId}` : ''}
+            </Typography>
+          </Box>
+          {run && <TaskHistoryStatusBadge status={run.status} />}
+          <IconButton
+            size="small"
+            onClick={onClose}
+            aria-label="Close run details"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+
+        <Box sx={{ p: 2, flex: 1, overflowY: 'auto' }}>
+          {isLoading && (
+            <Stack alignItems="center" py={4}>
+              <CircularProgress data-testid="run-detail-loading" />
+            </Stack>
+          )}
+
+          {!isLoading && latest.error && !entry && (
+            <Alert severity="error" data-testid="run-detail-error">
+              Failed to load the latest run: {latest.error.message}
+            </Alert>
+          )}
+
+          {!isLoading && !latest.error && !run && !showLog && (
+            <Alert severity="info" data-testid="run-detail-empty">
+              {at
+                ? 'No execution history was found for this run.'
+                : 'This task has not run yet.'}
+            </Alert>
+          )}
+
+          {!run && showLog && (
+            <TaskLogViewer taskHistoryId={logId} height={LOG_HEIGHT} />
+          )}
+
+          {run && (
+            <Stack gap={2}>
+              <Box
+                sx={{
+                  display: 'grid',
+                  gap: 2,
+                  gridTemplateColumns: {
+                    xs: '1fr 1fr',
+                    sm: 'repeat(3, 1fr)',
+                  },
+                }}
+              >
+                <SummaryField label="Started">
+                  {formatAbsoluteTime(run.started_at)}
+                </SummaryField>
+                <SummaryField label={running ? 'Elapsed' : 'Duration'}>
+                  <span data-testid="run-detail-duration">
+                    {formatDuration(running ? elapsed : run.duration)}
+                  </span>
+                </SummaryField>
+                <SummaryField label="Finished">
+                  {formatAbsoluteTime(run.finished_at)}
+                </SummaryField>
+                {run.executed_by && (
+                  <SummaryField label="Executed by">
+                    {run.executed_by}
+                  </SummaryField>
+                )}
+              </Box>
+
+              {run.status === 'failed' && (
+                <Alert
+                  severity="error"
+                  sx={{ whiteSpace: 'pre-wrap' }}
+                  data-testid="run-detail-failure"
+                >
+                  <AlertTitle>This run failed</AlertTitle>
+                  {failureReason ??
+                    'The reason is not reported with the run. The log below is the only record of what went wrong.'}
+                </Alert>
+              )}
+
+              {nonFailureNote && (
+                <Alert severity="warning" data-testid="run-detail-note">
+                  {nonFailureNote}
+                </Alert>
+              )}
+
+              {showLog && logId !== null && logId !== undefined ? (
+                <TaskLogViewer
+                  taskHistoryId={logId}
+                  taskStatus={run.status}
+                  height={LOG_HEIGHT}
+                />
+              ) : (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  data-testid="run-detail-no-log"
+                >
+                  {NO_LOG_NOTES[run.log_capture] ?? NO_LOG_NOTES.unknown}
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Box>
+      </Stack>
+    </Drawer>
+  );
+}

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/index.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export { TaskRunDetailDrawer } from './TaskRunDetailDrawer';
+export type { TaskRunDetailDrawerProps } from './TaskRunDetailDrawer';
+export { LastRunCard } from './LastRunCard';
+export type { LastRunCardProps } from './LastRunCard';
+export { runFailureReason, firstLine } from './runFailureReason';
+export { resolveOpenedRun } from './resolveOpenedRun';

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/resolveOpenedRun.test.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/resolveOpenedRun.test.ts
@@ -1,0 +1,42 @@
+import type { TaskHistoryEntry } from '../../hooks';
+import { resolveOpenedRun } from './resolveOpenedRun';
+
+const row = (id: number | null, status: string) =>
+  ({ id, status }) as unknown as TaskHistoryEntry;
+
+describe('resolveOpenedRun', () => {
+  it('returns nothing when no run is open', () => {
+    expect(resolveOpenedRun(null, [row(1, 'success')])).toBeNull();
+  });
+
+  it('picks up a status change the clicked row predates', () => {
+    // The point of the helper: a run watched in the drawer has to reach its
+    // terminal status without the drawer being closed and reopened.
+    const opened = row(1, 'running');
+
+    const resolved = resolveOpenedRun(opened, [
+      row(2, 'success'),
+      row(1, 'failed'),
+    ]);
+
+    expect(resolved?.status).toBe('failed');
+  });
+
+  it('keeps the clicked row when it has paged out of the list', () => {
+    const opened = row(1, 'running');
+
+    expect(resolveOpenedRun(opened, [row(2, 'success')])).toBe(opened);
+  });
+
+  it('keeps the clicked row when there is no list yet', () => {
+    const opened = row(1, 'running');
+
+    expect(resolveOpenedRun(opened, undefined)).toBe(opened);
+  });
+
+  it('keeps a run with no id, which there is nothing to match on', () => {
+    const opened = row(null, 'running');
+
+    expect(resolveOpenedRun(opened, [row(1, 'failed')])).toBe(opened);
+  });
+});

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/resolveOpenedRun.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/resolveOpenedRun.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { TaskHistoryEntry } from '../../hooks/useTaskHistory';
+
+/**
+ * Re-read a clicked run out of the list it came from.
+ *
+ * {@link TaskRunDetailDrawer} renders an `entry` exactly as given, so a caller
+ * that holds the row it was clicked with shows a stale run: one still in flight
+ * when the drawer opened keeps counting elapsed time and never reaches its
+ * terminal status, because the row object never changes even though the query
+ * behind the table is polling.
+ *
+ * Pairing the clicked row with the live list fixes that without a second
+ * request — the table's own query is already refetching while anything runs.
+ *
+ * The clicked row is returned unchanged when it has no id to match on, and when
+ * it is no longer in `items` — a run that has paged out of the list should keep
+ * the drawer showing what it last knew rather than collapsing to an empty view.
+ */
+export function resolveOpenedRun(
+  opened: TaskHistoryEntry | null,
+  items: TaskHistoryEntry[] | undefined
+): TaskHistoryEntry | null {
+  if (!opened || opened.id === null || opened.id === undefined) {
+    return opened;
+  }
+
+  return items?.find((item) => item.id === opened.id) ?? opened;
+}

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.test.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.test.ts
@@ -1,0 +1,90 @@
+import type { TaskHistoryEntry } from '../../hooks';
+import { firstLine, runFailureReason } from './runFailureReason';
+
+const entry = (overrides: Record<string, unknown>) =>
+  overrides as unknown as TaskHistoryEntry;
+
+describe('runFailureReason', () => {
+  it('returns null for the payload the wire carries today', () => {
+    // TaskHistoryResponse has no error field until SEP-2000 lands, so every
+    // candidate is absent and the UI falls back to pointing at the log.
+    expect(
+      runFailureReason(
+        entry({
+          status: 'failed',
+          has_logs: true,
+          execution_request: { tracking: {} },
+        })
+      )
+    ).toBeNull();
+  });
+
+  it('returns null without a run', () => {
+    expect(runFailureReason(null)).toBeNull();
+    expect(runFailureReason(undefined)).toBeNull();
+  });
+
+  it('reads a reason off the row', () => {
+    expect(runFailureReason(entry({ error_message: 'disk full' }))).toBe(
+      'disk full'
+    );
+  });
+
+  it('reads a reason out of the tracking bag', () => {
+    // The untyped escape hatch the backend already uses for per-run
+    // bookkeeping, and the likely first home for a reason.
+    expect(
+      runFailureReason(
+        entry({
+          execution_request: { tracking: { failure_reason: 'timeout' } },
+        })
+      )
+    ).toBe('timeout');
+  });
+
+  it('prefers the row over the tracking bag', () => {
+    expect(
+      runFailureReason(
+        entry({
+          error: 'from row',
+          execution_request: { tracking: { error: 'from tracking' } },
+        })
+      )
+    ).toBe('from row');
+  });
+
+  it('prefers the most specific name when several are populated', () => {
+    expect(
+      runFailureReason(entry({ error: 'generic', error_message: 'specific' }))
+    ).toBe('specific');
+  });
+
+  it('ignores a blank reason', () => {
+    expect(runFailureReason(entry({ error_message: '   ' }))).toBeNull();
+    expect(runFailureReason(entry({ error_message: 42 }))).toBeNull();
+  });
+
+  it('tolerates a null tracking bag', () => {
+    expect(
+      runFailureReason(entry({ execution_request: { tracking: null } }))
+    ).toBeNull();
+    expect(runFailureReason(entry({}))).toBeNull();
+  });
+});
+
+describe('firstLine', () => {
+  it('keeps a single-line reason whole', () => {
+    expect(firstLine('disk full')).toBe('disk full');
+  });
+
+  it('takes only the first line of a traceback', () => {
+    expect(firstLine('disk full\n  at /var/backups\n  at main')).toBe(
+      'disk full'
+    );
+  });
+
+  it('returns null for an absent or empty-first-line reason', () => {
+    expect(firstLine(null)).toBeNull();
+    expect(firstLine('\nreason on the second line')).toBeNull();
+  });
+});

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { TaskHistoryEntry } from '../../hooks/useTaskHistory';
+
+/**
+ * Field names a failure reason may arrive under.
+ *
+ * `TaskHistoryResponse` carries no error field today — status, started_at,
+ * finished_at, duration, has_logs and log_capture, and nothing else. SEP-2000
+ * adds one; until it lands every candidate here is absent and
+ * {@link runFailureReason} returns null, which the UI renders as a pointer to
+ * the log rather than as an empty error.
+ *
+ * Several names are accepted rather than one so the frontend does not have to
+ * ship in lockstep with whichever name the side-car settles on. Order is
+ * preference: the most specific name wins if two are ever populated.
+ *
+ * TODO(SEP-2000): once the side-car has shipped a field, narrow this to that
+ * one name and drop the tracking fallback. This file is a bet on a shape
+ * nobody has committed to yet, and it lives in vendored code — leaving three
+ * guesses in place after the real name is known is how it ends up silently
+ * matching the wrong thing through a future sync.
+ */
+const FAILURE_REASON_KEYS = [
+  'error_message',
+  'failure_reason',
+  'error',
+] as const;
+
+function firstNonEmptyString(source: Record<string, unknown>): string | null {
+  for (const key of FAILURE_REASON_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The reason a run failed, or null when the wire does not carry one.
+ *
+ * Reads the history row first, then `execution_request.tracking` — an untyped
+ * escape hatch the backend already uses for per-run bookkeeping, and the likely
+ * home for a reason that arrives before the response schema gains a field.
+ */
+export function runFailureReason(
+  entry: TaskHistoryEntry | null | undefined
+): string | null {
+  if (!entry) {
+    return null;
+  }
+
+  const direct = firstNonEmptyString(
+    entry as unknown as Record<string, unknown>
+  );
+  if (direct !== null) {
+    return direct;
+  }
+
+  const tracking = entry.execution_request?.tracking;
+  if (tracking !== null && typeof tracking === 'object') {
+    return firstNonEmptyString(tracking as Record<string, unknown>);
+  }
+
+  return null;
+}
+
+/**
+ * The first line of a failure reason, for surfaces that show a summary.
+ *
+ * A reason is often a multi-line traceback or a wall of stderr. The Overview
+ * block shows one line and sends the reader to the log for the rest, so the
+ * card keeps its height whatever the backend sends.
+ */
+export function firstLine(reason: string | null): string | null {
+  if (reason === null) {
+    return null;
+  }
+
+  const [line] = reason.split('\n');
+
+  return line?.trim() ? line.trim() : null;
+}

--- a/ui/packages/sep/framework/src/hooks/index.ts
+++ b/ui/packages/sep/framework/src/hooks/index.ts
@@ -31,6 +31,7 @@ export type {
   ExecutionEventsState,
 } from './useExecutionEvents';
 
+export { useElapsedSeconds } from './useElapsedSeconds';
 export { useLogDownload } from './useLogDownload';
 export type { DownloadLog } from './useLogDownload';
 
@@ -57,6 +58,7 @@ export {
   useTaskHistory,
   useTaskHistoryByName,
   useTaskHistoryByNames,
+  useLatestTaskRun,
   useStopTaskHistory,
   useExecuteTask,
   isRunningStatus,
@@ -66,6 +68,8 @@ export type {
   TaskHistoryStatus,
   TaskHistoryEntry,
   PaginatedTaskHistory,
+  LatestTaskRun,
+  UseLatestTaskRunOptions,
   UseTaskHistoryOptions,
   TaskExecuteBody,
 } from './useTaskHistory';

--- a/ui/packages/sep/framework/src/hooks/useElapsedSeconds.test.tsx
+++ b/ui/packages/sep/framework/src/hooks/useElapsedSeconds.test.tsx
@@ -1,0 +1,85 @@
+import { act, render, screen } from '@testing-library/react';
+import { useElapsedSeconds } from './useElapsedSeconds';
+
+const START = '2026-09-07T10:00:00Z';
+
+const Probe = ({
+  startedAt,
+  isRunning,
+}: {
+  startedAt?: string | null;
+  isRunning: boolean;
+}) => {
+  const elapsed = useElapsedSeconds(startedAt, isRunning);
+  return (
+    <span data-testid="elapsed">{elapsed === null ? 'none' : elapsed}</span>
+  );
+};
+
+const elapsedText = () => screen.getByTestId('elapsed').textContent;
+
+describe('useElapsedSeconds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-07T10:00:30Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports the seconds since the start time on first render', () => {
+    render(<Probe startedAt={START} isRunning />);
+
+    expect(elapsedText()).toBe('30');
+  });
+
+  it('advances once a second while running', () => {
+    render(<Probe startedAt={START} isRunning />);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(elapsedText()).toBe('33');
+  });
+
+  it('stops ticking once the run is no longer running', () => {
+    const { rerender } = render(<Probe startedAt={START} isRunning />);
+
+    rerender(<Probe startedAt={START} isRunning={false} />);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // The last observed value stays put rather than being zeroed, so a caller
+    // swapping to the server's `duration` never flashes an empty cell.
+    expect(elapsedText()).toBe('30');
+  });
+
+  it('does not tick when it never started running', () => {
+    render(<Probe startedAt={START} isRunning={false} />);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(elapsedText()).toBe('30');
+  });
+
+  it('recomputes immediately when the start time changes', () => {
+    const { rerender } = render(<Probe startedAt={START} isRunning />);
+
+    rerender(<Probe startedAt="2026-09-07T10:00:20Z" isRunning />);
+
+    expect(elapsedText()).toBe('10');
+  });
+
+  it('returns null without a usable start time', () => {
+    render(<Probe startedAt={null} isRunning />);
+    expect(elapsedText()).toBe('none');
+
+    render(<Probe startedAt="not-a-date" isRunning />);
+    expect(screen.getAllByTestId('elapsed')[1]?.textContent).toBe('none');
+  });
+});

--- a/ui/packages/sep/framework/src/hooks/useElapsedSeconds.ts
+++ b/ui/packages/sep/framework/src/hooks/useElapsedSeconds.ts
@@ -34,7 +34,7 @@ function secondsSince(startedAt: string): number | null {
  * The wire carries no duration for a run in flight — `TaskHistoryResponse.
  * duration` is server-computed from `finished_at` and stays null until the run
  * ends — so an in-flight elapsed time has to be derived here. Nothing else in
- * the framework tickes, so this is the only place a clock runs.
+ * the framework ticks, so this is the only place a clock runs.
  *
  * The ticker is torn down as soon as `isRunning` goes false, and the final
  * value is left in place rather than zeroed: a caller that swaps to the

--- a/ui/packages/sep/framework/src/hooks/useElapsedSeconds.ts
+++ b/ui/packages/sep/framework/src/hooks/useElapsedSeconds.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+
+const TICK_INTERVAL_MS = 1000;
+
+function secondsSince(startedAt: string): number | null {
+  const started = new Date(startedAt).getTime();
+  if (Number.isNaN(started)) {
+    return null;
+  }
+  return (Date.now() - started) / 1000;
+}
+
+/**
+ * Seconds elapsed since `startedAt`, re-rendering once a second while
+ * `isRunning`.
+ *
+ * The wire carries no duration for a run in flight — `TaskHistoryResponse.
+ * duration` is server-computed from `finished_at` and stays null until the run
+ * ends — so an in-flight elapsed time has to be derived here. Nothing else in
+ * the framework tickes, so this is the only place a clock runs.
+ *
+ * The ticker is torn down as soon as `isRunning` goes false, and the final
+ * value is left in place rather than zeroed: a caller that swaps to the
+ * server's `duration` on the same render never flashes an empty cell, and one
+ * that does not keeps showing the last elapsed time it observed.
+ *
+ * Returns null when there is no usable start time, which the caller should
+ * render the same way it renders an absent duration.
+ */
+export function useElapsedSeconds(
+  startedAt: string | null | undefined,
+  isRunning: boolean
+): number | null {
+  const [elapsed, setElapsed] = useState<number | null>(() =>
+    startedAt ? secondsSince(startedAt) : null
+  );
+
+  useEffect(() => {
+    if (!startedAt) {
+      setElapsed(null);
+      return;
+    }
+
+    // Recompute on every dependency change, not only on tick: a run that
+    // finishes between ticks, or a drawer reopened on a different run, must
+    // show the right number immediately rather than up to a second late.
+    setElapsed(secondsSince(startedAt));
+
+    if (!isRunning) {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setElapsed(secondsSince(startedAt));
+    }, TICK_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, [startedAt, isRunning]);
+
+  return elapsed;
+}

--- a/ui/packages/sep/framework/src/hooks/useTaskHistory.ts
+++ b/ui/packages/sep/framework/src/hooks/useTaskHistory.ts
@@ -15,6 +15,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+import { useMemo } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   apiClient,
@@ -96,7 +97,12 @@ function refetchIntervalFor(
   if (!data) {
     return false;
   }
-  const hasRunning = data.items.some((entry) => isRunningStatus(entry.status));
+  // `items` is optional in practice: an error or a truncated payload can
+  // resolve the query with a body that has no list, and this callback runs on
+  // every settle — throwing here takes down the tree that owns the query.
+  const hasRunning = (data.items ?? []).some((entry) =>
+    isRunningStatus(entry.status)
+  );
   return hasRunning ? pollingMs : false;
 }
 
@@ -198,6 +204,144 @@ export function useTaskHistoryByNames(
     refetchInterval: (query) =>
       refetchIntervalFor(query.state.data, pollingIntervalMs, disablePolling),
   });
+}
+
+/**
+ * How many history rows the latest-run lookup asks for.
+ *
+ * ``GET /api/sep/task-history/`` returns rows newest-first, so the newest run
+ * is in the first page; a handful rather than one is requested only so
+ * {@link newestRun} has something to disambiguate when several rows share a
+ * start time.
+ */
+const LATEST_RUN_PAGE_SIZE = 5;
+
+/**
+ * Page size when a specific run is being looked for by timestamp.
+ *
+ * Wider than the newest-run lookup because the run in question may not be the
+ * newest: a schedule's 02:00 backup can sit behind any number of manual runs
+ * by the time someone opens it.
+ */
+const DATED_RUN_PAGE_SIZE = 20;
+
+export interface UseLatestTaskRunOptions extends UseTaskHistoryOptions {
+  /**
+   * Pick the run that started at this time rather than the newest one.
+   *
+   * The schedules table knows when its own last run happened but not which
+   * history row that was — the periodic-task API reports `last_run_at` and no
+   * `task_history_id`. Without this the cell would resolve by name alone and
+   * open whichever run is newest, which for a task that also runs manually is
+   * routinely a different run than the one the row is describing.
+   */
+  at?: string | null;
+}
+
+export interface LatestTaskRun {
+  /** The newest run, or null while loading and for a task that never ran. */
+  entry: TaskHistoryEntry | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+function runOrderKey(entry: TaskHistoryEntry): number {
+  const stamp = entry.started_at ?? entry.created_at;
+  const parsed = stamp ? new Date(stamp).getTime() : Number.NaN;
+
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * The newest of a page of history rows.
+ *
+ * Sorted here rather than trusted from the response: a run queued but not yet
+ * started has no `started_at`, so ordering falls back to `created_at`, and ties
+ * (two runs in the same second, which a chained task produces) break on the
+ * higher id so the choice is at least stable across refetches.
+ */
+function newestRun(
+  items: TaskHistoryEntry[] | undefined
+): TaskHistoryEntry | null {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return items.reduce((newest, candidate) => {
+    const delta = runOrderKey(candidate) - runOrderKey(newest);
+    if (delta !== 0) {
+      return delta > 0 ? candidate : newest;
+    }
+
+    return (candidate.id ?? 0) > (newest.id ?? 0) ? candidate : newest;
+  });
+}
+
+/**
+ * The run of a page that started closest to `target`.
+ *
+ * Closest rather than exactly-equal: `last_run_at` is the scheduler's record of
+ * when it fired, which is near but not necessarily identical to the history
+ * row's `started_at`. Returns null for an empty page, and the closest match is
+ * still shown with its own timestamp in the detail, so a reader can see which
+ * run they are looking at.
+ */
+function runNearest(
+  items: TaskHistoryEntry[] | undefined,
+  target: string
+): TaskHistoryEntry | null {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  const want = new Date(target).getTime();
+  if (Number.isNaN(want)) {
+    return newestRun(items);
+  }
+
+  return items.reduce((closest, candidate) =>
+    Math.abs(runOrderKey(candidate) - want) <
+    Math.abs(runOrderKey(closest) - want)
+      ? candidate
+      : closest
+  );
+}
+
+/**
+ * The most recent run for a task, by name.
+ *
+ * The surfaces that need to open a run — the list status chip, the detail
+ * Overview and the schedules "Last Run" cell — hold a task name and no
+ * `task_history_id`; the periodic-task API's `last_run_status` carries no id
+ * either. This resolves one from the name so those surfaces can reach the same
+ * execution detail the history table opens directly.
+ *
+ * Inherits the poll-while-running behaviour of {@link useTaskHistoryByNames},
+ * so a block built on this follows a run to its terminal status without a
+ * reload. Pass `enabled: false` to hold the request back until the surface is
+ * actually shown.
+ */
+export function useLatestTaskRun(
+  taskNames: string | string[] | undefined,
+  options: UseLatestTaskRunOptions = {}
+): LatestTaskRun {
+  const { at, ...queryOptions } = options;
+  const names = typeof taskNames === 'string' ? [taskNames] : taskNames;
+  const query = useTaskHistoryByNames(names, {
+    limit: at ? DATED_RUN_PAGE_SIZE : LATEST_RUN_PAGE_SIZE,
+    ...queryOptions,
+  });
+  const entry = useMemo(
+    () =>
+      at ? runNearest(query.data?.items, at) : newestRun(query.data?.items),
+    [query.data, at]
+  );
+
+  return {
+    entry,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
 }
 
 /**

--- a/ui/packages/sep/framework/src/index.ts
+++ b/ui/packages/sep/framework/src/index.ts
@@ -103,6 +103,16 @@ export type {
   PaginatedTaskHistory,
   TaskFilesDialogProps,
 } from './components/TaskHistoryTable';
+export {
+  TaskRunDetailDrawer,
+  LastRunCard,
+  runFailureReason,
+} from './components/TaskRunDetailDrawer';
+export type {
+  TaskRunDetailDrawerProps,
+  LastRunCardProps,
+} from './components/TaskRunDetailDrawer';
+export { formatDuration } from './utils/formatDuration';
 export { SnippetExecutionAccordion } from './components/SnippetExecutionAccordion';
 export type { SnippetExecutionAccordionProps } from './components/SnippetExecutionAccordion';
 export { ChainBuilder } from './components/ChainBuilder';

--- a/ui/packages/sep/framework/src/utils/formatDuration.test.ts
+++ b/ui/packages/sep/framework/src/utils/formatDuration.test.ts
@@ -14,6 +14,18 @@ describe('formatDuration', () => {
     expect(formatDuration(59.9)).toBe('59.9s');
   });
 
+  it('rounds up into the minutes bucket at the boundary', () => {
+    // 59.95 renders as '60.0s' at one decimal, which is a minute — reporting
+    // it in the sub-minute bucket would show a duration the bucket excludes.
+    expect(formatDuration(59.95)).toBe('1m 0s');
+    expect(formatDuration(59.94)).toBe('59.9s');
+  });
+
+  it('rounds up into the hours bucket at the boundary', () => {
+    expect(formatDuration(3599.6)).toBe('1h 0m');
+    expect(formatDuration(3599.4)).toBe('59m 59s');
+  });
+
   it('drops the decimal from a minute up', () => {
     expect(formatDuration(60)).toBe('1m 0s');
     expect(formatDuration(127.4)).toBe('2m 7s');

--- a/ui/packages/sep/framework/src/utils/formatDuration.test.ts
+++ b/ui/packages/sep/framework/src/utils/formatDuration.test.ts
@@ -1,0 +1,34 @@
+import { formatDuration } from './formatDuration';
+
+describe('formatDuration', () => {
+  it('renders an absent duration as an em-dash', () => {
+    // The wire leaves `duration` null until a run finishes.
+    expect(formatDuration(null)).toBe('—');
+    expect(formatDuration(undefined)).toBe('—');
+    expect(formatDuration(Number.NaN)).toBe('—');
+  });
+
+  it('keeps a decimal below a minute', () => {
+    expect(formatDuration(0)).toBe('0.0s');
+    expect(formatDuration(2.44)).toBe('2.4s');
+    expect(formatDuration(59.9)).toBe('59.9s');
+  });
+
+  it('drops the decimal from a minute up', () => {
+    expect(formatDuration(60)).toBe('1m 0s');
+    expect(formatDuration(127.4)).toBe('2m 7s');
+    expect(formatDuration(3599)).toBe('59m 59s');
+  });
+
+  it('buckets an hour or more into hours and minutes', () => {
+    expect(formatDuration(3600)).toBe('1h 0m');
+    expect(formatDuration(6420)).toBe('1h 47m');
+    // The unbucketed minutes format this replaces read '120m 0s' here.
+    expect(formatDuration(7200)).toBe('2h 0m');
+  });
+
+  it('clamps a negative duration to zero', () => {
+    // A client clock behind the server's can subtract past a run's start.
+    expect(formatDuration(-4)).toBe('0.0s');
+  });
+});

--- a/ui/packages/sep/framework/src/utils/formatDuration.ts
+++ b/ui/packages/sep/framework/src/utils/formatDuration.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 3600;
+
+/**
+ * Format a duration in seconds for display next to a task run.
+ *
+ * Buckets are chosen so the number stays readable at every scale a backup
+ * reaches: sub-minute runs keep a decimal (a 2.4s check reads as work, `2s`
+ * reads as a rounding artefact), minutes drop it, and anything past an hour
+ * drops seconds entirely — `1h 47m` rather than the `107m 12s` an unbucketed
+ * minutes format would print for the same run.
+ *
+ * Absent input renders as an em-dash: the wire leaves `duration` null for a
+ * run that has not finished, and a `0s` there would read as an instant run
+ * rather than a missing value.
+ *
+ * A negative input is clamped to zero. `started_at` comes from the server and
+ * `Date.now()` from the browser, so a client whose clock runs behind can
+ * subtract its way past the start of a run that is genuinely under way.
+ */
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || Number.isNaN(seconds)) {
+    return '—';
+  }
+
+  const safe = Math.max(0, seconds);
+
+  if (safe < SECONDS_PER_MINUTE) {
+    return `${safe.toFixed(1)}s`;
+  }
+
+  const total = Math.round(safe);
+
+  if (total < SECONDS_PER_HOUR) {
+    return `${Math.floor(total / SECONDS_PER_MINUTE)}m ${total % SECONDS_PER_MINUTE}s`;
+  }
+
+  const hours = Math.floor(total / SECONDS_PER_HOUR);
+  const minutes = Math.floor((total % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+
+  return `${hours}h ${minutes}m`;
+}

--- a/ui/packages/sep/framework/src/utils/formatDuration.ts
+++ b/ui/packages/sep/framework/src/utils/formatDuration.ts
@@ -41,12 +41,16 @@ export function formatDuration(seconds: number | null | undefined): string {
   }
 
   const safe = Math.max(0, seconds);
+  // Bucket on the value as it will be rendered, not the raw one: 59.95s
+  // renders as `60.0s`, which belongs in the minutes bucket as `1m 0s` rather
+  // than being shown as a minute's worth of seconds.
+  const rounded = Math.round(safe * 10) / 10;
 
-  if (safe < SECONDS_PER_MINUTE) {
-    return `${safe.toFixed(1)}s`;
+  if (rounded < SECONDS_PER_MINUTE) {
+    return `${rounded.toFixed(1)}s`;
   }
 
-  const total = Math.round(safe);
+  const total = Math.round(rounded);
 
   if (total < SECONDS_PER_HOUR) {
     return `${Math.floor(total / SECONDS_PER_MINUTE)}m ${total % SECONDS_PER_MINUTE}s`;


### PR DESCRIPTION
Stacked on `PMM-15205-sep-fb`. Base will need retargeting to `main` once that lands.

## Problem

After a backup ran, the UI showed a status chip and nothing else. While it ran there was no elapsed time and no log. On failure the only message was a banner riding router state — gone after a reload — with a "View log" link rendered as low-contrast body text on the warning Alert's ground. Once it was gone the Overview held no error text at all, and the Execution History row and the Schedules "Last Run" cell were dead ends.

A DBA whose nightly backup failed had no way inside PMM to learn why, and no way to confirm a backup marked "Done" produced anything usable.

From Pedro Fernandes' UX pass over the MySQL Backups Tech Preview, finding **P1** on PMM-15380, under the PMM-15217 umbrella.

## What

`TaskRunDetailDrawer` — one execution detail behind every entry point, carrying status, timing, the failure reason and the log. It resolves a run three ways: a row handed in, the newest run for a task name, or a bare `task_history_id` (log only) for the post-create connectivity check, which reports an id and nothing else. It replaces the two log `Dialog`s `PluginDetailPage` owned.

All four entry points from the ticket:

| Entry point | Before | Now |
|---|---|---|
| List status chip | Inert (row click navigated to the task) | Opens that task's last run |
| Detail Overview | Said nothing about any run | New persistent `LastRunCard` — status, started, duration, first line of the reason, "View log" |
| Execution History row | Row inert; icon worked but was disabled for log-less runs | Whole row opens the run; icon always enabled |
| Schedules "Last Run" | Inert | Opens that schedule's run |

Three of those hold a task name and no run id — the periodic-task API's `last_run_status` carries no `task_history_id` — so `useLatestTaskRun` resolves one, on click rather than per row. The schedules cell also passes its own `last_run_at`: a task that runs manually as well as on a schedule would otherwise open a newer, unrelated run.

## Acceptance criteria

- [x] Each of the four entry points opens the execution detail for that run in one click.
- [x] The Execution History row's view control opens that same view — and so does the rest of the row.
- [x] A running backup shows elapsed time and streams its log without a reload. `duration` is null on the wire until a run finishes, so the elapsed time is derived from `started_at` by a new `useElapsedSeconds`.
- [x] A failed run renders at error severity. The statuses that are *not* script failures — `unlaunchable` above all — say so instead of being dressed as one.
- [ ] **Blocked on SEP-2000:** a failed run showing its reason without opening the log. `TaskHistoryResponse` carries no error field today (verified against `ui/packages/sep/api/src/generated/tasks.ts`: `status`, `started_at`, `finished_at`, `duration`, `has_logs`, `log_capture`, and no reason). `runFailureReason` is the seam it lands on and returns null until then, so a failed run points at its log rather than showing an empty error. It is marked `TODO(SEP-2000)` to be narrowed to the real field name once that ships. The card is *fetched* rather than handed router state, so the text will survive a reload the moment the wire carries it.

## Defects fixed along the way

Each one this change would otherwise have inherited:

- The view control was disabled for a run with no log — exactly the run whose `log_capture` says whether output was produced or lost. `log_capture` had no consumer at all before this.
- `TaskLogViewer`'s local running check matched only `'running'`, so a `pending` run — the seconds between launch and first output — took the one-shot REST path and never streamed. It now probes the canonical `RUNNING_STATUSES`, keeping the pre-existing case fold.
- `formatDuration` gains an hours bucket; the private copy it replaces printed `120m 0s` for a two-hour backup.
- `refetchIntervalFor` threw on a payload with no `items`, taking down the tree that owned the query.

## Notes

- This is **vendored** code (`ui/packages/sep/`), so the diff is PMM-side divergence and wants upstreaming to `percona/percona-sep` or it returns at the next sync.
- The list chip is wired for single-task plugins only: on a multi-entity list a row is an entity and `name` is not a task name, so there is no run to resolve from it. The chip is left as it was there.
- `useLatestTaskRun` trusts the documented newest-first ordering of `GET /api/sep/task-history/` and sorts defensively within the page it fetches. There is no fetch-one-run-by-id endpoint; if one is added, the name lookups should move to it.
- First right-anchored `Drawer` in this repo — every existing per-run overlay is a `Dialog`. Announced as a labelled dialog.

## Test plan

805 framework tests (up from 759), covering: each resolution mode and its precedence; the dated lookup picking the schedule's run over a newer one; elapsed time ticking and stopping; failure at error severity with and without a reason on the wire; the `log_capture` explanations; a run reaching its terminal status while the drawer is open; and every click-bubbling path — the chip not navigating, and the stop, download and chain controls not opening the run.

Verified:

- `cd ui && make test` — framework 805, atw 122, api 106, pmm app 482; all green
- `npx tsc --noEmit` clean in `ui/packages/sep/framework` and `ui/apps/pmm`
- `cd ui && make lint` — 0 errors
- `cd ui && make format-check` — clean
- Each new guard checked by removing it and confirming the tests fail

Reviewed for correctness and design before opening; the findings on click-bubbling, the stale run snapshot and the schedule's discarded timestamp are all fixed above with tests.