### PR TITLE
PMM-15457 Fit plugin list to the content width

### DIFF
--- a/ui/packages/sep/framework/package.json
+++ b/ui/packages/sep/framework/package.json
@@ -41,6 +41,7 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/prismjs": "^1.26.5",
     "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^29.1.1",
     "notistack": "^3.0.2",
@@ -62,6 +63,7 @@
     "@tanstack/react-query": "^5.75.0",
     "notistack": "^3.0.2",
     "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-hook-form": "^7.71.0",
     "react-router-dom": "^7.6.0"
   }

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
@@ -117,6 +117,36 @@ describe('PluginListPage — generic Schedules button', () => {
   });
 });
 
+describe('PluginListPage — table toolbar in the header row', () => {
+  it('hands the list the header element to render its toolbar controls into', () => {
+    renderPage();
+
+    const slot = screen.getByTestId('plugin-list-toolbar-slot');
+    const props = schemaListViewMock.mock.calls.at(-1)?.[0] as {
+      toolbarSlot?: HTMLElement | null;
+    };
+    expect(props.toolbarSlot).toBe(slot);
+    // Same row as the header's own actions, rather than a row of its own above
+    // the column headers.
+    expect(slot.parentElement).toContainElement(
+      screen.getByTestId('plugin-schedule-link')
+    );
+  });
+
+  it('still offers the slot on a list with no header actions of its own', () => {
+    // `listOnly` withholds every header button; the toolbar controls still
+    // need somewhere to go.
+    renderPage({ listOnly: true });
+
+    const props = schemaListViewMock.mock.calls.at(-1)?.[0] as {
+      toolbarSlot?: HTMLElement | null;
+    };
+    expect(props.toolbarSlot).toBe(
+      screen.getByTestId('plugin-list-toolbar-slot')
+    );
+  });
+});
+
 describe('PluginListPage — status column opens the last run', () => {
   const renderWithClient = (ui: ReactNode) =>
     render(

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.tsx
@@ -109,6 +109,11 @@ export function PluginListPage({
     name?: string;
   } | null>(null);
   const [runTaskName, setRunTaskName] = useState<string | null>(null);
+  // The table's search / filter / column-visibility controls are rendered into
+  // this element instead of into a toolbar row of their own above the column
+  // headers. State rather than a ref: the portal can only be created once the
+  // element is committed, and that has to re-render.
+  const [toolbarSlot, setToolbarSlot] = useState<HTMLDivElement | null>(null);
   const { entityName: entityNameParam } = useParams<{ entityName?: string }>();
   const entityName = entityNameOverride ?? entityNameParam;
   const entitySchema = useMemo(
@@ -344,29 +349,36 @@ export function PluginListPage({
             </Typography>
           )}
         </Box>
-        {!listOnly && (
-          <Stack direction="row" spacing={1}>
-            {!hideScheduleButton && schema.capabilities?.scheduling && (
-              <Button
-                variant="outlined"
-                startIcon={<ScheduleIcon />}
-                onClick={() => navigate('schedule', { relative: 'path' })}
-                data-testid="plugin-schedule-link"
-              >
-                Schedules
-              </Button>
-            )}
-            {!hideCreate && canMutate && (
-              <Button
-                variant="contained"
-                startIcon={<AddIcon />}
-                onClick={() => navigate('new', { relative: 'path' })}
-              >
-                New {multi ? title : schema.display_name}
-              </Button>
-            )}
-          </Stack>
-        )}
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Box
+            ref={setToolbarSlot}
+            sx={{ display: 'flex', alignItems: 'center' }}
+            data-testid="plugin-list-toolbar-slot"
+          />
+          {!listOnly && (
+            <>
+              {!hideScheduleButton && schema.capabilities?.scheduling && (
+                <Button
+                  variant="outlined"
+                  startIcon={<ScheduleIcon />}
+                  onClick={() => navigate('schedule', { relative: 'path' })}
+                  data-testid="plugin-schedule-link"
+                >
+                  Schedules
+                </Button>
+              )}
+              {!hideCreate && canMutate && (
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={() => navigate('new', { relative: 'path' })}
+                >
+                  New {multi ? title : schema.display_name}
+                </Button>
+              )}
+            </>
+          )}
+        </Stack>
       </Box>
 
       <DeleteConfirmDialog
@@ -422,6 +434,7 @@ export function PluginListPage({
         onDeleteRow={onDeleteRow}
         deletingRowId={deleteEntity.isPending ? deleteEntity.variables : null}
         renderListColumn={renderListColumnWithRunAccess}
+        toolbarSlot={toolbarSlot}
       />
 
       {/* Mounted only while open: the drawer resolves the run it shows with a

--- a/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
@@ -304,6 +304,14 @@ describe('SchemaListView — schedule-column glue', () => {
   });
 });
 
+/**
+ * Toolbar rows inside the table paper. MUI's `TablePagination` renders a
+ * toolbar of its own inside the bottom row, so it has to be excluded or every
+ * row counts twice.
+ */
+const TOOLBAR_ROW_SELECTOR =
+  '.MuiToolbar-root:not(.MuiTablePagination-toolbar)';
+
 describe('SchemaListView — toolbar placement', () => {
   let slot: HTMLDivElement;
 
@@ -324,18 +332,24 @@ describe('SchemaListView — toolbar placement', () => {
     expect(slot.contains(screen.getByLabelText('Show/Hide columns'))).toBe(
       true
     );
-    // The paper opens straight onto the table: nothing sits between it and the
-    // column headers.
+    // Not merely moved: the table itself holds none of them, and the only
+    // toolbar row left in it is the one carrying pagination. Asserted by what
+    // the paper contains rather than by child order, which is
+    // MaterialReactTable's own business.
     const paper = document.querySelector(`.${SEP_TABLE_CLASS}`);
-    expect(paper?.firstElementChild).toHaveClass('MuiTableContainer-root');
+    expect(paper).not.toContainElement(
+      screen.getByLabelText('Show/Hide columns')
+    );
+    expect(paper?.querySelectorAll(TOOLBAR_ROW_SELECTOR)).toHaveLength(1);
   });
 
   it('keeps its own toolbar row when no slot is supplied', () => {
     render(<SchemaListView listView={listView} data={rows} />);
 
-    expect(screen.getByLabelText('Show/Hide columns')).toBeInTheDocument();
     const paper = document.querySelector(`.${SEP_TABLE_CLASS}`);
-    expect(paper?.firstElementChild).toHaveClass('MuiToolbar-root');
+    expect(paper).toContainElement(screen.getByLabelText('Show/Hide columns'));
+    // Its own row, on top of the pagination one.
+    expect(paper?.querySelectorAll(TOOLBAR_ROW_SELECTOR)).toHaveLength(2);
   });
 });
 

--- a/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
@@ -45,6 +45,7 @@ import {
   SchemaListView,
   type RenderListColumnOverride,
 } from './SchemaListView';
+import { SEP_TABLE_CLASS } from '../../constants';
 import type { PeriodicTaskResponse } from '../ScheduledTasksPanel';
 
 const listView: ListView = {
@@ -300,5 +301,142 @@ describe('SchemaListView — schedule-column glue', () => {
   it('issues no schedule fetch when a schedule column exists but no plugin name is given', () => {
     render(<SchemaListView listView={scheduleListView} data={rows} />);
     expect(useScheduledTasksForPluginMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('SchemaListView — toolbar placement', () => {
+  let slot: HTMLDivElement;
+
+  beforeEach(() => {
+    slot = document.createElement('div');
+    document.body.append(slot);
+  });
+
+  afterEach(() => {
+    slot.remove();
+  });
+
+  it("renders the table's own controls into a supplied slot and no toolbar row", () => {
+    render(
+      <SchemaListView listView={listView} data={rows} toolbarSlot={slot} />
+    );
+
+    expect(slot.contains(screen.getByLabelText('Show/Hide columns'))).toBe(
+      true
+    );
+    // The paper opens straight onto the table: nothing sits between it and the
+    // column headers.
+    const paper = document.querySelector(`.${SEP_TABLE_CLASS}`);
+    expect(paper?.firstElementChild).toHaveClass('MuiTableContainer-root');
+  });
+
+  it('keeps its own toolbar row when no slot is supplied', () => {
+    render(<SchemaListView listView={listView} data={rows} />);
+
+    expect(screen.getByLabelText('Show/Hide columns')).toBeInTheDocument();
+    const paper = document.querySelector(`.${SEP_TABLE_CLASS}`);
+    expect(paper?.firstElementChild).toHaveClass('MuiToolbar-root');
+  });
+});
+
+/**
+ * Columns as the MySQL backups app declares them — the list the width budget
+ * below was measured against. The real schema is served by the side-car and
+ * is not reachable from this package, so this is a fixture: the guard is
+ * against `COLUMN_SIZING` regressions, not against the schema itself growing
+ * a column.
+ */
+const backupsListView: ListView = {
+  columns: [
+    { key: 'name', label: 'Name' },
+    { key: 'service', label: 'Service' },
+    { key: 'backup_type', label: 'Type', format: 'chip' },
+    { key: 'schedule', label: 'Schedule', format: 'schedule' },
+    { key: 'status', label: 'Status', format: 'status' },
+    { key: 'last_executed_at', label: 'Last Executed', format: 'relative' },
+    { key: 'actions', label: '', format: 'actions' },
+  ],
+};
+
+/**
+ * Room left for the list inside a 1512px window once Grafana's nav rail and
+ * the page's own padding are taken out. A column is floored at its declared
+ * ``size``, so the declared total is what decides whether the list scrolls
+ * sideways.
+ */
+const CONTENT_WIDTH_1512 = 1380;
+
+describe('SchemaListView — column widths', () => {
+  beforeEach(() => {
+    useScheduledTasksForPluginMock.mockReset();
+    useScheduledTasksForPluginMock.mockReturnValue({
+      periodicTasks: [],
+      isLoading: false,
+    });
+  });
+
+  it('declares a backups-shaped list narrow enough for a 1512px window', () => {
+    render(
+      <SchemaListView
+        listView={backupsListView}
+        data={[]}
+        pluginName="mysql_backups"
+        onDeleteRow={() => {}}
+        disableSchedulePolling
+      />
+    );
+
+    const table = document.querySelector('table');
+    const declaredWidth = backupsListView.columns.reduce(
+      (total, col) =>
+        total +
+        Number(table?.style.getPropertyValue(`--col-${col.key}-size`) ?? 0),
+      0
+    );
+
+    expect(declaredWidth).toBeGreaterThan(0);
+    expect(declaredWidth).toBeLessThanOrEqual(CONTENT_WIDTH_1512);
+  });
+
+  it('keeps a truncated header label reachable on hover', () => {
+    render(
+      <SchemaListView
+        listView={{
+          columns: [
+            { key: 'name', label: 'Name' },
+            { key: 'actions', label: '', format: 'actions' },
+          ],
+        }}
+        data={rows}
+        onDeleteRow={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Name').closest('th')).toHaveAttribute(
+      'title',
+      'Name'
+    );
+    // An empty label gets no empty tooltip.
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers.at(-1)).not.toHaveAttribute('title');
+  });
+
+  it('truncates a plain text cell and keeps the whole value on hover', () => {
+    render(
+      <SchemaListView
+        listView={listView}
+        data={[
+          {
+            id: 1,
+            name: 'mysql-primary.production.internal',
+            status: 'failed',
+          },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByText('mysql-primary.production.internal')
+    ).toHaveAttribute('title', 'mysql-primary.production.internal');
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.tsx
@@ -188,16 +188,24 @@ const truncatedTextSx = {
   whiteSpace: 'nowrap',
 } as const;
 
+/** Keeps a chip inside its cell instead of setting the column's width. */
+const cellChipSx = { maxWidth: '100%' } as const;
+
 /**
  * Chip sized for a table cell rather than for a page.
  *
  * MUI's ``size="small"`` chip is still 24px tall with 12px of label padding,
  * which reads as a control in a compact row. Trimmed to the row's own scale so
- * a type or status column costs the width of its label and little else.
+ * a type column costs the width of its label and little else.
+ *
+ * Not used for a ``status`` cell: a recognized status renders as
+ * {@link TaskHistoryStatusBadge}, which is shared with the task-history table
+ * and keeps MUI's own scale, so compacting only the unrecognized fallback
+ * would make one status column hold two chip heights.
  */
 const compactChipSx = {
+  ...cellChipSx,
   height: 20,
-  maxWidth: '100%',
   '& .MuiChip-label': {
     px: 0.75,
     fontSize: '0.6875rem',
@@ -229,7 +237,7 @@ function formatCellValue(
       return isTaskHistoryStatus(str) ? (
         <TaskHistoryStatusBadge status={str} />
       ) : (
-        <Chip label={str} size="small" sx={compactChipSx} />
+        <Chip label={str} size="small" sx={cellChipSx} />
       );
     case 'date':
       return new Date(str).toLocaleDateString();

--- a/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.tsx
@@ -16,6 +16,9 @@
  */
 
 import { useMemo, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import type { Theme } from '@mui/material/styles';
 import Chip from '@mui/material/Chip';
@@ -23,8 +26,11 @@ import IconButton from '@mui/material/IconButton';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import {
   MaterialReactTable,
+  MRT_GlobalFilterTextField,
+  MRT_ToolbarInternalButtons,
   type MRT_ColumnDef,
   type MRT_PaginationState,
+  type MRT_TableInstance,
 } from 'material-react-table';
 import {
   DEFAULT_PLUGIN_LIST_LIMIT,
@@ -104,7 +110,99 @@ interface SchemaListViewProps {
    * pagination over the full ``data`` prop).
    */
   pagination?: SchemaListServerPagination | null;
+  /**
+   * Portal target for the table's own toolbar controls (search, column filters,
+   * column visibility).
+   *
+   * Those controls otherwise occupy a row of their own above the column
+   * headers, holding a full row for three icons. Pass the element the page
+   * header renders for them and they move onto the header row next to its
+   * actions instead.
+   *
+   * Three states, and the difference between the last two is deliberate:
+   * omitted (``undefined``) keeps the table's own toolbar row; an element
+   * portals the controls into it; ``null`` — the element has not been
+   * committed yet — suppresses the row as well, so the default toolbar does
+   * not flash on first paint. A caller that passes ``null`` and never an
+   * element therefore renders no toolbar controls at all.
+   */
+  toolbarSlot?: HTMLElement | null;
 }
+
+/**
+ * Per-format column widths, in px.
+ *
+ * MaterialReactTable floors every column at ``max(size, minSize)`` and never
+ * shrinks it, so the sum of these is the table's real minimum width — the one
+ * lever that decides whether the list needs horizontal scrolling. Its own
+ * default is 180px for every column regardless of what the column holds, which
+ * puts an eight-column list past 1440px and so past the content width of a
+ * 1512px window. Sized by what the format actually renders instead, and paired
+ * with ``layoutMode: 'grid'`` below so a column still grows past its ``size``
+ * to take up whatever room is left — narrow columns cost nothing on a wide
+ * screen, they only stop a narrow one from scrolling.
+ */
+const COLUMN_SIZING: Record<
+  NonNullable<ListColumn['format']>,
+  { size: number; minSize: number }
+> = {
+  text: { size: 180, minSize: 110 },
+  code: { size: 180, minSize: 110 },
+  chip: { size: 110, minSize: 80 },
+  status: { size: 120, minSize: 100 },
+  date: { size: 120, minSize: 100 },
+  relative: { size: 130, minSize: 100 },
+  schedule: { size: 160, minSize: 130 },
+  actions: { size: 72, minSize: 72 },
+};
+
+/** A column with no declared format renders plain text. */
+const DEFAULT_COLUMN_FORMAT = 'text' satisfies NonNullable<
+  ListColumn['format']
+>;
+
+function columnSizing(format: ListColumn['format']) {
+  return COLUMN_SIZING[format ?? DEFAULT_COLUMN_FORMAT];
+}
+
+/**
+ * Hover text for a header whose label the column is too narrow to show. Empty
+ * labels (an ``actions`` column) get nothing rather than an empty tooltip.
+ */
+function headerTitleProps(label: string) {
+  return label ? { muiTableHeadCellProps: { title: label } } : {};
+}
+
+/**
+ * Truncation for a value that has no length limit of its own — a host name, a
+ * command line. ``minWidth: 0`` is what lets it shrink below its content: the
+ * cell is a flex container in grid layout, and a flex item defaults to its
+ * content's width.
+ */
+const truncatedTextSx = {
+  display: 'block',
+  width: '100%',
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+} as const;
+
+/**
+ * Chip sized for a table cell rather than for a page.
+ *
+ * MUI's ``size="small"`` chip is still 24px tall with 12px of label padding,
+ * which reads as a control in a compact row. Trimmed to the row's own scale so
+ * a type or status column costs the width of its label and little else.
+ */
+const compactChipSx = {
+  height: 20,
+  maxWidth: '100%',
+  '& .MuiChip-label': {
+    px: 0.75,
+    fontSize: '0.6875rem',
+  },
+} as const;
 
 function formatCellValue(
   value: unknown,
@@ -124,14 +222,14 @@ function formatCellValue(
 
   switch (format) {
     case 'chip':
-      return <Chip label={str} size="small" />;
+      return <Chip label={str} size="small" sx={compactChipSx} />;
     case 'status':
       // Unrecognized values (no live backend producer) fall back to a plain
       // chip rather than indexing StatusBadge's STATUS_MAP with an unknown key.
       return isTaskHistoryStatus(str) ? (
         <TaskHistoryStatusBadge status={str} />
       ) : (
-        <Chip label={str} size="small" />
+        <Chip label={str} size="small" sx={compactChipSx} />
       );
     case 'date':
       return new Date(str).toLocaleDateString();
@@ -155,13 +253,24 @@ function formatCellValue(
       return (
         <Typography
           variant="body2"
-          sx={{ fontFamily: "'Roboto Mono', monospace" }}
+          title={str}
+          sx={{ fontFamily: "'Roboto Mono', monospace", ...truncatedTextSx }}
         >
           {str}
         </Typography>
       );
     default:
-      return str;
+      // Truncated rather than wrapped, with the full value on hover: a host
+      // name or a path is the column that would otherwise set the table's
+      // width for every other row. A native `title` rather than a MUI
+      // `Tooltip` — every cell of every text column would need one, and a
+      // tooltip is only keyboard-reachable on a focusable child, which a
+      // table cell must not become.
+      return (
+        <Box component="span" title={str} sx={truncatedTextSx}>
+          {str}
+        </Box>
+      );
   }
 }
 
@@ -177,6 +286,27 @@ const opaqueTableSurface = (theme: Theme) => ({
       ? theme.palette.background.default
       : theme.palette.common.white,
 });
+
+/**
+ * The table's own toolbar controls, rendered wherever the caller asks for them.
+ *
+ * Reuses MaterialReactTable's own buttons rather than reimplementing search,
+ * column filters and column visibility, so which controls appear still follows
+ * the ``enable*`` props below. The search field collapses itself when its
+ * toggle is off, so it costs nothing until it is asked for.
+ */
+function ListToolbarControls({
+  table,
+}: {
+  table: MRT_TableInstance<Record<string, unknown>>;
+}) {
+  return (
+    <Stack direction="row" spacing={0.5} alignItems="center">
+      <MRT_GlobalFilterTextField table={table} />
+      <MRT_ToolbarInternalButtons table={table} />
+    </Stack>
+  );
+}
 
 /** Stable empty lookup so plugins without a schedule column never re-key. */
 const EMPTY_SCHEDULE = new Map<string, PeriodicTaskResponse>();
@@ -257,6 +387,7 @@ function SchemaListViewCore({
   deletingRowId,
   renderListColumn,
   pagination,
+  toolbarSlot,
   scheduleByTask,
   scheduleLoading = false,
 }: SchemaListViewProps & {
@@ -286,6 +417,8 @@ function SchemaListViewCore({
               accessorKey: col.key,
               header: col.label,
               enableSorting: col.sortable ?? false,
+              ...columnSizing(col.format),
+              ...headerTitleProps(col.label),
               Cell: ({ row }) => {
                 const name = row.original.name;
                 // Trim to match how the detail summary derives its lookup key
@@ -307,7 +440,8 @@ function SchemaListViewCore({
               accessorKey: col.key,
               header: col.label,
               enableSorting: false,
-              size: 72,
+              ...columnSizing(col.format),
+              maxSize: COLUMN_SIZING.actions.size,
               Cell: ({ row }) => {
                 const id = row.original.id;
                 if (id === undefined || id === null || !onDeleteRow) {
@@ -335,6 +469,10 @@ function SchemaListViewCore({
             accessorKey: col.key,
             header: col.label,
             enableSorting: col.sortable ?? true,
+            ...columnSizing(col.format),
+            // A truncated header would otherwise be unreadable with no way
+            // back to it, unlike a truncated cell.
+            ...headerTitleProps(col.label),
             Cell: ({ cell, row }) => {
               const value = cell.getValue();
               const overridden = renderListColumn?.({
@@ -372,6 +510,22 @@ function SchemaListViewCore({
       enableColumnActions={false}
       enableDensityToggle={false}
       enableFullScreenToggle={false}
+      // Cells become flex items sized from the column's own `size`, so a
+      // column neither stretches to its widest value nor forces the table
+      // past its container — the two ways a semantic table ends up scrolling
+      // sideways.
+      layoutMode="grid"
+      renderTopToolbar={
+        toolbarSlot === undefined
+          ? undefined
+          : ({ table }) =>
+              toolbarSlot
+                ? createPortal(
+                    <ListToolbarControls table={table} />,
+                    toolbarSlot
+                  )
+                : null
+      }
       enablePagination
       manualPagination={manualPagination}
       rowCount={manualPagination ? serverPagination.total : undefined}
@@ -418,6 +572,27 @@ function SchemaListViewCore({
       }}
       muiTableContainerProps={{
         sx: opaqueTableSurface,
+      }}
+      muiTableHeadCellProps={{
+        sx: {
+          // The label, not the sort control: a long header would otherwise set
+          // the column's width for every row under it.
+          '& .Mui-TableHeadCell-Content-Wrapper': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          },
+        },
+      }}
+      muiTableBodyCellProps={{
+        sx: {
+          // Grid layout already hides cell overflow, but `textOverflow` is
+          // inert without it — stated here so the rule cannot be read as
+          // doing something it does not.
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        },
       }}
       muiTableBodyRowProps={
         onRowClick

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -508,6 +508,9 @@ importers:
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.1.0
+        version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.0(@types/node@20.19.43)(esbuild@0.25.12)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))


### PR DESCRIPTION
## What

Fixes finding **P11** from Pedro's UX pass over the MySQL Backups Tech Preview (PMM-15380, under the PMM-15217 umbrella), in the vendored SEP framework.

The schema-driven list gave every column MaterialReactTable's 180 px default and let the table toolbar hold a row of its own above the column headers.

- **Column widths** are now derived from what each `format` actually renders (`COLUMN_SIZING`), and `layoutMode: 'grid'` lets a column grow past its declared `size` to fill a wider screen. MRT floors a column at `max(size, minSize)` and never shrinks it, so the declared total is the table's *minimum* width — that is the only lever that decides whether the list scrolls sideways.
- **Values with no natural length** — host names, destinations, paths — truncate with the whole value available on hover. Header labels do the same. A native `title` rather than a MUI `Tooltip`: every cell of every text column would need one, and a tooltip is only keyboard-reachable on a focusable child, which a table cell must not become.
- **Type and status chips** are trimmed to the row's scale instead of MUI's page-scale `size="small"`.
- **The toolbar** no longer occupies a row of its own. `SchemaListView` takes a `toolbarSlot` element and portals MRT's own search / column-filter / column-visibility controls into it; `PluginListPage` renders that element on its header row next to the header actions. Reusing MRT's own buttons rather than reimplementing them keeps which controls appear tied to the existing `enable*` props.

## Acceptance criteria

- [x] At 1512 px the list reads end to end with no horizontal scrolling and no cut-off column.
- [x] The toolbar does not occupy a row of its own above the header.
- [ ] **Blocked** — the list reflecting a completed run without a manual reload, for every member of the status vocabulary. The ticket gates this on the side-car declaring which statuses end a run and returning the dispatched run's state; both are additive wire changes that have not landed. Nothing here touches polling.

On that last point: the vendored status vocabulary is currently 8 values (`failed`, `pending`, `running`, `success`, `stopped`, `lost`, `stale`, `unlaunchable`) and `RUNNING_STATUSES` is `{running, pending}` — so today's complement is exactly the terminal set, and there is no client-side fix available until the schema carries terminality. Hardcoding a ninth value would just move the build-time snapshot.

## Verification

Docker/PMM Server were not available here, so the list was driven in a real browser through a throwaway harness (deleted, not committed) that mounts `PluginListPage` with a backups-shaped schema against a stub serving the plugin list endpoint. Measured on the `.MuiTableContainer-root`:

| viewport | before | after |
|---|---|---|
| 1512 px | table 1489 px in a 1430 px container — 59 px of overflow, `Last Executed` clipped | 1430 / 1430, no overflow |
| 1280 px | — | 1198 / 1198, no overflow |

Confirmed visually at both widths: all seven columns present, toolbar icons on the header row beside **Schedules** / **New MySQL Backups**, no toolbar row above the column headers, hosts and destinations ellipsised, `unlaunchable` still rendering as "Not in executor".

This still wants a pass on a Feature Build against the real side-car schema before it is called done for a user-visible change.

## Notes for review

- `toolbarSlot` is deliberately tri-state: omitted keeps the table's own toolbar row, an element portals into it, and `null` (element not yet committed) suppresses the row too so the default toolbar does not flash on first paint. Documented on the prop.
- The slot element is rendered on the header row **unconditionally**, including for `listOnly` mounts that suppress every header button. That is a deliberate blast radius — every schema-driven list in the framework gains the header-row toolbar, which is what "listing tables need to become consistent early" asks for — but it does change more surfaces than the backups list alone.
- `react-dom` moves from a dev-only dependency to a peer dependency of `@sep/framework`: the portal is this package's first runtime `react-dom` import. It is deduped in both the app's and the package's Vite configs, so no second reconciler is bundled.
- "Move low-value columns to the detail page", the ticket's third suggestion for fitting, is a schema decision the vendored frontend cannot make — the columns come from the side-car's `list_view`. Column width policy is keyed by `format` for the same reason; if per-column widths are ever needed, the schema carrying a width hint that `columnSizing` prefers is the natural next step.
- Reviewed by two independent code reviews before opening; the accessibility of truncated headers, the redundant-looking `text-overflow` rule and the width-budget test's fixture limitation were raised and addressed.

## Tests

- `SchemaListView`: toolbar renders into a supplied slot with no toolbar row; keeps its own row when no slot is given; a backups-shaped list stays within a 1380 px declared-width budget; truncated cell and header keep the full value on hover.
- `PluginListPage`: the header element is handed to the list, sits on the same row as the header actions, and is still offered when `listOnly` withholds every button.
- `pnpm --filter @sep/framework test` — 814 pass. `tsc --noEmit` clean, `oxlint` no new findings, `oxfmt --check` clean.
