### PR TITLE
PMM-15478 Report SEP enablement in server settings

### DIFF
--- a/api/server/v1/json/client/server_service/change_settings_responses.go
+++ b/api/server/v1/json/client/server_service/change_settings_responses.go
@@ -983,6 +983,10 @@ type ChangeSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if the SEP integration is enabled. Read-only: it reports how this PMM
+	// Server process was started, and cannot be changed through ChangeSettings.
+	SepEnabled bool `json:"sep_enabled,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *ChangeSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_read_only_settings_responses.go
@@ -707,6 +707,9 @@ type GetReadOnlySettingsOKBodySettings struct {
 
 	// True if Access Control is enabled.
 	EnableAccessControl bool `json:"enable_access_control,omitempty"`
+
+	// True if the SEP integration is enabled.
+	SepEnabled bool `json:"sep_enabled,omitempty"`
 }
 
 // Validate validates this get read only settings OK body settings

--- a/api/server/v1/json/client/server_service/get_settings_responses.go
+++ b/api/server/v1/json/client/server_service/get_settings_responses.go
@@ -732,6 +732,10 @@ type GetSettingsOKBodySettings struct {
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQAN bool `json:"enable_internal_pg_qan,omitempty"`
 
+	// True if the SEP integration is enabled. Read-only: it reports how this PMM
+	// Server process was started, and cannot be changed through ChangeSettings.
+	SepEnabled bool `json:"sep_enabled,omitempty"`
+
 	// advisor run intervals
 	AdvisorRunIntervals *GetSettingsOKBodySettingsAdvisorRunIntervals `json:"advisor_run_intervals,omitempty"`
 

--- a/api/server/v1/json/v1.json
+++ b/api/server/v1/json/v1.json
@@ -311,6 +311,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -629,6 +634,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -729,6 +739,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/server/v1/server.pb.go
+++ b/api/server/v1/server.pb.go
@@ -1013,8 +1013,11 @@ type Settings struct {
 	DefaultRoleId uint32 `protobuf:"varint,18,opt,name=default_role_id,json=defaultRoleId,proto3" json:"default_role_id,omitempty"`
 	// True if Query Analytics for PMM's internal PG database is enabled.
 	EnableInternalPgQan bool `protobuf:"varint,19,opt,name=enable_internal_pg_qan,json=enableInternalPgQan,proto3" json:"enable_internal_pg_qan,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if the SEP integration is enabled. Read-only: it reports how this PMM
+	// Server process was started, and cannot be changed through ChangeSettings.
+	SepEnabled    bool `protobuf:"varint,21,opt,name=sep_enabled,json=sepEnabled,proto3" json:"sep_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Settings) Reset() {
@@ -1175,6 +1178,13 @@ func (x *Settings) GetEnableInternalPgQan() bool {
 	return false
 }
 
+func (x *Settings) GetSepEnabled() bool {
+	if x != nil {
+		return x.SepEnabled
+	}
+	return false
+}
+
 // ReadOnlySettings represents a stripped-down version of PMM Server settings that can be accessed by users of all roles.
 type ReadOnlySettings struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1194,8 +1204,10 @@ type ReadOnlySettings struct {
 	AzurediscoverEnabled bool `protobuf:"varint,7,opt,name=azurediscover_enabled,json=azurediscoverEnabled,proto3" json:"azurediscover_enabled,omitempty"`
 	// True if Access Control is enabled.
 	EnableAccessControl bool `protobuf:"varint,8,opt,name=enable_access_control,json=enableAccessControl,proto3" json:"enable_access_control,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// True if the SEP integration is enabled.
+	SepEnabled    bool `protobuf:"varint,9,opt,name=sep_enabled,json=sepEnabled,proto3" json:"sep_enabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ReadOnlySettings) Reset() {
@@ -1280,6 +1292,13 @@ func (x *ReadOnlySettings) GetAzurediscoverEnabled() bool {
 func (x *ReadOnlySettings) GetEnableAccessControl() bool {
 	if x != nil {
 		return x.EnableAccessControl
+	}
+	return false
+}
+
+func (x *ReadOnlySettings) GetSepEnabled() bool {
+	if x != nil {
+		return x.SepEnabled
 	}
 	return false
 }
@@ -1703,7 +1722,7 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13AdvisorRunIntervals\x12F\n" +
 	"\x11standard_interval\x18\x01 \x01(\v2\x19.google.protobuf.DurationR\x10standardInterval\x12>\n" +
 	"\rrare_interval\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\frareInterval\x12F\n" +
-	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xbc\a\n" +
+	"\x11frequent_interval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x10frequentInterval\"\xdd\a\n" +
 	"\bSettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12N\n" +
@@ -1723,7 +1742,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x13telemetry_summaries\x18\x10 \x03(\tR\x12telemetrySummaries\x122\n" +
 	"\x15enable_access_control\x18\x11 \x01(\bR\x13enableAccessControl\x12&\n" +
 	"\x0fdefault_role_id\x18\x12 \x01(\rR\rdefaultRoleId\x123\n" +
-	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQanJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\x8f\x03\n" +
+	"\x16enable_internal_pg_qan\x18\x13 \x01(\bR\x13enableInternalPgQan\x12\x1f\n" +
+	"\vsep_enabled\x18\x15 \x01(\bR\n" +
+	"sepEnabledJ\x04\b\x14\x10\x15R\x16update_snooze_duration\"\xb0\x03\n" +
 	"\x10ReadOnlySettings\x12'\n" +
 	"\x0fupdates_enabled\x18\x01 \x01(\bR\x0eupdatesEnabled\x12+\n" +
 	"\x11telemetry_enabled\x18\x02 \x01(\bR\x10telemetryEnabled\x12'\n" +
@@ -1732,7 +1753,9 @@ const file_server_v1_server_proto_rawDesc = "" +
 	"\x12pmm_public_address\x18\x05 \x01(\tR\x10pmmPublicAddress\x12:\n" +
 	"\x19backup_management_enabled\x18\x06 \x01(\bR\x17backupManagementEnabled\x123\n" +
 	"\x15azurediscover_enabled\x18\a \x01(\bR\x14azurediscoverEnabled\x122\n" +
-	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\"\x14\n" +
+	"\x15enable_access_control\x18\b \x01(\bR\x13enableAccessControl\x12\x1f\n" +
+	"\vsep_enabled\x18\t \x01(\bR\n" +
+	"sepEnabled\"\x14\n" +
 	"\x12GetSettingsRequest\"\x1c\n" +
 	"\x1aGetReadOnlySettingsRequest\"F\n" +
 	"\x13GetSettingsResponse\x12/\n" +

--- a/api/server/v1/server.pb.validate.go
+++ b/api/server/v1/server.pb.validate.go
@@ -2283,6 +2283,8 @@ func (m *Settings) validate(all bool) error {
 
 	// no validation rules for EnableInternalPgQan
 
+	// no validation rules for SepEnabled
+
 	if len(errors) > 0 {
 		return SettingsMultiError(errors)
 	}
@@ -2398,6 +2400,8 @@ func (m *ReadOnlySettings) validate(all bool) error {
 	// no validation rules for AzurediscoverEnabled
 
 	// no validation rules for EnableAccessControl
+
+	// no validation rules for SepEnabled
 
 	if len(errors) > 0 {
 		return ReadOnlySettingsMultiError(errors)

--- a/api/server/v1/server.proto
+++ b/api/server/v1/server.proto
@@ -173,6 +173,9 @@ message Settings {
   uint32 default_role_id = 18;
   // True if Query Analytics for PMM's internal PG database is enabled.
   bool enable_internal_pg_qan = 19;
+  // True if the SEP integration is enabled. Read-only: it reports how this PMM
+  // Server process was started, and cannot be changed through ChangeSettings.
+  bool sep_enabled = 21;
   // Field 20 (update_snooze_duration) was removed when GUI-triggered upgrades were deprecated.
   reserved 20;
   reserved "update_snooze_duration";
@@ -196,6 +199,8 @@ message ReadOnlySettings {
   bool azurediscover_enabled = 7;
   // True if Access Control is enabled.
   bool enable_access_control = 8;
+  // True if the SEP integration is enabled.
+  bool sep_enabled = 9;
 }
 
 message GetSettingsRequest {}

--- a/api/swagger/swagger-dev.json
+++ b/api/swagger/swagger-dev.json
@@ -32442,6 +32442,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -32760,6 +32765,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -32860,6 +32870,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -31469,6 +31469,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -31787,6 +31792,11 @@
                       "description": "True if Query Analytics for PMM's internal PG database is enabled.",
                       "type": "boolean",
                       "x-order": 17
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled. Read-only: it reports how this PMM\nServer process was started, and cannot be changed through ChangeSettings.",
+                      "type": "boolean",
+                      "x-order": 18
                     }
                   },
                   "x-order": 0
@@ -31887,6 +31897,11 @@
                       "description": "True if Access Control is enabled.",
                       "type": "boolean",
                       "x-order": 7
+                    },
+                    "sep_enabled": {
+                      "description": "True if the SEP integration is enabled.",
+                      "type": "boolean",
+                      "x-order": 8
                     }
                   },
                   "x-order": 0

--- a/managed/services/server/server.go
+++ b/managed/services/server/server.go
@@ -41,6 +41,7 @@ import (
 	serverv1 "github.com/percona/pmm/api/server/v1"
 	"github.com/percona/pmm/managed/models"
 	"github.com/percona/pmm/managed/utils/distribution"
+	pkgenv "github.com/percona/pmm/managed/utils/env"
 	"github.com/percona/pmm/managed/utils/envvars"
 	"github.com/percona/pmm/version"
 )
@@ -376,6 +377,8 @@ func (s *Server) convertSettings(settings *models.Settings, disableInternalPgQan
 
 		EnableAccessControl: settings.IsAccessControlEnabled(),
 		DefaultRoleId:       convertDefaultRoleID(settings.DefaultRoleID),
+
+		SepEnabled: pkgenv.SEPEnabled(),
 	}
 
 	return res
@@ -400,6 +403,7 @@ func (s *Server) convertReadOnlySettings(settings *models.Settings) *serverv1.Re
 		BackupManagementEnabled: settings.IsBackupManagementEnabled(),
 		AzurediscoverEnabled:    settings.IsAzureDiscoverEnabled(),
 		EnableAccessControl:     settings.IsAccessControlEnabled(),
+		SepEnabled:              pkgenv.SEPEnabled(),
 	}
 
 	return res

--- a/managed/services/server/server_test.go
+++ b/managed/services/server/server_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 
 	serverv1 "github.com/percona/pmm/api/server/v1"
 	"github.com/percona/pmm/managed/models"
+	pkgenv "github.com/percona/pmm/managed/utils/env"
 	"github.com/percona/pmm/managed/utils/testdb"
 	"github.com/percona/pmm/managed/utils/tests"
 )
@@ -360,5 +362,22 @@ func TestUpdateStatus(t *testing.T) {
 		assert.True(t, res.Done, "an unverifiable auth token must still be accepted")
 		assert.Empty(t, res.LogLines, "the progress log is no longer served") //nolint:staticcheck
 		assert.Zero(t, res.LogOffset)                                         //nolint:staticcheck
+	})
+}
+
+func TestConvertReadOnlySettings(t *testing.T) {
+	s := &Server{}
+
+	t.Run("reports SEP as enabled when the process was started with it", func(t *testing.T) {
+		t.Setenv(pkgenv.EnableSEP, "1")
+
+		assert.True(t, s.convertReadOnlySettings(&models.Settings{}).SepEnabled)
+	})
+
+	t.Run("reports SEP as disabled when the variable is absent", func(t *testing.T) {
+		t.Setenv(pkgenv.EnableSEP, "")
+		os.Unsetenv(pkgenv.EnableSEP)
+
+		assert.False(t, s.convertReadOnlySettings(&models.Settings{}).SepEnabled)
 	})
 }

--- a/managed/utils/env/env.go
+++ b/managed/utils/env/env.go
@@ -41,6 +41,9 @@ const (
 	// EnableInternalPgQAN is used to enable Query Analytics for PMM's internal PostgreSQL.
 	EnableInternalPgQAN = "PMM_ENABLE_INTERNAL_PG_QAN"
 
+	// EnableSEP is used to enable the SEP integration.
+	EnableSEP = "PMM_ENABLE_SEP"
+
 	// ClickHouseNodes is used to store the ClickHouse nodes.
 	ClickHouseNodes = "PMM_CLICKHOUSE_NODES"
 
@@ -61,6 +64,18 @@ func GetBool(key string) bool {
 		return false
 	}
 	return b
+}
+
+// SEPEnabled reports whether the SEP integration is enabled for this process.
+//
+// It deliberately does not use GetBool. The container entrypoint decides whether
+// to render SEP's nginx locations and start the side-car, and it treats only "1"
+// and "true" as enabled. Accepting the wider set strconv.ParseBool allows would
+// let the API report SEP as enabled on a deployment whose entrypoint judged it
+// disabled, leaving the UI offering links nginx cannot route.
+func SEPEnabled() bool {
+	v, ok := os.LookupEnv(EnableSEP)
+	return ok && (v == "1" || v == "true")
 }
 
 // GetStringSlice returns the string slice value of the environment variable.

--- a/managed/utils/env/env_test.go
+++ b/managed/utils/env/env_test.go
@@ -16,6 +16,7 @@
 package env
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,6 +73,79 @@ func TestGetBool(t *testing.T) {
 			}
 			result := GetBool(tt.envKey)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSEPEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      bool
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "not set",
+			expected: false,
+		},
+		{
+			name:     "empty",
+			set:      true,
+			envValue: "",
+			expected: false,
+		},
+		{
+			name:     "1",
+			set:      true,
+			envValue: "1",
+			expected: true,
+		},
+		{
+			name:     "true",
+			set:      true,
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "0",
+			set:      true,
+			envValue: "0",
+			expected: false,
+		},
+		{
+			name:     "false",
+			set:      true,
+			envValue: "false",
+			expected: false,
+		},
+		// The container entrypoint treats only "1" and "true" as enabled, so
+		// these must not enable SEP here either: the API would advertise
+		// navigation that nginx has no location block to route.
+		{
+			name:     "True",
+			set:      true,
+			envValue: "True",
+			expected: false,
+		},
+		{
+			name:     "yes",
+			set:      true,
+			envValue: "yes",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(EnableSEP, tt.envValue)
+			} else {
+				// Setenv first, so the original value is restored on cleanup.
+				t.Setenv(EnableSEP, "")
+				os.Unsetenv(EnableSEP)
+			}
+
+			assert.Equal(t, tt.expected, SEPEnabled())
 		})
 	}
 }

--- a/managed/utils/envvars/parser.go
+++ b/managed/utils/envvars/parser.go
@@ -121,8 +121,11 @@ func ParseEnvVars(envs []string) (*models.ChangeSettingsParams, []error, []strin
 			"PMM_DISABLE_BUILTIN_POSTGRES":
 			// skip env variables for external postgres
 			continue
-		case "PMM_ENABLE_SEP", "PMM_SEP_POSTGRES_PASSWORD", "PMM_SEP_ADDRESS":
-			// skip env variables consumed by the entrypoint to wire up SEP
+		case pkgenv.EnableSEP, "PMM_SEP_POSTGRES_PASSWORD", "PMM_SEP_ADDRESS":
+			// skip env variables consumed by the entrypoint to wire up SEP.
+			// PMM_ENABLE_SEP is not a stored setting: it describes how this
+			// process was started, so it is read from the environment by
+			// env.SEPEnabled instead of being persisted here.
 			continue
 		case "PERCONA_TELEMETRY_DISABLE":
 			// skip the Pillars telemetry environment variable


### PR DESCRIPTION
Ticket number: [PMM-15478](https://perconadev.atlassian.net/browse/PMM-15478)

## What

Populate `sep_enabled` on `/v1/server/settings` and `/v1/server/settings/readonly` from `PMM_ENABLE_SEP`.

This is the backend follow-up #5876 named in its own description ("Consumes `sep_enabled` … once the backend exposes it; until then the UI treats SEP as disabled"). It was never written, so the flag stayed permanently falsy and SEP was unreachable in every build carrying that PR: no Management section in the sidebar at all — the group holds only the SEP apps — and direct navigation to a SEP route rendered "This feature is not enabled. Contact your administrator.", with a healthy side-car. Two people hit this on the current PMM+SEP feature build.

## Changes

- Add `sep_enabled` to `Settings` (tag 21) and `ReadOnlySettings` (tag 9); additive, `buf breaking` passes
- Add `env.EnableSEP` and `env.SEPEnabled()`; take `PMM_ENABLE_SEP` out of the settings parser's stored path
- Populate the field in `convertSettings` and `convertReadOnlySettings`
- Cover `SEPEnabled` value handling and the read-only converter with tests

## Notes

**Not persisted, and not settable.** SEP enablement describes how the process was started — the entrypoint renders SEP's nginx locations and brings up the side-car only when the variable is set. Routing it through `ChangeSettingsParams` (the path `EnableUpdates` takes) would write it to the settings table via `models.UpdateSettings`, and a nil pointer on a later start means "no change", so a deployment that dropped the variable would keep reporting `sep_enabled: true` after its SEP surface was gone. `enable_internal_pg_qan` is the precedent for computing a response field from live state instead.

**`SEPEnabled` deliberately does not use `env.GetBool`.** The entrypoint's `is_enabled` accepts only `1` and `true`. Accepting the wider set `strconv.ParseBool` allows would let `PMM_ENABLE_SEP=True` report SEP as enabled while no nginx location block exists — the UI would offer links nginx cannot route. The test covers `True` and `yes` as disabled for exactly this reason.

**No UI change is required.** `sepEnabled` already exists on `ReadonlySettings`, and `axios-case-converter` maps `sep_enabled` onto it.

## Verification

`buf breaking` and `buf lint` pass; `golangci-lint --new-from-rev=origin/PMM-15205-sep-fb` reports 0 issues; license check clean; `go build ./api/... ./managed/...` and the new tests pass; `go mod tidy` is a no-op.

Not yet exercised on a live server — this needs a new feature build off `PMM-15205-sep-fb` to confirm the Management section returns with `PMM_ENABLE_SEP=1` and stays hidden without it. Flagging that rather than claiming it.

If this PR adds, removes or alters one or more API endpoints, please review and update the relevant [API documentation](https://github.com/percona/pmm/tree/main/documentation/api) as well:

- [ ] API Docs updated

If this PR is related to other PRs, contributions, or ongoing work in this or other repositories, please reference them here:

- Completes the follow-up named in #5876 (PMM-15281)
- Related proxy work: PMM-15279 / #5759 (`PMM_ENABLE_SEP`, the `/sep/` location block)


[PMM-15478]: https://perconadev.atlassian.net/browse/PMM-15478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ