### PR TITLE
PMM-15205 Sync the vendored SEP frontend to be2859f3a

### DIFF
--- a/ui/packages/sep/api/specs/inventory.json
+++ b/ui/packages/sep/api/specs/inventory.json
@@ -2080,7 +2080,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether an **active** row in the ``settingoverride``\n    table applies to this ``(setting_class, key)`` pair. An inactive row is\n    skipped by the cache loader, so the served value falls back to the\n    declared default and reporting it as overridden would tell the UI a\n    field is overridden while showing it that default. A nested row also\n    marks every canonical prefix of its chain, so a parent reports ``True``\n    when only a deeper leaf carries a row.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.\n:param updated_at: When the override applying to this key was last saved,\n    falling back to the row's creation time for a row written before the\n    stamp was recorded. ``None`` when ``has_override`` is ``False``.\n    Timestamps carry second granularity.\n:param updated_by: The username that last saved that override, or ``None``\n    both when no override applies and when the row predates the actor\n    column. A key can draw on several rows (a nested parent reporting on its\n    leaves), in which case the pair comes from the row carrying the latest\n    timestamp. Two writes landing within the same second are\n    indistinguishable by timestamp, and the pair reported is then whichever\n    contributing row was created later, which need not be the one written\n    later.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -2153,6 +2153,29 @@
           "type": {
             "title": "Type",
             "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
           },
           "value": {
             "title": "Value"
@@ -2682,7 +2705,7 @@
     },
     "/admin/settings/{setting_class}": {
       "patch": {
-        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.",
+        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:param actor: The calling admin's username, recorded on every row the\n    batch writes and reported back on each response.\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.\n:raises HTTPBadGatewayException: For a remote class, when the owning\n    sub-app returns a server error (status >= 500) or is unreachable.\n:raises IntegrityError: When the replay of a batch that lost the\n    unique-index race conflicts again, which leaves nothing written.",
         "operationId": "settings_patch_settings_admin_settings__setting_class__patch",
         "parameters": [
           {

--- a/ui/packages/sep/api/specs/main.json
+++ b/ui/packages/sep/api/specs/main.json
@@ -544,7 +544,7 @@
     },
     "/api/users/": {
       "get": {
-        "description": "List users.\n\n:return: The list of users.\n:rtype: list[User]",
+        "description": "List users.\n\n:return: The list of users.",
         "operationId": "users_list_users_api_users__get",
         "responses": {
           "200": {

--- a/ui/packages/sep/api/specs/sep.json
+++ b/ui/packages/sep/api/specs/sep.json
@@ -341,6 +341,53 @@
         "title": "DashboardStatsResponse",
         "type": "object"
       },
+      "DeliveryConnectionDetail": {
+        "description": "Report one fact describing the delivery connection.\n\n:param label: The display label the plan declared, rendered verbatim. A\n    machine key would oblige the caller to carry receiver-specific names.\n:param value: The value that label reports.",
+        "properties": {
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "value": {
+            "title": "Value",
+            "type": "string"
+          }
+        },
+        "required": ["label", "value"],
+        "title": "DeliveryConnectionDetail",
+        "type": "object"
+      },
+      "DeliveryConnectionResponse": {
+        "description": "Report the facts describing the delivery connection, or why there are none.\n\n:param status: Which of the five outcomes the read reached.\n:param details: The resolved pairs in the plan's declaration order. Empty\n    for every status other than ``available``, and empty under ``available``\n    when every declared pointer missed, so a caller draws from this alone\n    and consults ``status`` only to explain an empty list.",
+        "properties": {
+          "details": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/DeliveryConnectionDetail"
+            },
+            "title": "Details",
+            "type": "array"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeliveryConnectionStatusEnum"
+          }
+        },
+        "required": ["status"],
+        "title": "DeliveryConnectionResponse",
+        "type": "object"
+      },
+      "DeliveryConnectionStatusEnum": {
+        "description": "Enumerate the mutually-exclusive outcomes of a connection-details read.",
+        "enum": [
+          "available",
+          "undeclared",
+          "not_configured",
+          "inputs_drifted",
+          "fetch_failed"
+        ],
+        "title": "DeliveryConnectionStatusEnum",
+        "type": "string"
+      },
       "ExecutionEvent": {
         "description": "Represent a single lifecycle event from a task executor (executor-agnostic shape).\n\n:param timestamp: When the event occurred (UTC).\n:param event_type: Executor-specific event category (for example a Nomad\n    task event type).\n:param description: Human-readable message for the event (no step prefix).\n:param step: Optional executor task/step name (for example a Nomad task\n    within the group).",
         "properties": {
@@ -559,30 +606,6 @@
         "title": "Node",
         "type": "object"
       },
-      "PaginatedResponse_Any_": {
-        "properties": {
-          "items": {
-            "items": {},
-            "title": "Items",
-            "type": "array"
-          },
-          "limit": {
-            "title": "Limit",
-            "type": "integer"
-          },
-          "offset": {
-            "title": "Offset",
-            "type": "integer"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": ["items", "total", "offset", "limit"],
-        "title": "PaginatedResponse[Any]",
-        "type": "object"
-      },
       "PaginatedResponse_ArbitraryMapping_": {
         "properties": {
           "items": {
@@ -608,6 +631,32 @@
         },
         "required": ["items", "total", "offset", "limit"],
         "title": "PaginatedResponse[ArbitraryMapping]",
+        "type": "object"
+      },
+      "PaginatedResponse_SepTaskHistoryResponse_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SepTaskHistoryResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "offset": {
+            "title": "Offset",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": ["items", "total", "offset", "limit"],
+        "title": "PaginatedResponse[SepTaskHistoryResponse]",
         "type": "object"
       },
       "PaginatedResponse_ServiceResponse_": {
@@ -660,32 +709,6 @@
         },
         "required": ["items", "total", "offset", "limit"],
         "title": "PaginatedResponse[SnippetResponse]",
-        "type": "object"
-      },
-      "PaginatedResponse_TaskHistoryResponse_": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/TaskHistoryResponse"
-            },
-            "title": "Items",
-            "type": "array"
-          },
-          "limit": {
-            "title": "Limit",
-            "type": "integer"
-          },
-          "offset": {
-            "title": "Offset",
-            "type": "integer"
-          },
-          "total": {
-            "title": "Total",
-            "type": "integer"
-          }
-        },
-        "required": ["items", "total", "offset", "limit"],
-        "title": "PaginatedResponse[TaskHistoryResponse]",
         "type": "object"
       },
       "RefreshResponse": {
@@ -803,6 +826,312 @@
         },
         "required": ["name", "service_id", "id"],
         "title": "Schema",
+        "type": "object"
+      },
+      "SepTaskHistoryResponse": {
+        "description": "Represent a task-history row as SEP serves it, with actors resolved.\n\n:param task: The task this execution belongs to, carrying resolved actors.\n:param executed_by: Display name for the actor that ran the task, or\n    ``None`` when none was recorded.",
+        "properties": {
+          "anonymize_mask": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymize Mask"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "display_name": {
+            "description": "Return a user-meaningful display label for this task history row.\n\nFor normal tasks, returns ``task.name``. For generic executor templates\n(``run-python``, ``exec-artifact``, ``exec-python-artifact``), builds a\n``\"<source>/<filename> on <target>\"`` label so otherwise-identical rows\nare distinguishable: the filename comes from the snippet metadata or the\n``file://`` payload basename, the source directory from whichever of those\ncarries one, and the target from the execution request. Falls back to\n``\"<task> on <target>\"`` when no filename is available.\n\n:return: The display label for the task history entry.",
+            "readOnly": true,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Return the duration of the task execution in seconds.\n\n:return: The duration in seconds, or None if not available.\n:rtype: float | None",
+            "readOnly": true,
+            "title": "Duration"
+          },
+          "executed_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.",
+            "title": "Executed By"
+          },
+          "execution_request": {
+            "$ref": "#/components/schemas/TaskExecutionRequest"
+          },
+          "failure_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Reason"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "has_logs": {
+            "default": false,
+            "title": "Has Logs",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "log_capture": {
+            "$ref": "#/components/schemas/LogCaptureStatusEnum",
+            "default": "unknown"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskHistoryStatusEnum",
+            "default": "pending"
+          },
+          "task": {
+            "$ref": "#/components/schemas/SepTaskResponse"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "execution_request",
+          "task",
+          "duration",
+          "display_name"
+        ],
+        "title": "SepTaskHistoryResponse",
+        "type": "object"
+      },
+      "SepTaskResponse": {
+        "description": "Represent a task definition as SEP serves it, with actors resolved.\n\nDiffer from :class:`~app.tasks.models.TaskResponse` only in what the two\nactor fields carry.\n\n:param created_by: Display name for the task's creator, or ``None`` when\n    none was recorded.\n:param last_updated_by: Display name for the user who last modified the\n    task, or ``None`` when none was recorded.",
+        "properties": {
+          "alert_detail_builder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alert Detail Builder"
+          },
+          "alert_on_fail": {
+            "default": false,
+            "title": "Alert On Fail",
+            "type": "boolean"
+          },
+          "anonymize_mask": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Anonymize Mask"
+          },
+          "anonymized_entities": {
+            "description": "Return sorted PII entity names decoded from ``anonymize_mask``.",
+            "items": {
+              "type": "string"
+            },
+            "readOnly": true,
+            "title": "Anonymized Entities",
+            "type": "array"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/TaskBackendEnum",
+            "default": "nomad"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.",
+            "title": "Created By"
+          },
+          "data": {
+            "additionalProperties": true,
+            "title": "Data",
+            "type": "object"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "is_template": {
+            "default": false,
+            "title": "Is Template",
+            "type": "boolean"
+          },
+          "last_updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.",
+            "title": "Last Updated By"
+          },
+          "name": {
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "output_files_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Files Path"
+          },
+          "owner": {
+            "default": "ANY",
+            "title": "Owner",
+            "type": "string"
+          },
+          "protected": {
+            "default": false,
+            "title": "Protected",
+            "type": "boolean"
+          },
+          "run_result_recorder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Result Recorder"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "data",
+          "deleted_at",
+          "created_by",
+          "last_updated_by",
+          "anonymized_entities"
+        ],
+        "title": "SepTaskResponse",
         "type": "object"
       },
       "ServiceEnum": {
@@ -1078,7 +1407,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether an **active** row in the ``settingoverride``\n    table applies to this ``(setting_class, key)`` pair. An inactive row is\n    skipped by the cache loader, so the served value falls back to the\n    declared default and reporting it as overridden would tell the UI a\n    field is overridden while showing it that default. A nested row also\n    marks every canonical prefix of its chain, so a parent reports ``True``\n    when only a deeper leaf carries a row.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.\n:param updated_at: When the override applying to this key was last saved,\n    falling back to the row's creation time for a row written before the\n    stamp was recorded. ``None`` when ``has_override`` is ``False``.\n    Timestamps carry second granularity.\n:param updated_by: The username that last saved that override, or ``None``\n    both when no override applies and when the row predates the actor\n    column. A key can draw on several rows (a nested parent reporting on its\n    leaves), in which case the pair comes from the row carrying the latest\n    timestamp. Two writes landing within the same second are\n    indistinguishable by timestamp, and the pair reported is then whichever\n    contributing row was created later, which need not be the one written\n    later.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -1151,6 +1480,29 @@
           "type": {
             "title": "Type",
             "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
           },
           "value": {
             "title": "Value"
@@ -1458,132 +1810,6 @@
         "title": "TaskExecutionRequest",
         "type": "object"
       },
-      "TaskHistoryResponse": {
-        "description": "Represent a task history API response.\n\n:param execution_request: The request that triggered the task execution.\n:param status: The status of the task execution.\n:param started_at: The datetime when the task execution started.\n:param finished_at: The datetime when the task execution finished.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the execution. Defaults to None, meaning it uses\n    the value defined in the associated task's :attr:`Task.anonymize_mask`.\n:param task: The task associated with this execution history.\n:param executed_by: The user ID of the user who executed the task.\n:param has_logs: Whether this task history has any readable log content --\n    either a chunk-store row or a legacy ``tracking[\"task_logs\"]`` blob.\n    Populated by list/retrieve routes; defaults to ``False``.\n:param log_capture: How completely SEP captured this execution's logs,\n    aggregated over its state rows: any incomplete stream reports\n    ``\"incomplete\"``, else any unknown reports ``\"unknown\"``, else\n    ``\"complete\"``. Populated by list/retrieve routes; defaults to\n    ``\"unknown\"``, which is also what a history carrying no state rows\n    reports.\n:param display_name: A user-meaningful label derived from the task name or\n    execution-request metadata. Read-only; computed on serialisation.",
-        "properties": {
-          "anonymize_mask": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Anonymize Mask"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "display_name": {
-            "description": "Return a user-meaningful display label for this task history row.\n\nFor normal tasks, returns ``task.name``. For generic executor templates\n(``run-python``, ``exec-artifact``, ``exec-python-artifact``), builds a\n``\"<source>/<filename> on <target>\"`` label so otherwise-identical rows\nare distinguishable: the filename comes from the snippet metadata or the\n``file://`` payload basename, the source directory from whichever of those\ncarries one, and the target from the execution request. Falls back to\n``\"<task> on <target>\"`` when no filename is available.\n\n:return: The display label for the task history entry.",
-            "readOnly": true,
-            "title": "Display Name",
-            "type": "string"
-          },
-          "duration": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Return the duration of the task execution in seconds.\n\n:return: The duration in seconds, or None if not available.\n:rtype: float | None",
-            "readOnly": true,
-            "title": "Duration"
-          },
-          "executed_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Executed By"
-          },
-          "execution_request": {
-            "$ref": "#/components/schemas/TaskExecutionRequest"
-          },
-          "finished_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At"
-          },
-          "has_logs": {
-            "default": false,
-            "title": "Has Logs",
-            "type": "boolean"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "log_capture": {
-            "$ref": "#/components/schemas/LogCaptureStatusEnum",
-            "default": "unknown"
-          },
-          "started_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Started At"
-          },
-          "status": {
-            "$ref": "#/components/schemas/TaskHistoryStatusEnum",
-            "default": "pending"
-          },
-          "task": {
-            "$ref": "#/components/schemas/TaskResponse"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "required": [
-          "id",
-          "execution_request",
-          "task",
-          "duration",
-          "display_name"
-        ],
-        "title": "TaskHistoryResponse",
-        "type": "object"
-      },
       "TaskHistoryStatusEnum": {
         "description": "Define status codes for task executions.\n\n:cvar FAILED: Enum value for failed tasks.\n:cvar PENDING: Enum value for pending tasks.\n:cvar RUNNING: Enum value for running tasks.\n:cvar SUCCESS: Enum value for successfully completed tasks.\n:cvar STOPPED: Enum value for stopped tasks.\n:cvar LOST: Enum value for tasks that are lost.\n:cvar STALE: Enum value for tasks skipped because executor placement\n    exceeded the configured staleness threshold (for example a Nomad\n    allocation that never left the queue).\n:cvar UNLAUNCHABLE: Enum value for tasks the executor node could not\n    launch at all, because some command in the invocation does not\n    resolve there. The payload never ran, so this is not a script\n    failure.",
         "enum": [
@@ -1598,172 +1824,6 @@
         ],
         "title": "TaskHistoryStatusEnum",
         "type": "string"
-      },
-      "TaskResponse": {
-        "description": "Represent a task API response.\n\n:param name: The name of the task.\n:param data: The task data stored in JSON format.\n:param backend: The backend used for task execution. Defaults to Nomad.\n:param owner: The owner of the task. Defaults to ``\"ANY\"``.\n:param is_template: Whether the task is a template. Defaults to False.\n:param protected: Whether the task is protected from deletion. Defaults to False.\n:param alert_on_fail: Whether to trigger an alert on task failure and\n    auto-resolve it on subsequent success. Defaults to False.\n:param alert_detail_builder: The ``\"module:function\"`` path of a plugin\n    callable that enriches this task's failure alert, or None.\n:param run_result_recorder: The ``\"module:function\"`` path of a plugin\n    callable that records this task's structured run result at terminal\n    status, or None.\n:param output_files_path: The path, relative to the executor's working\n    directory, where output files generated by the task are expected, or\n    None.\n:param deleted_at: The deletion timestamp, if applicable.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the task. Defaults to 0 (no anonymization).\n:param created_by: The user ID of the user who created the task.\n:param last_updated_by: The user ID of the user who last modified the task.\n:param anonymized_entities: Sorted list of PII entity names derived from\n    ``anonymize_mask`` (or from the owner's configured defaults when the\n    mask is ``None``). Each name is the raw ``PIIEntity`` member name\n    (e.g. ``\"EMAIL_ADDRESS\"``). Read-only; computed on serialisation.",
-        "properties": {
-          "alert_detail_builder": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Alert Detail Builder"
-          },
-          "alert_on_fail": {
-            "default": false,
-            "title": "Alert On Fail",
-            "type": "boolean"
-          },
-          "anonymize_mask": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Anonymize Mask"
-          },
-          "anonymized_entities": {
-            "description": "Return sorted PII entity names decoded from ``anonymize_mask``.",
-            "items": {
-              "type": "string"
-            },
-            "readOnly": true,
-            "title": "Anonymized Entities",
-            "type": "array"
-          },
-          "backend": {
-            "$ref": "#/components/schemas/TaskBackendEnum",
-            "default": "nomad"
-          },
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "created_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "data": {
-            "additionalProperties": true,
-            "title": "Data",
-            "type": "object"
-          },
-          "deleted_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Deleted At"
-          },
-          "id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "is_template": {
-            "default": false,
-            "title": "Is Template",
-            "type": "boolean"
-          },
-          "last_updated_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Updated By"
-          },
-          "name": {
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "type": "string"
-          },
-          "output_files_path": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Output Files Path"
-          },
-          "owner": {
-            "default": "ANY",
-            "title": "Owner",
-            "type": "string"
-          },
-          "protected": {
-            "default": false,
-            "title": "Protected",
-            "type": "boolean"
-          },
-          "run_result_recorder": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Run Result Recorder"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "format": "date-time",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Updated At"
-          }
-        },
-        "required": [
-          "id",
-          "name",
-          "data",
-          "deleted_at",
-          "created_by",
-          "last_updated_by",
-          "anonymized_entities"
-        ],
-        "title": "TaskResponse",
-        "type": "object"
       },
       "ValidationError": {
         "properties": {
@@ -4534,7 +4594,7 @@
         "type": "object"
       },
       "backup_mongo__BackupType": {
-        "description": "Backup types.",
+        "description": "Represent the backup tools a run can be taken with.\n\n:cvar LABELS: Display text for each stored value, keyed as the value is\n    stored on the wire. A value with no entry is rendered as-is by the\n    caller. Wrapped in :func:`enum.nonmember` because ``enum`` would\n    otherwise treat a class-body dict as a member candidate.",
         "enum": [
           "pbm_logical",
           "pbm_physical",
@@ -6113,7 +6173,7 @@
       },
       "framework__AppEntitySchema": {
         "additionalProperties": false,
-        "description": "Describe one CRUD entity for a multi-entity schema-driven plugin.\n\nUsed when a plugin exposes several independent resources (for example\ninventory nodes, services, schemas, and tables), each with its own list\nview and create/edit forms. Task-style plugins omit ``entities`` and use\nthe root ``forms`` / ``list_view`` instead.\n\n:param name: URL segment and API key for the entity (for example ``nodes``).\n:type name: NonEmptyStr\n:param display_name: Human-readable title for this entity's screens.\n:type display_name: NonEmptyStr\n:param description: Optional helper text for this entity. Defaults to\n    ``None``.\n:type description: NonEmptyStr | None\n:param forms: Form sections for create (and edit when the UI supports it).\n:type forms: list[FormSection]\n:param list_view: Column configuration for this entity's list table.\n:type list_view: ListView\n:param detail_highlights: Optional per-field syntax highlighter hints for\n    detail pages. Keys are field names; values are highlighting languages.\n    Defaults to an empty mapping.\n:type detail_highlights: dict[NonEmptyStr, DetailHighlightLanguage]\n:param cardinality_rules: Optional entity-wide cross-field cardinality\n    constraints. Defaults to ``None``.\n:type cardinality_rules: list[CardinalityRule] | None\n:param fail_when: Optional entity-wide predicate-only invariants.\n    Defaults to ``None``.\n:type fail_when: list[FailRule] | None",
+        "description": "Describe one CRUD entity for a multi-entity schema-driven plugin.\n\nUsed when a plugin exposes several independent resources (for example\ninventory nodes, services, schemas, and tables), each with its own list\nview and create/edit forms. Task-style plugins omit ``entities`` and use\nthe root ``forms`` / ``list_view`` instead.\n\n:param name: URL segment and API key for the entity (for example ``nodes``).\n:param display_name: Human-readable title for this entity's screens.\n:param item_display_name: What **one** record of this entity is called (for\n    example ``node``), as opposed to ``display_name``, which names the\n    entity's screens. Stored in mid-sentence form so a consumer composing a\n    label capitalises the first character itself. Defaults to this entity's\n    own ``display_name`` — not the parent app's, and never inferred from\n    ``item_display_name_plural``.\n:param item_display_name_plural: What **several** records of this entity are\n    called (for example ``nodes``). An independent declaration under the\n    same mid-sentence convention; nothing derives it from\n    ``item_display_name``. Defaults to this entity's own ``display_name``.\n:param description: Optional helper text for this entity. Defaults to\n    ``None``.\n:param forms: Form sections for create (and edit when the UI supports it).\n:param list_view: Column configuration for this entity's list table.\n:param detail_highlights: Optional per-field syntax highlighter hints for\n    detail pages. Keys are field names; values are highlighting languages.\n    Defaults to an empty mapping.\n:param cardinality_rules: Optional entity-wide cross-field cardinality\n    constraints. Defaults to ``None``.\n:param fail_when: Optional entity-wide predicate-only invariants.\n    Defaults to ``None``.",
         "properties": {
           "cardinality_rules": {
             "anyOf": [
@@ -6174,6 +6234,16 @@
             "title": "Forms",
             "type": "array"
           },
+          "item_display_name": {
+            "minLength": 1,
+            "title": "Item Display Name",
+            "type": "string"
+          },
+          "item_display_name_plural": {
+            "minLength": 1,
+            "title": "Item Display Name Plural",
+            "type": "string"
+          },
           "list_view": {
             "$ref": "#/components/schemas/framework__ListView"
           },
@@ -6184,13 +6254,20 @@
             "type": "string"
           }
         },
-        "required": ["name", "display_name", "forms", "list_view"],
+        "required": [
+          "name",
+          "display_name",
+          "item_display_name",
+          "item_display_name_plural",
+          "forms",
+          "list_view"
+        ],
         "title": "AppEntitySchema",
         "type": "object"
       },
       "framework__AppSchema": {
         "additionalProperties": false,
-        "description": "Represent a plugin's complete schema: form sections, list view, capabilities.\n\n:param name: The plugin identifier; must match Python identifier rules,\n    optionally with internal hyphens.\n:type name: NonEmptyStr\n:param display_name: The human-readable plugin title displayed in the UI.\n:type display_name: NonEmptyStr\n:param description: Optional helper text describing the plugin's\n    purpose. Defaults to ``None``.\n:type description: NonEmptyStr | None\n:param task_type: Optional task-type identifier used when creating tasks\n    via the shared task API. Defaults to ``None``.\n:type task_type: NonEmptyStr | None\n:param forms: Form sections for single-entity / task plugins. When\n    ``entities`` is non-empty, root ``forms`` must be empty (declare\n    forms on each entity instead); non-empty root ``forms`` are rejected\n    at construction. Defaults to an empty list.\n:type forms: list[FormSection]\n:param capabilities: Optional plugin-level feature flags. Defaults to\n    ``None``.\n:type capabilities: Capabilities | None\n:param list_view: List-view configuration when ``entities`` is unset\n    (single-entity / task plugins). Ignored when ``entities`` is set.\n:type list_view: ListView | None\n:param detail_view: Optional declarative layout for the task detail page's\n    section cards (task-style plugins only; ignored when ``entities`` is\n    set). Optional at the model layer for backwards compatibility. A\n    forward-looking guard refuses to load a plugin that sets\n    ``task_type`` without declaring ``detail_view``. Defaults to ``None``.\n:type detail_view: DetailView | None\n:param entities: Optional list of CRUD entities for multi-resource plugins.\n    When non-empty, the React shell renders one list/create/detail flow\n    per entity. Defaults to ``None`` (legacy single-entity mode).\n:param cardinality_rules: Optional plugin-wide cross-field cardinality\n    constraints (task-style plugins only). Rejected at construction when\n    ``entities`` is non-empty — declare rules on each entity instead.\n    Defaults to ``None``.\n:type cardinality_rules: list[CardinalityRule] | None\n:param fail_when: Optional plugin-wide predicate-only invariants (task-style\n    plugins only). Rejected at construction when ``entities`` is non-empty —\n    declare rules on each entity instead. Defaults to ``None``.\n:type fail_when: list[FailRule] | None\n:param derived: Optional declarative specs for sibling tasks derived from\n    the parent task on cascade. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the parent and N derived siblings. Defaults to ``None``.\n:type derived: list[DerivedTask] | None\n:param predecessors: Optional declarative specs for tasks that must run\n    before the parent. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the predecessors and the parent, including the chain wiring\n    applied at execute time. Defaults to ``None``.\n:type predecessors: list[ChainedPredecessor] | None\n:param related_apps: Optional separately registered apps the React shell\n    surfaces as sibling tabs (for example a restore app nested under a\n    backups parent). Defaults to ``None``.\n:type related_apps: list[RelatedApp] | None",
+        "description": "Represent a plugin's complete schema: form sections, list view, capabilities.\n\n:param name: The plugin identifier; must match Python identifier rules,\n    optionally with internal hyphens.\n:param display_name: The human-readable plugin title displayed in the UI.\n:param item_display_name: What **one** record this plugin's create form\n    produces is called (for example ``backup``), as opposed to\n    ``display_name``, which names the plugin. Stored in mid-sentence form —\n    lowercase unless it opens with a proper noun — so a consumer composing a\n    label capitalises the first character itself. Defaults to\n    ``display_name``, and is never inferred from\n    ``item_display_name_plural``. Unlike the optional UI hints on this\n    model, both record names are required and non-nullable so the generated\n    client types them as ``string`` and no consumer needs a fallback.\n:param item_display_name_plural: What **several** of those records are\n    called (for example ``backups``). An independent declaration under the\n    same mid-sentence convention; nothing derives it from\n    ``item_display_name``. Defaults to ``display_name``.\n:param description: Optional helper text describing the plugin's\n    purpose. Defaults to ``None``.\n:param task_type: Optional task-type identifier used when creating tasks\n    via the shared task API. Defaults to ``None``.\n:param forms: Form sections for single-entity / task plugins. When\n    ``entities`` is non-empty, root ``forms`` must be empty (declare\n    forms on each entity instead); non-empty root ``forms`` are rejected\n    at construction. Defaults to an empty list.\n:param capabilities: Optional plugin-level feature flags. Defaults to\n    ``None``.\n:param list_view: List-view configuration when ``entities`` is unset\n    (single-entity / task plugins). Ignored when ``entities`` is set.\n:param detail_view: Optional declarative layout for the task detail page's\n    section cards (task-style plugins only; ignored when ``entities`` is\n    set). Optional at the model layer for backwards compatibility. A\n    forward-looking guard refuses to load a plugin that sets\n    ``task_type`` without declaring ``detail_view``. Defaults to ``None``.\n:param entities: Optional list of CRUD entities for multi-resource plugins.\n    When non-empty, the React shell renders one list/create/detail flow\n    per entity. Defaults to ``None`` (legacy single-entity mode).\n:param cardinality_rules: Optional plugin-wide cross-field cardinality\n    constraints (task-style plugins only). Rejected at construction when\n    ``entities`` is non-empty — declare rules on each entity instead.\n    Defaults to ``None``.\n:param fail_when: Optional plugin-wide predicate-only invariants (task-style\n    plugins only). Rejected at construction when ``entities`` is non-empty —\n    declare rules on each entity instead. Defaults to ``None``.\n:param derived: Optional declarative specs for sibling tasks derived from\n    the parent task on cascade. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the parent and N derived siblings. Defaults to ``None``.\n:param predecessors: Optional declarative specs for tasks that must run\n    before the parent. Consumed by\n    :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE\n    across the predecessors and the parent, including the chain wiring\n    applied at execute time. Defaults to ``None``.\n:param related_apps: Optional separately registered apps the React shell\n    surfaces as sibling tabs (for example a restore app nested under a\n    backups parent). Defaults to ``None``.\n:param task_statuses: The task-status vocabulary a client polls against,\n    declaring per status value whether it ends a run. Server-authored, so a\n    supplied value is replaced rather than honoured. Withheld (``None``) for\n    a plugin declaring ``entities``, whose records are not task runs.",
         "properties": {
           "capabilities": {
             "anyOf": [
@@ -6292,6 +6369,16 @@
             "title": "Forms",
             "type": "array"
           },
+          "item_display_name": {
+            "minLength": 1,
+            "title": "Item Display Name",
+            "type": "string"
+          },
+          "item_display_name_plural": {
+            "minLength": 1,
+            "title": "Item Display Name Plural",
+            "type": "string"
+          },
           "list_view": {
             "anyOf": [
               {
@@ -6336,6 +6423,20 @@
             ],
             "title": "Related Apps"
           },
+          "task_statuses": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/framework__TaskStatusDescriptor"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Statuses"
+          },
           "task_type": {
             "anyOf": [
               {
@@ -6349,7 +6450,12 @@
             "title": "Task Type"
           }
         },
-        "required": ["name", "display_name"],
+        "required": [
+          "name",
+          "display_name",
+          "item_display_name",
+          "item_display_name_plural"
+        ],
         "title": "AppSchema",
         "type": "object"
       },
@@ -6703,6 +6809,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -6954,6 +7072,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -7012,7 +7142,7 @@
       },
       "framework__Column": {
         "additionalProperties": false,
-        "description": "Represent one column in a plugin list view.\n\n:param key: The task attribute path this column displays (for example,\n    ``\"status\"`` or ``\"target.service\"``).\n:type key: NonEmptyStr\n:param label: The human-readable column header.\n:type label: NonEmptyStr\n:param sortable: Whether the column can be used to sort the list.\n    Defaults to ``False``.\n:type sortable: bool\n:param format: Optional formatting hint applied when rendering the\n    column values. Defaults to ``None``.\n:type format: ColumnFormat | None",
+        "description": "Represent one column in a plugin list view.\n\n:param key: The task attribute path this column displays (for example,\n    ``\"status\"`` or ``\"target.service\"``). Must be non-empty.\n:param label: The human-readable column header. Must be non-empty.\n:param sortable: Whether the column can be used to sort the list.\n    Defaults to ``False``.\n:param format: Optional formatting hint applied when rendering the\n    column values. Defaults to ``None``.\n:param value_labels: Optional map from a raw cell value to the text a\n    renderer displays in its place. Defaults to ``None``, which the schema\n    route's ``exclude_none`` posture drops from the payload, so a column\n    declaring no labels stays byte-identical on the wire. A value absent\n    from the map is the consuming app's decision to render as-is.",
         "properties": {
           "format": {
             "anyOf": [
@@ -7038,6 +7168,21 @@
             "default": false,
             "title": "Sortable",
             "type": "boolean"
+          },
+          "value_labels": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Labels"
           }
         },
         "required": ["key", "label"],
@@ -7114,6 +7259,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -7232,7 +7389,7 @@
       },
       "framework__DetailField": {
         "additionalProperties": false,
-        "description": "Declare one labelled field rendered inside a :class:`DetailSection`.\n\n:param path: Dotted path into the task record (for example\n    ``\"data.meta.command\"``). Each segment must be a Python identifier,\n    optionally followed by one or more ``[N]`` array indices.\n:type path: DetailPath\n:param label: Human-readable label rendered alongside the resolved value.\n:type label: NonEmptyStr\n:param highlight: Optional syntax-highlighter hint. Defaults to ``None``.\n:type highlight: DetailHighlightLanguage | None",
+        "description": "Declare one labelled field rendered inside a :class:`DetailSection`.\n\n:param path: Dotted path into the task record (for example\n    ``\"data.meta.command\"``). Each segment must be a Python identifier,\n    optionally followed by one or more ``[N]`` array indices.\n:param label: Human-readable label rendered alongside the resolved value.\n    Must be non-empty.\n:param highlight: Optional syntax-highlighter hint. Defaults to ``None``.\n:param value_labels: Optional map from a raw resolved value to the text a\n    renderer displays in its place. Defaults to ``None``, which the schema\n    route's ``exclude_none`` posture drops from the payload, so a field\n    declaring no labels stays byte-identical on the wire. A value absent\n    from the map is the consuming app's decision to render as-is.",
         "properties": {
           "highlight": {
             "anyOf": [
@@ -7254,6 +7411,21 @@
             "pattern": "^[A-Za-z_][A-Za-z0-9_]*(?:\\[\\d+\\])*(?:\\.[A-Za-z_][A-Za-z0-9_]*(?:\\[\\d+\\])*)*$",
             "title": "Path",
             "type": "string"
+          },
+          "value_labels": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Labels"
           }
         },
         "required": ["path", "label"],
@@ -7268,7 +7440,7 @@
       },
       "framework__DetailSection": {
         "additionalProperties": false,
-        "description": "Declare one titled section inside a :class:`DetailView`.\n\n:param title: Heading rendered above the section's fields.\n:type title: NonEmptyStr\n:param fields: Ordered list of fields rendered inside the section. An\n    empty list is valid; the frontend hides the section when every\n    field resolves to an empty value.\n:type fields: list[DetailField]",
+        "description": "Declare one titled section inside a :class:`DetailView`.\n\n:param title: Heading rendered above the section's fields.\n:param fields: Ordered list of fields rendered inside the section. An\n    empty list is valid; the frontend hides the section when every\n    field resolves to an empty value.",
         "properties": {
           "fields": {
             "items": {
@@ -7401,6 +7573,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -7481,6 +7665,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -7773,6 +7969,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -7866,6 +8074,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -7957,7 +8177,7 @@
       },
       "framework__ListView": {
         "additionalProperties": false,
-        "description": "Represent the list-view configuration for a plugin.\n\n:param columns: The ordered list of columns displayed in the list view.\n:type columns: list[Column]\n:param default_sort: Optional key of the column to sort by on first\n    render. Prefix with ``-`` for descending order (for example,\n    ``\"-lastRun\"``). The unprefixed key must match one of the declared\n    column keys. Defaults to ``None``.\n:type default_sort: NonEmptyStr | None\n:param server_side_query: Opt-in capability flag declaring that the list\n    endpoint honors whole-result-set sort and search via server query\n    params. When ``True`` and the list is also server-paginated, the React\n    list view enables manual sorting and filtering and drives them through\n    those params instead of sorting the loaded page; a capability-on list\n    rendered without pagination stays client-side.\n    Typed ``bool | None`` so the discovery endpoint's\n    ``exclude_none`` posture drops it from the wire until a plugin opts\n    in, keeping the addition byte-compatible with existing schemas.\n    Defaults to ``None``.\n:type server_side_query: bool | None\n:param overview_hidden_fields: Additional task-level keys to suppress\n    from the auto-rendered \"extras\" loop on the plugin detail Overview\n    tab. The framework always hides a baseline set of internal fields\n    (``id``, ``backend``, ``protected``, ``data``, ``updated_at``,\n    ``last_updated_by``, ``connectivity_warning``); any keys listed here\n    are merged with that baseline. Defaults to ``[]``.\n:type overview_hidden_fields: list[str]",
+        "description": "Represent the list-view configuration for a plugin.\n\n:param columns: The ordered list of columns displayed in the list view.\n:param default_sort: Optional key of the column to sort by on first\n    render. Prefix with ``-`` for descending order (for example,\n    ``\"-lastRun\"``). The unprefixed key must match one of the declared\n    column keys. Defaults to ``None``.\n:param server_side_query: Opt-in capability flag declaring that the list\n    endpoint honors whole-result-set sort and search via server query\n    params. When ``True`` and the list is also server-paginated, the React\n    list view enables manual sorting and filtering and drives them through\n    those params instead of sorting the loaded page; a capability-on list\n    rendered without pagination stays client-side.\n    Typed ``bool | None`` so the discovery endpoint's\n    ``exclude_none`` posture drops it from the wire until a plugin opts\n    in, keeping the addition byte-compatible with existing schemas.\n    Defaults to ``None``.\n:param overview_hidden_fields: Additional task-level keys to suppress\n    from the auto-rendered \"extras\" loop on the plugin detail Overview\n    tab. The framework always hides a baseline set of internal fields\n    (``id``, ``backend``, ``protected``, ``data``, ``updated_at``,\n    ``last_updated_by``, ``connectivity_warning``); any keys listed here\n    are merged with that baseline. Defaults to ``[]``.",
         "properties": {
           "columns": {
             "items": {
@@ -8034,6 +8254,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -8138,6 +8370,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -8248,6 +8492,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -8339,6 +8595,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -8443,6 +8711,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -8941,6 +9221,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "endpoint_url": {
             "minLength": 1,
             "title": "Endpoint Url",
@@ -9042,6 +9334,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -9185,6 +9489,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "endpoint_url": {
             "minLength": 1,
             "title": "Endpoint Url",
@@ -9314,6 +9630,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -9401,6 +9729,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -9547,6 +9887,18 @@
             ],
             "title": "Description"
           },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
+          },
           "forbidden": {
             "anyOf": [
               {
@@ -9648,8 +10000,16 @@
         "type": "object"
       },
       "framework__TaskExecutionResponse": {
-        "description": "Represent the default response from a task execute route.\n\n:param task_name: The name of the task that was executed.\n:param task_id: The id of the task-history row created by the tasks API.",
+        "description": "Represent the default response from a task execute route.\n\n``started_at`` is deliberately not carried: the worker sets it, so it is\nstill ``None`` on the row this response is built from.\n\n:param task_name: The name of the task that was executed.\n:param task_id: The id of the task-history row created by the tasks API.\n    Optional because :class:`~app.tasks.models.TaskHistoryResponse` types it\n    so, not because a dispatched run is expected to lack one.\n:param status: The status of the task-history row the tasks API created,\n    as it stood at dispatch.\n:param created_at: When the tasks API created that row.",
         "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskHistoryStatusEnum"
+          },
           "task_id": {
             "anyOf": [
               {
@@ -9666,8 +10026,24 @@
             "type": "string"
           }
         },
-        "required": ["task_name"],
+        "required": ["task_name", "status", "created_at"],
         "title": "TaskExecutionResponse",
+        "type": "object"
+      },
+      "framework__TaskStatusDescriptor": {
+        "additionalProperties": false,
+        "description": "Declare one task-status value and whether it ends a run.\n\n:param value: The status as it appears on a task-history payload.\n:param terminal: Whether a run in this status will not transition again, so\n    a client polling for completion can stop re-reading on it.",
+        "properties": {
+          "terminal": {
+            "title": "Terminal",
+            "type": "boolean"
+          },
+          "value": {
+            "$ref": "#/components/schemas/TaskHistoryStatusEnum"
+          }
+        },
+        "required": ["value", "terminal"],
+        "title": "TaskStatusDescriptor",
         "type": "object"
       },
       "framework__TextAreaField": {
@@ -9694,6 +10070,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -9799,6 +10187,18 @@
               }
             ],
             "title": "Description"
+          },
+          "destructive": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destructive"
           },
           "forbidden": {
             "anyOf": [
@@ -10034,16 +10434,9 @@
             "title": "Awscli S3 Upload Extra Args"
           },
           "backup_dir": {
-            "anyOf": [
-              {
-                "minLength": 1,
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Backup Dir"
+            "minLength": 1,
+            "title": "Backup Dir",
+            "type": "string"
           },
           "backup_type": {
             "$ref": "#/components/schemas/mysql_backups__BackupType"
@@ -10536,13 +10929,32 @@
             "type": "boolean"
           }
         },
-        "required": ["task_name", "hostname", "service_id", "backup_type"],
+        "required": [
+          "task_name",
+          "hostname",
+          "service_id",
+          "backup_type",
+          "backup_dir"
+        ],
         "title": "BackupCreate",
         "type": "object"
       },
       "mysql_backups__BackupRunResponse": {
-        "description": "Expose one catalog record over the per-service query path.\n\n:param id: The record's primary key.\n:param service_name: The inventory service the backup was taken from.\n:param service_id: The inventory id of that service, or ``None`` on a record\n    written before the id was stamped.\n:param hostname: The backup target host.\n:param backup_type: The backup tool, ``\"M\"`` (mydumper) or ``\"X\"`` (xtrabackup).\n    Narrower than :class:`BackupType`: binlog runs are never catalogued, so\n    ``\"B\"`` never appears here.\n:param location: The resolved on-disk directory the run produced.\n:param upload_destination: The upload destination when one was configured.\n:param size_bytes: The backup size in bytes, when the run reported it.\n:param started_at: When the run started.\n:param finished_at: When the run finished.",
+        "description": "Expose one catalog record over the service-scoped and task-scoped queries.\n\n:param id: The record's primary key.\n:param service_name: The inventory service the backup was taken from.\n:param service_id: The inventory id of that service, or ``None`` on a record\n    written before the id was stamped.\n:param hostname: The backup target host.\n:param backup_type: The backup tool, ``\"M\"`` (mydumper) or ``\"X\"`` (xtrabackup).\n    Narrower than :class:`BackupType`: binlog runs are never catalogued, so\n    ``\"B\"`` never appears here.\n:param location: The resolved on-disk directory the run produced.\n:param upload_destination: The upload destination when one was configured.\n:param size_bytes: The backup size in bytes, when the run reported it.\n:param started_at: When the run started.\n:param finished_at: When the run finished.\n:param backup_source: The run's restore-form-valid source, derived from\n    ``upload_destination`` and ``location``; read-only, and absent from the\n    table this response is built from.",
         "properties": {
+          "backup_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Return the run's restore-form-valid source, or ``None``.\n\nResolved server-side so no caller re-derives it from the raw fields.\n``None`` means the run recorded no usable source, or recorded one the\nrestore form rejects — either way it cannot seed a restore.",
+            "readOnly": true,
+            "title": "Backup Source"
+          },
           "backup_type": {
             "enum": ["M", "X"],
             "title": "Backup Type",
@@ -10653,7 +11065,8 @@
           "upload_destination",
           "size_bytes",
           "started_at",
-          "finished_at"
+          "finished_at",
+          "backup_source"
         ],
         "title": "BackupRunResponse",
         "type": "object"
@@ -10824,7 +11237,7 @@
         "type": "object"
       },
       "mysql_backups__BackupType": {
-        "description": "Backup types.",
+        "description": "Represent the backup tools a run can be taken with.\n\n:cvar LABELS: Display text for each stored value, keyed as the value is\n    stored on the wire. A value with no entry is rendered as-is by the\n    caller. Wrapped in :func:`enum.nonmember` because ``enum`` would\n    otherwise treat a class-body dict as a member candidate.",
         "enum": ["M", "X", "B"],
         "title": "BackupType",
         "type": "string"
@@ -10920,7 +11333,7 @@
         "type": "object"
       },
       "mysql_backups__RestoreCreate": {
-        "description": "Declare the model-first create/update body and ``GET /schema`` source for Restores.\n\nDeclares every restore form field once, in section order (Task, General,\nMydumper, XtraBackup, Binlog), with the DSL markers driving the derived\nschema. The previously-inherited config models (:class:`RestoreConfigAll` and\n:class:`BaseRestoreConfigServer`) stay the YAML-serialization targets the\npayload builder populates via ``extract_model_from_instance``; this model\nre-declares their fields directly so it can also carry presentation metadata.\n\nThe per-``backup_type`` section visibility is expressed in the view layout\n(``restore/views.py``), not as field-level gates: several mode-specific config\nfields carry non-``None`` defaults (``myloader_threads``, ``xb_parallel``,\n``master_port``), so a field-level ``Forbidden`` gate would reject those\ndefaults on a cross-mode restore. Keeping the model permissive preserves the\nlegacy payload contract byte-for-byte.\n\n``service_id`` / ``schema_id`` keep their str-accepting annotation (carrying\nthe ``\"-1\"`` ``UNKNOWN_SERVICE_SENTINEL``); their ``ServiceRef`` / ``SchemaRef``\nmarkers drive only the ``GET /schema`` widgets, while the conditional,\n404-tolerant resolution lives in ``deps.resolve_restore_entities``.",
+        "description": "Declare the model-first create/update body and ``GET /schema`` source for Restores.\n\nDeclares every restore form field once, in section order (Task, General,\nMydumper, XtraBackup, Binlog), with the DSL markers driving the derived\nschema. The previously-inherited config models (:class:`RestoreConfigAll` and\n:class:`BaseRestoreConfigServer`) stay the YAML-serialization targets the\npayload builder populates via ``extract_model_from_instance``; this model\nre-declares their fields directly so it can also carry presentation metadata.\n\nThe per-``backup_type`` section visibility is expressed in the view layout\n(``restore/views.py``), not as field-level gates: several mode-specific config\nfields carry non-``None`` defaults (``myloader_threads``, ``xb_parallel``,\n``master_port``), so a field-level ``Forbidden`` gate would reject those\ndefaults on a cross-mode restore. Keeping the model permissive preserves the\nlegacy payload contract byte-for-byte.\n\nThe transport and decryption fields are the exception, and they pay that\nprice deliberately: ``source_transport`` and ``source_encryption`` declare\nwhere the backup lives and how it was encrypted, and the five fields those\ndeclarations govern are gated on them. Because a field-level ``Forbidden``\nrejects a field that is merely *present*, ``ssh_user`` / ``ssh_port`` /\n``s3_tool`` had to give up their defaults; :class:`RestoreConfigAll` still\ndeclares them and ``build_restore_spec`` applies them from there, so the\nemitted config is unchanged.\n\n``service_id`` / ``schema_id`` keep their str-accepting annotation (carrying\nthe ``\"-1\"`` ``UNKNOWN_SERVICE_SENTINEL``); their ``ServiceRef`` / ``SchemaRef``\nmarkers drive only the ``GET /schema`` widgets, while the conditional,\n404-tolerant resolution lives in ``deps.resolve_restore_entities``.",
         "properties": {
           "alert_on_fail": {
             "default": false,
@@ -11023,11 +11436,6 @@
               }
             ],
             "title": "Keyring File Data"
-          },
-          "kill_mysql": {
-            "default": false,
-            "title": "Kill Mysql",
-            "type": "boolean"
           },
           "local_path": {
             "anyOf": [
@@ -11171,8 +11579,15 @@
             "type": "boolean"
           },
           "s3_tool": {
-            "$ref": "#/components/schemas/mysql_backups__S3Tool",
-            "default": "s3cmd"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/mysql_backups__S3Tool"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "S3 Tool"
           },
           "schema_id": {
             "anyOf": [
@@ -11220,6 +11635,14 @@
             "title": "Slave From Master",
             "type": "boolean"
           },
+          "source_encryption": {
+            "$ref": "#/components/schemas/mysql_backups__EncryptionFormat",
+            "default": "none"
+          },
+          "source_transport": {
+            "$ref": "#/components/schemas/mysql_backups__SourceTransport",
+            "default": "local"
+          },
           "ssh_key": {
             "anyOf": [
               {
@@ -11241,7 +11664,6 @@
                 "type": "null"
               }
             ],
-            "default": 22,
             "title": "Ssh Port"
           },
           "ssh_user": {
@@ -11254,7 +11676,6 @@
                 "type": "null"
               }
             ],
-            "default": "percona",
             "title": "Ssh User"
           },
           "start_file": {
@@ -11580,6 +12001,12 @@
         "description": "Allowed tools to interact with S3-compatible services.",
         "enum": ["s3cmd", "awscli"],
         "title": "S3Tool",
+        "type": "string"
+      },
+      "mysql_backups__SourceTransport": {
+        "description": "Declare where the backup being restored is stored.",
+        "enum": ["local", "ssh", "s3", "gcs"],
+        "title": "SourceTransport",
         "type": "string"
       },
       "mysql_backups__UploadProvider": {
@@ -12434,7 +12861,7 @@
         "type": "object"
       },
       "tasks__TaskDetailResponse": {
-        "description": "Represent the aggregate payload for ``GET /api/apps/tasks/{task_name}``.\n\nBundle the task definition, execution history, periodic schedules, and\nexecutor host metadata into a single response for the React detail page.\n\n:param task: The task definition as returned by the tasks API.\n:type task: TaskResponse\n:param execution_history: Paginated task history from the tasks API\n    (``items``, ``total``, ``offset``, ``limit``).\n:type execution_history: dict[str, Any]\n:param periodic_summary: Read-only summaries of periodic schedules\n    attached to this task.\n:type periodic_summary: list[PeriodicTaskSummary]\n:param executor_hosts: Executor hosts available for display, with\n    inventory-resolved labels when possible.\n:type executor_hosts: list[ExecutorHostMetadata]",
+        "description": "Represent the aggregate payload for ``GET /api/apps/tasks/{task_name}``.\n\nBundle the task definition, execution history, periodic schedules, and\nexecutor host metadata into a single response for the React detail page.\n\n:param task: The task definition as returned by the tasks API, with its\n    actor fields carrying display names rather than user identifiers.\n:param execution_history: Paginated task history from the tasks API\n    (``items``, ``total``, ``offset``, ``limit``), passed through\n    unvalidated so every upstream key survives. Carries whatever actor text\n    the constructing route supplied; the model itself imposes no shape.\n:param periodic_summary: Read-only summaries of periodic schedules\n    attached to this task.\n:param executor_hosts: Executor hosts available for display, with\n    inventory-resolved labels when possible.",
         "properties": {
           "execution_history": {
             "additionalProperties": true,
@@ -12456,7 +12883,7 @@
             "type": "array"
           },
           "task": {
-            "$ref": "#/components/schemas/TaskResponse"
+            "$ref": "#/components/schemas/SepTaskResponse"
           }
         },
         "required": ["task"],
@@ -12464,7 +12891,7 @@
         "type": "object"
       },
       "tasks__TaskListResponse": {
-        "description": "Represent one task row in the read-only tasks plugin list API.\n\n:param name: The unique name of the task.\n:type name: str\n:param backend: The backend system used for task execution.\n:type backend: TaskBackendEnum\n:param created_at: When the task was created, or ``None`` if unavailable.\n:type created_at: UTCDatetime | None\n:param created_by: Display name for the task creator (Casdoor username when\n    resolvable, otherwise the stored user id), or ``None`` if unknown.\n:type created_by: str | None\n:param last_updated_by: Display name for the user who last updated the\n    task (Casdoor username when resolvable, otherwise the stored user id),\n    or ``None`` if unknown.\n:type last_updated_by: str | None",
+        "description": "Represent one task row in the read-only tasks plugin list API.\n\n:param name: The unique name of the task.\n:param backend: The backend system used for task execution.\n:param created_at: When the task was created, or ``None`` if unavailable.\n:param created_by: Display name for the task creator: the provider's\n    username when resolvable, a system label for system-created tasks,\n    otherwise the stored user id. ``None`` if unknown.\n:param last_updated_by: Display name for the user who last updated the\n    task, resolved on the same terms as ``created_by``. ``None`` if\n    unknown.",
         "properties": {
           "backend": {
             "$ref": "#/components/schemas/TaskBackendEnum"
@@ -16817,7 +17244,7 @@
     },
     "/api/apps/inventory/": {
       "get": {
-        "description": "Return the list of periodic task names for the Inventory plugin.\n\nHard-coded because the Inventory plugin's periodic tasks are a fixed pair\n(``inventory-sync`` and ``inventory-collection``). The shape matches what the\nReact ``usePluginTasks('inventory')`` hook expects: a list of objects with at\nminimum a ``name`` key.\n\n:return: The plugin's periodic tasks, each with its name and display name.",
+        "description": "Return the list of periodic task names for the Inventory plugin.\n\nHard-coded because the Inventory plugin's periodic tasks are a fixed pair\n(``inventory-sync`` and ``inventory-collection``).\n\n:return: The plugin's periodic tasks, each with its name and display name.",
         "operationId": "inventory_inventory_plugin_tasks_api_apps_inventory__get",
         "responses": {
           "200": {
@@ -16863,70 +17290,9 @@
         "tags": ["inventory"]
       }
     },
-    "/api/apps/inventory/nodes/{node_id}/system-observation": {
-      "get": {
-        "description": "Proxy the host-level system observation for a node (read-only).\n\nForwards to the inventory sub-app's ``/nodes/{node_id}/system-observation``\nendpoint via ``InventoryAPI``. This three-segment literal path cannot\ncollide with the two-segment ``/{entity}/{item_id:int}`` detail matcher. An\nupstream HTTP 404 propagates unchanged, along with the ``detail`` that tells\na node whose observation has not been collected yet — which the React panel\nrenders as an empty state — apart from a node that does not exist.\n\n:param node_id: Primary key of the node.\n:param inventory_api: Authenticated inventory ``RemoteAPI`` client.\n:return: The host-level system observation payload.",
-        "operationId": "inventory_inventory_node_system_observation_api_apps_inventory_nodes__node_id__system_observation_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "node_id",
-            "required": true,
-            "schema": {
-              "title": "Node Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Inventory Inventory Node System Observation Api Apps Inventory Nodes  Node Id  System Observation Get"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Node System Observation",
-        "tags": ["inventory"]
-      }
-    },
-    "/api/apps/inventory/schema": {
-      "get": {
-        "description": "Return the plugin schema captured at registration time.\n\n:return: The plugin schema instance.",
-        "operationId": "inventory_get_schema_api_apps_inventory_schema_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/framework__AppSchema"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Schema",
-        "tags": ["inventory"]
-      }
-    },
     "/api/apps/inventory/services/{service_id}/check-connectivity/": {
       "post": {
-        "description": "Run a database connectivity probe for a service from its executor host.\n\nBacks the React connectivity control on the service detail page. A probe\nthat ran but could not connect is reported as HTTP 200 with\n``success=false`` and the upstream message in ``error``; only a probe that\ncould not be attempted at all is an error status. This three-segment\nliteral path cannot collide with the two-segment\n``/{entity}/{item_id:int}`` detail matcher.\n\n:param service: The service to probe, resolved from the path id.\n:param tasks_api: Authenticated Tasks ``RemoteAPI`` client.\n:return: The upstream probe result.\n:raises HTTPBadRequestException: When the service cannot be probed —\n    unsupported type, missing node or port, or no executor registered for\n    the node address.\n:raises HTTPBadGatewayException: When the Tasks API is unreachable or\n    returns an unparseable body.",
+        "description": "Run a database connectivity probe for a service from its executor host.\n\nA probe that ran but could not connect is reported as HTTP 200 with\n``success=false`` and the upstream message in ``error``; only a probe that\ncould not be attempted at all is an error status.\n\n:param service: The service to probe, resolved from the path id.\n:param tasks_api: Authenticated Tasks ``RemoteAPI`` client.\n:return: The upstream probe result.\n:raises HTTPBadRequestException: When the service cannot be probed —\n    unsupported type, missing node or port, or no executor registered for\n    the node address.\n:raises HTTPBadGatewayException: When the Tasks API is unreachable or\n    returns an unparseable body.",
         "operationId": "inventory_inventory_service_check_connectivity_api_apps_inventory_services__service_id__check_connectivity__post",
         "parameters": [
           {
@@ -16962,47 +17328,6 @@
           }
         },
         "summary": "Inventory Service Check Connectivity",
-        "tags": ["inventory"]
-      }
-    },
-    "/api/apps/inventory/services/{service_id}/system-observation": {
-      "get": {
-        "description": "Proxy the service-level system observation for a service (read-only).\n\nForwards to the inventory sub-app's\n``/services/{service_id}/system-observation`` endpoint via ``InventoryAPI``.\nAn upstream HTTP 404 propagates unchanged, along with the ``detail`` that\ntells a service whose observation has not been collected yet — which the\nReact panel renders as an empty state — apart from a service that does not\nexist.\n\n:param service_id: Primary key of the service.\n:param inventory_api: Authenticated inventory ``RemoteAPI`` client.\n:return: The service-level system observation payload.",
-        "operationId": "inventory_inventory_service_system_observation_api_apps_inventory_services__service_id__system_observation_get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "service_id",
-            "required": true,
-            "schema": {
-              "title": "Service Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Inventory Inventory Service System Observation Api Apps Inventory Services  Service Id  System Observation Get"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Service System Observation",
         "tags": ["inventory"]
       }
     },
@@ -17048,7 +17373,7 @@
     },
     "/api/apps/inventory/sync/status/": {
       "get": {
-        "description": "Return whether an inventory-wide sync is running, plus recent run outcomes.\n\nReplaces the server-rendered ``sync_is_running`` template variable\nused by the Jinja2 inventory page so the React control can poll the\nsame state without scraping HTML.\n\n:param session: SQLModel async session.\n:return: The running flag and the most recent runs, newest first.",
+        "description": "Return whether an inventory-wide sync is running, plus recent run outcomes.\n\nLets an operator poll a sync they triggered through ``POST /sync/``\nwithout scraping any rendered page.\n\n:param session: SQLModel async session.\n:return: The running flag and the most recent runs, newest first.",
         "operationId": "inventory_inventory_sync_status_api_apps_inventory_sync_status__get",
         "responses": {
           "200": {
@@ -17063,166 +17388,6 @@
           }
         },
         "summary": "Inventory Sync Status",
-        "tags": ["inventory"]
-      }
-    },
-    "/api/apps/inventory/{entity}/": {
-      "get": {
-        "description": "List inventory nodes, services, schemas, or tables.\n\n:param request: Inbound request; its query string carries entity filters.\n:param entity: Inventory entity type (nodes, services, schemas, tables).\n:param inventory_api: Async client for the Inventory sub-app.\n:param pagination: Validated offset/limit forwarded to the upstream call.\n:param list_query: Allowlist-vetted sort/search for this entity.\n:return: A paginated envelope echoing the requested window.",
-        "operationId": "inventory_inventory_list_entity_api_apps_inventory__entity___get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "entity",
-            "required": true,
-            "schema": {
-              "title": "Entity",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "offset",
-            "required": false,
-            "schema": {
-              "default": 0,
-              "minimum": 0,
-              "title": "Offset",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 50,
-              "maximum": 200,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Sort key; prefix with '-' for descending order.",
-            "in": "query",
-            "name": "sort",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Sort key; prefix with '-' for descending order.",
-              "enum": [
-                "created_at",
-                "-created_at",
-                "name",
-                "-name",
-                "schema_id",
-                "-schema_id",
-                "service_id",
-                "-service_id"
-              ],
-              "title": "Sort"
-            }
-          },
-          {
-            "description": "Case-insensitive search across the searchable columns.",
-            "in": "query",
-            "name": "search",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Case-insensitive search across the searchable columns.",
-              "title": "Search"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_Any_"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory List Entity",
-        "tags": ["inventory"]
-      }
-    },
-    "/api/apps/inventory/{entity}/{item_id}": {
-      "get": {
-        "description": "Retrieve a single inventory node, service, schema, or table.",
-        "operationId": "inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "entity",
-            "required": true,
-            "schema": {
-              "title": "Entity",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "item_id",
-            "required": true,
-            "schema": {
-              "title": "Item Id",
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Response Inventory Inventory Get Entity Api Apps Inventory  Entity   Item Id  Get"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Inventory Get Entity",
         "tags": ["inventory"]
       }
     },
@@ -17906,6 +18071,70 @@
           }
         },
         "summary": "Update",
+        "tags": ["mysql_backups"]
+      }
+    },
+    "/api/apps/mysql_backups/{task_name}/backups": {
+      "get": {
+        "description": "Return a page of a backup task's catalogued runs, newest run first.\n\nThe ``task_name`` path parameter is resolved by\n:data:`~app.sep.apps.mysql_backups.deps.CataloguedHistoryIds`, so a task that\ndoes not exist or belongs to another app surfaces as a ``404`` while a known\ntask with no catalogued backup yields an empty page — keeping \"this task has\nnever produced a backup\" distinguishable from \"this task does not exist\".\n\nThe discovery walk behind that dependency is capped, so ``total`` counts the\nruns within the scanned window rather than every run the task ever produced,\nand carries no marker distinguishing a truncated page from a complete one.\nA run older than the window is reachable through the per-service catalog\nroute, which is uncapped — but only while its inventory service still\nresolves, and only for a caller that knows which service the run was recorded\nunder, which a task since re-pointed at another target no longer answers.\n\n:param history_ids: The task's catalogued task-history ids, newest first.\n:param session: The database session the catalog is queried on.\n:param pagination: The requested offset/limit window.\n:return: The requested page of the task's recorded backup runs, newest run\n    first.",
+        "operationId": "mysql_backups_list_task_backups_api_apps_mysql_backups__task_name__backups_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "task_name",
+            "required": true,
+            "schema": {
+              "title": "Task Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/mysql_backups__PaginatedResponse_BackupRunResponse_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Task Backups",
         "tags": ["mysql_backups"]
       }
     },
@@ -18905,7 +19134,7 @@
     },
     "/api/apps/tasks/{task_name}": {
       "get": {
-        "description": "Return the per-task detail bundle for the read-only plugin UI.\n\n:param task: The task definition resolved by name.\n:type task: Task\n:param tasks_api: Async client for the tasks sub-app.\n:type tasks_api: TaskAPI\n:param executor_hosts_ctx: Executor hosts enriched with inventory labels.\n:type executor_hosts_ctx: ExecutorHostsCtx\n:return: Task definition, history, periodic schedules, and executor hosts.\n:rtype: TaskDetailResponse",
+        "description": "Return the per-task detail bundle for the read-only plugin UI.\n\n:param task: The task definition resolved by name.\n:param tasks_api: Async client for the tasks sub-app.\n:param executor_hosts_ctx: Executor hosts enriched with inventory labels.\n:return: Task definition, history, periodic schedules, and executor hosts,\n    with every actor identifier on the task and inside the history rows\n    resolved to the name a reader should see.",
         "operationId": "task_manager_tasks_api_detail_api_apps_tasks__task_name__get",
         "parameters": [
           {
@@ -19087,6 +19316,26 @@
         "tags": ["sep"]
       }
     },
+    "/api/sep/admin/delivery-connection/": {
+      "get": {
+        "description": "Report the facts the delivery plan declares about its own connection.\n\nNo way the read can fail reaches the caller as an error: a deployment that\ndeclares no connection-details step, stored inputs that no longer fit the\nplan, a refused credential, an unreachable receiver and a read that outran\nits bound all answer 200 with the outcome that describes them, so a caller\nrenders a state rather than handling an error. The three configuration\noutcomes are decided before any request is issued; the read and the failure\noutcomes are decided only after one.\n\n:return: The resolved pairs in the plan's declaration order, or the outcome\n    explaining why there are none.",
+        "operationId": "sep_read_delivery_connection_api_sep_admin_delivery_connection__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeliveryConnectionResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Read Delivery Connection",
+        "tags": ["sep"]
+      }
+    },
     "/api/sep/admin/settings/": {
       "get": {
         "description": "List every exposed settings class with current values and metadata.\n\nLocal classes are read from their config singletons; remote classes\n(``remote_classes``) are fetched server-side from their owning sub-app\nand appended in declaration order; app-owned classes follow remote\ngroups with per-group app metadata. A failed remote fetch fails the\nwhole request with ``502`` -- the LIST never silently drops a remote\ngroup.\n\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:return: Grouped responses, one group per configured settings class.",
@@ -19174,7 +19423,7 @@
     },
     "/api/sep/admin/settings/{setting_class}": {
       "patch": {
-        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.",
+        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:param actor: The calling admin's username, recorded on every row the\n    batch writes and reported back on each response.\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.\n:raises HTTPBadGatewayException: For a remote class, when the owning\n    sub-app returns a server error (status >= 500) or is unreachable.\n:raises IntegrityError: When the replay of a batch that lost the\n    unique-index race conflicts again, which leaves nothing written.",
         "operationId": "sep_patch_settings_api_sep_admin_settings__setting_class__patch",
         "parameters": [
           {
@@ -19466,6 +19715,66 @@
           }
         },
         "summary": "List Periodic Tasks",
+        "tags": ["tasks"]
+      }
+    },
+    "/api/sep/periodic-tasks/schedule/preview/": {
+      "post": {
+        "description": "Dispatch a schedule preview to the Tasks API.\n\nTwo path segments so the sibling ``POST /{task_name}/`` cannot match this\nroute: a single-segment ``/preview/`` would be ambiguous with it, resolvable\nonly by declaration order and only at the cost of reserving ``preview`` as a\ntask name nobody could schedule.\n\n:param tasks_api: The Tasks API client used to compute the preview.\n:param body: The ``SchedulePreviewWrite`` JSON body, forwarded verbatim.\n:return: The schedule preview as returned by the Tasks API.\n:raises HTTPException: Re-raised unchanged for an upstream client error\n    (status < 500).\n:raises HTTPBadGatewayException: For an upstream server error (status >= 500)\n    or a connection-level ``OSError``.",
+        "operationId": "tasks_preview_schedule_api_sep_periodic_tasks_schedule_preview__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Tasks Preview Schedule Api Sep Periodic Tasks Schedule Preview  Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["detail"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Upstream Tasks API failure."
+          }
+        },
+        "summary": "Preview Schedule",
         "tags": ["tasks"]
       }
     },
@@ -19854,7 +20163,7 @@
     },
     "/api/sep/task-history/": {
       "get": {
-        "description": "Return task-history rows, listing all of them or merging selected names.\n\nThree-way on ``task_names``:\n\n* **omitted** (``None``) -- proxy the upstream ``GET /history/`` list, already\n  paginated, forwarding the ``status`` filter, ``exclude_internal`` flag, and\n  client ``offset`` / ``limit``.\n* **provided, at least one non-blank name** -- query each name independently\n  against the Tasks API, then merge, sort newest-first, and paginate globally.\n* **provided, every name blank after trimming** -- reject with ``422``.\n\n:param tasks_api: The Tasks API client used to fetch upstream history.\n:param pagination: Validated offset/limit query parameters.\n:param task_names: Zero or more task names (repeat the query param); omit to\n    list all history.\n:param task_status: Optional exact status filter forwarded upstream.\n:param exclude_internal: When ``True``, forward the filter to the upstream\n    list-all path so internal maintenance tasks are excluded before pagination.\n    Not forwarded on the ``task_names`` merge path. Defaults to ``False``.\n:return: Paginated task history, either the upstream list or the merged set.\n:raises HTTPUnprocessableEntityException: When ``task_names`` is supplied but\n    every value is empty after trimming.\n:raises HTTPBadGatewayException: For an upstream server error (status >= 500)\n    or a connection-level ``OSError``, on either the list-all passthrough or\n    the merged-history fan-out.",
+        "description": "Return task-history rows, listing all of them or merging selected names.\n\nThree-way on ``task_names``:\n\n* **omitted** (``None``) -- proxy the upstream ``GET /history/`` list, already\n  paginated, forwarding the ``status`` filter, ``exclude_internal`` flag, and\n  client ``offset`` / ``limit``.\n* **provided, at least one non-blank name** -- query each name independently\n  against the Tasks API, then merge, sort newest-first, and paginate globally.\n* **provided, every name blank after trimming** -- reject with ``422``.\n\n:param tasks_api: The Tasks API client used to fetch upstream history.\n:param pagination: Validated offset/limit query parameters.\n:param task_names: Zero or more task names (repeat the query param); omit to\n    list all history.\n:param task_status: Optional exact status filter forwarded upstream.\n:param exclude_internal: When ``True``, forward the filter to the upstream\n    list-all path so internal maintenance tasks are excluded before pagination.\n    Not forwarded on the ``task_names`` merge path. Defaults to ``False``.\n:return: Paginated task history, either the upstream list or the merged set,\n    with every actor identifier resolved to the name a reader should see.\n:raises HTTPUnprocessableEntityException: When ``task_names`` is supplied but\n    every value is empty after trimming.\n:raises HTTPBadGatewayException: For an upstream server error (status >= 500)\n    or a connection-level ``OSError``, on either the list-all passthrough or\n    the merged-history fan-out.",
         "operationId": "tasks_list_merged_task_history_api_sep_task_history__get",
         "parameters": [
           {
@@ -19931,7 +20240,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaginatedResponse_TaskHistoryResponse_"
+                  "$ref": "#/components/schemas/PaginatedResponse_SepTaskHistoryResponse_"
                 }
               }
             },

--- a/ui/packages/sep/api/specs/tasks.json
+++ b/ui/packages/sep/api/specs/tasks.json
@@ -65,7 +65,7 @@
         "type": "string"
       },
       "CrontabSchedule": {
-        "description": "Representing a crontab schedule.\n\n:param minute: Represents the minute component in cron format. Defaults to `\"*\"`.\n:type minute: str\n:param hour: Represents the hour component in cron format. Defaults to `\"*\"`.\n:type hour: str\n:param day_of_week: Represents the day of the week component in cron format.\n    Defaults to `\"*\"`.\n:type day_of_week: str\n:param day_of_month: Represents the day of the month component in cron format.\n    Defaults to `\"*\"`.\n:type day_of_month: str\n:param month_of_year: Represents the month component in cron format.\n    Defaults to `\"*\"`.\n:type month_of_year: str\n:param timezone: The timezone for the cron schedule. Defaults to \"UTC\". Must be a\n    valid timezone as returned in `available_timezones()`\n:type timezone: str",
+        "description": "Represent a crontab schedule.\n\n:param minute: The minute component in cron format. Defaults to ``\"*\"``.\n:param hour: The hour component in cron format. Defaults to ``\"*\"``.\n:param day_of_week: The day of the week component in cron format.\n    Defaults to ``\"*\"``.\n:param day_of_month: The day of the month component in cron format.\n    Defaults to ``\"*\"``.\n:param month_of_year: The month component in cron format.\n    Defaults to ``\"*\"``.\n:param timezone: The timezone for the cron schedule. Defaults to ``\"UTC\"``. Must\n    be a valid timezone as returned in ``available_timezones()``.",
         "properties": {
           "day_of_month": {
             "default": "*",
@@ -270,7 +270,7 @@
         "type": "string"
       },
       "PeriodicTaskCreate": {
-        "description": "Define the model for creating periodic tasks.\n\nExtends `PeriodicTaskWrite` and includes additional fields required for creating\nnew periodic tasks.\n\n:param task: The Celery task name.\n:type task: str\n:param execute_request: The execution request details for the task.\n:type execute_request: PeriodicTaskExecuteRequest | None\n:param interval: The interval schedule for the task. Defaults to None.\n:type interval: IntervalSchedule | None\n:param crontab: The crontab schedule for the task. Defaults to None.\n:type crontab: CrontabSchedule | None\n:param kwargs: A JSON string representing additional keyword arguments for the task.\n:type kwargs: str\n:param name: The name of the periodic task. Defaults to an empty string, meaning\n    the value will be automatically generated on create.\n:type name: str\n:param start_time: The start time for the task execution. Defaults to None.\n:type start_time:  UTCDatetime | None\n:param enabled: Whether the task is enabled. Defaults to True.\n:type enabled: bool\n:param description: A description of the task. Defaults to an empty string.\n:type description: str",
+        "description": "Define the model for creating periodic tasks.\n\nExtends `PeriodicTaskWrite` and includes additional fields required for creating\nnew periodic tasks.\n\n:param task: The Celery task name.\n:param execute_request: The execution request details for the task.\n:param interval: The interval schedule for the task. Defaults to None.\n:param crontab: The crontab schedule for the task. Defaults to None.\n:param kwargs: A JSON string representing additional keyword arguments for the task.\n:param name: The name of the periodic task. Defaults to an empty string, meaning\n    the value will be automatically generated on create.\n:param start_time: The start time for the task execution. Defaults to None.\n:param enabled: Whether the task is enabled. Defaults to True.\n:param description: A description of the task. Defaults to an empty string.",
         "properties": {
           "crontab": {
             "anyOf": [
@@ -409,7 +409,7 @@
         "type": "object"
       },
       "PeriodicTaskResponse": {
-        "description": "Represent a response for a periodic task API call.\n\nThis model extends `BasePeriodicTask` and includes additional fields such as ID,\nlast run time, total run count, and date changed.\n\n:param name: The name of the periodic task.\n:type name: str\n:param task: The SEP task name.\n:type task: str\n:param start_time: The start time for the task execution.\n:type start_time: UTCDatetime | None\n:param enabled: Whether the task is enabled.\n:type enabled: bool\n:param description: A description of the task.\n:type description: str\n:param execute_request: The execution request details for the task.\n:type execute_request: PeriodicTaskExecuteRequest | None\n:param id: The unique identifier of the periodic task.\n:type id: int\n:param last_run_at: The datetime of the last run.\n:type last_run_at: UTCDatetime | None\n:param total_run_count: The total number of times the task has run.\n:type total_run_count: int\n:param date_changed: The datetime when the task was last changed.\n:type date_changed: UTCDatetime | None\n:param last_run_status: The result of this schedule's own most recent\n    run, or ``None`` when the schedule has never run. Resolved as the\n    earliest system-triggered history for this task name at or after the\n    schedule's ``last_run_at``, so a later unrelated system run of the same\n    task name is not misattributed.\n:param interval: The interval schedule for the task. Defaults to None. This field\n    is populated with the alias \"model_intervalschedule\".\n:type interval: IntervalSchedule | None\n:param crontab: The crontab schedule for the task. Defaults to None. This field\n    is populated with the alias \"model_crontabschedule\".\n:type crontab: CrontabSchedule | None",
+        "description": "Represent a response for a periodic task API call.\n\nThis model extends `BasePeriodicTask` and includes additional fields such as ID,\nlast run time, total run count, and date changed.\n\n:param name: The name of the periodic task.\n:param task: The SEP task name.\n:param start_time: The start time for the task execution.\n:param enabled: Whether the task is enabled.\n:param description: A description of the task.\n:param execute_request: The execution request details for the task.\n:param id: The unique identifier of the periodic task.\n:param last_run_at: The datetime of the last run.\n:param total_run_count: The total number of times the task has run.\n:param date_changed: The datetime when the task was last changed.\n:param last_run_status: The result of this schedule's own most recent\n    run, or ``None`` when the schedule has never run. Resolved as the\n    earliest system-triggered history for this task name at or after the\n    schedule's ``last_run_at``, so a later unrelated system run of the same\n    task name is not misattributed.\n:param interval: The interval schedule for the task. Defaults to None. This field\n    is populated with the alias \"model_intervalschedule\".\n:param crontab: The crontab schedule for the task. Defaults to None. This field\n    is populated with the alias \"model_crontabschedule\".",
         "properties": {
           "crontab": {
             "anyOf": [
@@ -501,12 +501,22 @@
                 "type": "null"
               }
             ],
-            "description": "Compute the next scheduled execution time.\n\nReturn the next execution time based on the task's schedule. For crontab\nschedules, use `croniter` to compute the next fire time from the cron\nexpression in the schedule's timezone, converted to UTC. For interval\nschedules, add the interval duration to `last_run_at`, falling back to\n`start_time`, then the current time.\n\n:return: The next scheduled execution time in UTC, or `None` if the task\n    is disabled.\n:rtype: UTCDatetime | None",
+            "description": "Compute the next scheduled execution time.\n\n:return: The first of :attr:`next_runs`, or ``None`` when the task is\n    disabled.",
             "readOnly": true,
             "title": "Next Run At"
           },
+          "next_runs": {
+            "description": "Compute the next scheduled execution times.\n\nReport what Celery beat will do with this schedule, computed through the\nscheduler's own schedule objects, so the API's account of the task and\nthe scheduler's behaviour cannot disagree.\n\nCached per instance so a page of schedules computes each row once rather\nthan once per computed field reading it.\n\n:return: Up to :data:`~app.core.celery.schedules.NEXT_RUNS_PREVIEW_COUNT`\n    UTC execution times, empty when the task is disabled.",
+            "items": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "readOnly": true,
+            "title": "Next Runs",
+            "type": "array"
+          },
           "period": {
-            "description": "Get the period string for the periodic task.\n\nReturns a string representation of the task's schedule based on whether it uses\nan interval or crontab schedule.\n\n:return: A string representing the task's period.\n:rtype: str",
+            "description": "Get the period string for the periodic task.\n\nReturns a string representation of the task's schedule based on whether it uses\nan interval or crontab schedule.\n\n:return: A string representing the task's period.",
             "readOnly": true,
             "title": "Period",
             "type": "string"
@@ -527,6 +537,12 @@
             "title": "Task",
             "type": "string"
           },
+          "timezone": {
+            "description": "Report the zone this task's schedule is defined in.\n\nFor a crontab schedule this is the crontab's own zone. For an interval\nschedule it is ``UTC`` unconditionally, ``start_time`` set or not: an\ninterval's cadence is an absolute ``timedelta`` with no wall-clock\nanchor, and ``start_time`` is a ``UTCDatetime``, which coerces away\nwhatever zone the client sent, so neither could carry another zone.\n\n:return: The IANA zone name the schedule is defined in.",
+            "readOnly": true,
+            "title": "Timezone",
+            "type": "string"
+          },
           "total_run_count": {
             "default": 0,
             "title": "Total Run Count",
@@ -543,13 +559,15 @@
           "last_run_at",
           "date_changed",
           "period",
-          "next_run_at"
+          "next_runs",
+          "next_run_at",
+          "timezone"
         ],
         "title": "PeriodicTaskResponse",
         "type": "object"
       },
       "PeriodicTaskUpdate": {
-        "description": "Define the model for updating periodic tasks.\n\nExtends `PeriodicTaskWrite` and adds validations specific to updating tasks.\n\n:param name: The name of the periodic task.\n:type name: str\n:param task: The Celery task name.\n:type task: str\n:param start_time: The start time for the task execution.\n:type start_time: UTCDatetime | None\n:param enabled: Whether the task is enabled.\n:type enabled: bool\n:param description: A description of the task.\n:type description: str\n:param execute_request: The execution request details for the task.\n:type execute_request: PeriodicTaskExecuteRequest | None\n:param interval: The interval schedule for the task. Defaults to None.\n:type interval: IntervalSchedule | None\n:param crontab: The crontab schedule for the task. Defaults to None.\n:type crontab: CrontabSchedule | None\n:param kwargs: A JSON string representing additional keyword arguments for the task.\n:type kwargs: str",
+        "description": "Define the model for updating periodic tasks.\n\nExtends `PeriodicTaskWrite` and adds validations specific to updating tasks.\n\n:param name: The name of the periodic task.\n:param task: The Celery task name.\n:param start_time: The start time for the task execution.\n:param enabled: Whether the task is enabled.\n:param description: A description of the task.\n:param execute_request: The execution request details for the task.\n:param interval: The interval schedule for the task. Defaults to None.\n:param crontab: The crontab schedule for the task. Defaults to None.\n:param kwargs: A JSON string representing additional keyword arguments for the task.",
         "properties": {
           "crontab": {
             "anyOf": [
@@ -631,6 +649,77 @@
         "title": "ReloadClassification",
         "type": "string"
       },
+      "SchedulePreviewResponse": {
+        "description": "Represent the upcoming runs of a schedule that has not been saved.\n\nUses the same field names and shapes as the matching computed fields on\n:class:`PeriodicTaskResponse`, so a client renders a preview and a saved\nschedule through one code path.\n\n:param timezone: The zone the schedule is defined in.\n:param next_run_at: The first upcoming run, or ``None`` when there is none.\n:param next_runs: The upcoming runs, empty when there are none.",
+        "properties": {
+          "next_run_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Run At"
+          },
+          "next_runs": {
+            "items": {
+              "format": "date-time",
+              "type": "string"
+            },
+            "title": "Next Runs",
+            "type": "array"
+          },
+          "timezone": {
+            "title": "Timezone",
+            "type": "string"
+          }
+        },
+        "required": ["timezone", "next_run_at", "next_runs"],
+        "title": "SchedulePreviewResponse",
+        "type": "object"
+      },
+      "SchedulePreviewWrite": {
+        "description": "Define the schedule a preview is requested for.\n\nCarries the schedule fields of a create request and nothing else: a preview\npersists nothing, so it needs no task name, owner, or execution details.\n\n:param interval: The interval schedule to preview. Defaults to None.\n:param crontab: The crontab schedule to preview. Defaults to None.\n:param start_time: The earliest time the schedule may fire. Defaults to None.",
+        "properties": {
+          "crontab": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CrontabSchedule"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "interval": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IntervalSchedule"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          }
+        },
+        "title": "SchedulePreviewWrite",
+        "type": "object"
+      },
       "SettingClassGroup": {
         "description": "Group one settings class's fields for the LIST response.\n\n:param setting_class: The Pydantic class ``__name__`` this group represents.\n:param settings: The fields declared on the settings class, with their\n    current values and metadata.\n:param is_app_owned: Whether this group belongs to a SEP app under\n    ``app/sep/apps/`` rather than core SEP wiring.\n:param app_id: The owning app's registry key when ``is_app_owned`` is\n    ``True``; ``None`` for core groups.\n:param app_display_name: The owning app's human-facing label when\n    ``is_app_owned`` is ``True``; ``None`` for core groups.\n:param app_enabled: Whether the owning app is currently enabled when\n    ``is_app_owned`` is ``True``; ``None`` for core groups. Disabled\n    apps remain listed so the frontend can hide them without a second\n    lookup.",
         "properties": {
@@ -704,7 +793,7 @@
         "type": "object"
       },
       "SettingResponse": {
-        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether a row exists in the ``settingoverride`` table\n    for this ``(setting_class, key)`` pair, regardless of ``is_active``.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.",
+        "description": "Represent a single setting's metadata and current value.\n\n:param setting_class: The Pydantic class ``__name__`` the field belongs to.\n:param key: The field name on the settings class.\n:param key_path: Carry the canonical key segments for ``key`` such that\n    ``\"__\".join(key_path) == key``.\n:param value: The current value visible through the proxy, dumped to a\n    JSON-safe shape via the field's annotation. ``SecretStr`` fields are\n    redacted to ``\"**********\"``.\n:param default_value: The field's declared default value, dumped via the\n    same JSON serialiser. ``None`` when no default exists.\n:param type: A human-readable representation of the field's declared\n    annotation (for operator visibility; validation uses the actual\n    ``FieldInfo``).\n:param reload: The reload classification (HOT or NOT_OVERRIDABLE).\n:param description: The field's free-text description, or ``None``.\n:param is_secret: Whether the field's annotation contains a Pydantic secret\n    (``SecretStr`` / ``SecretBytes``) at any depth.\n:param is_complex: Whether the field's annotation is or contains a Pydantic\n    ``BaseModel`` subclass (true for nested submodels).\n:param has_override: Whether an **active** row in the ``settingoverride``\n    table applies to this ``(setting_class, key)`` pair. An inactive row is\n    skipped by the cache loader, so the served value falls back to the\n    declared default and reporting it as overridden would tell the UI a\n    field is overridden while showing it that default. A nested row also\n    marks every canonical prefix of its chain, so a parent reports ``True``\n    when only a deeper leaf carries a row.\n:param is_advanced: Whether the setting is flagged ``advanced`` so the UI can\n    present it separately from everyday settings. Display-only:\n    it does not affect PATCH/DELETE eligibility.\n:param is_applicable: Whether the setting applies under current runtime state\n    (e.g. the active auth provider). ``False`` lets the UI present the field\n    as inert. Display-only, like ``is_advanced``: it does not block\n    PATCH/DELETE server-side; the runtime gate is the real enforcement.\n:param options: Selectable enum members for dropdown UIs, or ``None`` when\n    the field is not an ``Enum`` annotation. Aliased members are excluded.\n:param updated_at: When the override applying to this key was last saved,\n    falling back to the row's creation time for a row written before the\n    stamp was recorded. ``None`` when ``has_override`` is ``False``.\n    Timestamps carry second granularity.\n:param updated_by: The username that last saved that override, or ``None``\n    both when no override applies and when the row predates the actor\n    column. A key can draw on several rows (a nested parent reporting on its\n    leaves), in which case the pair comes from the row carrying the latest\n    timestamp. Two writes landing within the same second are\n    indistinguishable by timestamp, and the pair reported is then whichever\n    contributing row was created later, which need not be the one written\n    later.",
         "properties": {
           "default_value": {
             "title": "Default Value"
@@ -777,6 +866,29 @@
           "type": {
             "title": "Type",
             "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "updated_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated By"
           },
           "value": {
             "title": "Value"
@@ -960,7 +1072,7 @@
         "type": "object"
       },
       "TaskHistory": {
-        "description": "Represent a task execution history.\n\n:param execution_request: The request that triggered the task execution.\n:param status: The status of the task execution. Defaults to pending.\n:param started_at: The datetime when the task execution started.\n:param finished_at: The datetime when the task execution finished.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the execution. Defaults to None, meaning it uses\n    the value defined in the associated task's :attr:`Task.anonymize_mask`.\n:param task_id: The ID of the task associated with the execution.\n:param task: The task associated with this execution history.\n:param sync_in_progress_started_at: Timestamp lock for a sync currently in progress.\n:param log_producer_epoch: Task-level high-water mark of the current\n    producer epoch (for example a Nomad allocation ``CreateIndex``), stamped\n    whenever the log frontier is reset. The log writer consults it on the\n    first-insert path (before any per-stream ``TaskHistoryLogState`` row\n    exists) to discard writes from a superseded producer. ``0`` is the\n    legacy/unknown sentinel that is trusted unconditionally.\n:param executed_by: The user ID of the user who executed the task.",
+        "description": "Represent a task execution history.\n\n:param execution_request: The request that triggered the task execution.\n:param status: The status of the task execution. Defaults to pending.\n:param started_at: The datetime when the task execution started.\n:param finished_at: The datetime when the task execution finished.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the execution. Defaults to None, meaning it uses\n    the value defined in the associated task's :attr:`Task.anonymize_mask`.\n:param task_id: The ID of the task associated with the execution.\n:param task: The task associated with this execution history.\n:param sync_in_progress_started_at: Timestamp lock for a sync currently in progress.\n:param log_producer_epoch: Task-level high-water mark of the current\n    producer epoch (for example a Nomad allocation ``CreateIndex``), stamped\n    whenever the log frontier is reset. The log writer consults it on the\n    first-insert path (before any per-stream ``TaskHistoryLogState`` row\n    exists) to discard writes from a superseded producer. ``0`` is the\n    legacy/unknown sentinel that is trusted unconditionally.\n:param executed_by: The user ID of the user who executed the task.\n:param failure_reason: A single-line, operator-facing reason for the run's\n    outcome, or None when the run did not fail or the reason is unknown.\n    Written only through :meth:`set_failure_reason`.",
         "properties": {
           "anonymize_mask": {
             "anyOf": [
@@ -991,6 +1103,17 @@
           },
           "execution_request": {
             "$ref": "#/components/schemas/TaskExecutionRequest"
+          },
+          "failure_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Reason"
           },
           "finished_at": {
             "anyOf": [
@@ -1118,7 +1241,7 @@
         "type": "object"
       },
       "TaskHistoryResponse": {
-        "description": "Represent a task history API response.\n\n:param execution_request: The request that triggered the task execution.\n:param status: The status of the task execution.\n:param started_at: The datetime when the task execution started.\n:param finished_at: The datetime when the task execution finished.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the execution. Defaults to None, meaning it uses\n    the value defined in the associated task's :attr:`Task.anonymize_mask`.\n:param task: The task associated with this execution history.\n:param executed_by: The user ID of the user who executed the task.\n:param has_logs: Whether this task history has any readable log content --\n    either a chunk-store row or a legacy ``tracking[\"task_logs\"]`` blob.\n    Populated by list/retrieve routes; defaults to ``False``.\n:param log_capture: How completely SEP captured this execution's logs,\n    aggregated over its state rows: any incomplete stream reports\n    ``\"incomplete\"``, else any unknown reports ``\"unknown\"``, else\n    ``\"complete\"``. Populated by list/retrieve routes; defaults to\n    ``\"unknown\"``, which is also what a history carrying no state rows\n    reports.\n:param display_name: A user-meaningful label derived from the task name or\n    execution-request metadata. Read-only; computed on serialisation.",
+        "description": "Represent a task history API response.\n\n:param execution_request: The request that triggered the task execution.\n:param status: The status of the task execution.\n:param started_at: The datetime when the task execution started.\n:param finished_at: The datetime when the task execution finished.\n:param anonymize_mask: The bitmask representing PII entities to be anonymized in\n    logs and files generated by the execution. Defaults to None, meaning it uses\n    the value defined in the associated task's :attr:`Task.anonymize_mask`.\n:param task: The task associated with this execution history.\n:param executed_by: The user ID of the user who executed the task.\n:param has_logs: Whether this task history has any readable log content --\n    either a chunk-store row or a legacy ``tracking[\"task_logs\"]`` blob.\n    Populated by list/retrieve routes; defaults to ``False``.\n:param log_capture: How completely SEP captured this execution's logs,\n    aggregated over its state rows: any incomplete stream reports\n    ``\"incomplete\"``, else any unknown reports ``\"unknown\"``, else\n    ``\"complete\"``. Populated by list/retrieve routes; defaults to\n    ``\"unknown\"``, which is also what a history carrying no state rows\n    reports.\n:param display_name: A user-meaningful label derived from the task name or\n    execution-request metadata. Read-only; computed on serialisation.\n:param failure_reason: A single-line, operator-facing reason for the run's\n    outcome, or None when the run did not fail or the reason is unknown. A\n    historic row predating the column reports None, which means \"unknown\"\n    rather than \"did not fail\".",
         "properties": {
           "anonymize_mask": {
             "anyOf": [
@@ -1168,6 +1291,17 @@
           },
           "execution_request": {
             "$ref": "#/components/schemas/TaskExecutionRequest"
+          },
+          "failure_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Failure Reason"
           },
           "finished_at": {
             "anyOf": [
@@ -1899,7 +2033,7 @@
     },
     "/admin/settings/{setting_class}": {
       "patch": {
-        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.",
+        "description": "Apply a batch of overrides for one settings class atomically.\n\nFor a remote class the batch is forwarded to the owning sub-app, which\nowns the validation and persistence; the upstream's per-field ``422``\n(and its ``detail``) is preserved so the UI can render inline messages.\n\nFor a local class: Phase A validates every key in ``body`` (existence on\nthe class, HOT classification, type/constraint coercion) and collects\nper-key errors. If any key fails, the whole batch is rejected with a\nstructured 422 and nothing is written. Phase B persists every valid entry\nin a single transaction, refreshes the proxy snapshot once, then fires\nthe rebind callbacks for any changed keys so a HOT target rebinds without\nwaiting for the next background refresh cycle.\n\n:param request: The incoming request; its ``app.state`` carries the\n    sub-app's rebind-callback registry.\n:param setting_class: The settings class the override targets.\n:param body: The batch of ``{key: value, ...}`` overrides.\n:param session: The sub-app's database session.\n:param remote_api: The client for remote settings classes (``None`` when\n    the router wires none).\n:param actor: The calling admin's username, recorded on every row the\n    batch writes and reported back on each response.\n:return: One :class:`SettingResponse` per applied key, in input order.\n:raises HTTPNotFoundException: If the class isn't exposed.\n:raises HTTPUnprocessableEntityException: If any key fails validation;\n    no rows are written.\n:raises HTTPBadGatewayException: For a remote class, when the owning\n    sub-app returns a server error (status >= 500) or is unreachable.\n:raises IntegrityError: When the replay of a batch that lost the\n    unique-index race conflicts again, which leaves nothing written.",
         "operationId": "settings_patch_settings_admin_settings__setting_class__patch",
         "parameters": [
           {
@@ -2294,7 +2428,7 @@
         "tags": ["tasks"]
       },
       "post": {
-        "description": "Create a new task history.\n\nNeither ``has_logs`` nor ``log_capture`` is populated on this response — a\nrow that was just created has no chunk-store entry, legacy tracking blob or\ncapture verdict yet, so both fall back to their serialization defaults.\n\n:param session: The SQLAlchemy asynchronous session.\n:param task: The task history to persist.\n:return: The saved task history record.",
+        "description": "Create a new task history.\n\nNeither ``has_logs`` nor ``log_capture`` is populated on this response — a\nrow that was just created has no chunk-store entry, legacy tracking blob or\ncapture verdict yet, so both fall back to their serialization defaults.\n\nA caller-supplied ``failure_reason`` is routed back through\n:meth:`TaskHistory.set_failure_reason` so the single-line and length bounds\nhold on every write path, not only on the reasons SEP composes itself.\n\nThe saved row is re-read with ``task`` joined and ``execution_request``\nundeferred: ``save`` re-defers that column, and the response model requires\nboth, so serializing the save's own return value attempts lazy IO from an\nasync context.\n\n:param session: The SQLAlchemy asynchronous session.\n:param task: The task history to persist.\n:return: The saved task history record.",
         "operationId": "tasks_create_task_history_history__post",
         "requestBody": {
           "content": {
@@ -2954,6 +3088,51 @@
           }
         ],
         "summary": "List Periodic Tasks",
+        "tags": ["periodic", "schedule", "tasks"]
+      }
+    },
+    "/periodic/schedule/preview/": {
+      "post": {
+        "description": "Report the upcoming runs of a schedule without saving it.\n\nAnswers for an unsaved request body what\n:class:`~app.tasks.periodic.models.PeriodicTaskResponse` answers for a stored\nschedule, through the same code path, so a client can preview a cron\nexpression while it is still being typed.\n\nTwo path segments so no single-segment ``/{param}`` sibling can match it,\nwhich is what keeps the SEP-side twin from reserving a task name.\n\n:param preview: The schedule to preview. Persisted nowhere.\n:return: The schedule's zone and its upcoming runs.",
+        "operationId": "periodic_preview_schedule_periodic_schedule_preview__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SchedulePreviewWrite"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SchedulePreviewResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Preview Schedule",
         "tags": ["periodic", "schedule", "tasks"]
       }
     },

--- a/ui/packages/sep/api/src/generated/inventory.ts
+++ b/ui/packages/sep/api/src/generated/inventory.ts
@@ -71,10 +71,16 @@ export interface paths {
      *     :param session: The sub-app's database session.
      *     :param remote_api: The client for remote settings classes (``None`` when
      *         the router wires none).
+     *     :param actor: The calling admin's username, recorded on every row the
+     *         batch writes and reported back on each response.
      *     :return: One :class:`SettingResponse` per applied key, in input order.
      *     :raises HTTPNotFoundException: If the class isn't exposed.
      *     :raises HTTPUnprocessableEntityException: If any key fails validation;
      *         no rows are written.
+     *     :raises HTTPBadGatewayException: For a remote class, when the owning
+     *         sub-app returns a server error (status >= 500) or is unreachable.
+     *     :raises IntegrityError: When the replay of a batch that lost the
+     *         unique-index race conflicts again, which leaves nothing written.
      */
     patch: operations['settings_patch_settings_admin_settings__setting_class__patch'];
     trace?: never;
@@ -2171,8 +2177,13 @@ export interface components {
      *         (``SecretStr`` / ``SecretBytes``) at any depth.
      *     :param is_complex: Whether the field's annotation is or contains a Pydantic
      *         ``BaseModel`` subclass (true for nested submodels).
-     *     :param has_override: Whether a row exists in the ``settingoverride`` table
-     *         for this ``(setting_class, key)`` pair, regardless of ``is_active``.
+     *     :param has_override: Whether an **active** row in the ``settingoverride``
+     *         table applies to this ``(setting_class, key)`` pair. An inactive row is
+     *         skipped by the cache loader, so the served value falls back to the
+     *         declared default and reporting it as overridden would tell the UI a
+     *         field is overridden while showing it that default. A nested row also
+     *         marks every canonical prefix of its chain, so a parent reports ``True``
+     *         when only a deeper leaf carries a row.
      *     :param is_advanced: Whether the setting is flagged ``advanced`` so the UI can
      *         present it separately from everyday settings. Display-only:
      *         it does not affect PATCH/DELETE eligibility.
@@ -2182,6 +2193,18 @@ export interface components {
      *         PATCH/DELETE server-side; the runtime gate is the real enforcement.
      *     :param options: Selectable enum members for dropdown UIs, or ``None`` when
      *         the field is not an ``Enum`` annotation. Aliased members are excluded.
+     *     :param updated_at: When the override applying to this key was last saved,
+     *         falling back to the row's creation time for a row written before the
+     *         stamp was recorded. ``None`` when ``has_override`` is ``False``.
+     *         Timestamps carry second granularity.
+     *     :param updated_by: The username that last saved that override, or ``None``
+     *         both when no override applies and when the row predates the actor
+     *         column. A key can draw on several rows (a nested parent reporting on its
+     *         leaves), in which case the pair comes from the row carrying the latest
+     *         timestamp. Two writes landing within the same second are
+     *         indistinguishable by timestamp, and the pair reported is then whichever
+     *         contributing row was created later, which need not be the one written
+     *         later.
      */
     SettingResponse: {
       /** Default Value */
@@ -2215,6 +2238,10 @@ export interface components {
       setting_class: string;
       /** Type */
       type: string;
+      /** Updated At */
+      updated_at?: string | null;
+      /** Updated By */
+      updated_by?: string | null;
       /** Value */
       value: unknown;
     };

--- a/ui/packages/sep/api/src/generated/main.ts
+++ b/ui/packages/sep/api/src/generated/main.ts
@@ -257,7 +257,6 @@ export interface paths {
      * @description List users.
      *
      *     :return: The list of users.
-     *     :rtype: list[User]
      */
     get: operations['users_list_users_api_users__get'];
     put?: never;

--- a/ui/packages/sep/api/src/generated/sep.ts
+++ b/ui/packages/sep/api/src/generated/sep.ts
@@ -1557,9 +1557,7 @@ export interface paths {
      * @description Return the list of periodic task names for the Inventory plugin.
      *
      *     Hard-coded because the Inventory plugin's periodic tasks are a fixed pair
-     *     (``inventory-sync`` and ``inventory-collection``). The shape matches what the
-     *     React ``usePluginTasks('inventory')`` hook expects: a list of objects with at
-     *     minimum a ``name`` key.
+     *     (``inventory-sync`` and ``inventory-collection``).
      *
      *     :return: The plugin's periodic tasks, each with its name and display name.
      */
@@ -1597,59 +1595,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/apps/inventory/nodes/{node_id}/system-observation': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Inventory Node System Observation
-     * @description Proxy the host-level system observation for a node (read-only).
-     *
-     *     Forwards to the inventory sub-app's ``/nodes/{node_id}/system-observation``
-     *     endpoint via ``InventoryAPI``. This three-segment literal path cannot
-     *     collide with the two-segment ``/{entity}/{item_id:int}`` detail matcher. An
-     *     upstream HTTP 404 propagates unchanged, along with the ``detail`` that tells
-     *     a node whose observation has not been collected yet — which the React panel
-     *     renders as an empty state — apart from a node that does not exist.
-     *
-     *     :param node_id: Primary key of the node.
-     *     :param inventory_api: Authenticated inventory ``RemoteAPI`` client.
-     *     :return: The host-level system observation payload.
-     */
-    get: operations['inventory_inventory_node_system_observation_api_apps_inventory_nodes__node_id__system_observation_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/apps/inventory/schema': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get Schema
-     * @description Return the plugin schema captured at registration time.
-     *
-     *     :return: The plugin schema instance.
-     */
-    get: operations['inventory_get_schema_api_apps_inventory_schema_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/apps/inventory/services/{service_id}/check-connectivity/': {
     parameters: {
       query?: never;
@@ -1663,12 +1608,9 @@ export interface paths {
      * Inventory Service Check Connectivity
      * @description Run a database connectivity probe for a service from its executor host.
      *
-     *     Backs the React connectivity control on the service detail page. A probe
-     *     that ran but could not connect is reported as HTTP 200 with
+     *     A probe that ran but could not connect is reported as HTTP 200 with
      *     ``success=false`` and the upstream message in ``error``; only a probe that
-     *     could not be attempted at all is an error status. This three-segment
-     *     literal path cannot collide with the two-segment
-     *     ``/{entity}/{item_id:int}`` detail matcher.
+     *     could not be attempted at all is an error status.
      *
      *     :param service: The service to probe, resolved from the path id.
      *     :param tasks_api: Authenticated Tasks ``RemoteAPI`` client.
@@ -1680,37 +1622,6 @@ export interface paths {
      *         returns an unparseable body.
      */
     post: operations['inventory_inventory_service_check_connectivity_api_apps_inventory_services__service_id__check_connectivity__post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/apps/inventory/services/{service_id}/system-observation': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Inventory Service System Observation
-     * @description Proxy the service-level system observation for a service (read-only).
-     *
-     *     Forwards to the inventory sub-app's
-     *     ``/services/{service_id}/system-observation`` endpoint via ``InventoryAPI``.
-     *     An upstream HTTP 404 propagates unchanged, along with the ``detail`` that
-     *     tells a service whose observation has not been collected yet — which the
-     *     React panel renders as an empty state — apart from a service that does not
-     *     exist.
-     *
-     *     :param service_id: Primary key of the service.
-     *     :param inventory_api: Authenticated inventory ``RemoteAPI`` client.
-     *     :return: The service-level system observation payload.
-     */
-    get: operations['inventory_inventory_service_system_observation_api_apps_inventory_services__service_id__system_observation_get'];
-    put?: never;
-    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -1770,61 +1681,13 @@ export interface paths {
      * Inventory Sync Status
      * @description Return whether an inventory-wide sync is running, plus recent run outcomes.
      *
-     *     Replaces the server-rendered ``sync_is_running`` template variable
-     *     used by the Jinja2 inventory page so the React control can poll the
-     *     same state without scraping HTML.
+     *     Lets an operator poll a sync they triggered through ``POST /sync/``
+     *     without scraping any rendered page.
      *
      *     :param session: SQLModel async session.
      *     :return: The running flag and the most recent runs, newest first.
      */
     get: operations['inventory_inventory_sync_status_api_apps_inventory_sync_status__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/apps/inventory/{entity}/': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Inventory List Entity
-     * @description List inventory nodes, services, schemas, or tables.
-     *
-     *     :param request: Inbound request; its query string carries entity filters.
-     *     :param entity: Inventory entity type (nodes, services, schemas, tables).
-     *     :param inventory_api: Async client for the Inventory sub-app.
-     *     :param pagination: Validated offset/limit forwarded to the upstream call.
-     *     :param list_query: Allowlist-vetted sort/search for this entity.
-     *     :return: A paginated envelope echoing the requested window.
-     */
-    get: operations['inventory_inventory_list_entity_api_apps_inventory__entity___get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/apps/inventory/{entity}/{item_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Inventory Get Entity
-     * @description Retrieve a single inventory node, service, schema, or table.
-     */
-    get: operations['inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get'];
     put?: never;
     post?: never;
     delete?: never;
@@ -2042,6 +1905,46 @@ export interface paths {
     post?: never;
     /** Delete */
     delete: operations['mysql_backups__delete_api_apps_mysql_backups__task_name__delete'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/apps/mysql_backups/{task_name}/backups': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Task Backups
+     * @description Return a page of a backup task's catalogued runs, newest run first.
+     *
+     *     The ``task_name`` path parameter is resolved by
+     *     :data:`~app.sep.apps.mysql_backups.deps.CataloguedHistoryIds`, so a task that
+     *     does not exist or belongs to another app surfaces as a ``404`` while a known
+     *     task with no catalogued backup yields an empty page — keeping "this task has
+     *     never produced a backup" distinguishable from "this task does not exist".
+     *
+     *     The discovery walk behind that dependency is capped, so ``total`` counts the
+     *     runs within the scanned window rather than every run the task ever produced,
+     *     and carries no marker distinguishing a truncated page from a complete one.
+     *     A run older than the window is reachable through the per-service catalog
+     *     route, which is uncapped — but only while its inventory service still
+     *     resolves, and only for a caller that knows which service the run was recorded
+     *     under, which a task since re-pointed at another target no longer answers.
+     *
+     *     :param history_ids: The task's catalogued task-history ids, newest first.
+     *     :param session: The database session the catalog is queried on.
+     *     :param pagination: The requested offset/limit window.
+     *     :return: The requested page of the task's recorded backup runs, newest run
+     *         first.
+     */
+    get: operations['mysql_backups_list_task_backups_api_apps_mysql_backups__task_name__backups_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -2643,13 +2546,11 @@ export interface paths {
      * @description Return the per-task detail bundle for the read-only plugin UI.
      *
      *     :param task: The task definition resolved by name.
-     *     :type task: Task
      *     :param tasks_api: Async client for the tasks sub-app.
-     *     :type tasks_api: TaskAPI
      *     :param executor_hosts_ctx: Executor hosts enriched with inventory labels.
-     *     :type executor_hosts_ctx: ExecutorHostsCtx
-     *     :return: Task definition, history, periodic schedules, and executor hosts.
-     *     :rtype: TaskDetailResponse
+     *     :return: Task definition, history, periodic schedules, and executor hosts,
+     *         with every actor identifier on the task and inside the history rows
+     *         resolved to the name a reader should see.
      */
     get: operations['task_manager_tasks_api_detail_api_apps_tasks__task_name__get'];
     put?: never;
@@ -2749,6 +2650,37 @@ export interface paths {
      *     :return: One normalized connectivity result per requested service.
      */
     post: operations['sep_check_connectivity_api_sep_admin_connectivity_check__post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/sep/admin/delivery-connection/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Read Delivery Connection
+     * @description Report the facts the delivery plan declares about its own connection.
+     *
+     *     No way the read can fail reaches the caller as an error: a deployment that
+     *     declares no connection-details step, stored inputs that no longer fit the
+     *     plan, a refused credential, an unreachable receiver and a read that outran
+     *     its bound all answer 200 with the outcome that describes them, so a caller
+     *     renders a state rather than handling an error. The three configuration
+     *     outcomes are decided before any request is issued; the read and the failure
+     *     outcomes are decided only after one.
+     *
+     *     :return: The resolved pairs in the plan's declaration order, or the outcome
+     *         explaining why there are none.
+     */
+    get: operations['sep_read_delivery_connection_api_sep_admin_delivery_connection__get'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -2875,10 +2807,16 @@ export interface paths {
      *     :param session: The sub-app's database session.
      *     :param remote_api: The client for remote settings classes (``None`` when
      *         the router wires none).
+     *     :param actor: The calling admin's username, recorded on every row the
+     *         batch writes and reported back on each response.
      *     :return: One :class:`SettingResponse` per applied key, in input order.
      *     :raises HTTPNotFoundException: If the class isn't exposed.
      *     :raises HTTPUnprocessableEntityException: If any key fails validation;
      *         no rows are written.
+     *     :raises HTTPBadGatewayException: For a remote class, when the owning
+     *         sub-app returns a server error (status >= 500) or is unreachable.
+     *     :raises IntegrityError: When the replay of a batch that lost the
+     *         unique-index race conflicts again, which leaves nothing written.
      */
     patch: operations['sep_patch_settings_api_sep_admin_settings__setting_class__patch'];
     trace?: never;
@@ -3093,6 +3031,39 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/sep/periodic-tasks/schedule/preview/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Preview Schedule
+     * @description Dispatch a schedule preview to the Tasks API.
+     *
+     *     Two path segments so the sibling ``POST /{task_name}/`` cannot match this
+     *     route: a single-segment ``/preview/`` would be ambiguous with it, resolvable
+     *     only by declaration order and only at the cost of reserving ``preview`` as a
+     *     task name nobody could schedule.
+     *
+     *     :param tasks_api: The Tasks API client used to compute the preview.
+     *     :param body: The ``SchedulePreviewWrite`` JSON body, forwarded verbatim.
+     *     :return: The schedule preview as returned by the Tasks API.
+     *     :raises HTTPException: Re-raised unchanged for an upstream client error
+     *         (status < 500).
+     *     :raises HTTPBadGatewayException: For an upstream server error (status >= 500)
+     *         or a connection-level ``OSError``.
+     */
+    post: operations['tasks_preview_schedule_api_sep_periodic_tasks_schedule_preview__post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/sep/periodic-tasks/{periodic_task_id}': {
     parameters: {
       query?: never;
@@ -3287,7 +3258,8 @@ export interface paths {
      *     :param exclude_internal: When ``True``, forward the filter to the upstream
      *         list-all path so internal maintenance tasks are excluded before pagination.
      *         Not forwarded on the ``task_names`` merge path. Defaults to ``False``.
-     *     :return: Paginated task history, either the upstream list or the merged set.
+     *     :return: Paginated task history, either the upstream list or the merged set,
+     *         with every actor identifier resolved to the name a reader should see.
      *     :raises HTTPUnprocessableEntityException: When ``task_names`` is supplied but
      *         every value is empty after trimming.
      *     :raises HTTPBadGatewayException: For an upstream server error (status >= 500)
@@ -3747,6 +3719,49 @@ export interface components {
       tasks: number;
     };
     /**
+     * DeliveryConnectionDetail
+     * @description Report one fact describing the delivery connection.
+     *
+     *     :param label: The display label the plan declared, rendered verbatim. A
+     *         machine key would oblige the caller to carry receiver-specific names.
+     *     :param value: The value that label reports.
+     */
+    DeliveryConnectionDetail: {
+      /** Label */
+      label: string;
+      /** Value */
+      value: string;
+    };
+    /**
+     * DeliveryConnectionResponse
+     * @description Report the facts describing the delivery connection, or why there are none.
+     *
+     *     :param status: Which of the five outcomes the read reached.
+     *     :param details: The resolved pairs in the plan's declaration order. Empty
+     *         for every status other than ``available``, and empty under ``available``
+     *         when every declared pointer missed, so a caller draws from this alone
+     *         and consults ``status`` only to explain an empty list.
+     */
+    DeliveryConnectionResponse: {
+      /**
+       * Details
+       * @default []
+       */
+      details: components['schemas']['DeliveryConnectionDetail'][];
+      status: components['schemas']['DeliveryConnectionStatusEnum'];
+    };
+    /**
+     * DeliveryConnectionStatusEnum
+     * @description Enumerate the mutually-exclusive outcomes of a connection-details read.
+     * @enum {string}
+     */
+    DeliveryConnectionStatusEnum:
+      | 'available'
+      | 'undeclared'
+      | 'not_configured'
+      | 'inputs_drifted'
+      | 'fetch_failed';
+    /**
      * ExecutionEvent
      * @description Represent a single lifecycle event from a task executor (executor-agnostic shape).
      *
@@ -3900,10 +3915,12 @@ export interface components {
       /** Updated At */
       updated_at?: string | null;
     };
-    /** PaginatedResponse[Any] */
-    PaginatedResponse_Any_: {
+    /** PaginatedResponse[ArbitraryMapping] */
+    PaginatedResponse_ArbitraryMapping_: {
       /** Items */
-      items: unknown[];
+      items: {
+        [key: string]: unknown;
+      }[];
       /** Limit */
       limit: number;
       /** Offset */
@@ -3911,12 +3928,10 @@ export interface components {
       /** Total */
       total: number;
     };
-    /** PaginatedResponse[ArbitraryMapping] */
-    PaginatedResponse_ArbitraryMapping_: {
+    /** PaginatedResponse[SepTaskHistoryResponse] */
+    PaginatedResponse_SepTaskHistoryResponse_: {
       /** Items */
-      items: {
-        [key: string]: unknown;
-      }[];
+      items: components['schemas']['SepTaskHistoryResponse'][];
       /** Limit */
       limit: number;
       /** Offset */
@@ -3939,17 +3954,6 @@ export interface components {
     PaginatedResponse_SnippetResponse_: {
       /** Items */
       items: components['schemas']['SnippetResponse'][];
-      /** Limit */
-      limit: number;
-      /** Offset */
-      offset: number;
-      /** Total */
-      total: number;
-    };
-    /** PaginatedResponse[TaskHistoryResponse] */
-    PaginatedResponse_TaskHistoryResponse_: {
-      /** Items */
-      items: components['schemas']['TaskHistoryResponse'][];
       /** Limit */
       limit: number;
       /** Offset */
@@ -4043,6 +4047,148 @@ export interface components {
       service_id: number;
       /** Sync Failing Since */
       sync_failing_since?: string | null;
+      /** Updated At */
+      updated_at?: string | null;
+    };
+    /**
+     * SepTaskHistoryResponse
+     * @description Represent a task-history row as SEP serves it, with actors resolved.
+     *
+     *     :param task: The task this execution belongs to, carrying resolved actors.
+     *     :param executed_by: Display name for the actor that ran the task, or
+     *         ``None`` when none was recorded.
+     */
+    SepTaskHistoryResponse: {
+      /** Anonymize Mask */
+      anonymize_mask?: number | null;
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at?: string;
+      /**
+       * Display Name
+       * @description Return a user-meaningful display label for this task history row.
+       *
+       *     For normal tasks, returns ``task.name``. For generic executor templates
+       *     (``run-python``, ``exec-artifact``, ``exec-python-artifact``), builds a
+       *     ``"<source>/<filename> on <target>"`` label so otherwise-identical rows
+       *     are distinguishable: the filename comes from the snippet metadata or the
+       *     ``file://`` payload basename, the source directory from whichever of those
+       *     carries one, and the target from the execution request. Falls back to
+       *     ``"<task> on <target>"`` when no filename is available.
+       *
+       *     :return: The display label for the task history entry.
+       */
+      readonly display_name: string;
+      /**
+       * Duration
+       * @description Return the duration of the task execution in seconds.
+       *
+       *     :return: The duration in seconds, or None if not available.
+       *     :rtype: float | None
+       */
+      readonly duration: number | null;
+      /**
+       * Executed By
+       * @description Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.
+       */
+      executed_by?: string | null;
+      execution_request: components['schemas']['TaskExecutionRequest'];
+      /** Failure Reason */
+      failure_reason?: string | null;
+      /** Finished At */
+      finished_at?: string | null;
+      /**
+       * Has Logs
+       * @default false
+       */
+      has_logs: boolean;
+      /** Id */
+      id: number | null;
+      /** @default unknown */
+      log_capture: components['schemas']['LogCaptureStatusEnum'];
+      /** Started At */
+      started_at?: string | null;
+      /** @default pending */
+      status: components['schemas']['TaskHistoryStatusEnum'];
+      task: components['schemas']['SepTaskResponse'];
+      /** Updated At */
+      updated_at?: string | null;
+    };
+    /**
+     * SepTaskResponse
+     * @description Represent a task definition as SEP serves it, with actors resolved.
+     *
+     *     Differ from :class:`~app.tasks.models.TaskResponse` only in what the two
+     *     actor fields carry.
+     *
+     *     :param created_by: Display name for the task's creator, or ``None`` when
+     *         none was recorded.
+     *     :param last_updated_by: Display name for the user who last modified the
+     *         task, or ``None`` when none was recorded.
+     */
+    SepTaskResponse: {
+      /** Alert Detail Builder */
+      alert_detail_builder?: string | null;
+      /**
+       * Alert On Fail
+       * @default false
+       */
+      alert_on_fail: boolean;
+      /** Anonymize Mask */
+      anonymize_mask?: number | null;
+      /**
+       * Anonymized Entities
+       * @description Return sorted PII entity names decoded from ``anonymize_mask``.
+       */
+      readonly anonymized_entities: string[];
+      /** @default nomad */
+      backend: components['schemas']['TaskBackendEnum'];
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at?: string;
+      /**
+       * Created By
+       * @description Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.
+       */
+      created_by: string | null;
+      /** Data */
+      data: {
+        [key: string]: unknown;
+      };
+      /** Deleted At */
+      deleted_at: string | null;
+      /** Id */
+      id: number | null;
+      /**
+       * Is Template
+       * @default false
+       */
+      is_template: boolean;
+      /**
+       * Last Updated By
+       * @description Display name for the actor: the provider's username when resolvable, a system label for system-initiated work, otherwise the stored identifier.
+       */
+      last_updated_by: string | null;
+      /** Name */
+      name: string;
+      /** Output Files Path */
+      output_files_path?: string | null;
+      /**
+       * Owner
+       * @default ANY
+       */
+      owner: string;
+      /**
+       * Protected
+       * @default false
+       */
+      protected: boolean;
+      /** Run Result Recorder */
+      run_result_recorder?: string | null;
       /** Updated At */
       updated_at?: string | null;
     };
@@ -4226,8 +4372,13 @@ export interface components {
      *         (``SecretStr`` / ``SecretBytes``) at any depth.
      *     :param is_complex: Whether the field's annotation is or contains a Pydantic
      *         ``BaseModel`` subclass (true for nested submodels).
-     *     :param has_override: Whether a row exists in the ``settingoverride`` table
-     *         for this ``(setting_class, key)`` pair, regardless of ``is_active``.
+     *     :param has_override: Whether an **active** row in the ``settingoverride``
+     *         table applies to this ``(setting_class, key)`` pair. An inactive row is
+     *         skipped by the cache loader, so the served value falls back to the
+     *         declared default and reporting it as overridden would tell the UI a
+     *         field is overridden while showing it that default. A nested row also
+     *         marks every canonical prefix of its chain, so a parent reports ``True``
+     *         when only a deeper leaf carries a row.
      *     :param is_advanced: Whether the setting is flagged ``advanced`` so the UI can
      *         present it separately from everyday settings. Display-only:
      *         it does not affect PATCH/DELETE eligibility.
@@ -4237,6 +4388,18 @@ export interface components {
      *         PATCH/DELETE server-side; the runtime gate is the real enforcement.
      *     :param options: Selectable enum members for dropdown UIs, or ``None`` when
      *         the field is not an ``Enum`` annotation. Aliased members are excluded.
+     *     :param updated_at: When the override applying to this key was last saved,
+     *         falling back to the row's creation time for a row written before the
+     *         stamp was recorded. ``None`` when ``has_override`` is ``False``.
+     *         Timestamps carry second granularity.
+     *     :param updated_by: The username that last saved that override, or ``None``
+     *         both when no override applies and when the row predates the actor
+     *         column. A key can draw on several rows (a nested parent reporting on its
+     *         leaves), in which case the pair comes from the row carrying the latest
+     *         timestamp. Two writes landing within the same second are
+     *         indistinguishable by timestamp, and the pair reported is then whichever
+     *         contributing row was created later, which need not be the one written
+     *         later.
      */
     SettingResponse: {
       /** Default Value */
@@ -4270,6 +4433,10 @@ export interface components {
       setting_class: string;
       /** Type */
       type: string;
+      /** Updated At */
+      updated_at?: string | null;
+      /** Updated By */
+      updated_by?: string | null;
       /** Value */
       value: unknown;
     };
@@ -4531,84 +4698,6 @@ export interface components {
       [key: string]: unknown;
     };
     /**
-     * TaskHistoryResponse
-     * @description Represent a task history API response.
-     *
-     *     :param execution_request: The request that triggered the task execution.
-     *     :param status: The status of the task execution.
-     *     :param started_at: The datetime when the task execution started.
-     *     :param finished_at: The datetime when the task execution finished.
-     *     :param anonymize_mask: The bitmask representing PII entities to be anonymized in
-     *         logs and files generated by the execution. Defaults to None, meaning it uses
-     *         the value defined in the associated task's :attr:`Task.anonymize_mask`.
-     *     :param task: The task associated with this execution history.
-     *     :param executed_by: The user ID of the user who executed the task.
-     *     :param has_logs: Whether this task history has any readable log content --
-     *         either a chunk-store row or a legacy ``tracking["task_logs"]`` blob.
-     *         Populated by list/retrieve routes; defaults to ``False``.
-     *     :param log_capture: How completely SEP captured this execution's logs,
-     *         aggregated over its state rows: any incomplete stream reports
-     *         ``"incomplete"``, else any unknown reports ``"unknown"``, else
-     *         ``"complete"``. Populated by list/retrieve routes; defaults to
-     *         ``"unknown"``, which is also what a history carrying no state rows
-     *         reports.
-     *     :param display_name: A user-meaningful label derived from the task name or
-     *         execution-request metadata. Read-only; computed on serialisation.
-     */
-    TaskHistoryResponse: {
-      /** Anonymize Mask */
-      anonymize_mask?: number | null;
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string;
-      /**
-       * Display Name
-       * @description Return a user-meaningful display label for this task history row.
-       *
-       *     For normal tasks, returns ``task.name``. For generic executor templates
-       *     (``run-python``, ``exec-artifact``, ``exec-python-artifact``), builds a
-       *     ``"<source>/<filename> on <target>"`` label so otherwise-identical rows
-       *     are distinguishable: the filename comes from the snippet metadata or the
-       *     ``file://`` payload basename, the source directory from whichever of those
-       *     carries one, and the target from the execution request. Falls back to
-       *     ``"<task> on <target>"`` when no filename is available.
-       *
-       *     :return: The display label for the task history entry.
-       */
-      readonly display_name: string;
-      /**
-       * Duration
-       * @description Return the duration of the task execution in seconds.
-       *
-       *     :return: The duration in seconds, or None if not available.
-       *     :rtype: float | None
-       */
-      readonly duration: number | null;
-      /** Executed By */
-      executed_by?: string | null;
-      execution_request: components['schemas']['TaskExecutionRequest'];
-      /** Finished At */
-      finished_at?: string | null;
-      /**
-       * Has Logs
-       * @default false
-       */
-      has_logs: boolean;
-      /** Id */
-      id: number | null;
-      /** @default unknown */
-      log_capture: components['schemas']['LogCaptureStatusEnum'];
-      /** Started At */
-      started_at?: string | null;
-      /** @default pending */
-      status: components['schemas']['TaskHistoryStatusEnum'];
-      task: components['schemas']['TaskResponse'];
-      /** Updated At */
-      updated_at?: string | null;
-    };
-    /**
      * TaskHistoryStatusEnum
      * @description Define status codes for task executions.
      *
@@ -4636,94 +4725,6 @@ export interface components {
       | 'lost'
       | 'stale'
       | 'unlaunchable';
-    /**
-     * TaskResponse
-     * @description Represent a task API response.
-     *
-     *     :param name: The name of the task.
-     *     :param data: The task data stored in JSON format.
-     *     :param backend: The backend used for task execution. Defaults to Nomad.
-     *     :param owner: The owner of the task. Defaults to ``"ANY"``.
-     *     :param is_template: Whether the task is a template. Defaults to False.
-     *     :param protected: Whether the task is protected from deletion. Defaults to False.
-     *     :param alert_on_fail: Whether to trigger an alert on task failure and
-     *         auto-resolve it on subsequent success. Defaults to False.
-     *     :param alert_detail_builder: The ``"module:function"`` path of a plugin
-     *         callable that enriches this task's failure alert, or None.
-     *     :param run_result_recorder: The ``"module:function"`` path of a plugin
-     *         callable that records this task's structured run result at terminal
-     *         status, or None.
-     *     :param output_files_path: The path, relative to the executor's working
-     *         directory, where output files generated by the task are expected, or
-     *         None.
-     *     :param deleted_at: The deletion timestamp, if applicable.
-     *     :param anonymize_mask: The bitmask representing PII entities to be anonymized in
-     *         logs and files generated by the task. Defaults to 0 (no anonymization).
-     *     :param created_by: The user ID of the user who created the task.
-     *     :param last_updated_by: The user ID of the user who last modified the task.
-     *     :param anonymized_entities: Sorted list of PII entity names derived from
-     *         ``anonymize_mask`` (or from the owner's configured defaults when the
-     *         mask is ``None``). Each name is the raw ``PIIEntity`` member name
-     *         (e.g. ``"EMAIL_ADDRESS"``). Read-only; computed on serialisation.
-     */
-    TaskResponse: {
-      /** Alert Detail Builder */
-      alert_detail_builder?: string | null;
-      /**
-       * Alert On Fail
-       * @default false
-       */
-      alert_on_fail: boolean;
-      /** Anonymize Mask */
-      anonymize_mask?: number | null;
-      /**
-       * Anonymized Entities
-       * @description Return sorted PII entity names decoded from ``anonymize_mask``.
-       */
-      readonly anonymized_entities: string[];
-      /** @default nomad */
-      backend: components['schemas']['TaskBackendEnum'];
-      /**
-       * Created At
-       * Format: date-time
-       */
-      created_at?: string;
-      /** Created By */
-      created_by: string | null;
-      /** Data */
-      data: {
-        [key: string]: unknown;
-      };
-      /** Deleted At */
-      deleted_at: string | null;
-      /** Id */
-      id: number | null;
-      /**
-       * Is Template
-       * @default false
-       */
-      is_template: boolean;
-      /** Last Updated By */
-      last_updated_by: string | null;
-      /** Name */
-      name: string;
-      /** Output Files Path */
-      output_files_path?: string | null;
-      /**
-       * Owner
-       * @default ANY
-       */
-      owner: string;
-      /**
-       * Protected
-       * @default false
-       */
-      protected: boolean;
-      /** Run Result Recorder */
-      run_result_recorder?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-    };
     /** ValidationError */
     ValidationError: {
       /** Context */
@@ -6242,7 +6243,12 @@ export interface components {
     };
     /**
      * BackupType
-     * @description Backup types.
+     * @description Represent the backup tools a run can be taken with.
+     *
+     *     :cvar LABELS: Display text for each stored value, keyed as the value is
+     *         stored on the wire. A value with no entry is rendered as-is by the
+     *         caller. Wrapped in :func:`enum.nonmember` because ``enum`` would
+     *         otherwise treat a class-body dict as a member candidate.
      * @enum {string}
      */
     backup_mongo__BackupType:
@@ -6912,26 +6918,28 @@ export interface components {
      *     the root ``forms`` / ``list_view`` instead.
      *
      *     :param name: URL segment and API key for the entity (for example ``nodes``).
-     *     :type name: NonEmptyStr
      *     :param display_name: Human-readable title for this entity's screens.
-     *     :type display_name: NonEmptyStr
+     *     :param item_display_name: What **one** record of this entity is called (for
+     *         example ``node``), as opposed to ``display_name``, which names the
+     *         entity's screens. Stored in mid-sentence form so a consumer composing a
+     *         label capitalises the first character itself. Defaults to this entity's
+     *         own ``display_name`` — not the parent app's, and never inferred from
+     *         ``item_display_name_plural``.
+     *     :param item_display_name_plural: What **several** records of this entity are
+     *         called (for example ``nodes``). An independent declaration under the
+     *         same mid-sentence convention; nothing derives it from
+     *         ``item_display_name``. Defaults to this entity's own ``display_name``.
      *     :param description: Optional helper text for this entity. Defaults to
      *         ``None``.
-     *     :type description: NonEmptyStr | None
      *     :param forms: Form sections for create (and edit when the UI supports it).
-     *     :type forms: list[FormSection]
      *     :param list_view: Column configuration for this entity's list table.
-     *     :type list_view: ListView
      *     :param detail_highlights: Optional per-field syntax highlighter hints for
      *         detail pages. Keys are field names; values are highlighting languages.
      *         Defaults to an empty mapping.
-     *     :type detail_highlights: dict[NonEmptyStr, DetailHighlightLanguage]
      *     :param cardinality_rules: Optional entity-wide cross-field cardinality
      *         constraints. Defaults to ``None``.
-     *     :type cardinality_rules: list[CardinalityRule] | None
      *     :param fail_when: Optional entity-wide predicate-only invariants.
      *         Defaults to ``None``.
-     *     :type fail_when: list[FailRule] | None
      */
     framework__AppEntitySchema: {
       /** Cardinality Rules */
@@ -6950,6 +6958,10 @@ export interface components {
       fail_when?: components['schemas']['framework__FailRule'][] | null;
       /** Forms */
       forms: components['schemas']['framework__FormSection'][];
+      /** Item Display Name */
+      item_display_name: string;
+      /** Item Display Name Plural */
+      item_display_name_plural: string;
       list_view: components['schemas']['framework__ListView'];
       /** Name */
       name: string;
@@ -6960,32 +6972,37 @@ export interface components {
      *
      *     :param name: The plugin identifier; must match Python identifier rules,
      *         optionally with internal hyphens.
-     *     :type name: NonEmptyStr
      *     :param display_name: The human-readable plugin title displayed in the UI.
-     *     :type display_name: NonEmptyStr
+     *     :param item_display_name: What **one** record this plugin's create form
+     *         produces is called (for example ``backup``), as opposed to
+     *         ``display_name``, which names the plugin. Stored in mid-sentence form —
+     *         lowercase unless it opens with a proper noun — so a consumer composing a
+     *         label capitalises the first character itself. Defaults to
+     *         ``display_name``, and is never inferred from
+     *         ``item_display_name_plural``. Unlike the optional UI hints on this
+     *         model, both record names are required and non-nullable so the generated
+     *         client types them as ``string`` and no consumer needs a fallback.
+     *     :param item_display_name_plural: What **several** of those records are
+     *         called (for example ``backups``). An independent declaration under the
+     *         same mid-sentence convention; nothing derives it from
+     *         ``item_display_name``. Defaults to ``display_name``.
      *     :param description: Optional helper text describing the plugin's
      *         purpose. Defaults to ``None``.
-     *     :type description: NonEmptyStr | None
      *     :param task_type: Optional task-type identifier used when creating tasks
      *         via the shared task API. Defaults to ``None``.
-     *     :type task_type: NonEmptyStr | None
      *     :param forms: Form sections for single-entity / task plugins. When
      *         ``entities`` is non-empty, root ``forms`` must be empty (declare
      *         forms on each entity instead); non-empty root ``forms`` are rejected
      *         at construction. Defaults to an empty list.
-     *     :type forms: list[FormSection]
      *     :param capabilities: Optional plugin-level feature flags. Defaults to
      *         ``None``.
-     *     :type capabilities: Capabilities | None
      *     :param list_view: List-view configuration when ``entities`` is unset
      *         (single-entity / task plugins). Ignored when ``entities`` is set.
-     *     :type list_view: ListView | None
      *     :param detail_view: Optional declarative layout for the task detail page's
      *         section cards (task-style plugins only; ignored when ``entities`` is
      *         set). Optional at the model layer for backwards compatibility. A
      *         forward-looking guard refuses to load a plugin that sets
      *         ``task_type`` without declaring ``detail_view``. Defaults to ``None``.
-     *     :type detail_view: DetailView | None
      *     :param entities: Optional list of CRUD entities for multi-resource plugins.
      *         When non-empty, the React shell renders one list/create/detail flow
      *         per entity. Defaults to ``None`` (legacy single-entity mode).
@@ -6993,26 +7010,25 @@ export interface components {
      *         constraints (task-style plugins only). Rejected at construction when
      *         ``entities`` is non-empty — declare rules on each entity instead.
      *         Defaults to ``None``.
-     *     :type cardinality_rules: list[CardinalityRule] | None
      *     :param fail_when: Optional plugin-wide predicate-only invariants (task-style
      *         plugins only). Rejected at construction when ``entities`` is non-empty —
      *         declare rules on each entity instead. Defaults to ``None``.
-     *     :type fail_when: list[FailRule] | None
      *     :param derived: Optional declarative specs for sibling tasks derived from
      *         the parent task on cascade. Consumed by
      *         :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE
      *         across the parent and N derived siblings. Defaults to ``None``.
-     *     :type derived: list[DerivedTask] | None
      *     :param predecessors: Optional declarative specs for tasks that must run
      *         before the parent. Consumed by
      *         :mod:`app.sep.apps.framework.cascade` to drive POST/PUT/DELETE
      *         across the predecessors and the parent, including the chain wiring
      *         applied at execute time. Defaults to ``None``.
-     *     :type predecessors: list[ChainedPredecessor] | None
      *     :param related_apps: Optional separately registered apps the React shell
      *         surfaces as sibling tabs (for example a restore app nested under a
      *         backups parent). Defaults to ``None``.
-     *     :type related_apps: list[RelatedApp] | None
+     *     :param task_statuses: The task-status vocabulary a client polls against,
+     *         declaring per status value whether it ends a run. Server-authored, so a
+     *         supplied value is replaced rather than honoured. Withheld (``None``) for
+     *         a plugin declaring ``entities``, whose records are not task runs.
      */
     framework__AppSchema: {
       capabilities?: components['schemas']['framework__Capabilities'] | null;
@@ -7033,6 +7049,10 @@ export interface components {
       fail_when?: components['schemas']['framework__FailRule'][] | null;
       /** Forms */
       forms?: components['schemas']['framework__FormSection'][];
+      /** Item Display Name */
+      item_display_name: string;
+      /** Item Display Name Plural */
+      item_display_name_plural: string;
       list_view?: components['schemas']['framework__ListView'] | null;
       /** Name */
       name: string;
@@ -7042,6 +7062,10 @@ export interface components {
         | null;
       /** Related Apps */
       related_apps?: components['schemas']['framework__RelatedApp'][] | null;
+      /** Task Statuses */
+      task_statuses?:
+        | components['schemas']['framework__TaskStatusDescriptor'][]
+        | null;
       /** Task Type */
       task_type?: string | null;
     };
@@ -7188,6 +7212,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -7385,6 +7411,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -7409,16 +7437,17 @@ export interface components {
      * @description Represent one column in a plugin list view.
      *
      *     :param key: The task attribute path this column displays (for example,
-     *         ``"status"`` or ``"target.service"``).
-     *     :type key: NonEmptyStr
-     *     :param label: The human-readable column header.
-     *     :type label: NonEmptyStr
+     *         ``"status"`` or ``"target.service"``). Must be non-empty.
+     *     :param label: The human-readable column header. Must be non-empty.
      *     :param sortable: Whether the column can be used to sort the list.
      *         Defaults to ``False``.
-     *     :type sortable: bool
      *     :param format: Optional formatting hint applied when rendering the
      *         column values. Defaults to ``None``.
-     *     :type format: ColumnFormat | None
+     *     :param value_labels: Optional map from a raw cell value to the text a
+     *         renderer displays in its place. Defaults to ``None``, which the schema
+     *         route's ``exclude_none`` posture drops from the payload, so a column
+     *         declaring no labels stays byte-identical on the wire. A value absent
+     *         from the map is the consuming app's decision to render as-is.
      */
     framework__Column: {
       format?: components['schemas']['framework__ColumnFormat'] | null;
@@ -7431,6 +7460,10 @@ export interface components {
        * @default false
        */
       sortable: boolean;
+      /** Value Labels */
+      value_labels?: {
+        [key: string]: string;
+      } | null;
     };
     /**
      * ColumnFormat
@@ -7504,6 +7537,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -7589,11 +7624,14 @@ export interface components {
      *     :param path: Dotted path into the task record (for example
      *         ``"data.meta.command"``). Each segment must be a Python identifier,
      *         optionally followed by one or more ``[N]`` array indices.
-     *     :type path: DetailPath
      *     :param label: Human-readable label rendered alongside the resolved value.
-     *     :type label: NonEmptyStr
+     *         Must be non-empty.
      *     :param highlight: Optional syntax-highlighter hint. Defaults to ``None``.
-     *     :type highlight: DetailHighlightLanguage | None
+     *     :param value_labels: Optional map from a raw resolved value to the text a
+     *         renderer displays in its place. Defaults to ``None``, which the schema
+     *         route's ``exclude_none`` posture drops from the payload, so a field
+     *         declaring no labels stays byte-identical on the wire. A value absent
+     *         from the map is the consuming app's decision to render as-is.
      */
     framework__DetailField: {
       highlight?:
@@ -7603,6 +7641,10 @@ export interface components {
       label: string;
       /** Path */
       path: string;
+      /** Value Labels */
+      value_labels?: {
+        [key: string]: string;
+      } | null;
     };
     /**
      * DetailHighlightLanguage
@@ -7615,11 +7657,9 @@ export interface components {
      * @description Declare one titled section inside a :class:`DetailView`.
      *
      *     :param title: Heading rendered above the section's fields.
-     *     :type title: NonEmptyStr
      *     :param fields: Ordered list of fields rendered inside the section. An
      *         empty list is valid; the frontend hides the section when every
      *         field resolves to an empty value.
-     *     :type fields: list[DetailField]
      */
     framework__DetailSection: {
       /** Fields */
@@ -7715,6 +7755,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -7756,6 +7798,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Ge */
@@ -7909,6 +7953,8 @@ export interface components {
       depends_on?: string | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -7952,6 +7998,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Ge */
@@ -7982,12 +8030,10 @@ export interface components {
      * @description Represent the list-view configuration for a plugin.
      *
      *     :param columns: The ordered list of columns displayed in the list view.
-     *     :type columns: list[Column]
      *     :param default_sort: Optional key of the column to sort by on first
      *         render. Prefix with ``-`` for descending order (for example,
      *         ``"-lastRun"``). The unprefixed key must match one of the declared
      *         column keys. Defaults to ``None``.
-     *     :type default_sort: NonEmptyStr | None
      *     :param server_side_query: Opt-in capability flag declaring that the list
      *         endpoint honors whole-result-set sort and search via server query
      *         params. When ``True`` and the list is also server-paginated, the React
@@ -7998,14 +8044,12 @@ export interface components {
      *         ``exclude_none`` posture drops it from the wire until a plugin opts
      *         in, keeping the addition byte-compatible with existing schemas.
      *         Defaults to ``None``.
-     *     :type server_side_query: bool | None
      *     :param overview_hidden_fields: Additional task-level keys to suppress
      *         from the auto-rendered "extras" loop on the plugin detail Overview
      *         tab. The framework always hides a baseline set of internal fields
      *         (``id``, ``backend``, ``protected``, ``data``, ``updated_at``,
      *         ``last_updated_by``, ``connectivity_warning``); any keys listed here
      *         are merged with that baseline. Defaults to ``[]``.
-     *     :type overview_hidden_fields: list[str]
      */
     framework__ListView: {
       /** Columns */
@@ -8034,6 +8078,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8089,6 +8135,8 @@ export interface components {
       depends_on?: string | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8135,6 +8183,8 @@ export interface components {
       depends_on: string;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8177,6 +8227,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8223,6 +8275,8 @@ export interface components {
       depends_on: string;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8434,6 +8488,8 @@ export interface components {
       depends_on?: string | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Endpoint Url */
       endpoint_url: string;
       /** Forbidden */
@@ -8489,6 +8545,8 @@ export interface components {
       depends_on: string;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8589,6 +8647,8 @@ export interface components {
       depends_on?: string[];
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Endpoint Url */
       endpoint_url: string;
       /** Forbidden */
@@ -8659,6 +8719,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8705,6 +8767,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8766,6 +8830,8 @@ export interface components {
       depends_on: string;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8805,14 +8871,41 @@ export interface components {
      * TaskExecutionResponse
      * @description Represent the default response from a task execute route.
      *
+     *     ``started_at`` is deliberately not carried: the worker sets it, so it is
+     *     still ``None`` on the row this response is built from.
+     *
      *     :param task_name: The name of the task that was executed.
      *     :param task_id: The id of the task-history row created by the tasks API.
+     *         Optional because :class:`~app.tasks.models.TaskHistoryResponse` types it
+     *         so, not because a dispatched run is expected to lack one.
+     *     :param status: The status of the task-history row the tasks API created,
+     *         as it stood at dispatch.
+     *     :param created_at: When the tasks API created that row.
      */
     framework__TaskExecutionResponse: {
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string;
+      status: components['schemas']['TaskHistoryStatusEnum'];
       /** Task Id */
       task_id?: number | null;
       /** Task Name */
       task_name: string;
+    };
+    /**
+     * TaskStatusDescriptor
+     * @description Declare one task-status value and whether it ends a run.
+     *
+     *     :param value: The status as it appears on a task-history payload.
+     *     :param terminal: Whether a run in this status will not transition again, so
+     *         a client polling for completion can stop re-reading on it.
+     */
+    framework__TaskStatusDescriptor: {
+      /** Terminal */
+      terminal: boolean;
+      value: components['schemas']['TaskHistoryStatusEnum'];
     };
     /**
      * TextAreaField
@@ -8832,6 +8925,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -8873,6 +8968,8 @@ export interface components {
       default?: unknown | null;
       /** Description */
       description?: string | null;
+      /** Destructive */
+      destructive?: string | null;
       /** Forbidden */
       forbidden?: components['schemas']['framework__FieldGate'][] | null;
       /** Label */
@@ -9027,7 +9124,7 @@ export interface components {
       /** Awscli S3 Upload Extra Args */
       awscli_s3_upload_extra_args?: string | null;
       /** Backup Dir */
-      backup_dir?: string | null;
+      backup_dir: string;
       backup_type: components['schemas']['mysql_backups__BackupType'];
       /** Binlog Alternative Host */
       binlog_alternative_host?: string | null;
@@ -9226,7 +9323,7 @@ export interface components {
     };
     /**
      * BackupRunResponse
-     * @description Expose one catalog record over the per-service query path.
+     * @description Expose one catalog record over the service-scoped and task-scoped queries.
      *
      *     :param id: The record's primary key.
      *     :param service_name: The inventory service the backup was taken from.
@@ -9241,8 +9338,20 @@ export interface components {
      *     :param size_bytes: The backup size in bytes, when the run reported it.
      *     :param started_at: When the run started.
      *     :param finished_at: When the run finished.
+     *     :param backup_source: The run's restore-form-valid source, derived from
+     *         ``upload_destination`` and ``location``; read-only, and absent from the
+     *         table this response is built from.
      */
     mysql_backups__BackupRunResponse: {
+      /**
+       * Backup Source
+       * @description Return the run's restore-form-valid source, or ``None``.
+       *
+       *     Resolved server-side so no caller re-derives it from the raw fields.
+       *     ``None`` means the run recorded no usable source, or recorded one the
+       *     restore form rejects — either way it cannot seed a restore.
+       */
+      readonly backup_source: string | null;
       /**
        * Backup Type
        * @enum {string}
@@ -9314,7 +9423,12 @@ export interface components {
     };
     /**
      * BackupType
-     * @description Backup types.
+     * @description Represent the backup tools a run can be taken with.
+     *
+     *     :cvar LABELS: Display text for each stored value, keyed as the value is
+     *         stored on the wire. A value with no entry is rendered as-is by the
+     *         caller. Wrapped in :func:`enum.nonmember` because ``enum`` would
+     *         otherwise treat a class-body dict as a member candidate.
      * @enum {string}
      */
     mysql_backups__BackupType: 'M' | 'X' | 'B';
@@ -9381,6 +9495,15 @@ export interface components {
      *     defaults on a cross-mode restore. Keeping the model permissive preserves the
      *     legacy payload contract byte-for-byte.
      *
+     *     The transport and decryption fields are the exception, and they pay that
+     *     price deliberately: ``source_transport`` and ``source_encryption`` declare
+     *     where the backup lives and how it was encrypted, and the five fields those
+     *     declarations govern are gated on them. Because a field-level ``Forbidden``
+     *     rejects a field that is merely *present*, ``ssh_user`` / ``ssh_port`` /
+     *     ``s3_tool`` had to give up their defaults; :class:`RestoreConfigAll` still
+     *     declares them and ``build_restore_spec`` applies them from there, so the
+     *     emitted config is unchanged.
+     *
      *     ``service_id`` / ``schema_id`` keep their str-accepting annotation (carrying
      *     the ``"-1"`` ``UNKNOWN_SERVICE_SENTINEL``); their ``ServiceRef`` / ``SchemaRef``
      *     markers drive only the ``GET /schema`` widgets, while the conditional,
@@ -9411,11 +9534,6 @@ export interface components {
       incremental_dest_path?: string | null;
       /** Keyring File Data */
       keyring_file_data?: string | null;
-      /**
-       * Kill Mysql
-       * @default false
-       */
-      kill_mysql: boolean;
       /** Local Path */
       local_path?: string | null;
       /** Logging Dir */
@@ -9454,8 +9572,8 @@ export interface components {
        * @default false
        */
       restore_mycnf: boolean;
-      /** @default s3cmd */
-      s3_tool: components['schemas']['mysql_backups__S3Tool'];
+      /** S3 Tool */
+      s3_tool?: components['schemas']['mysql_backups__S3Tool'] | null;
       /** Schema Id */
       schema_id?: string | null;
       /** Service Id */
@@ -9472,18 +9590,16 @@ export interface components {
        * @default false
        */
       slave_from_master: boolean;
+      /** @default none */
+      source_encryption: components['schemas']['mysql_backups__EncryptionFormat'];
+      /** @default local */
+      source_transport: components['schemas']['mysql_backups__SourceTransport'];
       /** Ssh Key */
       ssh_key?: string | null;
-      /**
-       * Ssh Port
-       * @default 22
-       */
-      ssh_port: number | null;
-      /**
-       * Ssh User
-       * @default percona
-       */
-      ssh_user: string | null;
+      /** Ssh Port */
+      ssh_port?: number | null;
+      /** Ssh User */
+      ssh_user?: string | null;
       /** Start File */
       start_file?: string | null;
       /** Start Position */
@@ -9580,6 +9696,12 @@ export interface components {
      * @enum {string}
      */
     mysql_backups__S3Tool: 's3cmd' | 'awscli';
+    /**
+     * SourceTransport
+     * @description Declare where the backup being restored is stored.
+     * @enum {string}
+     */
+    mysql_backups__SourceTransport: 'local' | 'ssh' | 's3' | 'gcs';
     /**
      * UploadProvider
      * @description Upload providers.
@@ -10298,17 +10420,16 @@ export interface components {
      *     Bundle the task definition, execution history, periodic schedules, and
      *     executor host metadata into a single response for the React detail page.
      *
-     *     :param task: The task definition as returned by the tasks API.
-     *     :type task: TaskResponse
+     *     :param task: The task definition as returned by the tasks API, with its
+     *         actor fields carrying display names rather than user identifiers.
      *     :param execution_history: Paginated task history from the tasks API
-     *         (``items``, ``total``, ``offset``, ``limit``).
-     *     :type execution_history: dict[str, Any]
+     *         (``items``, ``total``, ``offset``, ``limit``), passed through
+     *         unvalidated so every upstream key survives. Carries whatever actor text
+     *         the constructing route supplied; the model itself imposes no shape.
      *     :param periodic_summary: Read-only summaries of periodic schedules
      *         attached to this task.
-     *     :type periodic_summary: list[PeriodicTaskSummary]
      *     :param executor_hosts: Executor hosts available for display, with
      *         inventory-resolved labels when possible.
-     *     :type executor_hosts: list[ExecutorHostMetadata]
      */
     tasks__TaskDetailResponse: {
       /** Execution History */
@@ -10319,25 +10440,21 @@ export interface components {
       executor_hosts?: components['schemas']['tasks__ExecutorHostMetadata'][];
       /** Periodic Summary */
       periodic_summary?: components['schemas']['tasks__PeriodicTaskSummary'][];
-      task: components['schemas']['TaskResponse'];
+      task: components['schemas']['SepTaskResponse'];
     };
     /**
      * TaskListResponse
      * @description Represent one task row in the read-only tasks plugin list API.
      *
      *     :param name: The unique name of the task.
-     *     :type name: str
      *     :param backend: The backend system used for task execution.
-     *     :type backend: TaskBackendEnum
      *     :param created_at: When the task was created, or ``None`` if unavailable.
-     *     :type created_at: UTCDatetime | None
-     *     :param created_by: Display name for the task creator (Casdoor username when
-     *         resolvable, otherwise the stored user id), or ``None`` if unknown.
-     *     :type created_by: str | None
+     *     :param created_by: Display name for the task creator: the provider's
+     *         username when resolvable, a system label for system-created tasks,
+     *         otherwise the stored user id. ``None`` if unknown.
      *     :param last_updated_by: Display name for the user who last updated the
-     *         task (Casdoor username when resolvable, otherwise the stored user id),
-     *         or ``None`` if unknown.
-     *     :type last_updated_by: str | None
+     *         task, resolved on the same terms as ``created_by``. ``None`` if
+     *         unknown.
      */
     tasks__TaskListResponse: {
       backend: components['schemas']['TaskBackendEnum'];
@@ -13134,57 +13251,6 @@ export interface operations {
       };
     };
   };
-  inventory_inventory_node_system_observation_api_apps_inventory_nodes__node_id__system_observation_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        node_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  inventory_get_schema_api_apps_inventory_schema_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['framework__AppSchema'];
-        };
-      };
-    };
-  };
   inventory_inventory_service_check_connectivity_api_apps_inventory_services__service_id__check_connectivity__post: {
     parameters: {
       query?: never;
@@ -13203,37 +13269,6 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ConnectivityCheckResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  inventory_inventory_service_system_observation_api_apps_inventory_services__service_id__system_observation_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        service_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
         };
       };
       /** @description Validation Error */
@@ -13296,84 +13331,6 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['inventory__InventorySyncStatusResponse'];
-        };
-      };
-    };
-  };
-  inventory_inventory_list_entity_api_apps_inventory__entity___get: {
-    parameters: {
-      query?: {
-        offset?: number;
-        limit?: number;
-        /** @description Sort key; prefix with '-' for descending order. */
-        sort?:
-          | 'created_at'
-          | '-created_at'
-          | 'name'
-          | '-name'
-          | 'schema_id'
-          | '-schema_id'
-          | 'service_id'
-          | '-service_id';
-        /** @description Case-insensitive search across the searchable columns. */
-        search?: string | null;
-      };
-      header?: never;
-      path: {
-        entity: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['PaginatedResponse_Any_'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  inventory_inventory_get_entity_api_apps_inventory__entity___item_id__get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        entity: string;
-        item_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
         };
       };
     };
@@ -13833,6 +13790,40 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  mysql_backups_list_task_backups_api_apps_mysql_backups__task_name__backups_get: {
+    parameters: {
+      query?: {
+        offset?: number;
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        task_name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['mysql_backups__PaginatedResponse_BackupRunResponse_'];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -14670,6 +14661,26 @@ export interface operations {
       };
     };
   };
+  sep_read_delivery_connection_api_sep_admin_delivery_connection__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['DeliveryConnectionResponse'];
+        };
+      };
+    };
+  };
   sep_list_settings_api_sep_admin_settings__get: {
     parameters: {
       query?: never;
@@ -14919,6 +14930,54 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['PaginatedResponse_ArbitraryMapping_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+      /** @description Upstream Tasks API failure. */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            detail: string;
+          };
+        };
+      };
+    };
+  };
+  tasks_preview_schedule_api_sep_periodic_tasks_schedule_preview__post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            [key: string]: unknown;
+          };
         };
       };
       /** @description Validation Error */
@@ -15203,7 +15262,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PaginatedResponse_TaskHistoryResponse_'];
+          'application/json': components['schemas']['PaginatedResponse_SepTaskHistoryResponse_'];
         };
       };
       /** @description Validation Error */

--- a/ui/packages/sep/api/src/generated/tasks.ts
+++ b/ui/packages/sep/api/src/generated/tasks.ts
@@ -95,10 +95,16 @@ export interface paths {
      *     :param session: The sub-app's database session.
      *     :param remote_api: The client for remote settings classes (``None`` when
      *         the router wires none).
+     *     :param actor: The calling admin's username, recorded on every row the
+     *         batch writes and reported back on each response.
      *     :return: One :class:`SettingResponse` per applied key, in input order.
      *     :raises HTTPNotFoundException: If the class isn't exposed.
      *     :raises HTTPUnprocessableEntityException: If any key fails validation;
      *         no rows are written.
+     *     :raises HTTPBadGatewayException: For a remote class, when the owning
+     *         sub-app returns a server error (status >= 500) or is unreachable.
+     *     :raises IntegrityError: When the replay of a batch that lost the
+     *         unique-index race conflicts again, which leaves nothing written.
      */
     patch: operations['settings_patch_settings_admin_settings__setting_class__patch'];
     trace?: never;
@@ -245,6 +251,15 @@ export interface paths {
      *     Neither ``has_logs`` nor ``log_capture`` is populated on this response — a
      *     row that was just created has no chunk-store entry, legacy tracking blob or
      *     capture verdict yet, so both fall back to their serialization defaults.
+     *
+     *     A caller-supplied ``failure_reason`` is routed back through
+     *     :meth:`TaskHistory.set_failure_reason` so the single-line and length bounds
+     *     hold on every write path, not only on the reasons SEP composes itself.
+     *
+     *     The saved row is re-read with ``task`` joined and ``execution_request``
+     *     undeferred: ``save`` re-defers that column, and the response model requires
+     *     both, so serializing the save's own return value attempts lazy IO from an
+     *     async context.
      *
      *     :param session: The SQLAlchemy asynchronous session.
      *     :param task: The task history to persist.
@@ -489,6 +504,37 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/periodic/schedule/preview/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Preview Schedule
+     * @description Report the upcoming runs of a schedule without saving it.
+     *
+     *     Answers for an unsaved request body what
+     *     :class:`~app.tasks.periodic.models.PeriodicTaskResponse` answers for a stored
+     *     schedule, through the same code path, so a client can preview a cron
+     *     expression while it is still being typed.
+     *
+     *     Two path segments so no single-segment ``/{param}`` sibling can match it,
+     *     which is what keeps the SEP-side twin from reserving a task name.
+     *
+     *     :param preview: The schedule to preview. Persisted nowhere.
+     *     :return: The schedule's zone and its upcoming runs.
+     */
+    post: operations['periodic_preview_schedule_periodic_schedule_preview__post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/periodic/{periodic_task_id}': {
     parameters: {
       query?: never;
@@ -690,24 +736,18 @@ export interface components {
     ConnectivityServiceType: 'mysql' | 'postgresql' | 'mongodb';
     /**
      * CrontabSchedule
-     * @description Representing a crontab schedule.
+     * @description Represent a crontab schedule.
      *
-     *     :param minute: Represents the minute component in cron format. Defaults to `"*"`.
-     *     :type minute: str
-     *     :param hour: Represents the hour component in cron format. Defaults to `"*"`.
-     *     :type hour: str
-     *     :param day_of_week: Represents the day of the week component in cron format.
-     *         Defaults to `"*"`.
-     *     :type day_of_week: str
-     *     :param day_of_month: Represents the day of the month component in cron format.
-     *         Defaults to `"*"`.
-     *     :type day_of_month: str
-     *     :param month_of_year: Represents the month component in cron format.
-     *         Defaults to `"*"`.
-     *     :type month_of_year: str
-     *     :param timezone: The timezone for the cron schedule. Defaults to "UTC". Must be a
-     *         valid timezone as returned in `available_timezones()`
-     *     :type timezone: str
+     *     :param minute: The minute component in cron format. Defaults to ``"*"``.
+     *     :param hour: The hour component in cron format. Defaults to ``"*"``.
+     *     :param day_of_week: The day of the week component in cron format.
+     *         Defaults to ``"*"``.
+     *     :param day_of_month: The day of the month component in cron format.
+     *         Defaults to ``"*"``.
+     *     :param month_of_year: The month component in cron format.
+     *         Defaults to ``"*"``.
+     *     :param timezone: The timezone for the cron schedule. Defaults to ``"UTC"``. Must
+     *         be a valid timezone as returned in ``available_timezones()``.
      */
     CrontabSchedule: {
       /**
@@ -860,24 +900,15 @@ export interface components {
      *     new periodic tasks.
      *
      *     :param task: The Celery task name.
-     *     :type task: str
      *     :param execute_request: The execution request details for the task.
-     *     :type execute_request: PeriodicTaskExecuteRequest | None
      *     :param interval: The interval schedule for the task. Defaults to None.
-     *     :type interval: IntervalSchedule | None
      *     :param crontab: The crontab schedule for the task. Defaults to None.
-     *     :type crontab: CrontabSchedule | None
      *     :param kwargs: A JSON string representing additional keyword arguments for the task.
-     *     :type kwargs: str
      *     :param name: The name of the periodic task. Defaults to an empty string, meaning
      *         the value will be automatically generated on create.
-     *     :type name: str
      *     :param start_time: The start time for the task execution. Defaults to None.
-     *     :type start_time:  UTCDatetime | None
      *     :param enabled: Whether the task is enabled. Defaults to True.
-     *     :type enabled: bool
      *     :param description: A description of the task. Defaults to an empty string.
-     *     :type description: str
      */
     PeriodicTaskCreate: {
       crontab?: components['schemas']['CrontabSchedule'] | null;
@@ -951,25 +982,15 @@ export interface components {
      *     last run time, total run count, and date changed.
      *
      *     :param name: The name of the periodic task.
-     *     :type name: str
      *     :param task: The SEP task name.
-     *     :type task: str
      *     :param start_time: The start time for the task execution.
-     *     :type start_time: UTCDatetime | None
      *     :param enabled: Whether the task is enabled.
-     *     :type enabled: bool
      *     :param description: A description of the task.
-     *     :type description: str
      *     :param execute_request: The execution request details for the task.
-     *     :type execute_request: PeriodicTaskExecuteRequest | None
      *     :param id: The unique identifier of the periodic task.
-     *     :type id: int
      *     :param last_run_at: The datetime of the last run.
-     *     :type last_run_at: UTCDatetime | None
      *     :param total_run_count: The total number of times the task has run.
-     *     :type total_run_count: int
      *     :param date_changed: The datetime when the task was last changed.
-     *     :type date_changed: UTCDatetime | None
      *     :param last_run_status: The result of this schedule's own most recent
      *         run, or ``None`` when the schedule has never run. Resolved as the
      *         earliest system-triggered history for this task name at or after the
@@ -977,10 +998,8 @@ export interface components {
      *         task name is not misattributed.
      *     :param interval: The interval schedule for the task. Defaults to None. This field
      *         is populated with the alias "model_intervalschedule".
-     *     :type interval: IntervalSchedule | None
      *     :param crontab: The crontab schedule for the task. Defaults to None. This field
      *         is populated with the alias "model_crontabschedule".
-     *     :type crontab: CrontabSchedule | None
      */
     PeriodicTaskResponse: {
       crontab?: components['schemas']['CrontabSchedule'] | null;
@@ -1005,17 +1024,25 @@ export interface components {
        * Next Run At
        * @description Compute the next scheduled execution time.
        *
-       *     Return the next execution time based on the task's schedule. For crontab
-       *     schedules, use `croniter` to compute the next fire time from the cron
-       *     expression in the schedule's timezone, converted to UTC. For interval
-       *     schedules, add the interval duration to `last_run_at`, falling back to
-       *     `start_time`, then the current time.
-       *
-       *     :return: The next scheduled execution time in UTC, or `None` if the task
-       *         is disabled.
-       *     :rtype: UTCDatetime | None
+       *     :return: The first of :attr:`next_runs`, or ``None`` when the task is
+       *         disabled.
        */
       readonly next_run_at: string | null;
+      /**
+       * Next Runs
+       * @description Compute the next scheduled execution times.
+       *
+       *     Report what Celery beat will do with this schedule, computed through the
+       *     scheduler's own schedule objects, so the API's account of the task and
+       *     the scheduler's behaviour cannot disagree.
+       *
+       *     Cached per instance so a page of schedules computes each row once rather
+       *     than once per computed field reading it.
+       *
+       *     :return: Up to :data:`~app.core.celery.schedules.NEXT_RUNS_PREVIEW_COUNT`
+       *         UTC execution times, empty when the task is disabled.
+       */
+      readonly next_runs: string[];
       /**
        * Period
        * @description Get the period string for the periodic task.
@@ -1024,13 +1051,25 @@ export interface components {
        *     an interval or crontab schedule.
        *
        *     :return: A string representing the task's period.
-       *     :rtype: str
        */
       readonly period: string;
       /** Start Time */
       start_time: string | null;
       /** Task */
       task: string;
+      /**
+       * Timezone
+       * @description Report the zone this task's schedule is defined in.
+       *
+       *     For a crontab schedule this is the crontab's own zone. For an interval
+       *     schedule it is ``UTC`` unconditionally, ``start_time`` set or not: an
+       *     interval's cadence is an absolute ``timedelta`` with no wall-clock
+       *     anchor, and ``start_time`` is a ``UTCDatetime``, which coerces away
+       *     whatever zone the client sent, so neither could carry another zone.
+       *
+       *     :return: The IANA zone name the schedule is defined in.
+       */
+      readonly timezone: string;
       /**
        * Total Run Count
        * @default 0
@@ -1044,23 +1083,14 @@ export interface components {
      *     Extends `PeriodicTaskWrite` and adds validations specific to updating tasks.
      *
      *     :param name: The name of the periodic task.
-     *     :type name: str
      *     :param task: The Celery task name.
-     *     :type task: str
      *     :param start_time: The start time for the task execution.
-     *     :type start_time: UTCDatetime | None
      *     :param enabled: Whether the task is enabled.
-     *     :type enabled: bool
      *     :param description: A description of the task.
-     *     :type description: str
      *     :param execute_request: The execution request details for the task.
-     *     :type execute_request: PeriodicTaskExecuteRequest | None
      *     :param interval: The interval schedule for the task. Defaults to None.
-     *     :type interval: IntervalSchedule | None
      *     :param crontab: The crontab schedule for the task. Defaults to None.
-     *     :type crontab: CrontabSchedule | None
      *     :param kwargs: A JSON string representing additional keyword arguments for the task.
-     *     :type kwargs: str
      */
     PeriodicTaskUpdate: {
       crontab?: components['schemas']['CrontabSchedule'] | null;
@@ -1101,6 +1131,43 @@ export interface components {
      * @enum {string}
      */
     ReloadClassification: 'hot' | 'nested_only' | 'not_overridable';
+    /**
+     * SchedulePreviewResponse
+     * @description Represent the upcoming runs of a schedule that has not been saved.
+     *
+     *     Uses the same field names and shapes as the matching computed fields on
+     *     :class:`PeriodicTaskResponse`, so a client renders a preview and a saved
+     *     schedule through one code path.
+     *
+     *     :param timezone: The zone the schedule is defined in.
+     *     :param next_run_at: The first upcoming run, or ``None`` when there is none.
+     *     :param next_runs: The upcoming runs, empty when there are none.
+     */
+    SchedulePreviewResponse: {
+      /** Next Run At */
+      next_run_at: string | null;
+      /** Next Runs */
+      next_runs: string[];
+      /** Timezone */
+      timezone: string;
+    };
+    /**
+     * SchedulePreviewWrite
+     * @description Define the schedule a preview is requested for.
+     *
+     *     Carries the schedule fields of a create request and nothing else: a preview
+     *     persists nothing, so it needs no task name, owner, or execution details.
+     *
+     *     :param interval: The interval schedule to preview. Defaults to None.
+     *     :param crontab: The crontab schedule to preview. Defaults to None.
+     *     :param start_time: The earliest time the schedule may fire. Defaults to None.
+     */
+    SchedulePreviewWrite: {
+      crontab?: components['schemas']['CrontabSchedule'] | null;
+      interval?: components['schemas']['IntervalSchedule'] | null;
+      /** Start Time */
+      start_time?: string | null;
+    };
     /**
      * SettingClassGroup
      * @description Group one settings class's fields for the LIST response.
@@ -1171,8 +1238,13 @@ export interface components {
      *         (``SecretStr`` / ``SecretBytes``) at any depth.
      *     :param is_complex: Whether the field's annotation is or contains a Pydantic
      *         ``BaseModel`` subclass (true for nested submodels).
-     *     :param has_override: Whether a row exists in the ``settingoverride`` table
-     *         for this ``(setting_class, key)`` pair, regardless of ``is_active``.
+     *     :param has_override: Whether an **active** row in the ``settingoverride``
+     *         table applies to this ``(setting_class, key)`` pair. An inactive row is
+     *         skipped by the cache loader, so the served value falls back to the
+     *         declared default and reporting it as overridden would tell the UI a
+     *         field is overridden while showing it that default. A nested row also
+     *         marks every canonical prefix of its chain, so a parent reports ``True``
+     *         when only a deeper leaf carries a row.
      *     :param is_advanced: Whether the setting is flagged ``advanced`` so the UI can
      *         present it separately from everyday settings. Display-only:
      *         it does not affect PATCH/DELETE eligibility.
@@ -1182,6 +1254,18 @@ export interface components {
      *         PATCH/DELETE server-side; the runtime gate is the real enforcement.
      *     :param options: Selectable enum members for dropdown UIs, or ``None`` when
      *         the field is not an ``Enum`` annotation. Aliased members are excluded.
+     *     :param updated_at: When the override applying to this key was last saved,
+     *         falling back to the row's creation time for a row written before the
+     *         stamp was recorded. ``None`` when ``has_override`` is ``False``.
+     *         Timestamps carry second granularity.
+     *     :param updated_by: The username that last saved that override, or ``None``
+     *         both when no override applies and when the row predates the actor
+     *         column. A key can draw on several rows (a nested parent reporting on its
+     *         leaves), in which case the pair comes from the row carrying the latest
+     *         timestamp. Two writes landing within the same second are
+     *         indistinguishable by timestamp, and the pair reported is then whichever
+     *         contributing row was created later, which need not be the one written
+     *         later.
      */
     SettingResponse: {
       /** Default Value */
@@ -1215,6 +1299,10 @@ export interface components {
       setting_class: string;
       /** Type */
       type: string;
+      /** Updated At */
+      updated_at?: string | null;
+      /** Updated By */
+      updated_by?: string | null;
       /** Value */
       value: unknown;
     };
@@ -1361,6 +1449,9 @@ export interface components {
      *         exists) to discard writes from a superseded producer. ``0`` is the
      *         legacy/unknown sentinel that is trusted unconditionally.
      *     :param executed_by: The user ID of the user who executed the task.
+     *     :param failure_reason: A single-line, operator-facing reason for the run's
+     *         outcome, or None when the run did not fail or the reason is unknown.
+     *         Written only through :meth:`set_failure_reason`.
      */
     TaskHistory: {
       /** Anonymize Mask */
@@ -1373,6 +1464,8 @@ export interface components {
       /** Executed By */
       executed_by?: string | null;
       execution_request: components['schemas']['TaskExecutionRequest'];
+      /** Failure Reason */
+      failure_reason?: string | null;
       /** Finished At */
       finished_at?: string | null;
       /** Id */
@@ -1440,6 +1533,10 @@ export interface components {
      *         reports.
      *     :param display_name: A user-meaningful label derived from the task name or
      *         execution-request metadata. Read-only; computed on serialisation.
+     *     :param failure_reason: A single-line, operator-facing reason for the run's
+     *         outcome, or None when the run did not fail or the reason is unknown. A
+     *         historic row predating the column reports None, which means "unknown"
+     *         rather than "did not fail".
      */
     TaskHistoryResponse: {
       /** Anonymize Mask */
@@ -1475,6 +1572,8 @@ export interface components {
       /** Executed By */
       executed_by?: string | null;
       execution_request: components['schemas']['TaskExecutionRequest'];
+      /** Failure Reason */
+      failure_reason?: string | null;
       /** Finished At */
       finished_at?: string | null;
       /**
@@ -2452,6 +2551,39 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['PaginatedResponse_PeriodicTaskResponse_'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  periodic_preview_schedule_periodic_schedule_preview__post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SchedulePreviewWrite'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SchedulePreviewResponse'];
         };
       };
       /** @description Validation Error */

--- a/ui/packages/sep/api/src/index.ts
+++ b/ui/packages/sep/api/src/index.ts
@@ -136,6 +136,7 @@ export type {
   CardinalityRule,
   FailRule,
   RelatedApp,
+  TaskStatusDescriptor,
 } from './types/plugin-schema';
 
 // Hooks

--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -84,6 +84,15 @@ interface BaseField {
   requires?: FieldGate[];
   /** Self-cardinality gates: when matched, the field is forbidden. */
   forbidden?: FieldGate[];
+  /**
+   * Consequence text for a field whose enabled or set state irreversibly
+   * destroys user data. Presence is the mark — there is no separate boolean,
+   * so `if (field.destructive)` is the check, and the string is what a
+   * confirmation displays. Unmarked fields either omit the key or send it as
+   * null, depending on whether the serving route excludes nulls, so test
+   * truthiness rather than presence.
+   */
+  destructive?: string | null;
 }
 
 // ── Choice option ─────────────────────────────────────────────────────────
@@ -329,6 +338,8 @@ export interface ListColumn {
     | 'code'
     | 'actions'
     | 'schedule';
+  /** Optional map from a raw cell value to the text to display in its place. Absent when the app declares no labels; a value missing from the map renders as-is. */
+  value_labels?: Record<string, string>;
 }
 
 export interface ListView {
@@ -358,6 +369,8 @@ export interface DetailField {
   label: string;
   /** Optional syntax-highlighter hint; mirrors the backend ``DetailHighlightLanguage`` enum. */
   highlight?: 'sql' | 'json' | 'bash' | 'yaml';
+  /** Optional map from a raw resolved value to the text to display in its place. Absent when the app declares no labels; a value missing from the map renders as-is. */
+  value_labels?: Record<string, string>;
 }
 
 /** One titled section rendered on the task detail page. */
@@ -383,6 +396,11 @@ export interface PluginEntitySchema {
   /** Optional detail-view syntax hints keyed by field name; mirrors the backend
    * ``DetailHighlightLanguage`` enum. */
   detail_highlights?: Partial<Record<string, 'sql' | 'json' | 'bash' | 'yaml'>>;
+  /** What one record of this entity is called, in mid-sentence form — capitalise
+   * the first character when it opens a label. */
+  item_display_name: string;
+  /** What several records of this entity are called, same convention. */
+  item_display_name_plural: string;
 }
 
 // ── Related apps (sibling tabs) ─────────────────────────────────────────
@@ -398,6 +416,23 @@ export interface RelatedApp {
   label: string;
   /** Sub-path segment under the parent's `route_base` (for example `restores`). */
   route_segment: string;
+}
+
+// ── Task status vocabulary ──────────────────────────────────────────────
+
+/**
+ * One task-status value and whether it ends a run. A client polling a task to
+ * completion re-reads until the row reaches a status whose `terminal` is true.
+ */
+export interface TaskStatusDescriptor {
+  /** A `TaskHistoryStatusEnum` member, deliberately widened to `string` here
+   * rather than typed as a literal union like `ColumnFormat`: the point of
+   * publishing this list is that a client discovers the vocabulary at runtime
+   * instead of hardcoding it. The generated client in `generated/sep.ts`
+   * narrows the same field to a union of the current members, so a consumer
+   * that wants runtime discovery should read this type rather than that one. */
+  value: string;
+  terminal: boolean;
 }
 
 // ── Top-level schema ────────────────────────────────────────────────────
@@ -421,4 +456,11 @@ export interface PluginSchema {
   fail_when?: FailRule[];
   /** Separately registered apps rendered as sibling tabs in the React shell. */
   related_apps?: RelatedApp[];
+  /** What one record this app's create form produces is called, in mid-sentence
+   * form — capitalise the first character when it opens a label. */
+  item_display_name: string;
+  /** What several such records are called, same convention. */
+  item_display_name_plural: string;
+  /** Status vocabulary for task-style apps; omitted when `entities` is set. */
+  task_statuses?: TaskStatusDescriptor[];
 }

--- a/ui/packages/sep/framework/src/components/ScheduleCell/ScheduleCell.test.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduleCell/ScheduleCell.test.tsx
@@ -32,6 +32,12 @@ function makePeriodic(
     enabled: true,
     description: '',
     start_time: null,
+    next_runs: [
+      '2026-06-18T14:00:00Z',
+      '2026-06-18T15:00:00Z',
+      '2026-06-18T16:00:00Z',
+    ],
+    timezone: 'UTC',
     last_run_at: null,
     date_changed: null,
     total_run_count: 0,

--- a/ui/packages/sep/framework/src/components/ScheduleSummary/ScheduleSummary.test.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduleSummary/ScheduleSummary.test.tsx
@@ -56,6 +56,12 @@ function makePeriodic(
     enabled: true,
     description: '',
     start_time: null,
+    next_runs: [
+      '2026-06-18T14:00:00Z',
+      '2026-06-18T16:00:00Z',
+      '2026-06-18T18:00:00Z',
+    ],
+    timezone: 'UTC',
     last_run_at: null,
     date_changed: null,
     total_run_count: 0,

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.test.tsx
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/ScheduledTasksPanel.test.tsx
@@ -61,6 +61,8 @@ function makePeriodic(
     enabled: true,
     description: '',
     start_time: null,
+    next_runs: [],
+    timezone: 'UTC',
     last_run_at: null,
     date_changed: null,
     total_run_count: 0,

--- a/ui/packages/sep/framework/src/components/ScheduledTasksPanel/periods.test.ts
+++ b/ui/packages/sep/framework/src/components/ScheduledTasksPanel/periods.test.ts
@@ -31,6 +31,8 @@ function makePeriodic(
     enabled: true,
     description: '',
     start_time: null,
+    next_runs: [],
+    timezone: 'UTC',
     last_run_at: null,
     date_changed: null,
     total_run_count: 0,

--- a/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaDrivenPlugin/PluginListPage.test.tsx
@@ -89,6 +89,8 @@ beforeEach(() => {
 const schema: PluginSchema = {
   name: 'sched',
   display_name: 'Sched',
+  item_display_name: 'sched',
+  item_display_name_plural: 'scheds',
   capabilities: { scheduling: true },
   list_view: { columns: [{ key: 'name', label: 'Name' }] },
 };

--- a/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaListView/SchemaListView.test.tsx
@@ -190,6 +190,8 @@ function makePeriodic(
     enabled: true,
     description: '',
     start_time: null,
+    next_runs: [],
+    timezone: 'UTC',
     last_run_at: null,
     date_changed: null,
     total_run_count: 0,

--- a/ui/packages/sep/framework/src/components/SnippetExecutionAccordion/SnippetExecutionAccordion.test.tsx
+++ b/ui/packages/sep/framework/src/components/SnippetExecutionAccordion/SnippetExecutionAccordion.test.tsx
@@ -76,6 +76,8 @@ function makeSchema(extraFields: FormSection['fields'] = []): PluginSchema {
   return {
     name: 'snippets',
     display_name: 'Test Snippet',
+    item_display_name: 'test snippet',
+    item_display_name_plural: 'test snippets',
     forms: [
       {
         title: 'Execution',

--- a/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.ts
+++ b/ui/packages/sep/framework/src/components/TaskRunDetailDrawer/runFailureReason.ts
@@ -20,21 +20,22 @@ import type { TaskHistoryEntry } from '../../hooks/useTaskHistory';
 /**
  * Field names a failure reason may arrive under.
  *
- * `TaskHistoryResponse` carries no error field today — status, started_at,
- * finished_at, duration, has_logs and log_capture, and nothing else. SEP-2000
- * adds one; until it lands every candidate here is absent and
+ * The bet this file was written as has now settled: `TaskHistoryResponse`
+ * carries `failure_reason`, and the vendored spec has been synced to a
+ * side-car that serves it. An older side-car still sends none of these, and
  * {@link runFailureReason} returns null, which the UI renders as a pointer to
  * the log rather than as an empty error.
  *
- * Several names are accepted rather than one so the frontend does not have to
- * ship in lockstep with whichever name the side-car settles on. Order is
- * preference: the most specific name wins if two are ever populated.
+ * Order is preference, and it is now load-bearing in a way it was not when
+ * every name was hypothetical: `error_message` sorts ahead of the real field,
+ * so a side-car populating both would be read on the wrong one.
  *
- * TODO(SEP-2000): once the side-car has shipped a field, narrow this to that
- * one name and drop the tracking fallback. This file is a bet on a shape
- * nobody has committed to yet, and it lives in vendored code — leaving three
- * guesses in place after the real name is known is how it ends up silently
- * matching the wrong thing through a future sync.
+ * TODO: narrow this to `failure_reason` and drop the tracking fallback. The
+ * condition the original note put this off until — the side-car shipping a
+ * field — is met; what remains is rewriting the cases in
+ * `runFailureReason.test.ts` that are built around the multi-key and
+ * tracking-bag behaviour, which belongs with the drawer rather than with a
+ * sync.
  */
 const FAILURE_REASON_KEYS = [
   'error_message',


### PR DESCRIPTION
## What

Brings PMM's vendored SEP frontend level with the side-car at **`be2859f3a`**. Fourteen commits had touched the mirrored packages since the `c16578dfe` watermark.

**SEP-2008 merged mid-flight.** The port was made from its branch before it merged (as `be2859f3a`, #1493), so rather than assume the squash was faithful I checked it: all four specs are semantically identical — the only byte differences are PMM's 80-column formatter against SEP's 100 — and the `app-schema.ts` / `index.ts` additions are byte-identical. The squash changed nothing, so the watermark is a single coordinate rather than the pair this PR originally claimed.

(The branch name still says `efcc31e5f`, the tip before SEP-2008 landed. Left alone so the PR keeps its identity.)

## Why now

Eight of the twelve MySQL Backups UX tickets are written against payloads and schema fields that do not exist in this repo yet, and cannot start until this lands.

## What is in it

Specs copied wholesale and the client regenerated. The schema type additions were applied **per-commit** rather than by copying `app-schema.ts` over `plugin-schema.ts`:

| Addition | From |
|---|---|
| `destructive` — consequence text for a field whose set state destroys data | SEP-2001 |
| `value_labels` on `ListColumn` and `DetailField` | SEP-2005 |
| `item_display_name` / `item_display_name_plural` on `PluginEntitySchema` and `PluginSchema` | SEP-2007 |
| `TaskStatusDescriptor` + `task_statuses`, for polling a run to completion | SEP-2008 |

## What was deliberately left out

`MultiServiceField`, `MultiSchemaField`, `MultiTableField` and `MultiHostField`. They predate the `c16578dfe` watermark (SEP-1498), so they are **pre-existing drift rather than part of this sync**, and PMM vendors no `FreeSoloMultiSelect` to render them — importing the types alone would claim support the renderer does not have.

Also untaken: SEP's `Plugin`→`App` rename (396 occurrences across 48 files). Keeping PMM's `Plugin*` names means each ported hunk needs adapting, which is the tax this PR pays; ending it is worth its own change.

## Risk

The inventory-browser retirement removes five `/api/apps/inventory/…` paths. PMM routes no page for them and calls none of them — the paths behind backup-source selection (`sync`, `sync/status`, `available-syncers`, `services/{id}/check-connectivity`) all survive.

## Verification

- `check-types` clean across all seven workspace packages
- `format:check` clean, `lint` clean (0 errors)
- Vendored suites green: `@sep/api` 106, `@sep/framework` 807, `@sep/plugins-atw` 122

No test run outside the vendored packages: nothing in `ui/apps/pmm` references the changed types, and the workspace-wide typecheck covers the boundary.