### PR TITLE
Render the pt-mysql-summary option file with text/template

### DIFF
--- a/agent/runner/actions/pt_mysql_summary_action.go
+++ b/agent/runner/actions/pt_mysql_summary_action.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"html/template"
 	"net"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -112,6 +112,10 @@ func (a *ptMySQLSummaryAction) Run(ctx context.Context) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
+// text/template, not html/template: this renders a MySQL option file, and
+// HTML escaping silently rewrote every &, <, >, ' and " in a credential into
+// an entity, so a password such as pa&ss reached the client as pa&amp;ss and
+// the connection was refused (issue #5880).
 const myCnfTemplate = `[client]
 {{if .Host}}host={{ .Host }}{{end}}
 {{if .Port}}port={{ .Port }}{{end}}

--- a/agent/runner/actions/pt_mysql_summary_action_test.go
+++ b/agent/runner/actions/pt_mysql_summary_action_test.go
@@ -93,7 +93,21 @@ func TestBuildMyCnfConfig(t *testing.T) {
 		},
 		{
 			Params:   &agentv1.StartActionRequest_PTMySQLSummaryParams{Host: "", Port: 0, Socket: "", Username: "王华", Password: `"`},
-			Expected: "[client]\n\n\nuser=王华\npassword=&#34;\n\n",
+			Expected: "[client]\n\n\nuser=王华\npassword=\"\n\n",
+		},
+		// The option file is not HTML. Every one of these used to arrive at the
+		// MySQL client as an entity, and the connection was refused.
+		{
+			Params:   &agentv1.StartActionRequest_PTMySQLSummaryParams{Host: "localhost", Port: 3306, Username: "person", Password: "pa&ss"},
+			Expected: "[client]\nhost=localhost\nport=3306\nuser=person\npassword=pa&ss\n\n",
+		},
+		{
+			Params:   &agentv1.StartActionRequest_PTMySQLSummaryParams{Host: "localhost", Port: 3306, Username: "person", Password: "pa<s>s"},
+			Expected: "[client]\nhost=localhost\nport=3306\nuser=person\npassword=pa<s>s\n\n",
+		},
+		{
+			Params:   &agentv1.StartActionRequest_PTMySQLSummaryParams{Host: "localhost", Port: 3306, Username: "o'brien", Password: "pa'ss"},
+			Expected: "[client]\nhost=localhost\nport=3306\nuser=o'brien\npassword=pa'ss\n\n",
 		},
 		{
 			Params:  &agentv1.StartActionRequest_PTMySQLSummaryParams{Socket: "/tmp/mysqld.sock", Username: "test-user\r", Password: "test-password"},


### PR DESCRIPTION
Fixes #5880.

The report puts this down to the runner building a shell string and the shell splitting on `&`, but that is not what happens. `ptMySQLSummaryAction.Run` writes a `[client]` option file and calls `exec.CommandContext(ctx, a.command, "--defaults-file="+tmpFile.Name())`, so there is no shell anywhere on the path and no argument containing the password.

The real cause is one import. `buildMyCnfConfig` renders that option file through `html/template`, which HTML-escapes what it interpolates. Printing the generated config for a range of passwords shows it plainly:

    password "pa&ss"  -> "[client]\nhost=localhost\nport=3306\nuser=u\npassword=pa&amp;ss\n\n"
    password "pa<ss"  -> "...password=pa&lt;ss\n\n"
    password "pa'ss"  -> "...password=pa&#39;ss\n\n"
    password "plain"  -> "...password=plain\n\n"

So the MySQL client is handed `pa&amp;ss` and quite correctly refuses it, and a password without any of `& < > ' "` works. That matches the reported symptom exactly, including why the exporter keeps working: it never goes through this file. The username has the same problem, and an `o'brien` would have failed the same way.

Switched to `text/template`. The `\r` and `\n` rejection in `checkArgs` is what actually protects the option file's structure, and it is untouched.

One existing case in `TestBuildMyCnfConfig` asserted the escaped form (`password=&#34;` for a `"` password), so that expectation is corrected and three cases added for `&`, `<>` and `'`, the last of those in the username too. On the current code those four fail:

    expected: "...password=pa&ss\n\n"
    actual  : "...password=pa&amp;ss\n\n"

`go test ./runner/actions/ -run "TestPTMySQLSummary|TestBuildMyCnfConfig"` passes with the change. The rest of that package has failures in `TestQueryExplain`, `TestMongoDBActions` and friends, which want a live MySQL and MongoDB on localhost; they fail identically on `main` without this branch, which I checked rather than assumed. `go vet` and `gofmt` are clean.