### PR TITLE
PMM-15451 Fit a working backup within one screen

### DIFF
--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -93,6 +93,24 @@ interface BaseField {
    * truthiness rather than presence.
    */
   destructive?: string | null;
+  /**
+   * Name of a sibling `bool` field in the same section that this field
+   * parameterises. The renderer draws the field indented beneath that parent
+   * and keeps it non-interactive until the parent is on, instead of hiding it
+   * — a reader can see what enabling the parent will offer.
+   *
+   * Presentation only, and the renderer takes it on trust: the disable state
+   * comes from the named field's truthiness alone. Enforcement stays with the
+   * backend, through this field's own `forbidden` gate on the parent being
+   * falsy — which the renderer recognises structurally and consumes as the
+   * disable condition rather than applying it as a hide. Every other gate on
+   * the field keeps hiding it as usual, so declaring `parent` without that
+   * companion gate leaves the value unguarded server-side; a dev build warns.
+   *
+   * Must name a `bool` field in the same section, declared before this one.
+   * Chains and cycles are unsupported — a cycle leaves both toggles inert.
+   */
+  parent?: string;
 }
 
 // ── Choice option ─────────────────────────────────────────────────────────
@@ -304,6 +322,15 @@ export interface FormSection {
   title: string;
   description?: string;
   fields: SectionField[];
+  /**
+   * Heading of the collapsible group this section belongs to (for example
+   * `Advanced`). Runs of adjacent sections carrying the same value render
+   * inside one collapsed shell titled by it, so a form with many secondary
+   * sections costs one row instead of one per section. A section keeps its own
+   * `collapsible` / `collapsed_by_default` behaviour inside the group. Unset
+   * (the default) renders the section on its own, as before.
+   */
+  group?: string;
   /** Whether the section is wrapped in an expandable/collapsible shell. */
   collapsible?: boolean;
   /** Initial expansion state when collapsible is enabled. */

--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -323,14 +323,23 @@ export interface FormSection {
   description?: string;
   fields: SectionField[];
   /**
-   * Heading of the collapsible group this section belongs to (for example
-   * `Advanced`). Runs of adjacent sections carrying the same value render
-   * inside one collapsed shell titled by it, so a form with many secondary
-   * sections costs one row instead of one per section. A section keeps its own
-   * `collapsible` / `collapsed_by_default` behaviour inside the group. Unset
-   * (the default) renders the section on its own, as before.
+   * Whether this section holds expert options rather than the common case.
+   *
+   * Advanced sections are withheld behind a single "Show advanced options"
+   * control rendered after the ordinary ones, so a form with many expert
+   * sections costs one row at rest instead of one per section. Revealing them
+   * renders each as an ordinary top-level section — deliberately not nested
+   * inside a wrapper, which reads as one disclosure level too many.
+   *
+   * The renderer reveals them on its own, and expands the section concerned,
+   * whenever one holds a value other than its schema default or a field
+   * carrying a validation error: an option someone has already set must never
+   * be hidden from them. In practice the error case means a backend 422 — a
+   * field inside a section that was never opened is never registered, so
+   * client-side validation cannot flag it. Order is preserved, and advanced
+   * sections render after the ordinary ones wherever they sit in `forms`.
    */
-  group?: string;
+  advanced?: boolean;
   /** Whether the section is wrapped in an expandable/collapsible shell. */
   collapsible?: boolean;
   /** Initial expansion state when collapsible is enabled. */

--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -100,15 +100,20 @@ interface BaseField {
    * — a reader can see what enabling the parent will offer.
    *
    * Presentation only, and the renderer takes it on trust: the disable state
-   * comes from the named field's truthiness alone. Enforcement stays with the
-   * backend, through this field's own `forbidden` gate on the parent being
-   * falsy — which the renderer recognises structurally and consumes as the
-   * disable condition rather than applying it as a hide. Every other gate on
-   * the field keeps hiding it as usual, so declaring `parent` without that
-   * companion gate leaves the value unguarded server-side; a dev build warns.
+   * comes from the named field's truthiness alone. A parented field *may* also
+   * carry a `forbidden` gate on the parent being falsy, and where it does the
+   * renderer recognises that gate structurally and consumes it as the disable
+   * condition rather than applying it as a hide. It is not required — the
+   * backend treats the pointer as presentation, so most parented fields carry
+   * no gate at all. Every other gate on the field keeps hiding it as usual.
    *
-   * Must name a `bool` field in the same section, declared before this one.
-   * Chains and cycles are unsupported — a cycle leaves both toggles inert.
+   * While the parent is off the child is reset to its schema `default`, not
+   * blanked, so the greyed control shows what it would submit once the parent
+   * is on. A field that pairs the parent-off gate with a default the backend
+   * reads as present cannot satisfy both; a dev build warns.
+   *
+   * Must name a `bool` field in the same section. Chains and cycles are
+   * unsupported — a cycle leaves both toggles inert.
    */
   parent?: string;
   /**

--- a/ui/packages/sep/api/src/types/plugin-schema.ts
+++ b/ui/packages/sep/api/src/types/plugin-schema.ts
@@ -111,6 +111,25 @@ interface BaseField {
    * Chains and cycles are unsupported — a cycle leaves both toggles inert.
    */
   parent?: string;
+  /**
+   * Where the field's `description` is shown.
+   *
+   * `inline` puts it under the input, where a format hint belongs — visible
+   * while someone is typing into the field it describes. `tooltip` puts it
+   * behind a help icon beside the label, which keeps prose from dominating a
+   * form that has a lot of it.
+   *
+   * Unset (the default) decides by length: a description that fits roughly one
+   * line renders inline, a longer one goes behind the icon. Set this when the
+   * default reads wrong for a particular field — a terse-but-secondary note, or
+   * a long one someone needs in front of them while they type.
+   *
+   * Reference and selector fields (`service`, `host`, `schema`, `table`,
+   * `remote_choice`) are always inline: their label is a plain string the
+   * renderer also uses in validation messages, so there is no node to hang a
+   * help icon from.
+   */
+  help_placement?: 'tooltip' | 'inline';
 }
 
 // ── Choice option ─────────────────────────────────────────────────────────

--- a/ui/packages/sep/framework/src/components/RemoteChoiceSelector/RemoteChoiceSelector.tsx
+++ b/ui/packages/sep/framework/src/components/RemoteChoiceSelector/RemoteChoiceSelector.tsx
@@ -50,6 +50,8 @@ export interface RemoteChoiceSelectorProps {
   disabled?: boolean;
   /** Fully-resolved fetch path (relative to the `/api` base) the options load from. */
   endpointUrl: string;
+  /** Field help shown under the control when no cascade hint takes the slot. */
+  description?: string;
   /** Optional parent field name; when set, the field cascades and — unless `allowCustom` is set — stays disabled until the parent has a value. */
   dependsOn?: string;
   /** Offer free-text (free-solo) entry alongside the fetched options. */
@@ -256,6 +258,7 @@ export function RemoteChoiceSelector({
   disabled,
   endpointUrl,
   dependsOn,
+  description,
   allowCustom,
 }: RemoteChoiceSelectorProps) {
   const { control, setValue } = useFormContext();
@@ -310,7 +313,7 @@ export function RemoteChoiceSelector({
       ? (error?.message ?? 'Failed to load options')
       : empty
         ? 'No options available'
-        : undefined;
+        : description;
   const noOptionsText = parentMissing
     ? parentMissingText
     : isLoading

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
@@ -18,7 +18,7 @@
 import { memo } from 'react';
 import Box from '@mui/material/Box';
 import { FieldRenderer } from './fields';
-import { fieldIndex, isFullRowField } from './fieldLayout';
+import { fieldIndex } from './fieldLayout';
 import { useFormFields } from './formFieldsContext';
 import { useConditionalField } from './hooks/useConditionalField';
 import type { PluginField, RenderFieldOverride } from './types';
@@ -26,12 +26,19 @@ import type { PluginField, RenderFieldOverride } from './types';
 export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
   field,
   renderField,
+  markOptional = false,
 }: {
   field: PluginField;
   renderField?: RenderFieldOverride;
+  /**
+   * Spell out "(optional)" on a field that is not required. Set by the section
+   * when its required fields outnumber its optional ones, where a missing
+   * asterisk is the only thing distinguishing them and is easy to miss.
+   */
+  markOptional?: boolean;
 }) {
   const { isHidden, isRequired, isDisabled } = useConditionalField(field);
-  const { parentNames, byName } = fieldIndex(useFormFields());
+  const { byName } = fieldIndex(useFormFields());
   const parentLabel = field.parent
     ? (byName.get(field.parent)?.label ?? field.parent)
     : undefined;
@@ -40,19 +47,22 @@ export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
     return null;
   }
 
+  const showOptional = markOptional && !isRequired;
   const resolvedField =
-    Boolean(field.required) !== isRequired
-      ? { ...field, required: isRequired }
+    Boolean(field.required) !== isRequired || showOptional
+      ? {
+          ...field,
+          required: isRequired,
+          label: showOptional ? `${field.label} (optional)` : field.label,
+        }
       : field;
   const renderDefault = () => <FieldRenderer field={resolvedField} />;
   const content =
     renderField?.({ field: resolvedField, renderDefault }) ?? renderDefault();
 
-  const gridColumn = isFullRowField(field, parentNames) ? '1 / -1' : 'auto';
-
   if (!field.parent) {
     return (
-      <Box sx={{ mb: 2, gridColumn }} data-field-name={field.name}>
+      <Box sx={{ mb: 2 }} data-field-name={field.name}>
         {content}
       </Box>
     );
@@ -70,7 +80,6 @@ export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
       data-field-name={field.name}
       data-parent-field={field.parent}
       sx={{
-        gridColumn,
         m: 0,
         mb: 2,
         ml: 1,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
@@ -15,9 +15,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import Box from '@mui/material/Box';
 import { FieldRenderer } from './fields';
+import { collectParentNames, isFullRowField } from './fieldLayout';
+import { useFormFields } from './formFieldsContext';
 import { useConditionalField } from './hooks/useConditionalField';
 import type { PluginField, RenderFieldOverride } from './types';
 
@@ -28,7 +30,15 @@ export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
   field: PluginField;
   renderField?: RenderFieldOverride;
 }) {
-  const { isHidden, isRequired } = useConditionalField(field);
+  const { isHidden, isRequired, isDisabled } = useConditionalField(field);
+  const formFields = useFormFields();
+  const parentNames = useMemo(
+    () => collectParentNames(formFields),
+    [formFields]
+  );
+  const parentLabel = field.parent
+    ? (formFields.find((f) => f.name === field.parent)?.label ?? field.parent)
+    : undefined;
 
   if (isHidden) {
     return null;
@@ -39,11 +49,68 @@ export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
       ? { ...field, required: isRequired }
       : field;
   const renderDefault = () => <FieldRenderer field={resolvedField} />;
+  const content =
+    renderField?.({ field: resolvedField, renderDefault }) ?? renderDefault();
 
+  const gridColumn = isFullRowField(field, parentNames) ? '1 / -1' : 'auto';
+
+  if (!field.parent) {
+    return (
+      <Box sx={{ mb: 2, gridColumn }} data-field-name={field.name}>
+        {content}
+      </Box>
+    );
+  }
+
+  // A parented field renders as a `fieldset`, so one `disabled` attribute
+  // reaches every control inside it — no field renderer has to know it is
+  // being disabled, and a `renderField` override inherits the behaviour for
+  // free. The rule down the left edge is what makes the nesting readable.
   return (
-    <Box sx={{ mb: 2 }} data-field-name={field.name}>
-      {renderField?.({ field: resolvedField, renderDefault }) ??
-        renderDefault()}
+    <Box
+      component="fieldset"
+      disabled={isDisabled}
+      aria-disabled={isDisabled || undefined}
+      data-field-name={field.name}
+      data-parent-field={field.parent}
+      sx={{
+        gridColumn,
+        m: 0,
+        mb: 2,
+        ml: 1,
+        p: 0,
+        pl: 2,
+        border: 0,
+        borderLeft: '2px solid',
+        borderLeftColor: 'divider',
+        // A fieldset sizes to `min-content` by default and would refuse to
+        // shrink inside the form's flow.
+        minWidth: 0,
+        minInlineSize: 0,
+        opacity: isDisabled ? 0.6 : 1,
+      }}
+    >
+      {/*
+        Names the group for a screen reader, which otherwise reaches a set of
+        controls it cannot focus with nothing said about why. Visually the
+        indent rule and the greying already carry it.
+      */}
+      <Box
+        component="legend"
+        sx={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {isDisabled
+          ? `Requires ${parentLabel}, which is off`
+          : `Part of ${parentLabel}`}
+      </Box>
+      {content}
     </Box>
   );
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/ConditionalFieldSlot.tsx
@@ -15,10 +15,10 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import Box from '@mui/material/Box';
 import { FieldRenderer } from './fields';
-import { collectParentNames, isFullRowField } from './fieldLayout';
+import { fieldIndex, isFullRowField } from './fieldLayout';
 import { useFormFields } from './formFieldsContext';
 import { useConditionalField } from './hooks/useConditionalField';
 import type { PluginField, RenderFieldOverride } from './types';
@@ -31,13 +31,9 @@ export const ConditionalFieldSlot = memo(function ConditionalFieldSlot({
   renderField?: RenderFieldOverride;
 }) {
   const { isHidden, isRequired, isDisabled } = useConditionalField(field);
-  const formFields = useFormFields();
-  const parentNames = useMemo(
-    () => collectParentNames(formFields),
-    [formFields]
-  );
+  const { parentNames, byName } = fieldIndex(useFormFields());
   const parentLabel = field.parent
-    ? (formFields.find((f) => f.name === field.parent)?.label ?? field.parent)
+    ? (byName.get(field.parent)?.label ?? field.parent)
     : undefined;
 
   if (isHidden) {

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/OneOfGroupSlot.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/OneOfGroupSlot.tsx
@@ -23,6 +23,7 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import type { OneOfGroup } from '@sep/api';
 import { ConditionalFieldSlot } from './ConditionalFieldSlot';
+import { SECTION_GRID_SX } from './fieldLayout';
 import type { RenderFieldOverride } from './types';
 
 export interface OneOfGroupSlotProps {
@@ -78,7 +79,10 @@ export const OneOfGroupSlot = memo(function OneOfGroupSlot({
   };
 
   return (
-    <Box sx={{ mb: 2 }} data-testid={`one-of-${group.name}`}>
+    <Box
+      sx={{ mb: 2, gridColumn: '1 / -1' }}
+      data-testid={`one-of-${group.name}`}
+    >
       <Typography
         component="div"
         variant="subtitle2"
@@ -109,13 +113,15 @@ export const OneOfGroupSlot = memo(function OneOfGroupSlot({
           </ToggleButton>
         ))}
       </ToggleButtonGroup>
-      {activeBranch.fields.map((field) => (
-        <ConditionalFieldSlot
-          key={field.name}
-          field={field}
-          renderField={renderField}
-        />
-      ))}
+      <Box sx={SECTION_GRID_SX}>
+        {activeBranch.fields.map((field) => (
+          <ConditionalFieldSlot
+            key={field.name}
+            field={field}
+            renderField={renderField}
+          />
+        ))}
+      </Box>
     </Box>
   );
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/OneOfGroupSlot.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/OneOfGroupSlot.tsx
@@ -23,7 +23,6 @@ import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import type { OneOfGroup } from '@sep/api';
 import { ConditionalFieldSlot } from './ConditionalFieldSlot';
-import { SECTION_GRID_SX } from './fieldLayout';
 import type { RenderFieldOverride } from './types';
 
 export interface OneOfGroupSlotProps {
@@ -113,15 +112,13 @@ export const OneOfGroupSlot = memo(function OneOfGroupSlot({
           </ToggleButton>
         ))}
       </ToggleButtonGroup>
-      <Box sx={SECTION_GRID_SX}>
-        {activeBranch.fields.map((field) => (
-          <ConditionalFieldSlot
-            key={field.name}
-            field={field}
-            renderField={renderField}
-          />
-        ))}
-      </Box>
+      {activeBranch.fields.map((field) => (
+        <ConditionalFieldSlot
+          key={field.name}
+          field={field}
+          renderField={renderField}
+        />
+      ))}
     </Box>
   );
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.fieldErrors.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.fieldErrors.test.tsx
@@ -34,17 +34,26 @@ function renderWithProviders(ui: ReactNode) {
 }
 
 // One field per helperText-based component plus a choice field, to prove every
-// rendered field type surfaces its mapped error inline.
+// rendered field type surfaces its mapped error inline. The described fields
+// pin `help_placement` so the help icon is what is under test here — left to
+// the default, a description this short would render inline instead.
 const SECTIONS: FormSection[] = [
   {
     title: 'Task',
     fields: [
-      { type: 'string', name: 'title', label: 'Title', description: 'A title' },
+      {
+        type: 'string',
+        name: 'title',
+        label: 'Title',
+        description: 'A title',
+        help_placement: 'tooltip',
+      },
       {
         type: 'integer',
         name: 'limit',
         label: 'Row Limit',
         description: 'Max rows',
+        help_placement: 'tooltip',
       },
       {
         type: 'choice',

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.spotCheck.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.spotCheck.test.tsx
@@ -65,6 +65,10 @@ function expectHelp(label: string, present: boolean) {
   }
 }
 
+// Every described field here pins `help_placement: 'tooltip'`. The file is
+// about the icon reaching each field kind across real app shapes; the
+// length-based default would put most of these descriptions inline instead,
+// which is covered on its own in the placement tests.
 describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
   it('mysql_backups-like create form: icons on described fields only', () => {
     const sections: FormSection[] = [
@@ -76,6 +80,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'db_host',
             label: 'Database Host',
             description: 'Host the backup connects to on the executor node.',
+            help_placement: 'tooltip',
           },
           { type: 'string', name: 'server_alias', label: 'Server Alias' },
         ],
@@ -97,6 +102,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'compress',
             label: 'Compress backup data',
             description: 'Compress the backup stream as it is written.',
+            help_placement: 'tooltip',
           },
           { type: 'string', name: 'log_dir', label: 'Logging directory' },
         ],
@@ -110,6 +116,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             label: 'Safe replica backup',
             description:
               'Passes --safe-slave-backup so xtrabackup pauses the replica SQL thread during the backup.',
+            help_placement: 'tooltip',
           },
           {
             type: 'integer',
@@ -161,12 +168,14 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             label: 'Run with sudo',
             description:
               'Prepend sudo to the interpreter when the snippet is executed.',
+            help_placement: 'tooltip',
           },
           {
             type: 'integer',
             name: 'minutes',
             label: 'Lookback minutes',
             description: 'Shared window applied to every selected snippet.',
+            help_placement: 'tooltip',
           },
           { type: 'string', name: 'note', label: 'Operator note' },
         ],
@@ -181,6 +190,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'overrides.snip0.path',
             label: 'Path',
             description: 'Filesystem path to inspect for this snippet only.',
+            help_placement: 'tooltip',
           },
           {
             type: 'integer',
@@ -225,6 +235,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'table_name',
             label: 'Table Name',
             description: 'Table to inspect on the executor host.',
+            help_placement: 'tooltip',
           },
           { type: 'string', name: 'database_name', label: 'Database Name' },
           {
@@ -232,6 +243,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'format',
             label: 'Output format',
             description: 'How to render the snippet result.',
+            help_placement: 'tooltip',
             // >3 choices use the select shell (help icon); ≤3 use radios + caption.
             choices: [
               { label: 'Plain text', value: 'text' },
@@ -245,6 +257,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             name: 'verbose',
             label: 'Verbose',
             description: 'Increase output verbosity.',
+            help_placement: 'tooltip',
           },
           { type: 'integer', name: 'limit', label: 'Row limit' },
         ],
@@ -264,6 +277,7 @@ describe('SchemaFormRenderer — cross-plugin help-icon spot-check', () => {
             label: 'Run with sudo',
             description:
               'Prepend sudo to the interpreter when the snippet is executed.',
+            help_placement: 'tooltip',
           },
         ],
       },

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
@@ -15,7 +15,15 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
+import {
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+  type MockInstance,
+} from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -28,6 +36,7 @@ import {
   coerceFormValues,
 } from './utils/validationMapper';
 import { evaluatePredicate, isPresent } from './utils/predicateEvaluator';
+import { resetSchemaWarnings } from './utils/schemaWarnings';
 import type { FormSection, RenderFieldOverride } from './types';
 
 const useAlertConfigMock = vi.fn();
@@ -2723,5 +2732,664 @@ describe('SchemaFormRenderer — one_of groups', () => {
     expect(payload).toMatchObject({ include_target: false });
     expect(payload).not.toHaveProperty('target');
     expect(payload).not.toHaveProperty('target_mode');
+  });
+});
+
+// ── Section groups (PMM-15451) ───────────────────────────────────────────────
+//
+// A run of adjacent sections sharing `group` collapses into one shell, so a
+// form with many expert sections costs one row at rest instead of one per
+// section. Membership is positional, and a group whose members are all gated
+// out must not leave an empty accordion behind.
+
+describe('SchemaFormRenderer — section groups', () => {
+  const grouped: FormSection[] = [
+    {
+      title: 'Task',
+      fields: [
+        {
+          type: 'string',
+          name: 'task_name',
+          label: 'Task name',
+          required: true,
+        },
+      ],
+    },
+    {
+      title: 'General',
+      group: 'Advanced',
+      collapsible: true,
+      collapsed_by_default: true,
+      fields: [{ type: 'string', name: 'logging_dir', label: 'Logging dir' }],
+    },
+    {
+      title: 'Upload',
+      group: 'Advanced',
+      collapsible: true,
+      collapsed_by_default: true,
+      fields: [{ type: 'string', name: 's3_bucket', label: 'S3 bucket' }],
+    },
+  ];
+
+  it('renders one shell for a run of sections sharing a group', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SchemaFormRenderer sections={grouped} onSubmit={() => {}} />
+    );
+
+    // At rest the two member sections cost a single row.
+    expect(screen.getByText('Advanced')).toBeInTheDocument();
+    expect(screen.queryByText('General')).toBeNull();
+    expect(screen.queryByText('Upload')).toBeNull();
+
+    await user.click(screen.getByText('Advanced'));
+
+    expect(await screen.findByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Upload')).toBeInTheDocument();
+  });
+
+  it('leaves an ungrouped schema rendering exactly as before', () => {
+    const ungrouped = grouped.map(({ group: _group, ...section }) => section);
+    renderWithProviders(
+      <SchemaFormRenderer sections={ungrouped} onSubmit={() => {}} />
+    );
+
+    expect(screen.queryByText('Advanced')).toBeNull();
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Upload')).toBeInTheDocument();
+  });
+
+  it('starts two shells for the same group name when the run is broken', () => {
+    const split: FormSection[] = [
+      grouped[0],
+      grouped[1],
+      { title: 'Encryption', fields: [] },
+      grouped[2],
+    ];
+    renderWithProviders(
+      <SchemaFormRenderer sections={split} onSubmit={() => {}} />
+    );
+
+    expect(screen.getAllByText('Advanced')).toHaveLength(2);
+  });
+
+  it('skips the shell when every member is gated out', async () => {
+    const user = userEvent.setup();
+    const gated: FormSection[] = [
+      {
+        title: 'Mode',
+        fields: [
+          {
+            type: 'choice',
+            name: 'backup_type',
+            label: 'Backup Type',
+            choices: [
+              { label: 'Mydumper backup', value: 'M' },
+              { label: 'XtraBackup backup', value: 'X' },
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Mydumper',
+        group: 'Advanced',
+        forbidden: [{ when: { not_equals: { backup_type: 'M' } } }],
+        fields: [
+          {
+            type: 'string',
+            name: 'mydumper_extra_args',
+            label: 'Mydumper args',
+          },
+        ],
+      },
+      {
+        title: 'XtraBackup',
+        group: 'Advanced',
+        forbidden: [{ when: { not_equals: { backup_type: 'X' } } }],
+        fields: [
+          {
+            type: 'string',
+            name: 'xtrabackup_extra_args',
+            label: 'XtraBackup args',
+          },
+        ],
+      },
+    ];
+
+    renderWithProviders(
+      <SchemaFormRenderer sections={gated} onSubmit={() => {}} />
+    );
+
+    // Nothing picked yet, so both members are hidden and the shell is skipped.
+    expect(screen.queryByText('Advanced')).toBeNull();
+
+    await user.click(screen.getByTestId('radio-option-M'));
+
+    // One surviving member is enough to bring the shell back.
+    expect(await screen.findByText('Advanced')).toBeInTheDocument();
+  });
+
+  it('still drops the fields of a gated-out member from the payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const gated: FormSection[] = [
+      {
+        title: 'Mode',
+        fields: [
+          {
+            type: 'choice',
+            name: 'backup_type',
+            label: 'Backup Type',
+            choices: [
+              { label: 'Mydumper backup', value: 'M' },
+              { label: 'XtraBackup backup', value: 'X' },
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Mydumper',
+        group: 'Advanced',
+        forbidden: [{ when: { not_equals: { backup_type: 'M' } } }],
+        fields: [
+          {
+            type: 'string',
+            name: 'mydumper_extra_args',
+            label: 'Mydumper args',
+          },
+        ],
+      },
+      {
+        title: 'XtraBackup',
+        group: 'Advanced',
+        forbidden: [{ when: { not_equals: { backup_type: 'X' } } }],
+        fields: [
+          {
+            type: 'string',
+            name: 'xtrabackup_extra_args',
+            label: 'XtraBackup args',
+          },
+        ],
+      },
+    ];
+
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={gated}
+        onSubmit={onSubmit}
+        defaultValues={{
+          backup_type: 'M',
+          mydumper_extra_args: 'kept',
+          xtrabackup_extra_args: 'should-not-ship',
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    const payload = onSubmit.mock.calls[0]?.[0];
+    expect(payload).toMatchObject({ mydumper_extra_args: 'kept' });
+    expect(payload).not.toHaveProperty('xtrabackup_extra_args');
+  });
+});
+
+// ── Parented fields (PMM-15451) ──────────────────────────────────────────────
+//
+// A field carrying `parent` renders indented beneath that toggle and inert
+// until it is on, rather than vanishing. The backend keeps its own
+// `forbidden` gate on the parent being falsy — `Ui(parent=...)` is
+// presentation-only — so the renderer has to consume that one gate as the
+// disable condition while every other gate on the field still hides it.
+
+describe('SchemaFormRenderer — parented fields', () => {
+  const sections: FormSection[] = [
+    {
+      title: 'Encryption',
+      fields: [
+        { type: 'bool', name: 'encrypt', label: 'Encrypt backup' },
+        {
+          type: 'bool',
+          name: 'post_run_encrypt',
+          label: 'Encrypt after backup',
+        },
+        {
+          type: 'string',
+          name: 'encrypt_tmpdir',
+          label: 'Encrypt using tmpdir',
+          parent: 'encrypt',
+          forbidden: [
+            // The parent gate — consumed as the disable condition.
+            { when: { falsy: 'encrypt' } },
+            // A genuine exclusion — still hides the field.
+            { when: { truthy: 'post_run_encrypt' } },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('shows the child disabled while its parent is off', () => {
+    renderWithProviders(
+      <SchemaFormRenderer sections={sections} onSubmit={() => {}} />
+    );
+
+    const child = screen.getByLabelText('Encrypt using tmpdir');
+    expect(child).toBeInTheDocument();
+    expect(child).toBeDisabled();
+  });
+
+  it('makes the child interactive once the parent is on', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SchemaFormRenderer sections={sections} onSubmit={() => {}} />
+    );
+
+    await user.click(screen.getByLabelText('Encrypt backup'));
+
+    const child = screen.getByLabelText('Encrypt using tmpdir');
+    await waitFor(() => expect(child).toBeEnabled());
+    await user.type(child, '/tmp/enc');
+    expect((child as HTMLInputElement).value).toBe('/tmp/enc');
+  });
+
+  it('nests the child under its parent for assistive tech', () => {
+    renderWithProviders(
+      <SchemaFormRenderer sections={sections} onSubmit={() => {}} />
+    );
+
+    const slot = document.querySelector('[data-field-name="encrypt_tmpdir"]');
+    expect(slot?.tagName).toBe('FIELDSET');
+    expect(slot).toHaveAttribute('data-parent-field', 'encrypt');
+    expect(slot).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('still hides the child on a gate that is not the parent gate', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SchemaFormRenderer sections={sections} onSubmit={() => {}} />
+    );
+
+    await user.click(screen.getByLabelText('Encrypt backup'));
+    await waitFor(() =>
+      expect(screen.getByLabelText('Encrypt using tmpdir')).toBeEnabled()
+    );
+
+    await user.click(screen.getByLabelText('Encrypt after backup'));
+    await waitFor(() =>
+      expect(screen.queryByLabelText('Encrypt using tmpdir')).toBeNull()
+    );
+  });
+
+  it('clears a disabled child so its value never ships', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={sections}
+        onSubmit={onSubmit}
+        defaultValues={{ encrypt: false, encrypt_tmpdir: '/stale' }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ encrypt_tmpdir: '' });
+  });
+
+  it('clears the child again when the parent is switched back off', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer sections={sections} onSubmit={onSubmit} />
+    );
+
+    await user.click(screen.getByLabelText('Encrypt backup'));
+    const child = screen.getByLabelText('Encrypt using tmpdir');
+    await waitFor(() => expect(child).toBeEnabled());
+    await user.type(child, '/tmp/enc');
+    await user.click(screen.getByLabelText('Encrypt backup'));
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ encrypt_tmpdir: '' });
+  });
+
+  it('does not let a disabled required child block submission', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const requiredChild: FormSection[] = [
+      {
+        title: 'Replication',
+        fields: [
+          {
+            type: 'bool',
+            name: 'slave_from_master',
+            label: 'Slave from master',
+          },
+          {
+            type: 'string',
+            name: 'master_ip',
+            label: 'Master IP',
+            required: true,
+            parent: 'slave_from_master',
+            forbidden: [{ when: { falsy: 'slave_from_master' } }],
+          },
+        ],
+      },
+    ];
+
+    renderWithProviders(
+      <SchemaFormRenderer sections={requiredChild} onSubmit={onSubmit} />
+    );
+
+    expect(screen.getByLabelText(/Master IP/)).toBeDisabled();
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  });
+});
+
+// ── Malformed-schema diagnostics (PMM-15451) ─────────────────────────────────
+//
+// A schema arrives from the side-car at runtime, so neither this package's
+// types nor its tests can catch an authoring mistake in it. These cases pin
+// the graceful-degradation behaviour and assert the dev warning that makes the
+// mistake findable.
+
+describe('SchemaFormRenderer — malformed parent/group schemas', () => {
+  let warn: MockInstance<(...args: unknown[]) => void>;
+
+  beforeEach(() => {
+    resetSchemaWarnings();
+    warn = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {}) as unknown as MockInstance<
+      (...args: unknown[]) => void
+    >;
+    onTestFinished(() => warn.mockRestore());
+  });
+
+  function warnings(): string {
+    return warn.mock.calls.map((c) => String(c[0])).join('\n');
+  }
+
+  it('leaves a field disabled, not crashed, when its parent does not exist', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Broken',
+            fields: [
+              {
+                type: 'string',
+                name: 'orphan',
+                label: 'Orphan',
+                parent: 'nope',
+                forbidden: [{ when: { falsy: 'nope' } }],
+              },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText('Orphan')).toBeDisabled();
+    expect(warnings()).toContain("names parent 'nope', which is not a field");
+  });
+
+  it('warns when the parent is not a bool', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Broken',
+            fields: [
+              { type: 'string', name: 'host', label: 'Host' },
+              {
+                type: 'string',
+                name: 'child',
+                label: 'Child',
+                parent: 'host',
+                forbidden: [{ when: { falsy: 'host' } }],
+              },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(warnings()).toContain("which is a 'string' field");
+  });
+
+  it('warns when a parented field carries no companion forbidden gate', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Broken',
+            fields: [
+              { type: 'bool', name: 'enable', label: 'Enable' },
+              {
+                type: 'string',
+                name: 'child',
+                label: 'Child',
+                parent: 'enable',
+              },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(warnings()).toContain('carries no forbidden gate');
+  });
+
+  it('warns on a parent cycle, which leaves both toggles inert', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Cycle',
+            fields: [
+              {
+                type: 'bool',
+                name: 'a',
+                label: 'A',
+                parent: 'b',
+                forbidden: [{ when: { falsy: 'b' } }],
+              },
+              {
+                type: 'bool',
+                name: 'b',
+                label: 'B',
+                parent: 'a',
+                forbidden: [{ when: { falsy: 'a' } }],
+              },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(warnings()).toContain('Chained parents are not supported');
+    expect(screen.getByLabelText('A')).toBeDisabled();
+    expect(screen.getByLabelText('B')).toBeDisabled();
+  });
+
+  it('warns when a group run is broken by an outside section', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          { title: 'General', group: 'Advanced', fields: [] },
+          { title: 'Middle', fields: [] },
+          { title: 'Upload', group: 'Advanced', fields: [] },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(warnings()).toContain("rejoins group 'Advanced'");
+  });
+});
+
+// ── Payload hygiene inside collapsed shells (PMM-15451) ──────────────────────
+//
+// `buildFormDefaults` seeds every leaf in the schema, and a collapsed
+// accordion mounts none of its children (`unmountOnExit`). So the effects that
+// keep a gated-out value out of the payload cannot live in the field or
+// section components — they live in the form body, and these cases prove it.
+
+describe('SchemaFormRenderer — collapsed shells and the payload', () => {
+  const gatedInsideCollapsed: FormSection[] = [
+    {
+      title: 'Mode',
+      fields: [
+        {
+          type: 'choice',
+          name: 'mode',
+          label: 'Mode',
+          choices: [
+            { label: 'Simple', value: 'simple' },
+            { label: 'Full', value: 'full' },
+          ],
+          default: 'simple',
+        },
+      ],
+    },
+    {
+      title: 'Advanced',
+      group: 'Extras',
+      collapsible: true,
+      collapsed_by_default: true,
+      fields: [
+        {
+          type: 'string',
+          name: 'full_only',
+          label: 'Full only',
+          // A gated field that still carries a schema default is the shape
+          // that leaks: the default is seeded whether or not the slot mounts.
+          default: 'seeded-default',
+          forbidden: [{ when: { not_equals: { mode: 'full' } } }],
+        },
+        { type: 'string', name: 'always', label: 'Always' },
+      ],
+    },
+  ];
+
+  it('drops a gated field inside a never-expanded group from the payload', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer sections={gatedInsideCollapsed} onSubmit={onSubmit} />
+    );
+
+    // Never expand anything — the group is collapsed, so the field never mounts.
+    expect(screen.queryByLabelText('Full only')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty('full_only');
+  });
+
+  it('keeps the field once its gate stops firing, still unexpanded', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={gatedInsideCollapsed}
+        onSubmit={onSubmit}
+        defaultValues={{ mode: 'full' }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      full_only: 'seeded-default',
+    });
+  });
+
+  it('clears an unmounted parent-off child rather than shipping its default', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Advanced',
+            group: 'Extras',
+            collapsible: true,
+            collapsed_by_default: true,
+            fields: [
+              { type: 'bool', name: 'enable', label: 'Enable' },
+              {
+                type: 'string',
+                name: 'tuning',
+                label: 'Tuning',
+                default: 'seeded-default',
+                parent: 'enable',
+                forbidden: [{ when: { falsy: 'enable' } }],
+              },
+            ],
+          },
+        ]}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.queryByLabelText('Tuning')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ tuning: '' });
+  });
+
+  it('unregisters rather than clears when a child is both hidden and parent-off', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Encryption',
+            fields: [
+              { type: 'bool', name: 'encrypt', label: 'Encrypt' },
+              { type: 'bool', name: 'post_run', label: 'Post run' },
+              {
+                type: 'string',
+                name: 'tmpdir',
+                label: 'Tmpdir',
+                parent: 'encrypt',
+                forbidden: [
+                  { when: { falsy: 'encrypt' } },
+                  { when: { truthy: 'post_run' } },
+                ],
+              },
+            ],
+          },
+        ]}
+        onSubmit={onSubmit}
+        defaultValues={{ encrypt: false, post_run: true }}
+      />
+    );
+
+    // The non-parent gate hides it; the parent gate would otherwise clear it
+    // straight back into the payload.
+    expect(screen.queryByLabelText('Tmpdir')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty('tmpdir');
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
@@ -35,6 +35,7 @@ import {
   buildValidationRules,
   coerceFormValues,
 } from './utils/validationMapper';
+import { INLINE_HELP_MAX_LENGTH } from './fieldHelp';
 import { evaluatePredicate, isPresent } from './utils/predicateEvaluator';
 import { resetSchemaWarnings } from './utils/schemaWarnings';
 import type { FormSection, RenderFieldOverride } from './types';
@@ -312,16 +313,41 @@ describe('SchemaFormRenderer — field rendering', () => {
     expect(legend.tagName.toLowerCase()).toBe('legend');
   });
 
-  it('shows a help icon only when a field has a description', () => {
+  it('places help by length, and honours an explicit placement', () => {
+    const longProse = `prose ${'x'.repeat(INLINE_HELP_MAX_LENGTH)}`;
+    const longForced = `forced ${'y'.repeat(INLINE_HELP_MAX_LENGTH)}`;
     const helpSections: FormSection[] = [
       {
         title: 'Basics',
         fields: [
+          // Short enough to sit on one line: stays visible under the input.
           {
             type: 'string',
             name: 'title',
             label: 'Title',
             description: 'A title',
+          },
+          // Prose: behind the icon, so it cannot dominate the form.
+          {
+            type: 'string',
+            name: 'notes',
+            label: 'Notes',
+            description: longProse,
+          },
+          // The schema overriding the default, in both directions.
+          {
+            type: 'string',
+            name: 'pinned',
+            label: 'Pinned',
+            description: 'Short but secondary',
+            help_placement: 'tooltip',
+          },
+          {
+            type: 'string',
+            name: 'shown',
+            label: 'Shown',
+            description: longForced,
+            help_placement: 'inline',
           },
           { type: 'string', name: 'code', label: 'Code' },
         ],
@@ -331,13 +357,22 @@ describe('SchemaFormRenderer — field rendering', () => {
       <SchemaFormRenderer sections={helpSections} onSubmit={() => {}} />
     );
 
-    // Notched-outline clone is aria-hidden; pin count + require a visible <label> hit.
-    expect(document.querySelectorAll('[data-help-for="Title"]')).toHaveLength(
-      2
-    );
-    expect(
-      document.querySelectorAll('label [data-help-for="Title"]')
-    ).toHaveLength(1);
+    const icon = (label: string) =>
+      document.querySelectorAll(`label [data-help-for="${label}"]`).length;
+
+    expect(icon('Title')).toBe(0);
+    expect(screen.getByText('A title')).toBeInTheDocument();
+
+    expect(icon('Notes')).toBe(1);
+    expect(screen.queryByText(longProse)).toBeNull();
+
+    expect(icon('Pinned')).toBe(1);
+    expect(screen.queryByText('Short but secondary')).toBeNull();
+
+    expect(icon('Shown')).toBe(0);
+    expect(screen.getByText(longForced)).toBeInTheDocument();
+
+    // A field with no description gets neither.
     expect(document.querySelectorAll('[data-help-for="Code"]')).toHaveLength(0);
   });
 });
@@ -3423,5 +3458,60 @@ describe('SchemaFormRenderer — optional marker', () => {
 
     expect(screen.getByLabelText('Two')).toBeInTheDocument();
     expect(screen.queryByLabelText('Two (optional)')).toBeNull();
+  });
+
+  it('leaves a defaulted lone optional field unmarked', () => {
+    // A field carrying a default is pre-filled, not blank-optional; calling it
+    // "(optional)" suggests a choice nobody has made yet.
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Task',
+            fields: [
+              { type: 'string', name: 'a', label: 'Task name', required: true },
+              { type: 'string', name: 'b', label: 'Host', required: true },
+              {
+                type: 'choice',
+                name: 'c',
+                label: 'Transport',
+                default: 'local',
+                choices: [
+                  { label: 'Local', value: 'local' },
+                  { label: 'SSH', value: 'ssh' },
+                ],
+              },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Transport')).toBeInTheDocument();
+    expect(screen.queryByText(/Transport \(optional\)/)).toBeNull();
+  });
+
+  it('leaves two optional fields unmarked, where the asterisks already read', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Task',
+            fields: [
+              { type: 'string', name: 'a', label: 'One', required: true },
+              { type: 'string', name: 'b', label: 'Two', required: true },
+              { type: 'string', name: 'c', label: 'Three', required: true },
+              { type: 'string', name: 'd', label: 'Four' },
+              { type: 'string', name: 'e', label: 'Five' },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText('Four')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Four (optional)')).toBeNull();
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
@@ -3202,19 +3202,23 @@ describe('SchemaFormRenderer — malformed parent/group schemas', () => {
     expect(warnings()).toContain("which is a 'string' field");
   });
 
-  it('warns when a parented field carries no companion forbidden gate', () => {
+  it('warns when a parent-off gate pairs with a present default', () => {
+    // The one combination the reset cannot satisfy: while the parent is off
+    // the child resets to its default, and that default trips its own gate.
     renderWithProviders(
       <SchemaFormRenderer
         sections={[
           {
-            title: 'Broken',
+            title: 'Replication',
             fields: [
               { type: 'bool', name: 'enable', label: 'Enable' },
               {
-                type: 'string',
-                name: 'child',
-                label: 'Child',
+                type: 'integer',
+                name: 'port',
+                label: 'Port',
+                default: 3306,
                 parent: 'enable',
+                forbidden: [{ when: { falsy: 'enable' } }],
               },
             ],
           },
@@ -3223,7 +3227,29 @@ describe('SchemaFormRenderer — malformed parent/group schemas', () => {
       />
     );
 
-    expect(warnings()).toContain('carries no forbidden gate');
+    expect(warnings()).toContain('a default the backend reads as present');
+  });
+
+  it('accepts a parented field with no gate at all', () => {
+    // `Ui(parent=...)` is presentation-only on the backend, so most parented
+    // fields carry no forbidden gate; that must not warn.
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Replication',
+            fields: [
+              { type: 'bool', name: 'enable', label: 'Enable' },
+              { type: 'string', name: 'host', label: 'Host', parent: 'enable' },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(warnings()).not.toContain('forbidden');
+    expect(screen.getByLabelText('Host')).toBeDisabled();
   });
 
   it('warns on a parent cycle, which leaves both toggles inert', () => {
@@ -3339,7 +3365,7 @@ describe('SchemaFormRenderer — collapsed shells and the payload', () => {
     });
   });
 
-  it('clears an unmounted parent-off child rather than shipping its default', async () => {
+  it('resets an unmounted parent-off child to its default, not a stale value', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     renderWithProviders(
@@ -3372,7 +3398,12 @@ describe('SchemaFormRenderer — collapsed shells and the payload', () => {
     await user.click(screen.getByRole('button', { name: /Run/ }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
 
-    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ tuning: '' });
+    // The schema default, not blank: a greyed control shows what it would
+    // submit once its parent is on. What must not survive is a value someone
+    // typed while the parent was on and then switched off.
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      tuning: 'seeded-default',
+    });
   });
 
   it('unregisters rather than clears when a child is both hidden and parent-off', async () => {
@@ -3513,5 +3544,79 @@ describe('SchemaFormRenderer — optional marker', () => {
 
     expect(screen.getByLabelText('Four')).toBeInTheDocument();
     expect(screen.queryByLabelText('Four (optional)')).toBeNull();
+  });
+});
+
+// ── Parent-off children show their default (PMM-15451) ───────────────────────
+
+describe('SchemaFormRenderer — a disabled child shows its default', () => {
+  it('greys a defaulted child at its default rather than blank', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Replication',
+            fields: [
+              { type: 'bool', name: 'slave', label: 'Slave from master' },
+              {
+                type: 'integer',
+                name: 'master_port',
+                label: 'Master port',
+                default: 3306,
+                parent: 'slave',
+              },
+            ],
+          },
+        ]}
+        onSubmit={onSubmit}
+      />
+    );
+
+    const port = screen.getByLabelText('Master port');
+    expect(port).toBeDisabled();
+    expect(port).toHaveValue(3306);
+
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ master_port: 3306 });
+  });
+
+  it('drops a value typed while the parent was on, once it goes off', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Replication',
+            fields: [
+              { type: 'bool', name: 'slave', label: 'Slave from master' },
+              {
+                type: 'integer',
+                name: 'master_port',
+                label: 'Master port',
+                default: 3306,
+                parent: 'slave',
+              },
+            ],
+          },
+        ]}
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByLabelText('Slave from master'));
+    const port = screen.getByLabelText('Master port');
+    await waitFor(() => expect(port).toBeEnabled());
+    await user.clear(port);
+    await user.type(port, '5306');
+    await user.click(screen.getByLabelText('Slave from master'));
+
+    await waitFor(() => expect(port).toBeDisabled());
+    await user.click(screen.getByRole('button', { name: /Run/ }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ master_port: 3306 });
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.test.tsx
@@ -2735,15 +2735,14 @@ describe('SchemaFormRenderer — one_of groups', () => {
   });
 });
 
-// ── Section groups (PMM-15451) ───────────────────────────────────────────────
+// ── Advanced sections (PMM-15451) ────────────────────────────────────────────
 //
-// A run of adjacent sections sharing `group` collapses into one shell, so a
-// form with many expert sections costs one row at rest instead of one per
-// section. Membership is positional, and a group whose members are all gated
-// out must not leave an empty accordion behind.
+// Expert sections are withheld behind one "Show advanced options" control so
+// the common case fits a screen. The control must never hide something the
+// reader has already put a value in, or an error they have to fix.
 
-describe('SchemaFormRenderer — section groups', () => {
-  const grouped: FormSection[] = [
+describe('SchemaFormRenderer — advanced sections', () => {
+  const sections: FormSection[] = [
     {
       title: 'Task',
       fields: [
@@ -2757,119 +2756,112 @@ describe('SchemaFormRenderer — section groups', () => {
     },
     {
       title: 'General',
-      group: 'Advanced',
+      advanced: true,
       collapsible: true,
       collapsed_by_default: true,
       fields: [{ type: 'string', name: 'logging_dir', label: 'Logging dir' }],
     },
     {
       title: 'Upload',
-      group: 'Advanced',
+      advanced: true,
       collapsible: true,
       collapsed_by_default: true,
       fields: [{ type: 'string', name: 's3_bucket', label: 'S3 bucket' }],
     },
   ];
 
-  it('renders one shell for a run of sections sharing a group', async () => {
+  it('withholds advanced sections behind a single control', async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <SchemaFormRenderer sections={grouped} onSubmit={() => {}} />
+      <SchemaFormRenderer sections={sections} onSubmit={() => {}} />
     );
 
-    // At rest the two member sections cost a single row.
-    expect(screen.getByText('Advanced')).toBeInTheDocument();
     expect(screen.queryByText('General')).toBeNull();
     expect(screen.queryByText('Upload')).toBeNull();
 
-    await user.click(screen.getByText('Advanced'));
+    await user.click(screen.getByTestId('show-advanced-options'));
 
+    // Revealed as ordinary top-level sections, not nested in a wrapper.
     expect(await screen.findByText('General')).toBeInTheDocument();
     expect(screen.getByText('Upload')).toBeInTheDocument();
+    expect(screen.queryByTestId('show-advanced-options')).toBeNull();
   });
 
-  it('leaves an ungrouped schema rendering exactly as before', () => {
-    const ungrouped = grouped.map(({ group: _group, ...section }) => section);
+  it('renders no control when the schema marks nothing advanced', () => {
+    const plain = sections.map(
+      ({ advanced: _advanced, ...section }) => section
+    );
     renderWithProviders(
-      <SchemaFormRenderer sections={ungrouped} onSubmit={() => {}} />
+      <SchemaFormRenderer sections={plain} onSubmit={() => {}} />
     );
 
-    expect(screen.queryByText('Advanced')).toBeNull();
+    expect(screen.queryByTestId('show-advanced-options')).toBeNull();
     expect(screen.getByText('General')).toBeInTheDocument();
     expect(screen.getByText('Upload')).toBeInTheDocument();
   });
 
-  it('starts two shells for the same group name when the run is broken', () => {
-    const split: FormSection[] = [
-      grouped[0],
-      grouped[1],
-      { title: 'Encryption', fields: [] },
-      grouped[2],
-    ];
-    renderWithProviders(
-      <SchemaFormRenderer sections={split} onSubmit={() => {}} />
-    );
-
-    expect(screen.getAllByText('Advanced')).toHaveLength(2);
-  });
-
-  it('skips the shell when every member is gated out', async () => {
+  it('collects advanced sections wherever they appear, after the rest', async () => {
     const user = userEvent.setup();
-    const gated: FormSection[] = [
-      {
-        title: 'Mode',
-        fields: [
-          {
-            type: 'choice',
-            name: 'backup_type',
-            label: 'Backup Type',
-            choices: [
-              { label: 'Mydumper backup', value: 'M' },
-              { label: 'XtraBackup backup', value: 'X' },
-            ],
-          },
-        ],
-      },
-      {
-        title: 'Mydumper',
-        group: 'Advanced',
-        forbidden: [{ when: { not_equals: { backup_type: 'M' } } }],
-        fields: [
-          {
-            type: 'string',
-            name: 'mydumper_extra_args',
-            label: 'Mydumper args',
-          },
-        ],
-      },
-      {
-        title: 'XtraBackup',
-        group: 'Advanced',
-        forbidden: [{ when: { not_equals: { backup_type: 'X' } } }],
-        fields: [
-          {
-            type: 'string',
-            name: 'xtrabackup_extra_args',
-            label: 'XtraBackup args',
-          },
-        ],
-      },
-    ];
-
+    // Advanced first in the schema, an ordinary section after it.
+    const interleaved: FormSection[] = [sections[1], sections[0], sections[2]];
     renderWithProviders(
-      <SchemaFormRenderer sections={gated} onSubmit={() => {}} />
+      <SchemaFormRenderer sections={interleaved} onSubmit={() => {}} />
     );
 
-    // Nothing picked yet, so both members are hidden and the shell is skipped.
-    expect(screen.queryByText('Advanced')).toBeNull();
+    await user.click(screen.getByTestId('show-advanced-options'));
 
-    await user.click(screen.getByTestId('radio-option-M'));
-
-    // One surviving member is enough to bring the shell back.
-    expect(await screen.findByText('Advanced')).toBeInTheDocument();
+    const headings = (await screen.findAllByRole('group')).map(
+      (el) => el.querySelector('legend')?.textContent
+    );
+    expect(headings).toEqual(['Task', 'General', 'Upload']);
   });
 
-  it('still drops the fields of a gated-out member from the payload', async () => {
+  it('reveals and expands a section that arrives with a value in it', async () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={sections}
+        onSubmit={() => {}}
+        defaultValues={{ s3_bucket: 'saved-bucket' }}
+      />
+    );
+
+    // No click: an edit form must not hide what the task already sets.
+    expect(screen.queryByTestId('show-advanced-options')).toBeNull();
+    const input = await screen.findByLabelText('S3 bucket');
+    expect(input).toHaveValue('saved-bucket');
+  });
+
+  it('leaves the control in place when seeded values match the defaults', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={sections}
+        onSubmit={() => {}}
+        defaultValues={{ s3_bucket: '' }}
+      />
+    );
+
+    expect(screen.getByTestId('show-advanced-options')).toBeInTheDocument();
+  });
+
+  it('reveals and expands a section a backend error points into', async () => {
+    // The realistic case. A required field inside a never-opened section is
+    // never registered, so client-side validation cannot flag it — the error
+    // that lands in an unrevealed section comes back from the server as a 422.
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={sections}
+        onSubmit={() => {}}
+        submitError={'Failed\n• S3 bucket: must not be blank'}
+        fieldErrors={[{ path: 's3_bucket', message: 'must not be blank' }]}
+      />
+    );
+
+    expect(await screen.findByLabelText('S3 bucket')).toBeInTheDocument();
+    expect(screen.queryByTestId('show-advanced-options')).toBeNull();
+    expect(screen.getByText('must not be blank')).toBeInTheDocument();
+  });
+
+  it('still drops a gated-out advanced section from the payload', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     const gated: FormSection[] = [
@@ -2888,20 +2880,8 @@ describe('SchemaFormRenderer — section groups', () => {
         ],
       },
       {
-        title: 'Mydumper',
-        group: 'Advanced',
-        forbidden: [{ when: { not_equals: { backup_type: 'M' } } }],
-        fields: [
-          {
-            type: 'string',
-            name: 'mydumper_extra_args',
-            label: 'Mydumper args',
-          },
-        ],
-      },
-      {
         title: 'XtraBackup',
-        group: 'Advanced',
+        advanced: true,
         forbidden: [{ when: { not_equals: { backup_type: 'X' } } }],
         fields: [
           {
@@ -2919,7 +2899,6 @@ describe('SchemaFormRenderer — section groups', () => {
         onSubmit={onSubmit}
         defaultValues={{
           backup_type: 'M',
-          mydumper_extra_args: 'kept',
           xtrabackup_extra_args: 'should-not-ship',
         }}
       />
@@ -2928,9 +2907,31 @@ describe('SchemaFormRenderer — section groups', () => {
     await user.click(screen.getByRole('button', { name: /Run/ }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
 
-    const payload = onSubmit.mock.calls[0]?.[0];
-    expect(payload).toMatchObject({ mydumper_extra_args: 'kept' });
-    expect(payload).not.toHaveProperty('xtrabackup_extra_args');
+    expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty(
+      'xtrabackup_extra_args'
+    );
+  });
+
+  it('hides the control when every advanced section is gated out', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Mode',
+            fields: [{ type: 'bool', name: 'expert', label: 'Expert' }],
+          },
+          {
+            title: 'Extras',
+            advanced: true,
+            forbidden: [{ when: { falsy: 'expert' } }],
+            fields: [{ type: 'string', name: 'extra', label: 'Extra' }],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.queryByTestId('show-advanced-options')).toBeNull();
   });
 });
 
@@ -3222,21 +3223,6 @@ describe('SchemaFormRenderer — malformed parent/group schemas', () => {
     expect(screen.getByLabelText('A')).toBeDisabled();
     expect(screen.getByLabelText('B')).toBeDisabled();
   });
-
-  it('warns when a group run is broken by an outside section', () => {
-    renderWithProviders(
-      <SchemaFormRenderer
-        sections={[
-          { title: 'General', group: 'Advanced', fields: [] },
-          { title: 'Middle', fields: [] },
-          { title: 'Upload', group: 'Advanced', fields: [] },
-        ]}
-        onSubmit={() => {}}
-      />
-    );
-
-    expect(warnings()).toContain("rejoins group 'Advanced'");
-  });
 });
 
 // ── Payload hygiene inside collapsed shells (PMM-15451) ──────────────────────
@@ -3265,7 +3251,7 @@ describe('SchemaFormRenderer — collapsed shells and the payload', () => {
     },
     {
       title: 'Advanced',
-      group: 'Extras',
+      advanced: true,
       collapsible: true,
       collapsed_by_default: true,
       fields: [
@@ -3326,7 +3312,7 @@ describe('SchemaFormRenderer — collapsed shells and the payload', () => {
         sections={[
           {
             title: 'Advanced',
-            group: 'Extras',
+            advanced: true,
             collapsible: true,
             collapsed_by_default: true,
             fields: [
@@ -3391,5 +3377,51 @@ describe('SchemaFormRenderer — collapsed shells and the payload', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
 
     expect(onSubmit.mock.calls[0]?.[0]).not.toHaveProperty('tmpdir');
+  });
+});
+
+// ── Marking the odd optional field out (PMM-15451) ───────────────────────────
+
+describe('SchemaFormRenderer — optional marker', () => {
+  it('spells out "(optional)" in a section that is otherwise required', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'Task',
+            fields: [
+              { type: 'string', name: 'a', label: 'Task name', required: true },
+              { type: 'string', name: 'b', label: 'Host', required: true },
+              { type: 'string', name: 'c', label: 'Alias' },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText('Alias (optional)')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Task name/)).toBeInTheDocument();
+  });
+
+  it('marks nothing when optional fields are not the exception', () => {
+    renderWithProviders(
+      <SchemaFormRenderer
+        sections={[
+          {
+            title: 'General',
+            fields: [
+              { type: 'string', name: 'a', label: 'One', required: true },
+              { type: 'string', name: 'b', label: 'Two' },
+              { type: 'string', name: 'c', label: 'Three' },
+            ],
+          },
+        ]}
+        onSubmit={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText('Two')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Two (optional)')).toBeNull();
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
@@ -22,6 +22,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type FormEvent,
 } from 'react';
 import {
@@ -56,7 +57,6 @@ import {
 } from '../AlertOnFailField';
 import { ConditionalFieldSlot } from './ConditionalFieldSlot';
 import { useFieldPayloadCleanup } from './hooks/useConditionalField';
-import { SECTION_GRID_SX } from './fieldLayout';
 import { OneOfGroupSlot } from './OneOfGroupSlot';
 import {
   useConditionalSections,
@@ -67,7 +67,6 @@ import { useFailRules } from './hooks/useFailRules';
 import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard';
 import { coerceFormValues } from './utils/validationMapper';
 import { fieldDefault } from './utils/fieldDefault';
-import { warnSchema } from './utils/schemaWarnings';
 import { getAtPath, setAtPath } from './utils/fieldPath';
 import {
   collectOneOfGroups,
@@ -137,46 +136,63 @@ interface SectionEntry {
 }
 
 /**
- * A run of adjacent sections sharing a `group`, or a single ungrouped section.
- * Grouping is positional so a schema controls membership by section order,
- * the same way it already controls section order itself.
+ * Split sections into the ones a form opens on and the expert ones withheld
+ * behind the reveal control, preserving each group's own order.
+ *
+ * Advanced sections are collected wherever they appear rather than having to be
+ * adjacent, so a schema controls membership with one flag and nothing depends
+ * on where the fields happen to be declared on the model.
  */
-type SectionRenderItem =
-  | { kind: 'section'; entry: SectionEntry }
-  | { kind: 'group'; title: string; entries: SectionEntry[] };
-
-function groupAdjacentSections(
-  entries: SectionEntry[],
-  // Shared across the before- and after-submit passes: a group whose members
-  // straddle that boundary is adjacent by the documented rule yet renders as
-  // two shells, which is exactly what this warns about.
-  opened: Set<string>
-): SectionRenderItem[] {
-  const items: SectionRenderItem[] = [];
+function partitionAdvanced(entries: SectionEntry[]): {
+  standard: SectionEntry[];
+  advanced: SectionEntry[];
+} {
+  const standard: SectionEntry[] = [];
+  const advanced: SectionEntry[] = [];
   for (const entry of entries) {
-    const group = entry.section.group;
-    if (!group) {
-      items.push({ kind: 'section', entry });
-      continue;
-    }
-    const last = items[items.length - 1];
-    if (last?.kind === 'group' && last.title === group) {
-      last.entries.push(entry);
-      continue;
-    }
-    if (opened.has(group)) {
-      // Two shells with the same heading is never what an author meant; it
-      // means a section was inserted into the middle of the run.
-      warnSchema(
-        `section '${entry.section.title}' rejoins group '${group}' after a ` +
-          `section outside it, so the group renders as two separate shells. ` +
-          `Group members have to be adjacent in the schema's section order.`
-      );
-    }
-    opened.add(group);
-    items.push({ kind: 'group', title: group, entries: [entry] });
+    (entry.section.advanced ? advanced : standard).push(entry);
   }
-  return items;
+  return { standard, advanced };
+}
+
+/**
+ * Whether a section holds a value that differs from what the schema would have
+ * pre-filled, judged against the values the form opened with.
+ *
+ * Read once, from the caller's `defaultValues`, rather than watched: this
+ * decides whether an *unopened* advanced section has something in it worth
+ * revealing, and a value the user has just typed means they opened it already.
+ */
+function sectionHasNonDefaultValue(
+  section: FormSection,
+  defaultValues: Record<string, unknown> | undefined
+): boolean {
+  if (!defaultValues) {
+    return false;
+  }
+  return flattenSectionFields([section]).some((field) => {
+    const seeded = getAtPath(defaultValues, field.name);
+    if (seeded === undefined) {
+      return false;
+    }
+    return !Object.is(seeded, fieldDefault(field));
+  });
+}
+
+/**
+ * Whether any field in a section currently carries a validation error.
+ *
+ * In an unrevealed section that means a backend error applied through
+ * `setError`: an unmounted field is never registered, so react-hook-form's own
+ * validation has nothing to run against it.
+ */
+function sectionHasError(
+  section: FormSection,
+  errors: FieldErrors<Record<string, unknown>>
+): boolean {
+  return flattenSectionFields([section]).some((field) =>
+    Boolean(get(errors, field.name))
+  );
 }
 
 interface SectionRendererProps {
@@ -185,8 +201,13 @@ interface SectionRendererProps {
   isHidden: boolean;
   violations: Array<{ message: string }>;
   renderField?: RenderFieldOverride;
-  /** Rendered inside a group shell: drop the outer chrome the group provides. */
-  nested?: boolean;
+  /**
+   * Open a collapsible section that would otherwise start collapsed, because
+   * it holds something the reader needs to see. Raising this later — when a
+   * submit puts an error inside a collapsed section — opens it then; the
+   * reader can still collapse it again afterwards.
+   */
+  forceExpanded?: boolean;
 }
 
 const SectionRenderer = memo(function SectionRenderer({
@@ -195,8 +216,26 @@ const SectionRenderer = memo(function SectionRenderer({
   isHidden,
   violations,
   renderField,
-  nested = false,
+  forceExpanded = false,
 }: SectionRendererProps) {
+  const [expanded, setExpanded] = useState(
+    !section.collapsed_by_default || forceExpanded
+  );
+
+  useEffect(() => {
+    if (forceExpanded) {
+      setExpanded(true);
+    }
+  }, [forceExpanded]);
+
+  // Mark the odd optional field out in a section that is otherwise required —
+  // the absence of an asterisk is easy to miss when every neighbour has one.
+  const markOptional = useMemo(() => {
+    const leaves = section.fields.filter((f) => !isOneOfGroup(f));
+    const required = leaves.filter((f) => f.required).length;
+    return required > leaves.length - required;
+  }, [section.fields]);
+
   if (isHidden) {
     return null;
   }
@@ -213,42 +252,41 @@ const SectionRenderer = memo(function SectionRenderer({
           {v.message}
         </Alert>
       ))}
-      <Box sx={SECTION_GRID_SX}>
-        {section.fields.map((field) =>
-          isOneOfGroup(field) ? (
-            <OneOfGroupSlot
-              key={field.name}
-              group={field}
-              renderField={renderField}
-            />
-          ) : (
-            <ConditionalFieldSlot
-              key={field.name}
-              field={field}
-              renderField={renderField}
-            />
-          )
-        )}
-      </Box>
+      {section.fields.map((field) =>
+        isOneOfGroup(field) ? (
+          <OneOfGroupSlot
+            key={field.name}
+            group={field}
+            renderField={renderField}
+          />
+        ) : (
+          <ConditionalFieldSlot
+            key={field.name}
+            field={field}
+            renderField={renderField}
+            markOptional={markOptional}
+          />
+        )
+      )}
     </>
   );
 
   // A collapsed shell already draws its own rule, and stacking several of them
   // is the bulk of an expert-heavy form's resting height — so no divider above
   // one, and a tighter gap between them.
-  const showDivider = !nested && idx > 0 && !section.collapsible;
+  const showDivider = idx > 0 && !section.collapsible;
 
   return (
     <Box
       component="fieldset"
-      sx={{ border: 0, p: 0, mb: section.collapsible || nested ? 1 : 3 }}
+      sx={{ border: 0, p: 0, mb: section.collapsible ? 1 : 3 }}
     >
       {showDivider && <Divider sx={{ mb: 2 }} />}
       {section.collapsible ? (
         <Accordion
-          defaultExpanded={!section.collapsed_by_default}
+          expanded={expanded}
+          onChange={(_, isExpanded) => setExpanded(isExpanded)}
           disableGutters
-          variant={nested ? 'outlined' : undefined}
           slotProps={{ transition: { unmountOnExit: true } }}
         >
           <AccordionSummary
@@ -274,11 +312,7 @@ const SectionRenderer = memo(function SectionRenderer({
         </Accordion>
       ) : (
         <>
-          <Typography
-            component="legend"
-            variant={nested ? 'subtitle1' : 'h6'}
-            sx={{ mb: 1, px: 0, fontWeight: nested ? 600 : undefined }}
-          >
+          <Typography component="legend" variant="h6" sx={{ mb: 1, px: 0 }}>
             {section.title}
           </Typography>
           {sectionContent}
@@ -288,75 +322,29 @@ const SectionRenderer = memo(function SectionRenderer({
   );
 });
 
-interface SectionGroupProps {
-  title: string;
-  entries: SectionEntry[];
-  /** Hidden flags positionally matching {@link entries}. */
-  hidden: boolean[];
-  /** Section violations positionally matching {@link entries}. */
-  violations: Array<Array<{ message: string }>>;
-  renderField?: RenderFieldOverride;
-}
-
 /**
- * One collapsed shell over a run of sections.
+ * The control that reveals a form's advanced sections.
  *
- * When every member is hidden the shell is skipped rather than left standing
- * empty. Members are still rendered in that case so the tree shape does not
- * change; they each return null. Note that a *collapsed* shell mounts no
- * members at all (`unmountOnExit`), which is why nothing here may be
- * responsible for keeping gated-out values out of the payload — the form body
- * owns that, for sections and fields alike.
+ * A link-style button rather than another accordion: the sections it reveals
+ * are themselves collapsible, and wrapping them in a further shell puts the
+ * common case two disclosures deep. Once revealed it stays out of the way —
+ * there is no "hide again", because collapsing a section the reader has
+ * already put a value in is the behaviour this whole control exists to avoid.
  */
-function SectionGroup({
-  title,
-  entries,
-  hidden,
-  violations,
-  renderField,
-}: SectionGroupProps) {
-  const members = entries.map((entry, i) => (
-    <SectionRenderer
-      key={`${entry.section.title}-${entry.index}`}
-      section={entry.section}
-      idx={i}
-      isHidden={hidden[i] ?? false}
-      violations={violations[i] ?? []}
-      renderField={renderField}
-      nested
-    />
-  ));
-
-  if (hidden.every(Boolean)) {
-    return <>{members}</>;
-  }
-
+function AdvancedReveal({ onReveal }: { onReveal: () => void }) {
   return (
-    <Box component="fieldset" sx={{ border: 0, p: 0, mb: 1 }}>
-      <Accordion
-        defaultExpanded={false}
-        disableGutters
-        slotProps={{ transition: { unmountOnExit: true } }}
+    <Box sx={{ mb: 3 }}>
+      <Button
+        type="button"
+        variant="text"
+        size="small"
+        onClick={onReveal}
+        startIcon={<ExpandMoreIcon />}
+        data-testid="show-advanced-options"
+        sx={{ px: 0.5 }}
       >
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          sx={{
-            pl: 2,
-            pr: 1,
-            minHeight: 48,
-            '& .MuiAccordionSummary-content': { my: 1 },
-          }}
-        >
-          <Typography
-            component="legend"
-            variant="subtitle1"
-            sx={{ fontWeight: 600 }}
-          >
-            {title}
-          </Typography>
-        </AccordionSummary>
-        <AccordionDetails sx={{ pl: 2, pr: 2 }}>{members}</AccordionDetails>
-      </Accordion>
+        Show advanced options
+      </Button>
     </Box>
   );
 }
@@ -437,6 +425,7 @@ function SchemaFormBody({
   onSubmit,
   submitLabel = 'Run',
   loading = false,
+  defaultValues,
   submitError,
   fieldErrors,
   capabilities,
@@ -481,20 +470,52 @@ function SchemaFormBody({
   // gated out, and `buildFormDefaults` has already seeded them.
   useUnregisterHiddenSections(sections, hiddenSections);
   useFieldPayloadCleanup(allFields);
-  const [beforeSubmitItems, afterSubmitItems] = useMemo(() => {
-    const entries = sections.map((section, index) => ({ section, index }));
-    const opened = new Set<string>();
-    return [
-      groupAdjacentSections(
-        entries.filter(({ section }) => !section.render_after_submit),
-        opened
+  const { standardEntries, advancedEntries, afterSubmitEntries } =
+    useMemo(() => {
+      const entries = sections.map((section, index) => ({ section, index }));
+      const { standard, advanced } = partitionAdvanced(
+        entries.filter(({ section }) => !section.render_after_submit)
+      );
+      return {
+        standardEntries: standard,
+        advancedEntries: advanced,
+        afterSubmitEntries: entries.filter(
+          ({ section }) => section.render_after_submit
+        ),
+      };
+    }, [sections]);
+
+  // An advanced section arriving with a value already in it — an edit form, or
+  // a task cloned from another — must not be hidden behind the reveal.
+  const seededAdvanced = useMemo(
+    () =>
+      new Set(
+        advancedEntries
+          .filter(({ section }) =>
+            sectionHasNonDefaultValue(section, defaultValues)
+          )
+          .map(({ index }) => index)
       ),
-      groupAdjacentSections(
-        entries.filter(({ section }) => section.render_after_submit),
-        opened
+    [advancedEntries, defaultValues]
+  );
+  const erroredAdvanced = useMemo(
+    () =>
+      new Set(
+        advancedEntries
+          .filter(({ section }) => sectionHasError(section, formState.errors))
+          .map(({ index }) => index)
       ),
-    ];
-  }, [sections]);
+    [advancedEntries, formState.errors]
+  );
+  const [advancedRevealed, setAdvancedRevealed] = useState(false);
+  // Reveal, never re-hide: a submit that puts an error in an advanced section
+  // has to show it, and pulling the section back once the reader fixes it
+  // would move the ground under them.
+  const showAdvanced =
+    advancedRevealed || seededAdvanced.size > 0 || erroredAdvanced.size > 0;
+  const visibleAdvanced = advancedEntries.filter(
+    ({ index }) => !(hiddenSections[index] ?? false)
+  );
   const cardinalityViolations = useCardinalityRules(sections);
   const failViolations = useFailRules(sections);
 
@@ -516,37 +537,23 @@ function SchemaFormBody({
   );
   const hasInlineErrors = Object.keys(formState.errors).length > 0;
 
-  const renderItem = (
-    item: SectionRenderItem,
+  const renderSection = (
+    entry: SectionEntry,
     idx: number,
     keyPrefix: string
-  ) => {
-    if (item.kind === 'group') {
-      return (
-        <SectionGroup
-          key={`${keyPrefix}-group-${item.title}-${idx}`}
-          title={item.title}
-          entries={item.entries}
-          hidden={item.entries.map((e) => hiddenSections[e.index] ?? false)}
-          violations={item.entries.map(
-            (e) => violationsBySection.get(e.section) ?? []
-          )}
-          renderField={renderField}
-        />
-      );
-    }
-    const { entry } = item;
-    return (
-      <SectionRenderer
-        key={`${keyPrefix}-${entry.section.title}-${entry.index}`}
-        section={entry.section}
-        idx={idx}
-        isHidden={hiddenSections[entry.index] ?? false}
-        violations={violationsBySection.get(entry.section) ?? []}
-        renderField={renderField}
-      />
-    );
-  };
+  ) => (
+    <SectionRenderer
+      key={`${keyPrefix}-${entry.section.title}-${entry.index}`}
+      section={entry.section}
+      idx={idx}
+      isHidden={hiddenSections[entry.index] ?? false}
+      violations={violationsBySection.get(entry.section) ?? []}
+      renderField={renderField}
+      forceExpanded={
+        seededAdvanced.has(entry.index) || erroredAdvanced.has(entry.index)
+      }
+    />
+  );
 
   const handleFormSubmit: SubmitHandler<Record<string, unknown>> = (values) => {
     onSubmit(coerceFormValues(values, allFields));
@@ -616,7 +623,18 @@ function SchemaFormBody({
           </Alert>
         )}
 
-        {beforeSubmitItems.map((item, idx) => renderItem(item, idx, 'before'))}
+        {standardEntries.map((entry, idx) =>
+          renderSection(entry, idx, 'standard')
+        )}
+
+        {visibleAdvanced.length > 0 &&
+          (showAdvanced ? (
+            visibleAdvanced.map((entry, idx) =>
+              renderSection(entry, standardEntries.length + idx, 'advanced')
+            )
+          ) : (
+            <AdvancedReveal onReveal={() => setAdvancedRevealed(true)} />
+          ))}
 
         {capabilities?.alert_on_fail && (
           <Box sx={{ mb: 2 }}>
@@ -635,10 +653,10 @@ function SchemaFormBody({
           {submitLabel}
         </Button>
 
-        {afterSubmitItems.length > 0 ? (
+        {afterSubmitEntries.length > 0 ? (
           <Box sx={{ mt: 3 }}>
-            {afterSubmitItems.map((item, idx) =>
-              renderItem(item, idx, 'after')
+            {afterSubmitEntries.map((entry, idx) =>
+              renderSection(entry, idx, 'after')
             )}
           </Box>
         ) : null}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
@@ -230,10 +230,22 @@ const SectionRenderer = memo(function SectionRenderer({
 
   // Mark the odd optional field out in a section that is otherwise required —
   // the absence of an asterisk is easy to miss when every neighbour has one.
-  const markOptional = useMemo(() => {
+  //
+  // Deliberately narrow: one unfilled field among required ones. Two or more
+  // and the section is a mix, where the asterisks already read as the
+  // exception; and a field carrying a default is not blank-optional but
+  // pre-filled, so "(optional)" would suggest a choice that has been made for
+  // the reader already.
+  const optionalNames = useMemo(() => {
     const leaves = section.fields.filter((f) => !isOneOfGroup(f));
-    const required = leaves.filter((f) => f.required).length;
-    return required > leaves.length - required;
+    const required = leaves.filter((f) => f.required);
+    const optional = leaves.filter((f) => !f.required);
+    if (required.length < 2 || optional.length !== 1) {
+      return new Set<string>();
+    }
+    const [only] = optional;
+    const seeded = only.default !== undefined && only.default !== null;
+    return seeded ? new Set<string>() : new Set([only.name]);
   }, [section.fields]);
 
   if (isHidden) {
@@ -264,7 +276,7 @@ const SectionRenderer = memo(function SectionRenderer({
             key={field.name}
             field={field}
             renderField={renderField}
-            markOptional={markOptional}
+            markOptional={optionalNames.has(field.name)}
           />
         )
       )}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaFormRenderer.tsx
@@ -55,12 +55,19 @@ import {
   ALERT_ON_FAIL_FIELD_NAME,
 } from '../AlertOnFailField';
 import { ConditionalFieldSlot } from './ConditionalFieldSlot';
+import { useFieldPayloadCleanup } from './hooks/useConditionalField';
+import { SECTION_GRID_SX } from './fieldLayout';
 import { OneOfGroupSlot } from './OneOfGroupSlot';
-import { useConditionalSection } from './hooks/useConditionalSection';
+import {
+  useConditionalSections,
+  useUnregisterHiddenSections,
+} from './hooks/useConditionalSection';
 import { useCardinalityRules } from './hooks/useCardinalityRules';
 import { useFailRules } from './hooks/useFailRules';
 import { useUnsavedChangesGuard } from './hooks/useUnsavedChangesGuard';
 import { coerceFormValues } from './utils/validationMapper';
+import { fieldDefault } from './utils/fieldDefault';
+import { warnSchema } from './utils/schemaWarnings';
 import { getAtPath, setAtPath } from './utils/fieldPath';
 import {
   collectOneOfGroups,
@@ -68,32 +75,6 @@ import {
   isOneOfGroup,
 } from './utils/flattenSectionFields';
 import type { FormSection, PluginField, RenderFieldOverride } from './types';
-
-function fieldDefault(field: PluginField): unknown {
-  switch (field.type) {
-    case 'bool':
-      return field.default ?? false;
-    case 'integer':
-    case 'float':
-      return field.default ?? '';
-    case 'multi_choice':
-      return field.default ?? [];
-    case 'file':
-      return undefined;
-    case 'service':
-    case 'schema':
-    case 'table':
-    case 'host':
-      return field.default ?? '';
-    case 'remote_choice':
-      // Mirror the selector's empty commit (`null`), not `''` — an empty string
-      // passes some client checks yet fails the backend NonEmptyStr with
-      // "String should have at least 1 character".
-      return field.default ?? null;
-    default:
-      return field.default ?? '';
-  }
-}
 
 function flattenFields(sections: FormSection[]): PluginField[] {
   return flattenSectionFields(sections);
@@ -149,21 +130,73 @@ function buildFormDefaults(
   return defaults;
 }
 
+/** One section paired with its position in the schema's own section list. */
+interface SectionEntry {
+  section: FormSection;
+  index: number;
+}
+
+/**
+ * A run of adjacent sections sharing a `group`, or a single ungrouped section.
+ * Grouping is positional so a schema controls membership by section order,
+ * the same way it already controls section order itself.
+ */
+type SectionRenderItem =
+  | { kind: 'section'; entry: SectionEntry }
+  | { kind: 'group'; title: string; entries: SectionEntry[] };
+
+function groupAdjacentSections(
+  entries: SectionEntry[],
+  // Shared across the before- and after-submit passes: a group whose members
+  // straddle that boundary is adjacent by the documented rule yet renders as
+  // two shells, which is exactly what this warns about.
+  opened: Set<string>
+): SectionRenderItem[] {
+  const items: SectionRenderItem[] = [];
+  for (const entry of entries) {
+    const group = entry.section.group;
+    if (!group) {
+      items.push({ kind: 'section', entry });
+      continue;
+    }
+    const last = items[items.length - 1];
+    if (last?.kind === 'group' && last.title === group) {
+      last.entries.push(entry);
+      continue;
+    }
+    if (opened.has(group)) {
+      // Two shells with the same heading is never what an author meant; it
+      // means a section was inserted into the middle of the run.
+      warnSchema(
+        `section '${entry.section.title}' rejoins group '${group}' after a ` +
+          `section outside it, so the group renders as two separate shells. ` +
+          `Group members have to be adjacent in the schema's section order.`
+      );
+    }
+    opened.add(group);
+    items.push({ kind: 'group', title: group, entries: [entry] });
+  }
+  return items;
+}
+
 interface SectionRendererProps {
   section: FormSection;
   idx: number;
+  isHidden: boolean;
   violations: Array<{ message: string }>;
   renderField?: RenderFieldOverride;
+  /** Rendered inside a group shell: drop the outer chrome the group provides. */
+  nested?: boolean;
 }
 
 const SectionRenderer = memo(function SectionRenderer({
   section,
   idx,
+  isHidden,
   violations,
   renderField,
+  nested = false,
 }: SectionRendererProps) {
-  const { isHidden } = useConditionalSection(section);
-
   if (isHidden) {
     return null;
   }
@@ -180,31 +213,42 @@ const SectionRenderer = memo(function SectionRenderer({
           {v.message}
         </Alert>
       ))}
-      {section.fields.map((field) =>
-        isOneOfGroup(field) ? (
-          <OneOfGroupSlot
-            key={field.name}
-            group={field}
-            renderField={renderField}
-          />
-        ) : (
-          <ConditionalFieldSlot
-            key={field.name}
-            field={field}
-            renderField={renderField}
-          />
-        )
-      )}
+      <Box sx={SECTION_GRID_SX}>
+        {section.fields.map((field) =>
+          isOneOfGroup(field) ? (
+            <OneOfGroupSlot
+              key={field.name}
+              group={field}
+              renderField={renderField}
+            />
+          ) : (
+            <ConditionalFieldSlot
+              key={field.name}
+              field={field}
+              renderField={renderField}
+            />
+          )
+        )}
+      </Box>
     </>
   );
 
+  // A collapsed shell already draws its own rule, and stacking several of them
+  // is the bulk of an expert-heavy form's resting height — so no divider above
+  // one, and a tighter gap between them.
+  const showDivider = !nested && idx > 0 && !section.collapsible;
+
   return (
-    <Box component="fieldset" sx={{ border: 0, p: 0, mb: 3 }}>
-      {idx > 0 && <Divider sx={{ mb: 2 }} />}
+    <Box
+      component="fieldset"
+      sx={{ border: 0, p: 0, mb: section.collapsible || nested ? 1 : 3 }}
+    >
+      {showDivider && <Divider sx={{ mb: 2 }} />}
       {section.collapsible ? (
         <Accordion
           defaultExpanded={!section.collapsed_by_default}
           disableGutters
+          variant={nested ? 'outlined' : undefined}
           slotProps={{ transition: { unmountOnExit: true } }}
         >
           <AccordionSummary
@@ -230,7 +274,11 @@ const SectionRenderer = memo(function SectionRenderer({
         </Accordion>
       ) : (
         <>
-          <Typography component="legend" variant="h6" sx={{ mb: 1, px: 0 }}>
+          <Typography
+            component="legend"
+            variant={nested ? 'subtitle1' : 'h6'}
+            sx={{ mb: 1, px: 0, fontWeight: nested ? 600 : undefined }}
+          >
             {section.title}
           </Typography>
           {sectionContent}
@@ -239,6 +287,79 @@ const SectionRenderer = memo(function SectionRenderer({
     </Box>
   );
 });
+
+interface SectionGroupProps {
+  title: string;
+  entries: SectionEntry[];
+  /** Hidden flags positionally matching {@link entries}. */
+  hidden: boolean[];
+  /** Section violations positionally matching {@link entries}. */
+  violations: Array<Array<{ message: string }>>;
+  renderField?: RenderFieldOverride;
+}
+
+/**
+ * One collapsed shell over a run of sections.
+ *
+ * When every member is hidden the shell is skipped rather than left standing
+ * empty. Members are still rendered in that case so the tree shape does not
+ * change; they each return null. Note that a *collapsed* shell mounts no
+ * members at all (`unmountOnExit`), which is why nothing here may be
+ * responsible for keeping gated-out values out of the payload — the form body
+ * owns that, for sections and fields alike.
+ */
+function SectionGroup({
+  title,
+  entries,
+  hidden,
+  violations,
+  renderField,
+}: SectionGroupProps) {
+  const members = entries.map((entry, i) => (
+    <SectionRenderer
+      key={`${entry.section.title}-${entry.index}`}
+      section={entry.section}
+      idx={i}
+      isHidden={hidden[i] ?? false}
+      violations={violations[i] ?? []}
+      renderField={renderField}
+      nested
+    />
+  ));
+
+  if (hidden.every(Boolean)) {
+    return <>{members}</>;
+  }
+
+  return (
+    <Box component="fieldset" sx={{ border: 0, p: 0, mb: 1 }}>
+      <Accordion
+        defaultExpanded={false}
+        disableGutters
+        slotProps={{ transition: { unmountOnExit: true } }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          sx={{
+            pl: 2,
+            pr: 1,
+            minHeight: 48,
+            '& .MuiAccordionSummary-content': { my: 1 },
+          }}
+        >
+          <Typography
+            component="legend"
+            variant="subtitle1"
+            sx={{ fontWeight: 600 }}
+          >
+            {title}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails sx={{ pl: 2, pr: 2 }}>{members}</AccordionDetails>
+      </Accordion>
+    </Box>
+  );
+}
 
 export interface SchemaFormRendererProps {
   sections: FormSection[];
@@ -352,14 +473,28 @@ function SchemaFormBody({
   const isGuarded = useUnsavedChangesGuard(submitError);
   const inDataRouter = Boolean(useContext(UNSAFE_DataRouterContext));
   const allFields = useMemo(() => flattenFields(sections), [sections]);
-  const beforeSubmitSections = useMemo(
-    () => sections.filter((section) => !section.render_after_submit),
-    [sections]
-  );
-  const afterSubmitSections = useMemo(
-    () => sections.filter((section) => section.render_after_submit),
-    [sections]
-  );
+  // Evaluated once for every section, so a group shell can know whether all of
+  // its members are gated out before it renders.
+  const hiddenSections = useConditionalSections(sections);
+  // Both owned here, not by the section or field components: anything inside a
+  // collapsed shell never mounts, so it cannot drop its own values when it is
+  // gated out, and `buildFormDefaults` has already seeded them.
+  useUnregisterHiddenSections(sections, hiddenSections);
+  useFieldPayloadCleanup(allFields);
+  const [beforeSubmitItems, afterSubmitItems] = useMemo(() => {
+    const entries = sections.map((section, index) => ({ section, index }));
+    const opened = new Set<string>();
+    return [
+      groupAdjacentSections(
+        entries.filter(({ section }) => !section.render_after_submit),
+        opened
+      ),
+      groupAdjacentSections(
+        entries.filter(({ section }) => section.render_after_submit),
+        opened
+      ),
+    ];
+  }, [sections]);
   const cardinalityViolations = useCardinalityRules(sections);
   const failViolations = useFailRules(sections);
 
@@ -380,6 +515,38 @@ function SchemaFormBody({
     [violationsBySection]
   );
   const hasInlineErrors = Object.keys(formState.errors).length > 0;
+
+  const renderItem = (
+    item: SectionRenderItem,
+    idx: number,
+    keyPrefix: string
+  ) => {
+    if (item.kind === 'group') {
+      return (
+        <SectionGroup
+          key={`${keyPrefix}-group-${item.title}-${idx}`}
+          title={item.title}
+          entries={item.entries}
+          hidden={item.entries.map((e) => hiddenSections[e.index] ?? false)}
+          violations={item.entries.map(
+            (e) => violationsBySection.get(e.section) ?? []
+          )}
+          renderField={renderField}
+        />
+      );
+    }
+    const { entry } = item;
+    return (
+      <SectionRenderer
+        key={`${keyPrefix}-${entry.section.title}-${entry.index}`}
+        section={entry.section}
+        idx={idx}
+        isHidden={hiddenSections[entry.index] ?? false}
+        violations={violationsBySection.get(entry.section) ?? []}
+        renderField={renderField}
+      />
+    );
+  };
 
   const handleFormSubmit: SubmitHandler<Record<string, unknown>> = (values) => {
     onSubmit(coerceFormValues(values, allFields));
@@ -449,15 +616,7 @@ function SchemaFormBody({
           </Alert>
         )}
 
-        {beforeSubmitSections.map((section, idx) => (
-          <SectionRenderer
-            key={`${section.title}-${idx}`}
-            section={section}
-            idx={idx}
-            violations={violationsBySection.get(section) ?? []}
-            renderField={renderField}
-          />
-        ))}
+        {beforeSubmitItems.map((item, idx) => renderItem(item, idx, 'before'))}
 
         {capabilities?.alert_on_fail && (
           <Box sx={{ mb: 2 }}>
@@ -476,17 +635,11 @@ function SchemaFormBody({
           {submitLabel}
         </Button>
 
-        {afterSubmitSections.length > 0 ? (
+        {afterSubmitItems.length > 0 ? (
           <Box sx={{ mt: 3 }}>
-            {afterSubmitSections.map((section, idx) => (
-              <SectionRenderer
-                key={`${section.title}-after-${idx}`}
-                section={section}
-                idx={idx}
-                violations={violationsBySection.get(section) ?? []}
-                renderField={renderField}
-              />
-            ))}
+            {afterSubmitItems.map((item, idx) =>
+              renderItem(item, idx, 'after')
+            )}
           </Box>
         ) : null}
       </Box>

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaSelectShell.test.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaSelectShell.test.tsx
@@ -49,7 +49,8 @@ function renderShell(
     field?: Partial<ControllerRenderProps>;
     required?: boolean;
     error?: FieldError;
-    description?: string;
+    tooltip?: string;
+    inline?: string;
   } = {}
 ) {
   return render(
@@ -59,7 +60,8 @@ function renderShell(
       label="Fruit"
       required={opts.required}
       error={opts.error}
-      description={opts.description}
+      tooltip={opts.tooltip}
+      inline={opts.inline}
       renderValue={(value) =>
         value === undefined || value === null || value === ''
           ? 'Select…'
@@ -105,8 +107,8 @@ describe('SchemaSelectShell', () => {
     expect(screen.getByText('Fruit is required')).toBeInTheDocument();
   });
 
-  it('shows the description as helper text when there is no error', () => {
-    renderShell({ description: 'Pick one' });
+  it('shows inline help as helper text when there is no error', () => {
+    renderShell({ inline: 'Pick one' });
 
     expect(screen.getByTestId('select-input-fruit')).toHaveAttribute(
       'aria-invalid',
@@ -115,9 +117,9 @@ describe('SchemaSelectShell', () => {
     expect(screen.getByText('Pick one')).toBeInTheDocument();
   });
 
-  it('shows an info-icon tooltip when description is set', async () => {
+  it('shows an info-icon tooltip when tooltip help is set', async () => {
     const user = userEvent.setup();
-    renderShell({ description: 'Pick one' });
+    renderShell({ tooltip: 'Pick one' });
 
     const help = screen.getByLabelText('Help for Fruit');
     expect(help).toHaveAttribute('data-help-for', 'Fruit');
@@ -131,9 +133,9 @@ describe('SchemaSelectShell', () => {
     expect(screen.queryByLabelText('Help for Fruit')).not.toBeInTheDocument();
   });
 
-  it('keeps the info icon when an error replaces the helper text', () => {
+  it('keeps the info icon when an error takes the helper-text slot', () => {
     renderShell({
-      description: 'Pick one',
+      tooltip: 'Pick one',
       error: { type: 'required', message: 'Fruit is required' },
     });
 

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaSelectShell.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/SchemaSelectShell.tsx
@@ -41,7 +41,10 @@ export interface SchemaSelectShellProps {
   /** rhf field error; presence flips `aria-invalid` and the outline color. */
   error?: FieldError;
   /** Helper text and tooltip body for the label help icon; shown as helper text when there is no error. */
-  description?: string;
+  /** Shown behind the help icon beside the label. */
+  tooltip?: string;
+  /** Shown under the control, unless an error takes the slot. */
+  inline?: string;
   /** Render a multi-select (value is an array). */
   multiple?: boolean;
   /** Owns the empty-placeholder vs populated branch — differs per field. */
@@ -64,7 +67,8 @@ export function SchemaSelectShell({
   label,
   required,
   error,
-  description,
+  tooltip,
+  inline,
   multiple,
   renderValue,
   children,
@@ -72,7 +76,7 @@ export function SchemaSelectShell({
   return (
     <FormControl fullWidth size="small" error={!!error}>
       <InputLabel id={labelId} shrink required={required}>
-        <FieldLabelWithHelp label={label} description={description} />
+        <FieldLabelWithHelp label={label} description={tooltip} />
       </InputLabel>
       <Select
         {...field}
@@ -87,8 +91,8 @@ export function SchemaSelectShell({
       >
         {children}
       </Select>
-      {(error?.message || description) && (
-        <FormHelperText>{error?.message ?? description}</FormHelperText>
+      {(error?.message || inline) && (
+        <FormHelperText>{error?.message ?? inline}</FormHelperText>
       )}
     </FormControl>
   );

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldHelp.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldHelp.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { PluginField } from './types';
+
+/**
+ * Longest description still shown under the input by default.
+ *
+ * Roughly one rendered line at the form's 800px width. The point of the
+ * boundary is that a hint short enough to sit on one line costs almost nothing
+ * to leave visible, while prose that wraps two or three times is what turns a
+ * form with sixty fields into several screens.
+ */
+export const INLINE_HELP_MAX_LENGTH = 120;
+
+/**
+ * Whether a field's description belongs under the input rather than behind the
+ * help icon beside its label.
+ *
+ * The schema decides when it says so; otherwise length does. Keeping the
+ * default automatic matters because most apps never set the key: a short
+ * format hint stays visible for them without anyone having to annotate it.
+ */
+export function isInlineHelp(field: PluginField): boolean {
+  if (field.help_placement) {
+    return field.help_placement === 'inline';
+  }
+  return (field.description?.length ?? 0) <= INLINE_HELP_MAX_LENGTH;
+}
+
+/**
+ * Split a field's description into the two slots a renderer can put it in.
+ *
+ * Every field kind that can show help both ways goes through this, so the
+ * policy lives in one place instead of being decided again in each of a dozen
+ * renderers — which is how the description came to be rendered twice on some
+ * kinds and not at all on others.
+ *
+ * @returns `tooltip` for the help icon beside the label, `inline` for text
+ * under the input. At most one is ever set.
+ */
+export function fieldHelp(field: PluginField): {
+  tooltip?: string;
+  inline?: string;
+} {
+  const description = field.description;
+  if (!description) {
+    return {};
+  }
+  return isInlineHelp(field)
+    ? { inline: description }
+    : { tooltip: description };
+}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
@@ -16,10 +16,10 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { collectParentNames, isFullRowField } from './fieldLayout';
+import { fieldIndex, isFullRowField } from './fieldLayout';
 import type { PluginField } from './types';
 
-describe('collectParentNames', () => {
+describe('fieldIndex', () => {
   it('gathers every name pointed at by a `parent`', () => {
     const fields: PluginField[] = [
       { type: 'bool', name: 'encrypt', label: 'Encrypt' },
@@ -28,15 +28,35 @@ describe('collectParentNames', () => {
       { type: 'string', name: 'memory', label: 'Memory', parent: 'prepare' },
       { type: 'string', name: 'loose', label: 'Loose' },
     ];
-    expect([...collectParentNames(fields)].sort()).toEqual([
+    expect([...fieldIndex(fields).parentNames].sort()).toEqual([
       'encrypt',
       'prepare',
     ]);
   });
 
+  it('indexes every field by name so a parent resolves to its label', () => {
+    const fields: PluginField[] = [
+      { type: 'bool', name: 'encrypt', label: 'Encrypt backup' },
+      { type: 'string', name: 'tmpdir', label: 'Tmpdir', parent: 'encrypt' },
+    ];
+    expect(fieldIndex(fields).byName.get('encrypt')?.label).toBe(
+      'Encrypt backup'
+    );
+  });
+
+  it('derives the index once per fields array', () => {
+    // Every slot in a form is handed the same array from context; recomputing
+    // per slot is the O(N^2) this cache exists to avoid.
+    const fields: PluginField[] = [
+      { type: 'bool', name: 'encrypt', label: 'Encrypt' },
+    ];
+    expect(fieldIndex(fields)).toBe(fieldIndex(fields));
+    expect(fieldIndex([...fields])).not.toBe(fieldIndex(fields));
+  });
+
   it('is empty for a schema with no parented fields', () => {
     expect(
-      collectParentNames([{ type: 'string', name: 'a', label: 'A' }]).size
+      fieldIndex([{ type: 'string', name: 'a', label: 'A' }]).parentNames.size
     ).toBe(0);
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { collectParentNames, isFullRowField } from './fieldLayout';
+import type { PluginField } from './types';
+
+describe('collectParentNames', () => {
+  it('gathers every name pointed at by a `parent`', () => {
+    const fields: PluginField[] = [
+      { type: 'bool', name: 'encrypt', label: 'Encrypt' },
+      { type: 'bool', name: 'prepare', label: 'Prepare' },
+      { type: 'string', name: 'tmpdir', label: 'Tmpdir', parent: 'encrypt' },
+      { type: 'string', name: 'memory', label: 'Memory', parent: 'prepare' },
+      { type: 'string', name: 'loose', label: 'Loose' },
+    ];
+    expect([...collectParentNames(fields)].sort()).toEqual([
+      'encrypt',
+      'prepare',
+    ]);
+  });
+
+  it('is empty for a schema with no parented fields', () => {
+    expect(
+      collectParentNames([{ type: 'string', name: 'a', label: 'A' }]).size
+    ).toBe(0);
+  });
+});
+
+describe('isFullRowField', () => {
+  const scalar: PluginField = { type: 'string', name: 'a', label: 'A' };
+
+  it('puts an ordinary scalar field in one column', () => {
+    expect(isFullRowField(scalar)).toBe(false);
+  });
+
+  it.each(['textarea', 'yaml', 'script_preview', 'multi_choice', 'file'])(
+    'gives %s the whole row',
+    (type) => {
+      expect(
+        isFullRowField({ ...scalar, type } as unknown as PluginField)
+      ).toBe(true);
+    }
+  );
+
+  it('gives a parented child the whole row so it starts a fresh line', () => {
+    expect(isFullRowField({ ...scalar, parent: 'encrypt' })).toBe(true);
+  });
+
+  it('gives a toggle that has children the whole row', () => {
+    const parents = new Set(['encrypt']);
+    expect(
+      isFullRowField({ type: 'bool', name: 'encrypt', label: 'E' }, parents)
+    ).toBe(true);
+    expect(
+      isFullRowField({ type: 'bool', name: 'other', label: 'O' }, parents)
+    ).toBe(false);
+  });
+});

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { fieldIndex, isFullRowField } from './fieldLayout';
+import { fieldIndex } from './fieldLayout';
 import type { PluginField } from './types';
 
 describe('fieldIndex', () => {
@@ -58,36 +58,5 @@ describe('fieldIndex', () => {
     expect(
       fieldIndex([{ type: 'string', name: 'a', label: 'A' }]).parentNames.size
     ).toBe(0);
-  });
-});
-
-describe('isFullRowField', () => {
-  const scalar: PluginField = { type: 'string', name: 'a', label: 'A' };
-
-  it('puts an ordinary scalar field in one column', () => {
-    expect(isFullRowField(scalar)).toBe(false);
-  });
-
-  it.each(['textarea', 'yaml', 'script_preview', 'multi_choice', 'file'])(
-    'gives %s the whole row',
-    (type) => {
-      expect(
-        isFullRowField({ ...scalar, type } as unknown as PluginField)
-      ).toBe(true);
-    }
-  );
-
-  it('gives a parented child the whole row so it starts a fresh line', () => {
-    expect(isFullRowField({ ...scalar, parent: 'encrypt' })).toBe(true);
-  });
-
-  it('gives a toggle that has children the whole row', () => {
-    const parents = new Set(['encrypt']);
-    expect(
-      isFullRowField({ type: 'bool', name: 'encrypt', label: 'E' }, parents)
-    ).toBe(true);
-    expect(
-      isFullRowField({ type: 'bool', name: 'other', label: 'O' }, parents)
-    ).toBe(false);
   });
 });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { PluginField } from './types';
+
+/**
+ * Sections lay their fields out on a two-column grid above `md`, which is the
+ * difference between a form the common case can read at a glance and one that
+ * scrolls. Single-column below that, so the layout still works in a narrow
+ * pane.
+ */
+export const SECTION_GRID_SX = {
+  display: 'grid',
+  gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' },
+  columnGap: 2,
+} as const;
+
+/**
+ * Field types that read badly at half width — long free text, a code pane, or
+ * a chip list that wraps as soon as it is narrowed.
+ */
+const FULL_ROW_TYPES: ReadonlySet<PluginField['type']> = new Set([
+  'textarea',
+  'yaml',
+  'script_preview',
+  'multi_choice',
+  'file',
+]);
+
+/**
+ * Whether a field claims the whole grid row rather than one column.
+ *
+ * `parentNames` are the fields some other field points at with `parent`; a
+ * toggle with children takes a full row so its children land directly beneath
+ * it rather than under whatever happened to share its row.
+ */
+export function isFullRowField(
+  field: PluginField,
+  parentNames?: ReadonlySet<string>
+): boolean {
+  // A nested child sits under its parent, so it has to start on a fresh row —
+  // half of one would read as a sibling of whatever shares the row.
+  if (field.parent) {
+    return true;
+  }
+  if (parentNames?.has(field.name)) {
+    return true;
+  }
+  return FULL_ROW_TYPES.has(field.type);
+}
+
+/**
+ * The set of field names that some field in `fields` declares as its `parent`.
+ *
+ * Callers pass the whole form's fields rather than one section's. `parent` is
+ * documented as same-section, but field names are payload keys and so unique
+ * across the form, which makes the wider lookup equivalent and saves threading
+ * section scope through every slot.
+ */
+export function collectParentNames(
+  fields: readonly PluginField[]
+): ReadonlySet<string> {
+  const names = new Set<string>();
+  for (const field of fields) {
+    if (field.parent) {
+      names.add(field.parent);
+    }
+  }
+  return names;
+}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
@@ -63,22 +63,41 @@ export function isFullRowField(
   return FULL_ROW_TYPES.has(field.type);
 }
 
+/** What one pass over a form's fields yields for the layout to read back. */
+interface FieldIndex {
+  /** Names some field declares as its `parent`. */
+  parentNames: ReadonlySet<string>;
+  /** Every field by name, for resolving a parent pointer to its label. */
+  byName: ReadonlyMap<string, PluginField>;
+}
+
+// Every slot in a form is handed the same fields array from context, so the
+// index is derived once per form rather than once per slot — a component-local
+// `useMemo` would still walk the whole form for each of its N fields.
+const indexCache = new WeakMap<readonly PluginField[], FieldIndex>();
+
 /**
- * The set of field names that some field in `fields` declares as its `parent`.
+ * Return the derived index for a form's fields, computing it at most once.
  *
  * Callers pass the whole form's fields rather than one section's. `parent` is
  * documented as same-section, but field names are payload keys and so unique
  * across the form, which makes the wider lookup equivalent and saves threading
  * section scope through every slot.
  */
-export function collectParentNames(
-  fields: readonly PluginField[]
-): ReadonlySet<string> {
-  const names = new Set<string>();
+export function fieldIndex(fields: readonly PluginField[]): FieldIndex {
+  const cached = indexCache.get(fields);
+  if (cached) {
+    return cached;
+  }
+  const parentNames = new Set<string>();
+  const byName = new Map<string, PluginField>();
   for (const field of fields) {
+    byName.set(field.name, field);
     if (field.parent) {
-      names.add(field.parent);
+      parentNames.add(field.parent);
     }
   }
-  return names;
+  const index: FieldIndex = { parentNames, byName };
+  indexCache.set(fields, index);
+  return index;
 }

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fieldLayout.ts
@@ -17,52 +17,6 @@
 
 import type { PluginField } from './types';
 
-/**
- * Sections lay their fields out on a two-column grid above `md`, which is the
- * difference between a form the common case can read at a glance and one that
- * scrolls. Single-column below that, so the layout still works in a narrow
- * pane.
- */
-export const SECTION_GRID_SX = {
-  display: 'grid',
-  gridTemplateColumns: { xs: '1fr', md: 'repeat(2, minmax(0, 1fr))' },
-  columnGap: 2,
-} as const;
-
-/**
- * Field types that read badly at half width — long free text, a code pane, or
- * a chip list that wraps as soon as it is narrowed.
- */
-const FULL_ROW_TYPES: ReadonlySet<PluginField['type']> = new Set([
-  'textarea',
-  'yaml',
-  'script_preview',
-  'multi_choice',
-  'file',
-]);
-
-/**
- * Whether a field claims the whole grid row rather than one column.
- *
- * `parentNames` are the fields some other field points at with `parent`; a
- * toggle with children takes a full row so its children land directly beneath
- * it rather than under whatever happened to share its row.
- */
-export function isFullRowField(
-  field: PluginField,
-  parentNames?: ReadonlySet<string>
-): boolean {
-  // A nested child sits under its parent, so it has to start on a fresh row —
-  // half of one would read as a sibling of whatever shares the row.
-  if (field.parent) {
-    return true;
-  }
-  if (parentNames?.has(field.name)) {
-    return true;
-  }
-  return FULL_ROW_TYPES.has(field.type);
-}
-
 /** What one pass over a form's fields yields for the layout to read back. */
 interface FieldIndex {
   /** Names some field declares as its `parent`. */

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/BoolField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/BoolField.tsx
@@ -30,12 +30,13 @@ export function BoolField({ field }: BoolFieldProps) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
       <Box sx={{ minWidth: 0 }}>
-        <SwitchInput
-          name={field.name}
-          label={field.label}
-          labelCaption={field.description}
-          control={control}
-        />
+        {/*
+          The description reaches the reader through the help icon beside the
+          switch, the same way every other field type surfaces it. Repeating it
+          as a caption cost a line of height under every toggle — the bulk of
+          an expert-heavy section.
+        */}
+        <SwitchInput name={field.name} label={field.label} control={control} />
       </Box>
       {field.description ? (
         <FieldHelpIcon description={field.description} label={field.label} />

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/BoolField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/BoolField.tsx
@@ -19,6 +19,7 @@ import { useFormContext } from 'react-hook-form';
 import Box from '@mui/material/Box';
 import { SwitchInput } from '@percona/peak-ui';
 import { FieldHelpIcon } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { BoolField as BoolFieldType } from '../types';
 
 interface BoolFieldProps {
@@ -27,19 +28,19 @@ interface BoolFieldProps {
 
 export function BoolField({ field }: BoolFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
       <Box sx={{ minWidth: 0 }}>
-        {/*
-          The description reaches the reader through the help icon beside the
-          switch, the same way every other field type surfaces it. Repeating it
-          as a caption cost a line of height under every toggle — the bulk of
-          an expert-heavy section.
-        */}
-        <SwitchInput name={field.name} label={field.label} control={control} />
+        <SwitchInput
+          name={field.name}
+          label={field.label}
+          labelCaption={help.inline}
+          control={control}
+        />
       </Box>
-      {field.description ? (
-        <FieldHelpIcon description={field.description} label={field.label} />
+      {help.tooltip ? (
+        <FieldHelpIcon description={help.tooltip} label={field.label} />
       ) : null}
     </Box>
   );

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/ChoiceField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/ChoiceField.tsx
@@ -26,6 +26,7 @@ import Radio from '@mui/material/Radio';
 import { LabeledContent, RadioGroup } from '@percona/peak-ui';
 import { SchemaSelectShell } from '../SchemaSelectShell';
 import type { ChoiceField as ChoiceFieldType } from '../types';
+import { fieldHelp } from '../fieldHelp';
 import { buildValidationRules } from '../utils/validationMapper';
 import { renderChoiceLabel } from './choiceLabel';
 
@@ -39,6 +40,7 @@ const RADIO_THRESHOLD = 3;
 export function ChoiceField({ field }: ChoiceFieldProps) {
   const { control } = useFormContext();
   const rules = buildValidationRules(field);
+  const help = fieldHelp(field);
   const hasDisabledChoice = field.choices.some((choice) => choice.disabled);
 
   if (field.choices.length > 0 && field.choices.length <= RADIO_THRESHOLD) {
@@ -53,7 +55,7 @@ export function ChoiceField({ field }: ChoiceFieldProps) {
         <LabeledContent
           label={field.label}
           isRequired={field.required}
-          caption={field.description}
+          caption={help.inline ?? help.tooltip}
         >
           <Controller
             name={field.name}
@@ -88,7 +90,7 @@ export function ChoiceField({ field }: ChoiceFieldProps) {
         label={field.label}
         isRequired={field.required}
         control={control}
-        labelProps={{ caption: field.description }}
+        labelProps={{ caption: help.inline ?? help.tooltip }}
         options={field.choices}
         controllerProps={{ rules }}
       />
@@ -109,7 +111,8 @@ export function ChoiceField({ field }: ChoiceFieldProps) {
           label={field.label}
           required={field.required}
           error={error}
-          description={field.description}
+          tooltip={help.tooltip}
+          inline={help.inline}
           renderValue={(value) => {
             if (value === undefined || value === null || value === '') {
               return (

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/DateTimeField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/DateTimeField.tsx
@@ -41,7 +41,6 @@ export function DateTimeField({ field }: DateTimeFieldProps) {
           />
         ),
         type: 'datetime-local',
-        helperText: field.description,
         fullWidth: true,
         InputLabelProps: { shrink: true },
       }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/DateTimeField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/DateTimeField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { DateTimeField as DateTimeFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface DateTimeFieldProps {
 
 export function DateTimeField({ field }: DateTimeFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,12 +37,10 @@ export function DateTimeField({ field }: DateTimeFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
         type: 'datetime-local',
+        helperText: help.inline,
         fullWidth: true,
         InputLabelProps: { shrink: true },
       }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FileField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FileField.tsx
@@ -19,6 +19,7 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { IconButton, InputAdornment, TextField } from '@mui/material';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { FileField as FileFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -46,7 +47,7 @@ export function FileField({ field }: FileFieldProps) {
           label={
             <FieldLabelWithHelp
               label={field.label}
-              description={field.description}
+              description={fieldHelp(field).tooltip}
             />
           }
           required={field.required}
@@ -54,7 +55,7 @@ export function FileField({ field }: FileFieldProps) {
           size="small"
           value={rhf.value instanceof File ? rhf.value.name : ''}
           error={!!error}
-          helperText={error?.message}
+          helperText={error ? error.message : fieldHelp(field).inline}
           slotProps={{
             input: {
               readOnly: true,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FileField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FileField.tsx
@@ -54,7 +54,7 @@ export function FileField({ field }: FileFieldProps) {
           size="small"
           value={rhf.value instanceof File ? rhf.value.name : ''}
           error={!!error}
-          helperText={error ? error.message : field.description}
+          helperText={error?.message}
           slotProps={{
             input: {
               readOnly: true,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FloatField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FloatField.tsx
@@ -41,7 +41,6 @@ export function FloatField({ field }: FloatFieldProps) {
           />
         ),
         type: 'number',
-        helperText: field.description,
         fullWidth: true,
         inputProps: {
           min: field.ge,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FloatField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/FloatField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { FloatField as FloatFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface FloatFieldProps {
 
 export function FloatField({ field }: FloatFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,12 +37,10 @@ export function FloatField({ field }: FloatFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
         type: 'number',
+        helperText: help.inline,
         fullWidth: true,
         inputProps: {
           min: field.ge,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/HostField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/HostField.tsx
@@ -31,6 +31,7 @@ export function HostField({ field }: HostFieldProps) {
     <HostSelector
       name={field.name}
       label={field.label}
+      helperText={field.description}
       required={field.required}
       dependsOn={field.depends_on}
       serviceTypes={serviceTypes}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/IntegerField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/IntegerField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { IntegerField as IntegerFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface IntegerFieldProps {
 
 export function IntegerField({ field }: IntegerFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,12 +37,10 @@ export function IntegerField({ field }: IntegerFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
         type: 'number',
+        helperText: help.inline,
         fullWidth: true,
         inputProps: {
           min: field.ge,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/IntegerField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/IntegerField.tsx
@@ -41,7 +41,6 @@ export function IntegerField({ field }: IntegerFieldProps) {
           />
         ),
         type: 'number',
-        helperText: field.description,
         fullWidth: true,
         inputProps: {
           min: field.ge,

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/MultiChoiceField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/MultiChoiceField.tsx
@@ -22,6 +22,7 @@ import ListItemText from '@mui/material/ListItemText';
 import MenuItem from '@mui/material/MenuItem';
 import { SchemaSelectShell } from '../SchemaSelectShell';
 import type { MultiChoiceField as MultiChoiceFieldType } from '../types';
+import { fieldHelp } from '../fieldHelp';
 import { buildValidationRules } from '../utils/validationMapper';
 import { renderChoiceLabel } from './choiceLabel';
 
@@ -31,6 +32,7 @@ interface MultiChoiceFieldProps {
 
 export function MultiChoiceField({ field }: MultiChoiceFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   const selected =
     (useWatch({ control, name: field.name }) as string[] | undefined) ?? [];
   const labelId = `${field.name}-label`;
@@ -47,7 +49,8 @@ export function MultiChoiceField({ field }: MultiChoiceFieldProps) {
           label={field.label}
           required={field.required}
           error={error}
-          description={field.description}
+          tooltip={help.tooltip}
+          inline={help.inline}
           multiple
           renderValue={(value) => {
             const values = (value as string[] | undefined) ?? [];

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/RemoteChoiceField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/RemoteChoiceField.tsx
@@ -27,6 +27,7 @@ export function RemoteChoiceField({ field }: RemoteChoiceFieldProps) {
     <RemoteChoiceSelector
       name={field.name}
       label={field.label}
+      description={field.description}
       required={field.required}
       endpointUrl={field.endpoint_url}
       dependsOn={field.depends_on}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/SchemaField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/SchemaField.tsx
@@ -27,6 +27,7 @@ export function SchemaField({ field }: SchemaFieldProps) {
     <SchemaSelector
       name={field.name}
       label={field.label}
+      description={field.description}
       required={field.required}
       dependsOn={field.depends_on}
       allowCustom={field.allow_custom}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/ServiceField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/ServiceField.tsx
@@ -28,6 +28,7 @@ export function ServiceField({ field }: ServiceFieldProps) {
     <ServiceSelector
       name={field.name}
       label={field.label}
+      helperText={field.description}
       required={field.required}
       serviceTypes={field.service_types as readonly ServiceType[]}
       allowCustom={field.allow_custom}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/StringField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/StringField.tsx
@@ -41,7 +41,6 @@ export function StringField({ field }: StringFieldProps) {
           />
         ),
         placeholder: field.placeholder,
-        helperText: field.description,
         fullWidth: true,
       }}
       controllerProps={{ rules: buildValidationRules(field) }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/StringField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/StringField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { StringField as StringFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface StringFieldProps {
 
 export function StringField({ field }: StringFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,11 +37,9 @@ export function StringField({ field }: StringFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
+        helperText: help.inline,
         placeholder: field.placeholder,
         fullWidth: true,
       }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TableField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TableField.tsx
@@ -27,6 +27,7 @@ export function TableField({ field }: TableFieldProps) {
     <TableSelector
       name={field.name}
       label={field.label}
+      description={field.description}
       required={field.required}
       dependsOn={field.depends_on}
       allowCustom={field.allow_custom}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TextAreaField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TextAreaField.tsx
@@ -43,7 +43,6 @@ export function TextAreaField({ field }: TextAreaFieldProps) {
         multiline: true,
         rows: field.rows ?? 4,
         placeholder: field.placeholder,
-        helperText: field.description,
         fullWidth: true,
       }}
       controllerProps={{ rules: buildValidationRules(field) }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TextAreaField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/TextAreaField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { TextAreaField as TextAreaFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface TextAreaFieldProps {
 
 export function TextAreaField({ field }: TextAreaFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,13 +37,11 @@ export function TextAreaField({ field }: TextAreaFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
         multiline: true,
         rows: field.rows ?? 4,
+        helperText: help.inline,
         placeholder: field.placeholder,
         fullWidth: true,
       }}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/YamlField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/YamlField.tsx
@@ -18,6 +18,7 @@
 import { useFormContext } from 'react-hook-form';
 import { TextInput } from '@percona/peak-ui';
 import { FieldLabelWithHelp } from '../FieldLabelWithHelp';
+import { fieldHelp } from '../fieldHelp';
 import type { YamlField as YamlFieldType } from '../types';
 import { buildValidationRules } from '../utils/validationMapper';
 
@@ -27,6 +28,7 @@ interface YamlFieldProps {
 
 export function YamlField({ field }: YamlFieldProps) {
   const { control } = useFormContext();
+  const help = fieldHelp(field);
   return (
     <TextInput
       name={field.name}
@@ -35,13 +37,11 @@ export function YamlField({ field }: YamlFieldProps) {
       control={control}
       textFieldProps={{
         label: (
-          <FieldLabelWithHelp
-            label={field.label}
-            description={field.description}
-          />
+          <FieldLabelWithHelp label={field.label} description={help.tooltip} />
         ),
         multiline: true,
         rows: field.rows ?? 8,
+        helperText: help.inline,
         placeholder: field.placeholder,
         fullWidth: true,
         inputProps: {

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/YamlField.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/fields/YamlField.tsx
@@ -43,7 +43,6 @@ export function YamlField({ field }: YamlFieldProps) {
         multiline: true,
         rows: field.rows ?? 8,
         placeholder: field.placeholder,
-        helperText: field.description,
         fullWidth: true,
         inputProps: {
           style: { fontFamily: "'Roboto Mono', monospace", fontSize: 13 },

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalField.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalField.ts
@@ -17,7 +17,10 @@
 
 import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import type { PluginField } from '../types';
+import type { FieldGate, PluginField, Predicate } from '../types';
+import { useFormFields } from '../formFieldsContext';
+import { emptyFieldValue } from '../utils/fieldDefault';
+import { warnSchema } from '../utils/schemaWarnings';
 import {
   evaluatePredicate,
   getGateFieldNames,
@@ -27,24 +30,125 @@ import { watchValuesByName } from '../utils/watchValuesByName';
 export interface ConditionalFieldState {
   isHidden: boolean;
   isRequired: boolean;
+  /**
+   * The field declares a `parent` that is currently off. It renders, indented
+   * beneath that parent, but takes no input — see {@link PluginField.parent}.
+   */
+  isDisabled: boolean;
 }
 
 /**
- * Evaluate a field's `requires` and `forbidden` gates against current form
- * values and return the resolved visibility + required state.
+ * Whether a gate is exactly "the parent toggle is off".
  *
- * When `isHidden` becomes true the hook unregisters the field from
- * react-hook-form so its stale value is excluded from submission.
+ * A parented field keeps the backend's own `forbidden` gate on its parent —
+ * `Ui(parent=...)` is presentation-only, so the runtime rule has to live
+ * somewhere — and that gate would otherwise hide the very field the parent
+ * pointer asks to show greyed out. Matching it structurally lets the renderer
+ * consume it as the disable condition while every other gate on the field goes
+ * on hiding it.
+ */
+function isParentOffGate(when: Predicate, parent: string): boolean {
+  const entries = Object.entries(when);
+  if (entries.length !== 1) {
+    return false;
+  }
+  const [op, operand] = entries[0];
+  if (op === 'falsy') {
+    return operand === parent;
+  }
+  if (op !== 'not') {
+    return false;
+  }
+  const innerEntries = Object.entries(operand as Predicate);
+  if (innerEntries.length !== 1) {
+    return false;
+  }
+  const [innerOp, innerOperand] = innerEntries[0];
+  return innerOp === 'truthy' && innerOperand === parent;
+}
+
+/**
+ * A field's `forbidden` gates minus the one its `parent` pointer accounts for.
+ *
+ * The parent-off gate is the backend's runtime rule for the same relationship
+ * the pointer describes; the renderer consumes it as the disable condition, so
+ * applying it again as a hide would make the nested child vanish instead of
+ * greying out. Everything else on the field still hides it.
+ */
+export function hidingGates(field: PluginField): FieldGate[] {
+  const gates = field.forbidden ?? [];
+  const parent = field.parent;
+  if (!parent) {
+    return gates;
+  }
+  return gates.filter((gate) => !isParentOffGate(gate.when, parent));
+}
+
+/**
+ * Resolve one field's visibility, required-ness and disabled state.
+ *
+ * Pure: keeping a hidden or disabled field's value out of the submission
+ * payload belongs to {@link useFieldPayloadCleanup}, which the form body calls
+ * once for every field in the schema. That split is not cosmetic — a field
+ * inside a collapsed section is never mounted, so a hook that only runs while
+ * the slot is on screen cannot be the thing that guards the payload.
  */
 export function useConditionalField(field: PluginField): ConditionalFieldState {
-  const { control, unregister } = useFormContext();
+  const { control } = useFormContext();
+  const formFields = useFormFields();
+  const parent = field.parent;
+
+  // The renderer trusts `parent` and derives the disable state from the named
+  // field's truthiness alone; it cannot validate the schema. Say so out loud
+  // in dev, because each of these mistakes renders a plausible-looking form
+  // that behaves wrongly rather than failing.
+  useEffect(() => {
+    if (!parent) {
+      return;
+    }
+    const target = formFields.find((f) => f.name === parent);
+    if (!target) {
+      warnSchema(
+        `field '${field.name}' names parent '${parent}', which is not a field ` +
+          `in this form. It will stay disabled forever.`
+      );
+      return;
+    }
+    if (target.type !== 'bool') {
+      warnSchema(
+        `field '${field.name}' names parent '${parent}', which is a ` +
+          `'${target.type}' field. Only a bool can be a parent toggle.`
+      );
+    }
+    if (target.parent) {
+      warnSchema(
+        `field '${field.name}' names parent '${parent}', which is itself ` +
+          `parented to '${target.parent}'. Chained parents are not supported ` +
+          `and a cycle leaves both toggles permanently inert.`
+      );
+    }
+    if (!(field.forbidden ?? []).some((g) => isParentOffGate(g.when, parent))) {
+      warnSchema(
+        `field '${field.name}' names parent '${parent}' but carries no ` +
+          `forbidden gate on that parent being falsy. The renderer disables ` +
+          `the field, but nothing stops the backend accepting a value for it.`
+      );
+    }
+  }, [field, parent, formFields]);
+
+  // Gates the parent pointer already accounts for drop out of the hide set;
+  // what remains still hides the field the way it always has.
+  const forbidden = useMemo<FieldGate[]>(() => hidingGates(field), [field]);
 
   const watchedNames = useMemo<string[]>(() => {
     const requires = field.requires ?? [];
-    const forbidden = field.forbidden ?? [];
-    return getGateFieldNames([...requires, ...forbidden]);
+    const names = getGateFieldNames([...requires, ...forbidden]);
+    if (parent && !names.includes(parent)) {
+      names.push(parent);
+    }
+    return names;
     // field schema is static for the form's lifetime; dep on field is safe.
-  }, [field]);
+  }, [field, forbidden, parent]);
 
   // disabled=true when there are no gate fields — avoids subscribing to the
   // whole form when useWatch receives an empty name array.
@@ -55,14 +159,26 @@ export function useConditionalField(field: PluginField): ConditionalFieldState {
   }) as unknown[];
 
   const isHidden = useMemo(() => {
-    if (!field.forbidden?.length) {
+    if (!forbidden.length) {
       return false;
     }
     const map = watchValuesByName(watchedNames, rawValues);
-    return field.forbidden.some((gate) => evaluatePredicate(gate.when, map));
-  }, [rawValues, field, watchedNames]);
+    return forbidden.some((gate) => evaluatePredicate(gate.when, map));
+  }, [rawValues, forbidden, watchedNames]);
+
+  const isDisabled = useMemo(() => {
+    if (!parent) {
+      return false;
+    }
+    const map = watchValuesByName(watchedNames, rawValues);
+    return !evaluatePredicate({ truthy: parent }, map);
+  }, [rawValues, parent, watchedNames]);
 
   const isRequired = useMemo(() => {
+    // A field the user cannot reach must never block submission.
+    if (isDisabled) {
+      return false;
+    }
     if (field.required) {
       return true;
     }
@@ -71,18 +187,82 @@ export function useConditionalField(field: PluginField): ConditionalFieldState {
     }
     const map = watchValuesByName(watchedNames, rawValues);
     return field.requires.some((gate) => evaluatePredicate(gate.when, map));
-  }, [rawValues, field, watchedNames]);
+  }, [rawValues, field, watchedNames, isDisabled]);
 
-  // When a field becomes hidden its value must not appear in the submission
-  // payload. Unregistering removes it from RHF state immediately.
-  // On re-show, ConditionalFieldSlot remounts FieldRenderer, which re-calls
-  // register() and the field starts fresh — intentional: the hidden value
-  // is stale and should not silently resubmit.
-  useEffect(() => {
-    if (isHidden) {
-      unregister(field.name);
+  return { isHidden, isRequired, isDisabled };
+}
+
+/**
+ * Keep gated-out values out of the submission payload, for every field in the
+ * schema at once.
+ *
+ * Owned by the form body rather than by each field's slot, because a slot
+ * inside a collapsed section or a collapsed group is never mounted:
+ * `buildFormDefaults` still seeds its value, so a hook that ran only while the
+ * slot was on screen would let a gated-out field's default ship whenever the
+ * user submitted without expanding the section.
+ *
+ * Hidden wins over disabled: a hidden field is unregistered, which drops the
+ * key entirely, so clearing it afterwards would only put it back.
+ */
+export function useFieldPayloadCleanup(fields: PluginField[]): void {
+  const { control, unregister, setValue } = useFormContext();
+
+  const watchedNames = useMemo<string[]>(() => {
+    const names = new Set<string>();
+    for (const field of fields) {
+      for (const name of getGateFieldNames(hidingGates(field))) {
+        names.add(name);
+      }
+      if (field.parent) {
+        names.add(field.parent);
+      }
     }
-  }, [isHidden, field.name, unregister]);
+    return [...names];
+  }, [fields]);
 
-  return { isHidden, isRequired };
+  const rawValues = useWatch({
+    control,
+    name: watchedNames,
+    disabled: watchedNames.length === 0,
+  }) as unknown[];
+
+  const { hide, clear } = useMemo(() => {
+    const map = watchValuesByName(watchedNames, rawValues);
+    const hidden: string[] = [];
+    const cleared: PluginField[] = [];
+    for (const field of fields) {
+      if (
+        hidingGates(field).some((gate) => evaluatePredicate(gate.when, map))
+      ) {
+        hidden.push(field.name);
+        continue;
+      }
+      if (field.parent && !evaluatePredicate({ truthy: field.parent }, map)) {
+        cleared.push(field);
+      }
+    }
+    return { hide: hidden, clear: cleared };
+  }, [fields, watchedNames, rawValues]);
+
+  // `useWatch` returns a fresh array every render, so the memo above does too.
+  // Key the effect on what it would actually do instead: `setValue` notifies
+  // subscribers even when the value is unchanged, so an effect that re-ran on
+  // every render would spin.
+  const signature = `${hide.join('|')}#${clear.map((f) => f.name).join('|')}`;
+
+  useEffect(() => {
+    for (const name of hide) {
+      unregister(name);
+    }
+    for (const field of clear) {
+      setValue(field.name, emptyFieldValue(field), {
+        shouldDirty: false,
+        shouldValidate: false,
+      });
+    }
+    // `hide` / `clear` are re-derived every render; `signature` is what
+    // actually changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signature, unregister, setValue]);
 }

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalField.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalField.ts
@@ -19,11 +19,12 @@ import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FieldGate, PluginField, Predicate } from '../types';
 import { useFormFields } from '../formFieldsContext';
-import { emptyFieldValue } from '../utils/fieldDefault';
+import { fieldDefault } from '../utils/fieldDefault';
 import { warnSchema } from '../utils/schemaWarnings';
 import {
   evaluatePredicate,
   getGateFieldNames,
+  isPresent,
 } from '../utils/predicateEvaluator';
 import { watchValuesByName } from '../utils/watchValuesByName';
 
@@ -120,18 +121,22 @@ export function useConditionalField(field: PluginField): ConditionalFieldState {
           `'${target.type}' field. Only a bool can be a parent toggle.`
       );
     }
+    const parentOffGate = (field.forbidden ?? []).some((g) =>
+      isParentOffGate(g.when, parent)
+    );
+    if (parentOffGate && isPresent(fieldDefault(field))) {
+      warnSchema(
+        `field '${field.name}' pairs a forbidden gate on '${parent}' being ` +
+          `falsy with a default the backend reads as present, so the value it ` +
+          `resets to while disabled is one that gate rejects. Drop the gate or ` +
+          `the default.`
+      );
+    }
     if (target.parent) {
       warnSchema(
         `field '${field.name}' names parent '${parent}', which is itself ` +
           `parented to '${target.parent}'. Chained parents are not supported ` +
           `and a cycle leaves both toggles permanently inert.`
-      );
-    }
-    if (!(field.forbidden ?? []).some((g) => isParentOffGate(g.when, parent))) {
-      warnSchema(
-        `field '${field.name}' names parent '${parent}' but carries no ` +
-          `forbidden gate on that parent being falsy. The renderer disables ` +
-          `the field, but nothing stops the backend accepting a value for it.`
       );
     }
   }, [field, parent, formFields]);
@@ -203,7 +208,12 @@ export function useConditionalField(field: PluginField): ConditionalFieldState {
  * user submitted without expanding the section.
  *
  * Hidden wins over disabled: a hidden field is unregistered, which drops the
- * key entirely, so clearing it afterwards would only put it back.
+ * key entirely, so resetting it afterwards would only put it back.
+ *
+ * A disabled child is reset to its schema default rather than blanked, so the
+ * greyed control shows what it would submit if the parent were switched on —
+ * `master_port` reads 3306 rather than empty. What it must not keep is a value
+ * someone typed while the parent was on and then switched off.
  */
 export function useFieldPayloadCleanup(fields: PluginField[]): void {
   const { control, unregister, setValue } = useFormContext();
@@ -256,7 +266,7 @@ export function useFieldPayloadCleanup(fields: PluginField[]): void {
       unregister(name);
     }
     for (const field of clear) {
-      setValue(field.name, emptyFieldValue(field), {
+      setValue(field.name, fieldDefault(field), {
         shouldDirty: false,
         shouldValidate: false,
       });

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalSection.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/hooks/useConditionalSection.ts
@@ -15,7 +15,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { FormSection } from '../types';
 import { isOneOfGroup } from '../utils/flattenSectionFields';
@@ -30,25 +30,35 @@ export interface ConditionalSectionState {
 }
 
 /**
- * Evaluate a FormSection's ``forbidden`` gates against current form values.
- * When any gate fires the section becomes hidden and every child field is
- * unregistered from react-hook-form so stale values do not ship in the
- * submission payload.
+ * Evaluate the `forbidden` gates of several sections against one watch.
  *
- * Cardinality (repeated) sections are out of scope for this hook — none
- * of the current schema-driven plugins gate a cardinality_rules-driven
- * section. Revisit if a future plugin needs the combination.
+ * The batched form exists so a caller can know a whole run of sections is
+ * hidden *before* rendering the shell that would contain them — a grouped
+ * shell whose every member is gated out must not render as an empty
+ * accordion. Subscribing once to the union of gate fields also keeps a form
+ * with many gated sections to a single `useWatch`.
+ *
+ * Returns one flag per input section, positionally.
+ *
+ * Deliberately not exported from the package: it is only half the contract.
+ * A caller that reads these flags without also calling
+ * {@link useUnregisterHiddenSections} ships a hidden section's values in the
+ * submission payload. {@link useConditionalSection} pairs the two for the
+ * single-section case and is the supported entry point.
  */
-export function useConditionalSection(
-  section: FormSection
-): ConditionalSectionState {
-  const { control, unregister } = useFormContext();
+export function useConditionalSections(sections: FormSection[]): boolean[] {
+  const { control } = useFormContext();
 
   const watchedNames = useMemo<string[]>(() => {
-    const forbidden = section.forbidden ?? [];
-    return getGateFieldNames(forbidden);
-    // section schema is static for the form's lifetime; dep on section is safe.
-  }, [section]);
+    const names = new Set<string>();
+    for (const section of sections) {
+      for (const name of getGateFieldNames(section.forbidden ?? [])) {
+        names.add(name);
+      }
+    }
+    return [...names];
+    // section schemas are static for the form's lifetime; dep on sections is safe.
+  }, [sections]);
 
   const rawValues = useWatch({
     control,
@@ -56,44 +66,95 @@ export function useConditionalSection(
     disabled: watchedNames.length === 0,
   }) as unknown[];
 
-  const isHidden = useMemo(() => {
-    if (!section.forbidden?.length) {
-      return false;
-    }
+  const flags = useMemo(() => {
     const map = watchValuesByName(watchedNames, rawValues);
-    return section.forbidden.some((gate) => evaluatePredicate(gate.when, map));
-  }, [rawValues, section, watchedNames]);
+    return sections.map((section) =>
+      Boolean(
+        section.forbidden?.some((gate) => evaluatePredicate(gate.when, map))
+      )
+    );
+  }, [sections, watchedNames, rawValues]);
 
-  const sectionFieldNames = useMemo<string[]>(() => {
-    const names = new Set<string>();
-    for (const field of section.fields) {
-      if (isOneOfGroup(field)) {
-        names.add(field.name);
-        names.add(field.discriminator);
-        for (const branch of field.branches) {
-          for (const leaf of branch.fields) {
-            names.add(leaf.name);
-          }
-        }
-        continue;
-      }
+  // `useWatch` hands back a fresh array every render, so the memo above
+  // recomputes every render too. Hold the previous result while the flags
+  // themselves are unchanged, so callers can put the array straight into an
+  // effect's dependency list without that effect re-firing continuously.
+  const stable = useRef<boolean[]>(flags);
+  if (
+    stable.current.length !== flags.length ||
+    flags.some((flag, i) => stable.current[i] !== flag)
+  ) {
+    stable.current = flags;
+  }
+  return stable.current;
+}
+
+/** The react-hook-form names every field in a section registers under. */
+function sectionFieldNames(section: FormSection): string[] {
+  const names = new Set<string>();
+  for (const field of section.fields) {
+    if (isOneOfGroup(field)) {
       names.add(field.name);
+      names.add(field.discriminator);
+      for (const branch of field.branches) {
+        for (const leaf of branch.fields) {
+          names.add(leaf.name);
+        }
+      }
+      continue;
     }
-    return [...names];
-  }, [section.fields]);
+    names.add(field.name);
+  }
+  return [...names];
+}
 
-  // When the section becomes hidden every child field must drop out of
-  // RHF state so its (possibly default) value does not ship. On re-show,
-  // SectionRenderer re-mounts the children which re-call register() and
-  // start fresh — intentional: stale user input from the prior session
-  // would otherwise ship in the payload and fail backend cross-mode validation.
+/**
+ * Drop every hidden section's fields from react-hook-form state.
+ *
+ * Owned by the form body rather than by each section's own component, because
+ * a section that never mounts cannot clean up after itself — a member of a
+ * collapsed group is not in the tree at all, and would otherwise ship its
+ * default value while gated out.
+ */
+export function useUnregisterHiddenSections(
+  sections: FormSection[],
+  hidden: boolean[]
+): void {
+  const { unregister } = useFormContext();
+
+  const namesBySection = useMemo(
+    () => sections.map(sectionFieldNames),
+    [sections]
+  );
+
   useEffect(() => {
-    if (isHidden) {
-      for (const name of sectionFieldNames) {
+    hidden.forEach((isHidden, i) => {
+      if (!isHidden) {
+        return;
+      }
+      for (const name of namesBySection[i] ?? []) {
         unregister(name);
       }
-    }
-  }, [isHidden, sectionFieldNames, unregister]);
+    });
+  }, [hidden, namesBySection, unregister]);
+}
 
-  return { isHidden };
+/**
+ * Evaluate one section's gates and drop its fields while it is hidden.
+ *
+ * When the section becomes hidden every child field must drop out of
+ * RHF state so its (possibly default) value does not ship. On re-show,
+ * the renderer re-mounts the children which re-call register() and
+ * start fresh — intentional: stale user input from the prior session
+ * would otherwise ship in the payload and fail backend cross-mode validation.
+ */
+export function useConditionalSection(
+  section: FormSection
+): ConditionalSectionState {
+  const sections = useMemo(() => [section], [section]);
+  const hidden = useConditionalSections(sections);
+
+  useUnregisterHiddenSections(sections, hidden);
+
+  return { isHidden: hidden[0] ?? false };
 }

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/fieldDefault.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/fieldDefault.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type { PluginField } from '../types';
+
+/**
+ * The value that reads as *unset* for a field's widget.
+ *
+ * Matches what the backend's ``_field_is_present`` treats as absent, so a field
+ * carrying this value satisfies a `forbidden` gate rather than tripping it.
+ * Deliberately ignores the schema's `default`: this is what a field is cleared
+ * *to*, not what it starts *at*.
+ */
+export function emptyFieldValue(field: PluginField): unknown {
+  switch (field.type) {
+    case 'bool':
+      return false;
+    case 'multi_choice':
+      return [];
+    case 'file':
+      return undefined;
+    case 'remote_choice':
+      // Mirror the selector's empty commit (`null`), not `''` — an empty string
+      // passes some client checks yet fails the backend NonEmptyStr with
+      // "String should have at least 1 character".
+      return null;
+    default:
+      return '';
+  }
+}
+
+/** The value a field starts at: its schema `default`, else {@link emptyFieldValue}. */
+export function fieldDefault(field: PluginField): unknown {
+  if (field.type === 'file') {
+    return undefined;
+  }
+  return field.default ?? emptyFieldValue(field);
+}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/schemaWarnings.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/schemaWarnings.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Dev-only diagnostics for a malformed plugin schema.
+ *
+ * A schema arrives from the side-car at runtime, so a mistake in it cannot be
+ * caught by this package's types or its tests — it surfaces as a form that
+ * quietly renders wrong. These warnings make the common authoring mistakes
+ * loud for whoever is writing the schema, and compile out of a production
+ * bundle (Vite replaces `import.meta.env.DEV` statically).
+ */
+
+const IS_DEV = import.meta.env.DEV;
+
+// One line per distinct problem, however many times the form re-renders.
+const seen = new Set<string>();
+
+export function warnSchema(message: string): void {
+  if (!IS_DEV || seen.has(message)) {
+    return;
+  }
+  seen.add(message);
+  // eslint-disable-next-line no-console -- surface a malformed schema in dev
+  console.warn(`[SchemaFormRenderer] ${message}`);
+}
+
+/** Test seam — the dedupe cache is module state and would leak between cases. */
+export function resetSchemaWarnings(): void {
+  seen.clear();
+}

--- a/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/schemaWarnings.ts
+++ b/ui/packages/sep/framework/src/components/SchemaFormRenderer/utils/schemaWarnings.ts
@@ -25,7 +25,12 @@
  * bundle (Vite replaces `import.meta.env.DEV` statically).
  */
 
-const IS_DEV = import.meta.env.DEV;
+// The bare `import.meta.env.DEV` is left intact for that static replacement —
+// wrapping it in optional chaining would keep the warning machinery in the
+// production bundle. The guard costs nothing under Vite and stops the module
+// throwing at evaluation time under a bundler that defines no
+// `import.meta.env`, which would take the whole form renderer down with it.
+const IS_DEV = import.meta.env !== undefined && import.meta.env.DEV;
 
 // One line per distinct problem, however many times the form re-renders.
 const seen = new Set<string>();

--- a/ui/packages/sep/framework/src/components/SchemaSelector/SchemaSelector.tsx
+++ b/ui/packages/sep/framework/src/components/SchemaSelector/SchemaSelector.tsx
@@ -39,6 +39,8 @@ export interface SchemaSelectorProps {
    * either a `ServiceOption` (from `<ServiceSelector>`) or a raw service id.
    */
   dependsOn: string;
+  /** Field help shown under the control when no cascade hint takes the slot. */
+  description?: string;
   disabled?: boolean;
   /** Offer free-text (free-solo) entry alongside the inventory options. */
   allowCustom?: boolean;
@@ -56,6 +58,7 @@ export function SchemaSelector({
   label,
   required,
   dependsOn,
+  description,
   disabled,
   allowCustom,
 }: SchemaSelectorProps) {
@@ -107,7 +110,7 @@ export function SchemaSelector({
       ? (error?.message ?? 'Failed to load schemas')
       : empty
         ? 'No schemas in this service'
-        : undefined;
+        : description;
 
   if (allowCustom) {
     // Only a truly absent parent disables the control; a custom (free-typed)
@@ -127,7 +130,7 @@ export function SchemaSelector({
             ? 'Select a service first'
             : isError
               ? helperText
-              : undefined
+              : description
         }
         error={isError}
         noOptionsText={

--- a/ui/packages/sep/framework/src/components/TableSelector/TableSelector.tsx
+++ b/ui/packages/sep/framework/src/components/TableSelector/TableSelector.tsx
@@ -39,6 +39,8 @@ export interface TableSelectorProps {
    * either a `SchemaOption` or a raw schema id.
    */
   dependsOn: string;
+  /** Field help shown under the control when no cascade hint takes the slot. */
+  description?: string;
   disabled?: boolean;
   /** Offer free-text (free-solo) entry alongside the inventory options. */
   allowCustom?: boolean;
@@ -55,6 +57,7 @@ export function TableSelector({
   label,
   required,
   dependsOn,
+  description,
   disabled,
   allowCustom,
 }: TableSelectorProps) {
@@ -100,7 +103,7 @@ export function TableSelector({
       ? (error?.message ?? 'Failed to load tables')
       : empty
         ? 'No tables in this schema'
-        : undefined;
+        : description;
 
   if (allowCustom) {
     // Only a truly absent parent disables the control; a custom (free-typed)
@@ -120,7 +123,7 @@ export function TableSelector({
             ? 'Select a schema first'
             : isError
               ? helperText
-              : undefined
+              : description
         }
         error={isError}
         noOptionsText={

--- a/ui/packages/sep/framework/src/vite-env.d.ts
+++ b/ui/packages/sep/framework/src/vite-env.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2026 Percona LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Minimal ImportMeta declaration so @sep/framework can read
+// `import.meta.env.DEV` without depending on Vite directly, mirroring the
+// same file in @sep/api. Consuming apps pull in the full `vite/client` types
+// through their own vite-env.d.ts.
+declare global {
+  interface ImportMetaEnv {
+    readonly DEV: boolean;
+    readonly PROD: boolean;
+    readonly MODE: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+}
+
+export {};


### PR DESCRIPTION
Frontend half of finding **P3** from Pedro's UX pass over the MySQL Backups Tech Preview (PMM-15380, under the PMM-15217 umbrella). Stacked on `PMM-15205-sep-fb`.

## What was already done

Two of the five acceptance criteria turned out to be delivered by the side-car half (PMM-15480), vendored here in `be2859f3a`:

- **Only the selected backup type's sections render** — `mysql_backups/views.py` gates the Mydumper / XtraBackup / Binlog `SectionLayout`s on `backup_type`, and every non-Task section is already `collapsed_by_default`.
- **A local, unencrypted restore shows no SSH, S3 or GPG fields** — `source_transport` defaults to `local` and `source_encryption` to `none`, and the credential fields carry `forbidden` gates the renderer already evaluates.

Those need verification against a current build, not new code.

## What this changes

The other two ACs needed information the schema could not express, and the shape of the disclosure comes from **Pedro's answers to the seven open questions** (see below).

- **`FormSection.advanced`** — a per-section flag. Advanced sections are withheld behind one **"Show advanced options"** control rendered after the ordinary sections; revealing it renders each as an ordinary top-level section. Deliberately *not* a wrapper accordion: nesting collapsible sections inside another collapsible shell puts the common case two disclosures deep. A flag rather than a group name also means membership does not depend on sections being adjacent, so nothing rests on where fields happen to be declared on the model.
- **The reveal is not purely manual.** An advanced section that arrives holding a value other than its schema default, or one a backend error points into, is revealed and expanded on its own — an option someone has already set must never be hidden from them. That covers the edit form and the 422 path. A client-side error cannot arise in an unrevealed section, since a field that never mounts is never registered.
- **`PluginField.parent`** — names a sibling `bool` field this field parameterises. The child renders indented beneath it and inert until it is on, rather than vanishing, and shows its schema default while disabled so a reader can see what it would send. That is the split the ACs ask for and Pedro confirmed: a field that *parameterises* a switch greys out showing its default, a field belonging to *a different mode* disappears.

  `Ui(parent=...)` is presentation-only on the side-car — Yan's call on percona/SEP#1497, on the grounds that a presentation attribute must not change what the server accepts — so the companion `Forbidden` gate is **optional**. Where a field does carry one, the renderer recognises it structurally and consumes it as the disable condition rather than applying it as a hide; every other gate goes on hiding the field.

Both keys are absent from today's wire, so behaviour is unchanged until the side-car change ships.

Plus a density pass, which is what actually recovers the height:

- **Single column.** Two columns were the contingency lever; the answer is that a form like this stays one column.
- **`help_placement`, and one rule for where a description goes.** Covered in its own section below — it started as "stop rendering the description twice" and turned into fixing a contract that was never coherent.
- **The odd optional field out is marked "(optional)"** when it is a single unfilled field among required ones. Deliberately narrow: two or more optional fields and the asterisks already read as the exception, and a field carrying a default is pre-filled rather than blank-optional.

## Where a field's description goes

Worth reading before this is synced back to SEP, because it changes a contract every schema-driven app shares.

Stripping the duplicated description was originally just density work. Checking it against all thirteen app schemas showed the problem was one app's:

| | descriptions | over 120 chars |
|---|---|---|
| `mysql_backups` + restore | 104 | **44** |
| the other nine apps | 59 | **5** |

So a global tooltip-only rule would have solved this form at the expense of every other app's short format hints — `Tables as schema.table`, `` `daily`, `weekly`, or an ISO weekday number (1-7…) `` — which want to be visible while someone types.

It also turned out description handling had never been coherent:

| Field kinds | Before |
|---|---|
| string, integer, float, datetime, textarea, yaml, file | tooltip **and** helper text — rendered twice |
| bool | tooltip icon **and** caption — twice |
| choice, multi_choice | inline only, no tooltip |
| `SchemaSelectShell` (the select path) | tooltip **and** helper text — twice again |
| **service, host, schema, table, remote_choice** | **nowhere at all** |

That last row is a live bug this ticket was already failing on: MySQL Restore's `backup_source` carries a 300-character description listing every accepted path form — `/backups/mydumper/20240101`, `db01:/path`, `s3://bucket/path`, `/latest` — and none of it renders. `ServiceSelector` even has a `helperText` prop that `ServiceField` never passed. AC 5 says no field should require reading the SEP API contract; this one did.

Now there is one rule, in `fieldHelp.ts`:

- A description that fits roughly one line (≤120 chars) renders under the input; longer prose goes behind the help icon.
- **`help_placement: 'tooltip' | 'inline'`** overrides that per field, for a terse note that is still secondary or a long one someone needs in front of them.
- Reference and selector fields are always inline — their label is a plain string the renderer interpolates into validation messages, so there is no node to hang an icon from. They now surface the description they had been dropping.


## Payload hygiene moved to the form body

A section or field inside a collapsed shell is never mounted (`unmountOnExit`), but `buildFormDefaults` has already seeded its value — so an effect that only ran while the slot was on screen let a gated-out default ship whenever the user submitted without expanding the section. That was already true of any `collapsed_by_default` section; grouping would have added a second layer of it. `useUnregisterHiddenSections` and `useFieldPayloadCleanup` now own this at the body level, and `useConditionalField` is pure presentation state. Hidden wins over disabled, so a field that is both is unregistered rather than cleared back into the payload.

## Acceptance criteria

| AC | Status |
|----|--------|
| Working local, unencrypted backup within one screen at 1512 px | ⚠️ 1003 px against 982 px — 21 px over, see below |
| Only the selected backup type's sections render | ✅ already delivered by the side-car |
| Dependent toggle nested under its parent, inert until it is on | ✅ renderer side; needs the side-car to emit `parent` |
| Local, unencrypted restore shows no SSH / S3 / GPG fields | ✅ already delivered by the side-car |
| No field needs the API contract to understand | ✅ every field carries a description, rendered as a tooltip |

## Test plan

`cd ui && make lint && make format-check && make test` — 843 framework + 106 api + 122 atw + 505 pmm tests pass, 0 lint errors, format clean.

New coverage: the advanced control (withheld, revealed, absent when no section is marked, collected wherever they appear, auto-revealed on a seeded value, left in place when seeded values match defaults, auto-revealed on a backend error, gated-out sections still dropped from the payload, control hidden when every advanced section is gated out); parented fields (disabled while the parent is off, interactive when on, non-parent gates still hide, cleared on parent-off, a disabled required child does not block submit); collapsed-shell payload hygiene, all four cases of which fail without the body-level hook; malformed schemas; and the optional marker.

**Measurement.** No side-car needed — the schema snapshot in `percona/SEP:tests/app/sep/snapshots/schema/mysql_backups.json` *is* the wire payload. A throwaway harness mounted the create form against it and Playwright measured at 1512 × 982, now including the PMM chrome and an expanded sidebar per Pedro's answer, with XtraBackup selected and no encryption or upload:

| | form height | bottom of form |
|---|---|---|
| before this branch | **1192 px** | 1360 px |
| this branch, today's schema | **1004 px** | 1172 px |
| this branch, with `advanced` + `parent` | **854 px** | 1022 px |
| …discounting two host-lookup errors the harness provokes with no backend | **816 px** | 984 px |
| …plus the two Task fields that regained inline help | **835 px** | **1003 px** |

Against a 982 px viewport with 168 px of chrome above the form, that is **21 px over**. It was 2 px over before the help-placement rule put `service_id`'s and `alias`'s descriptions back under their inputs — `service_id` had been showing no help at all. That is the trade this makes deliberately, and Pedro's answer was that one screen is a target rather than a hard gate. If those 21 px are wanted back, the side-car can set `help_placement: 'tooltip'` on either field; the override exists for exactly that. The form is `maxWidth: 800`, and the content column stays 1272 px wide with the sidebar expanded, so the sidebar costs width but no height.

A real browser also confirmed the nested toggle goes disabled → enabled → disabled-and-cleared as the parent flips. The harness is deleted; it is reproducible from the recipe in the plan.

## The side-car half — percona/SEP#1497 (SEP-2039)

This PR is the renderer. The two headline features do nothing until the side-car emits the keys, which **[percona/SEP#1497](https://github.com/percona/SEP/pull/1497)** adds. That PR is **being updated to match Pedro's answers**: it currently emits `SectionLayout.group` (a heading string) and needs to emit a per-section `advanced` boolean instead, which also lets it drop the adjacency validator and the field-block reordering that existed only to satisfy it.

- `FormSection.advanced` on General / Encryption / Upload in both `mysql_backups` and its restore app.
- `BaseField.parent` on `encrypt` → `encrypt_using_tmpdir`; `xtrabackup_kill_queries` → its timeout and query type; `xtrabackup_prepare` → prepare memory; and on the restore side `slave_from_master` → `master_ip`, `master_user`, `master_password`, `wait_for_catchup`.

The two can land in either order and meet at the next vendored-frontend sync. Until then this PR is inert on the disclosure and the nesting; the density work applies immediately and accounts for 1192 px → 1004 px on its own.

Two things on that PR worth knowing here:

- **The renderer consumes the parent's `forbidden` gate.** `Ui(parent=...)` is presentation-only by the DSL's governing rule, so the side-car keeps enforcing the relationship with the field's own gate. That gate would otherwise hide the very field the pointer asks to show greyed out, which is why `isParentOffGate` matches it structurally. The side-car requires the pair at derivation time, so the two halves cannot drift.
- **It carries a deliberate validation tightening** (a `breaking` changelog fragment): seven fields gained the companion gate, so combinations previously accepted are now rejected on create and update. Signed off before implementing, and stored bodies are exempt so no saved task is stranded.

## UX answers, and what is still open

Pedro answered all seven. Six are settled and built; the changes his answers forced are in the commit above.

| Question | Answer | Effect |
|---|---|---|
| Which sections are advanced? | General, Encryption, Upload; type-specific stay top-level. | As built. |
| How should the disclosure work? | **Neither option offered** — the group accordion nests too deep. A "Show advanced options" control after the type-specific section; revealed sections are ordinary top-level ones. Anything holding a non-default value or an error reveals and expands itself. | Reworked. Also simplified the wire key from `group` to `advanced`. |
| Disable, or hide? | The split rule as built; nothing sits on the wrong side. | No change. |
| Which fields are children of which? | **Open** — needs a databases/backups opinion, likely Max. | The eight pairs are provisional. Schema-only, so a different set changes SEP#1497 alone, not this PR. |
| What is "one screen"? | 1512 × 982 including PMM chrome with the sidebar expanded. No supported-device definition exists yet and defining one is deliberately deferred. | Re-measured on that basis; the numbers above include chrome. |
| Keep `alias` with the required fields? | Yes, marked "Optional" — it is how people find the backup later. | Added the optional marker. |
| Two-column layout? | **No** — single column is the norm for a form like this. If it still overshoots, pair only short related fields (host + port). One screen is a target, not a hard gate. | Reverted to single column; recovered the height from the duplicated descriptions instead. Landed at 2 px over, so no field pairing was needed. |

Still open, and worth flagging to reviewers:

- **The parent/child pairs need a Backups sign-off.** Both PRs encode a reading of the form, not domain knowledge.
- **Managed Services should see the disclosure behaviour** on a feature build — Pedro called that out explicitly as where an expert opinion would help.
- **The one-screen result is 2 px inside the target** on an assumed-common viewport, and there is no supported-device definition to check it against. Treat it as "as close as sensible", which is what was asked for.

## Notes for review

- Everything touched is under `ui/packages/sep/`, **vendored** from `percona/SEP` `frontend/packages/` — a future sync can silently revert it, as with PMM-15457. The `group` / `parent` types here mirror what SEP#1497 adds to SEP's own `frontend/packages/api/src/types/app-schema.ts`, so a later sync should be a no-op on them rather than a conflict.
- Stacked on `PMM-15205-sep-fb`, so CodeRabbit will skip it; reviewed locally instead.



