### PR TITLE
[Doc] PMM-15060 uptime panel overlapping labels victoriametrics

### DIFF
--- a/documentation/docs/reference/dashboards/dashboard-victoriametrics-agents-overview.md
+++ b/documentation/docs/reference/dashboards/dashboard-victoriametrics-agents-overview.md
@@ -1,3 +1,6 @@
 # VictoriaMetrics Agents Overview
 
+<!-- TODO(doc): screenshot — retake on an instance with more than 8 monitored nodes so pagination is visible; current image predates pagination and still shows the removed legend -->
 ![!image](../../images/PMM_VictoriaMetrics_Agents_Overview.jpg)
+
+The **Uptime** panel shows up to 8 nodes per page, with pagination controls at the bottom of the panel when more nodes are selected. Nodes that stop reporting are grouped at the top. The panel has no separate legend: the UP (green) and DOWN (red) states and their labels appear directly on each bar. The **Current Uptime** table opens sorted with the shortest uptime first; click the column header to reverse the order.


### PR DESCRIPTION
Ticket number: PMM-15060

Feature build: not applicable — documentation-only change.

## Summary

The Uptime panel on the VictoriaMetrics Agents Overview dashboard used to squeeze every monitored node's label onto one screen, which became unreadable past a handful of nodes. It now paginates 8 nodes per page, groups nodes that stop reporting at the top, and drops its separate legend since the UP/DOWN colors and in-bar labels already carry that information. This PR adds a short description of that behavior to the dashboard's reference page, which previously held only a title and a now-outdated screenshot.

## Changes

- [documentation/docs/reference/dashboards/dashboard-victoriametrics-agents-overview.md](https://github.com/percona/pmm/blob/d220bf0a06e77d41eb860b1cb9bcbff4ec0a8854/documentation/docs/reference/dashboards/dashboard-victoriametrics-agents-overview.md) — add a paragraph on the Uptime panel's pagination, down-first ordering, and legend removal, and the Current Uptime table's default sort; flag the existing screenshot as stale

## Evidence

| Claim | Source |
|---|---|
| Uptime panel: 8 rows per page | [VictoriaMetrics_Agents_Overview.json#L572](https://github.com/percona/pmm/blob/d220bf0a06e77d41eb860b1cb9bcbff4ec0a8854/dashboards/dashboards/Insight/VictoriaMetrics_Agents_Overview.json#L572) |
| Legend hidden; UP (green) / DOWN (red) carried by value mapping + in-bar labels | [#L569](https://github.com/percona/pmm/blob/d220bf0a06e77d41eb860b1cb9bcbff4ec0a8854/dashboards/dashboards/Insight/VictoriaMetrics_Agents_Overview.json#L569) (`showLegend: false`); `fieldConfig.mappings` in the same file maps `1→UP #56A64B`, `null→DOWN #E02F44` |
| Non-reporting nodes grouped first via `sort()` | [#L583](https://github.com/percona/pmm/blob/d220bf0a06e77d41eb860b1cb9bcbff4ec0a8854/dashboards/dashboards/Insight/VictoriaMetrics_Agents_Overview.json#L583) |
| Current Uptime table opens ascending (shortest uptime first) | [#L190-L196](https://github.com/percona/pmm/blob/d220bf0a06e77d41eb860b1cb9bcbff4ec0a8854/dashboards/dashboards/Insight/VictoriaMetrics_Agents_Overview.json#L190-L196) |
| Pagination control hidden entirely when everything fits on one page | [percona/grafana#920](https://github.com/percona/grafana/pull/920), [hooks.tsx#L66](https://github.com/percona/grafana/blob/0471020bc8de3d2f1ac9f6945e8e3f3773df827e/public/app/plugins/panel/state-timeline/hooks.tsx#L66) |
| Source PR (percona/pmm) | [percona/pmm#5766](https://github.com/percona/pmm/pull/5766) |

## Analysis depth

- Analysed from a checkout: `percona/pmm` @ `d220bf0a0`
- Read over the GitHub API (shallower): `percona/grafana` — `hooks.tsx`/`hooks.test.tsx` diff for PR #920 (the `hideWhenSinglePage` change)
- Excluded: `Percona-Lab/pmm-submodules#4524` — feature-build submodule pointer, no product change

## Verification

- [x] Diff confined to `documentation/`, no binaries
- [x] Nav updated for new pages — or: no new pages (page already existed)
- [x] Relative links resolve
- [ ] `make doc-build` — not run: neither local mkdocs nor Docker available in this environment

## Human TODO

- Screenshot: **Dashboards > Insight > VictoriaMetrics Agents Overview**, the **Uptime** panel, on an instance with more than 8 monitored nodes so pagination is visible — replaces `documentation/docs/images/PMM_VictoriaMetrics_Agents_Overview.jpg`, which still shows the old legend and no pagination

## Not covered

- Release notes — owned by the release-notes PR; `fixVersions` is unset on PMM-15060 despite status Merged
- API docs — not applicable, no API endpoint changed
- In-product copy — not applicable; the panel description string is already correct as shipped and isn't part of this diff
- [PMM-15351](https://perconadev.atlassian.net/browse/PMM-15351) (Pending Release) generalizes the same `perPage` pagination fix to 7 other dashboards (MongoDB, HAProxy, ProxySQL, PostgreSQL) — already on `main`, but out of scope for this ticket. Those dashboards' own reference pages will need the equivalent note, ideally via their own documentation ticket/run.

## Assumptions

- None outstanding. One nuance resolved during analysis rather than left open: a QA comment on the ticket questioned whether "down" nodes really render red versus the bar just stopping, since the underlying metric doesn't literally report `0`. The panel's `fieldConfig.mappings` (`null → DOWN`, red) confirms the shipped behavior matches the ticket's description, so this is not flagged as a divergence.

- [ ] API Docs updated — not applicable, no API endpoints changed

[PMM-15351]: https://perconadev.atlassian.net/browse/PMM-15351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ