### PR TITLE
PMM-15326 Handle SEP's paginated /hosts and /services

### DIFF
--- a/managed/services/om/inventory.go
+++ b/managed/services/om/inventory.go
@@ -17,6 +17,7 @@ package om
 
 import (
 	"context"
+	"maps"
 	"math"
 	"net/http"
 	"net/url"
@@ -91,9 +92,16 @@ func (s *Service) ListInventoryHosts(ctx context.Context, req *omv1.ListInventor
 		query.Set("executor", strconv.FormatBool(req.GetExecutor()))
 	}
 
-	hosts := []sepHost{}
-	call := inventoryCall{method: http.MethodGet, path: "hosts", query: query}
-	err = probe.call(ctx, call, &hosts)
+	hosts, err := fetchAllPages(func(offset, limit int) (sepPage[sepHost], error) {
+		pageQuery := url.Values{}
+		maps.Copy(pageQuery, query)
+		pageQuery.Set("offset", strconv.Itoa(offset))
+		pageQuery.Set("limit", strconv.Itoa(limit))
+		page := sepPage[sepHost]{}
+		call := inventoryCall{method: http.MethodGet, path: "hosts", query: pageQuery}
+		err := probe.call(ctx, call, &page)
+		return page, err
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/managed/services/om/inventory_client.go
+++ b/managed/services/om/inventory_client.go
@@ -146,6 +146,47 @@ type sepError struct {
 	Detail any `json:"detail"`
 }
 
+// sepPage is one page of a paginated SEP list endpoint -- the wire shape of
+// SEP's own app.core.pagination.PaginatedResponse envelope
+// (app/core/pagination/models.py). GET /hosts and GET /services both answer
+// this now (PMM-15326: "Bound the estate listings"), rather than a bare
+// array of T: total counts every row matching the request's filters, not
+// just this page, so a caller can tell "this is the whole estate" from
+// "this is the first page of it" without a second request.
+type sepPage[T any] struct {
+	Items  []T `json:"items"`
+	Total  int `json:"total"`
+	Offset int `json:"offset"`
+	Limit  int `json:"limit"`
+}
+
+// sepPageSize is the limit requested on each page fetchAllPages walks --
+// SEP's own MAX_PAGINATION_LIMIT (app/core/pagination/models.py), so a full
+// estate takes as few round-trips as SEP itself allows in one request.
+const sepPageSize = 200
+
+// fetchAllPages walks a paginated SEP endpoint via fetchPage, which must
+// return the page at the given offset/limit, until every row sepPage.Total
+// reports has been read. Parametrized over how one page is actually
+// fetched, not over sepApp.call directly, because callers want different
+// request mechanics and error mappings for the same page shape -- see
+// probeSource.fetch's own comment on why its errors are not gRPC statuses.
+func fetchAllPages[T any](fetchPage func(offset, limit int) (sepPage[T], error)) ([]T, error) {
+	all := make([]T, 0)
+	offset := 0
+	for {
+		page, err := fetchPage(offset, sepPageSize)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page.Items...)
+		offset += len(page.Items)
+		if len(page.Items) == 0 || offset >= page.Total {
+			return all, nil
+		}
+	}
+}
+
 // inventoryCall describes one proxied request.
 type inventoryCall struct {
 	method string

--- a/managed/services/om/inventory_test.go
+++ b/managed/services/om/inventory_test.go
@@ -36,14 +36,16 @@ import (
 	omv1 "github.com/percona/pmm/api/om/v1"
 )
 
-// hostsBody is one om_inventory GET /hosts answer.
+// hostsBody is one om_inventory GET /hosts answer, wrapped in SEP's own
+// paginated envelope (PMM-15326: "Bound the estate listings" --
+// app/core/pagination/models.py's PaginatedResponse) rather than a bare array.
 //
 // Two hosts on purpose, because the pair is the whole reason the host table exists.
 // `n1` runs a registered database and reports an unregistered mongod beside it -- the
 // arbiter case, which PMM registers no service for, so nothing else in OM would mention
 // the process. `n2` carries a PMM client and no database at all, which is the case a
 // service-keyed inventory cannot represent.
-const hostsBody = `[
+const hostsBody = `{"items": [
   {
     "node_id": "n1", "name": "db00", "address": "10.0.0.1", "executor_host": "db00",
     "observed": {
@@ -85,7 +87,7 @@ const hostsBody = `[
     "consecutive_failures": 3, "last_error": "no executor host",
     "services": []
   }
-]`
+], "total": 2, "offset": 0, "limit": 200}`
 
 // configBody is one om_inventory GET /config answer, trimmed to the two rows that make
 // the point: a nested schedule leaf and a field the deployment owns outright.
@@ -292,7 +294,7 @@ func TestListInventoryHosts(t *testing.T) {
 	t.Run("passes the filters through", func(t *testing.T) {
 		t.Parallel()
 
-		stub := newSEPStub(t, http.StatusOK, `[]`)
+		stub := newSEPStub(t, http.StatusOK, `{"items": [], "total": 0, "offset": 0, "limit": 200}`)
 
 		// Addressable locals rather than a helper: these are proto3 `optional` bools, so
 		// what the request carries is a plain *bool, and false has to be distinguishable
@@ -320,12 +322,14 @@ func TestListInventoryHosts(t *testing.T) {
 		// has_service=false means "only hosts with no database", which is a very
 		// different listing from the default. Sending it because the caller said nothing
 		// would silently hide every host that has one.
-		stub := newSEPStub(t, http.StatusOK, `[]`)
+		stub := newSEPStub(t, http.StatusOK, `{"items": [], "total": 0, "offset": 0, "limit": 200}`)
 
 		_, err := stub.service(t).ListInventoryHosts(t.Context(), &omv1.ListInventoryHostsRequest{})
 
 		require.NoError(t, err)
-		assert.Empty(t, stub.query)
+		assert.NotContains(t, stub.query, "has_service")
+		assert.NotContains(t, stub.query, "failing")
+		assert.NotContains(t, stub.query, "executor")
 	})
 }
 
@@ -806,7 +810,7 @@ func TestInventoryBearerIsSent(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seen = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`{"items": [], "total": 0, "offset": 0, "limit": 200}`))
 	}))
 	t.Cleanup(server.Close)
 
@@ -829,13 +833,25 @@ func mustParseTime(t *testing.T, stamp string) time.Time {
 func TestInventoryFixturesAreValid(t *testing.T) {
 	t.Parallel()
 
-	for name, body := range map[string]string{"hosts": hostsBody, "config": configBody} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
+	// hosts is checked separately from config: it is wrapped in SEP's own
+	// paginated envelope (PMM-15326: "Bound the estate listings") and config
+	// deliberately is not -- see sepPage's own comment on which endpoints
+	// changed shape and which stayed a bare array.
+	t.Run("hosts", func(t *testing.T) {
+		t.Parallel()
 
-			var parsed []map[string]any
-			require.NoError(t, json.Unmarshal([]byte(body), &parsed))
-			assert.NotEmpty(t, parsed)
-		})
-	}
+		var parsed struct {
+			Items []map[string]any `json:"items"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(hostsBody), &parsed))
+		assert.NotEmpty(t, parsed.Items)
+	})
+
+	t.Run("config", func(t *testing.T) {
+		t.Parallel()
+
+		var parsed []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(configBody), &parsed))
+		assert.NotEmpty(t, parsed)
+	})
 }

--- a/managed/services/om/probe_source.go
+++ b/managed/services/om/probe_source.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -250,31 +252,39 @@ func (p probeService) failureSummary() string {
 	return fmt.Sprintf("%s: %s", name, p.LastError)
 }
 
-// fetch reads the app's service estate.
+// fetch reads the app's service estate, walking every page GET /services
+// answers (PMM-15326: "Bound the estate listings" -- see sepPage's own
+// comment) until fetchAllPages has read every row.
 func (s probeSource) fetch(ctx context.Context) ([]probeService, error) {
 	ctx, cancel := context.WithTimeout(ctx, probeRequestTimeout)
 	defer cancel()
 
-	url := s.app.endpoint(probeServicesPath)
-	req, err := s.app.request(ctx, http.MethodGet, probeServicesPath, nil, nil, false)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build the request: %w", err)
-	}
+	return fetchAllPages(func(offset, limit int) (sepPage[probeService], error) {
+		query := url.Values{
+			"offset": {strconv.Itoa(offset)},
+			"limit":  {strconv.Itoa(limit)},
+		}
+		endpoint := s.app.endpoint(probeServicesPath) + "?" + query.Encode()
+		req, err := s.app.request(ctx, http.MethodGet, probeServicesPath, query, nil, false)
+		if err != nil {
+			return sepPage[probeService]{}, fmt.Errorf("failed to build the request: %w", err)
+		}
 
-	resp, err := s.app.client.http.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", url, err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
+		resp, err := s.app.client.http.Do(req)
+		if err != nil {
+			return sepPage[probeService]{}, fmt.Errorf("GET %s: %w", endpoint, err)
+		}
+		defer resp.Body.Close() //nolint:errcheck
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: unexpected status %s", url, resp.Status)
-	}
+		if resp.StatusCode != http.StatusOK {
+			return sepPage[probeService]{}, fmt.Errorf("GET %s: unexpected status %s", endpoint, resp.Status)
+		}
 
-	answer := []probeService{}
-	err = json.NewDecoder(resp.Body).Decode(&answer)
-	if err != nil {
-		return nil, fmt.Errorf("GET %s: failed to decode the response: %w", url, err)
-	}
-	return answer, nil
+		page := sepPage[probeService]{}
+		err = json.NewDecoder(resp.Body).Decode(&page)
+		if err != nil {
+			return sepPage[probeService]{}, fmt.Errorf("GET %s: failed to decode the response: %w", endpoint, err)
+		}
+		return page, nil
+	})
 }

--- a/managed/services/om/probe_source_test.go
+++ b/managed/services/om/probe_source_test.go
@@ -32,8 +32,12 @@ import (
 
 // servicesBody is one om_inventory GET /services answer, shaped as the app sends it:
 // a row per service PMM has registered, each carrying the document the last successful
-// probe stored. `gone` is a service the app knows and this PMM does not.
-const servicesBody = `[
+// probe stored, wrapped in SEP's own paginated envelope (PMM-15326: "Bound the estate
+// listings" -- app/core/pagination/models.py's PaginatedResponse) rather than a bare
+// array. `gone` is a service the app knows and this PMM does not. `total` matches
+// `items`'s own length so fetchAllPages stops after this one page, matching every
+// test below that asserts on exactly one request.
+const servicesBody = `{"items": [
   {
     "service_id": "s1", "node_id": "n1", "name": "mongo-1", "port": 27017, "role": null,
     "observed": {
@@ -55,18 +59,18 @@ const servicesBody = `[
     "last_success_at": "2026-08-11T11:32:30Z", "failing_since": null,
     "consecutive_failures": 0, "last_error": null
   }
-]`
+], "total": 2, "offset": 0, "limit": 200}`
 
 // unprobedBody is a service the app holds a row for and has never reached: an empty
 // document and null timestamps, which is a normal state rather than an absence.
-const unprobedBody = `[
+const unprobedBody = `{"items": [
   {
     "service_id": "s1", "node_id": "n1", "name": "mongo-1", "port": 27017, "role": null,
     "observed": {}, "first_seen_at": "2026-08-11T10:00:00Z",
     "last_attempt_at": null, "last_success_at": null, "failing_since": null,
     "consecutive_failures": 0, "last_error": null
   }
-]`
+], "total": 1, "offset": 0, "limit": 200}`
 
 func probeTestServices() []*models.Service {
 	return []*models.Service{
@@ -171,7 +175,7 @@ func TestProbeSource(t *testing.T) {
 
 		// The app is installed and has never swept. Not anybody's failure.
 		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte(`[]`))
+			_, _ = w.Write([]byte(`{"items": [], "total": 0, "offset": 0, "limit": 200}`))
 		})
 
 		result := source.collect(context.Background(), probeTestServices())
@@ -204,7 +208,7 @@ func TestProbeSource(t *testing.T) {
 		// probe. Reporting that as "ok, 0 facts" reads as "there is nothing to probe
 		// here", which is the opposite of what happened.
 		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte(`[
+			_, _ = w.Write([]byte(`{"items": [
 			  {"service_id":"s1","node_id":"n1","name":"mongo-1","observed":{},
 			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
 			   "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
@@ -212,7 +216,8 @@ func TestProbeSource(t *testing.T) {
 			  {"service_id":"s2","node_id":"n2","name":"mongo-2","observed":{},
 			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
 			   "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
-			   "consecutive_failures":37,"last_error":"Cannot connect to host localhost:8000"}]`))
+			   "consecutive_failures":37,"last_error":"Cannot connect to host localhost:8000"}],
+			  "total": 2, "offset": 0, "limit": 200}`))
 		})
 
 		result := source.collect(context.Background(), probeTestServices())
@@ -231,10 +236,11 @@ func TestProbeSource(t *testing.T) {
 		t.Parallel()
 
 		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte(`[{"service_id":"s1","node_id":"n1","name":"mongo-1","observed":{},
+			_, _ = w.Write([]byte(`{"items": [{"service_id":"s1","node_id":"n1","name":"mongo-1","observed":{},
 			  "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T19:53:44Z",
 			  "last_success_at":null,"failing_since":"2026-08-09T19:53:44Z",
-			  "consecutive_failures":37,"last_error":null}]`))
+			  "consecutive_failures":37,"last_error":null}],
+			  "total": 1, "offset": 0, "limit": 200}`))
 		})
 
 		result := source.collect(context.Background(), probeTestServices())
@@ -250,7 +256,7 @@ func TestProbeSource(t *testing.T) {
 		// The steady state of a real estate: one node unreachable, the rest answering.
 		// Not a failure of this source, and not a clean run either.
 		source := newProbeSource(t, func(w http.ResponseWriter, _ *http.Request) {
-			_, _ = w.Write([]byte(`[
+			_, _ = w.Write([]byte(`{"items": [
 			  {"service_id":"s1","node_id":"n1","name":"mongo-1",
 			   "observed":{"collected_at":"2026-08-11T11:32:30+00:00","installed_version":"7.0.40-22"},
 			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T11:32:30Z",
@@ -259,7 +265,8 @@ func TestProbeSource(t *testing.T) {
 			  {"service_id":"s2","node_id":"n2","name":"mongo-2","observed":{},
 			   "first_seen_at":"2026-08-11T10:00:00Z","last_attempt_at":"2026-08-11T11:32:30Z",
 			   "last_success_at":null,"failing_since":"2026-08-11T11:00:00Z",
-			   "consecutive_failures":2,"last_error":"unreachable"}]`))
+			   "consecutive_failures":2,"last_error":"unreachable"}],
+			  "total": 2, "offset": 0, "limit": 200}`))
 		})
 
 		result := source.collect(context.Background(), probeTestServices())


### PR DESCRIPTION
## Summary

`GET /hosts` and `GET /services` on SEP's `om_inventory` app changed from a
bare array to a paginated envelope (`{items, total, offset, limit}`) in
`PMM-15326-om-inventory`'s "Bound the estate listings" review-round commit.
That commit's own message flagged the coupling: *"pmm-managed reads these,
so its OM service needs the matching change before this deploys."* This is
that change.

- `ListInventoryHosts` (the Hosts page) and `probeSource.fetch` (the
  on-host-facts source behind `IsAvailable`/topology collection) both
  decoded a bare array directly and broke against the new shape:
  `failed to decode the inventory app's answer: json: cannot unmarshal
  object into Go value of type []om.sepHost`.
- Confirmed live: `ChangeSettings` refused to enable OpenManager at all
  (`IsAvailable`'s own check), and the Hosts page failed outright with the
  decode error above.
- Adds a shared `sepPage[T]`/`fetchAllPages` helper that walks every page
  SEP reports until its own `total` is covered, rather than decoding just
  the first page and silently truncating a large estate. Both call sites
  page through the same way, with their existing (different) request
  mechanics and error mappings kept separate.

Draft: opened while the PMM-15326/PMM-15360/PMM-15347 integration
branches are being reconciled; marking ready once that settles.

## Test plan

- [x] `go test ./managed/services/om/...` -- full package, including new
      fixtures for the paginated envelope shape.
- [x] `golangci-lint run ./managed/services/om/...` -- 0 issues.
- [x] `gofmt -l` -- clean.
- [x] Verified live against a real stack: `pmm-managed` rebuilt from this
      branch, `GET /v1/om/inventory/hosts` and `GET /v1/om/topology` both
      return real data (previously a 500 with the decode error above).