### PR TITLE
[Doc] PMM-15014 upgrade internal postgresql 14 18

### DIFF
--- a/documentation/docs/pmm-upgrade/index.md
+++ b/documentation/docs/pmm-upgrade/index.md
@@ -11,3 +11,9 @@ Choose your preferred upgrade method based on your setup:
 * [Upgrade PMM Server using Docker](upgrade_docker.md)
 * [Upgrade PMM Server using Helm](upgrade_helm.md)
 * [Migrate from PMM 2](migrating_from_pmm_2.md) (direct migration deprecated)
+
+## Internal PostgreSQL database
+
+Starting with PMM 3.10.0, PMM Server's built-in PostgreSQL database (used by pmm-managed and Grafana) is PostgreSQL 18. If your PMM Server data volume still has PostgreSQL 14 data, PMM migrates it automatically the first time the container starts on the new version — no manual steps are required. The PostgreSQL 14 data stays untouched until the migration finishes, and PMM retries automatically on every restart until it succeeds.
+
+This doesn't apply if you use PMM HA or an external PostgreSQL database — PostgreSQL is managed separately in both cases.

--- a/documentation/docs/reference/pmm_components_and_versions.md
+++ b/documentation/docs/reference/pmm_components_and_versions.md
@@ -7,7 +7,7 @@ The following table lists all the PMM client/server components and their version
 | Grafana  | 11.6.13*  | [Grafana documentation](https://grafana.com/docs/grafana/latest/)|[Github Grafana](https://github.com/percona-platform/grafana)|
 | VictoriaMetrics| v1.140.0 | [VictoriaMetrics documentation](https://docs.victoriametrics.com/)|[Github VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics)    |
 | Nginx    | 1.26.3  | [Nginx documentation](http://nginx.org/en/docs/)|[Github Nginx](https://github.com/nginx/nginx)                                                    |
-| Percona Distribution for PostgreSQL  | 14.5     | [Percona Distribution for PostgreSQL 14 documentation](https://www.percona.com/doc/postgresql/LATEST/index.html)|              |
+| Percona Distribution for PostgreSQL  | 18     | [Percona Distribution for PostgreSQL 18 documentation](https://www.percona.com/doc/postgresql/LATEST/index.html)|              |
 | ClickHouse| 25.3.6.56 |[ClickHouse documentation](https://clickhouse.com/docs/en/)|[Github ClickHouse](https://github.com/ClickHouse/ClickHouse)|
 | PerconaToolkit  | 3.5.2    | [Percona Toolkit documentation](https://www.percona.com/doc/percona-toolkit/3.0/index.html)|[Github Percona Toolkit](https://github.com/percona/percona-toolkit)|
 | Nomad | v2.0.0 | [Nomad documentation](https://developer.hashicorp.com/nomad/docs) | [GitHub](https://github.com/hashicorp/nomad) |


### PR DESCRIPTION
Ticket number: PMM-15014

Feature build: not applicable — documentation-only change.

## Summary

PMM Server's built-in PostgreSQL database (used by pmm-managed and Grafana) moves from PostgreSQL 14 to PostgreSQL 18 starting with PMM 3.10.0. On a standalone deployment with existing PostgreSQL 14 data, PMM migrates it automatically on first start — no manual steps needed, and PMM retries automatically if an attempt is interrupted. This PR updates the bundled-components reference table and adds a short note to the upgrade landing page so users know what to expect and that HA/external-PostgreSQL setups are unaffected.

## Changes

- [documentation/docs/reference/pmm_components_and_versions.md](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/documentation/docs/reference/pmm_components_and_versions.md) — bump the "Percona Distribution for PostgreSQL" row from 14.5 to 18
- [documentation/docs/pmm-upgrade/index.md](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/documentation/docs/pmm-upgrade/index.md) — add an "Internal PostgreSQL database" note: automatic migration, no manual steps, rollback safety, and scope (standalone only, not HA/external)

## Evidence

| Claim | Source |
|---|---|
| Built-in PostgreSQL bumped 14→18 | [postgres/tasks/main.yml#L23-L28](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/build/ansible/roles/postgres/tasks/main.yml#L23-L28) |
| Automatic migration triggers only when PG14 data exists and PG18 doesn't yet — so it retries every restart until it succeeds | [postgres-migration#L58](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/build/ansible/roles/postgres/files/postgres-migration#L58), [#L62](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/build/ansible/roles/postgres/files/postgres-migration#L62) |
| Migration skipped entirely for HA / external Postgres | [entrypoint.sh#L117-L140](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/build/docker/server/entrypoint.sh#L117-L140) |
| Old PG14 directory kept intact until migration succeeds, renamed only after (rollback safety) | [postgres-migration#L138](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/build/ansible/roles/postgres/files/postgres-migration#L138) |
| External-PostgreSQL version floor deliberately kept at 14 (no change needed to that prerequisite page) | [database.go#L52](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/models/database.go#L52), [#L1386-L1387](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/models/database.go#L1386-L1387) |
| Source PR | [percona/pmm#5295](https://github.com/percona/pmm/pull/5295) |

## Analysis depth

- Analysed from a checkout: `percona/pmm` @ `d5e48ce33`
- No satellite repos needed for this ticket
- Excluded: `Percona-Lab/pmm-submodules#4324` — feature-build submodule pointer, no product change

## Verification

- [x] Diff confined to `documentation/`, no binaries
- [x] Nav updated for new pages — or: no new pages
- [x] Relative links resolve
- [ ] `make doc-build` — not run: neither local mkdocs nor Docker available in this environment

## Not covered

- Release notes — owned by the release-notes PR; this is a natural 3.10.0 release-note line
- API docs — not applicable, no API endpoint changed
- In-product copy — not applicable
- A full migration/rollback runbook (manual dump/restore or rollback commands) — deliberately not added. The team's own `build/docs/MIGRATION.md` draft covered that level of detail and was explicitly deleted by [PMM-15404](https://perconadev.atlassian.net/browse/PMM-15404) as "an early draft that never served as a user-facing document." Matching that decision rather than reintroducing it into `documentation/`.
- [PMM-15238](https://perconadev.atlassian.net/browse/PMM-15238) ("relates to", Pending Release) adds SEP integration on the same embedded-Postgres startup path — separate ticket, out of scope here.

## Divergences

- The ticket's own QA comment flagged what looked like 3 conflicting PostgreSQL version numbers during review (14 enforced, a "bump to 15" TODO, docs briefly said "18+"). The final commit trail resolves this with a deliberate "Keep minPGVersion at 14" decision (raising the floor would reject external PG14 servers not yet migrated) — confirmed on `main`: `minPGVersion` is still `14`, and `reference/third-party/postgresql.md` still correctly says "14+". No live divergence; not touching that page.
- The ticket's AC says the rollback backup lives at `/srv/backup/postgres14`; the shipped code renames in place to `/srv/postgres14.old` instead. Stale AC wording, not a code defect.

## Assumptions

- The exact PostgreSQL 18 minor/patch version isn't pinned in this repo's code (the Ansible task installs `percona-postgresql18-server` from Percona's `ppg-18` repo without a version pin, unlike e.g. VictoriaMetrics which has a dedicated version-pinned spec file). I've used the major version only ("18") in the components table rather than inventing or lifting a minor version from a QA comment describing one specific build. If a precise minor version is wanted, confirm it against the actual 3.10.0 release artifact.

- [ ] API Docs updated — not applicable, no API endpoints changed

[PMM-15404]: https://perconadev.atlassian.net/browse/PMM-15404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ