### PR TITLE
PMM-T9994 Pass TLS client cert flags to valkey_exporter

### DIFF
--- a/managed/services/agents/valkey.go
+++ b/managed/services/agents/valkey.go
@@ -45,6 +45,28 @@ func valkeyExporterConfig(node *models.Node, service *models.Service, exporter *
 
 	args = append(args, "--redis.addr="+exporter.DSN(service, dsnParams, nil, pmmAgentVersion))
 	args = append(args, "--connection-timeout="+connectionTimeout.String())
+
+	// The rediss:// scheme alone is not enough: valkey_exporter only takes its TLS
+	// dial path when the client-certificate flags are also present, otherwise it
+	// treats the scheme as a network and fails with "unknown network rediss".
+	if exporter.TLS {
+		for k := range exporter.Files() {
+			switch k {
+			case "tlsCa":
+				args = append(args, "--tls-ca-cert-file="+tdp.Left+" .TextFiles.tlsCa "+tdp.Right)
+			case "tlsCert":
+				args = append(args, "--tls-client-cert-file="+tdp.Left+" .TextFiles.tlsCert "+tdp.Right)
+			case "tlsKey":
+				args = append(args, "--tls-client-key-file="+tdp.Left+" .TextFiles.tlsKey "+tdp.Right)
+			default:
+				continue
+			}
+		}
+		if exporter.TLSSkipVerify {
+			args = append(args, "--skip-tls-verification")
+		}
+	}
+
 	// valkey_exporter parses flags with the stdlib flag package, which rejects --log.level
 	// and has no fatal level (PMM-15201).
 	args = withLogLevelFlag(args, "--log-level", exporter.LogLevel, pmmAgentVersion, false)

--- a/managed/services/agents/valkey_test.go
+++ b/managed/services/agents/valkey_test.go
@@ -78,6 +78,33 @@ func TestValkeyExporterConfig(t *testing.T) {
 		require.Contains(t, actual.Args, "--redis.addr=redis://username:secret@1.2.3.4:6379")
 	})
 
+	t.Run("TLS", func(t *testing.T) {
+		t.Parallel()
+		exporter := &models.Agent{
+			AgentID:       "agent-id",
+			AgentType:     models.ValkeyExporterType,
+			Username:      new("username"),
+			Password:      new("secret"),
+			TLS:           true,
+			TLSSkipVerify: true,
+		}
+		exporter.ValkeyOptions.SSLCa = "ca-cert"
+		exporter.ValkeyOptions.SSLCert = "client-cert"
+		exporter.ValkeyOptions.SSLKey = "client-key"
+
+		actual := valkeyExporterConfig(node, service, exporter, redactSecrets, pmmAgentVersion)
+		require.Contains(t, actual.Args, "--redis.addr=rediss://username:secret@1.2.3.4:6379")
+		require.Contains(t, actual.Args, "--tls-ca-cert-file={{ .TextFiles.tlsCa }}")
+		require.Contains(t, actual.Args, "--tls-client-cert-file={{ .TextFiles.tlsCert }}")
+		require.Contains(t, actual.Args, "--tls-client-key-file={{ .TextFiles.tlsKey }}")
+		require.Contains(t, actual.Args, "--skip-tls-verification")
+		require.Equal(t, map[string]string{
+			"tlsCa":   "ca-cert",
+			"tlsCert": "client-cert",
+			"tlsKey":  "client-key",
+		}, actual.TextFiles)
+	})
+
 	// PMM-15201: valkey_exporter only knows --log-level. Passing --log.level made it print
 	// its usage, exit with code 2 and land the agent in the DONE state.
 	t.Run("LogLevel", func(t *testing.T) {


### PR DESCRIPTION
Ticket number: PMM-T9994

Feature build: SUBMODULES-0

## What / why

Valkey TLS monitoring never actually connected. When TLS is enabled, `Agent.DSN` builds a `rediss://` address for the exporter, but `valkeyExporterConfig` never passed the exporter's TLS client-certificate flags. Without them the bundled `valkey_exporter` does not take its TLS dial path and dies with:

```
redis_exporter_last_scrape_error{err="dial rediss: unknown network rediss"} 1
redis_up 0
```

so the service stays `Down` over TLS.

Verified directly against the exporter binary on a live box:

| `--redis.addr` | TLS client-cert flags | `redis_up` |
|---|---|---|
| `rediss://…` | none (current behaviour) | **0** — `dial rediss: unknown network rediss` |
| `redis://…` | present | **0** — `dial redis: unknown network redis` |
| `rediss://…` | present | **1** ✅ |

The scheme and the flags are both required.

## Change

`managed/services/agents/valkey.go`: when `exporter.TLS` is set, append `--tls-ca-cert-file` / `--tls-client-cert-file` / `--tls-client-key-file` (from the exporter's text files) and `--skip-tls-verification` when TLS skip-verification is enabled — mirroring the existing `mysql_exporter` handling. Added a `TLS` subtest to `valkey_test.go`.

## Testing

- `go test ./managed/services/agents/ -run TestValkeyExporterConfig` — pass; `go vet` clean; `gofmt` clean.
- End-to-end on a live PMM Server + Valkey native cluster (patched `pmm-managed` hot-swapped in): the pmm-qa e2e test **PMM-T9994 – Verify Change agent tls** goes `Down` (TLS-only, exporter not yet configured) then back `Up` after `pmm-admin inventory change agent valkey-exporter … --tls …`. **1 passed.**

## Related work

- pmm-qa test fix (CA cert path + readability): https://github.com/percona/pmm-qa/pull/1361

> Note: `PMM-T9994` is the e2e test id used to track this work; please retitle to the real Jira `PMM-XXXX` key before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLycPTYMgrZfdc3ifb8nXe