### PR TITLE
[Doc] PMM-14665 incorrect list nodes while adding service

### DIFF
--- a/documentation/docs/install-pmm/HA-clustered.md
+++ b/documentation/docs/install-pmm/HA-clustered.md
@@ -145,7 +145,7 @@ PMM HA uses several mechanisms to ensure continuous operation:
 ### Known issues
 
 - Only databases deployed in the same Kubernetes cluster can be added to monitoring. Remote database monitoring will be added in a future release.
-- **[PMM-14665](https://perconadev.atlassian.net/browse/PMM-14665)**: When adding a service, the node list incorrectly includes PostgreSQL database instance nodes alongside PMM HA nodes.
+- **[PMM-14665](https://perconadev.atlassian.net/browse/PMM-14665)**: When adding a service, the node list still includes PostgreSQL database instance nodes as monitoring delegates. Starting with PMM 3.10.0, the PMM HA server nodes themselves are no longer offered or accepted.
 - **[PMM-14678](https://perconadev.atlassian.net/browse/PMM-14678)**: Database dashboards don't display metrics for services added via pmm-admin, though they work correctly for services added through the UI.
 - **[PMM-14680](https://perconadev.atlassian.net/browse/PMM-14680)**: PostgreSQL database instance nodes and services display with an incorrect 'pmm-' prefix in their names.
 - **[PMM-14734](https://perconadev.atlassian.net/browse/PMM-14734)**: HA cluster status always displays as "Healthy" even when follower or leader pods are deleted or not ready.

--- a/documentation/docs/install-pmm/install-HA-clustered.md
+++ b/documentation/docs/install-pmm/install-HA-clustered.md
@@ -1097,7 +1097,7 @@ We are aware of the following issues in this Tech Preview version and plan to fi
 
 | Issue | Impact | Workaround |
 |-------|--------|------------|
-| **[PMM-14704](https://perconadev.atlassian.net/browse/PMM-14704)**: PostgreSQL nodes in dropdown | Node selector shows database instances alongside PMM nodes | Select only nodes named `pmm-ha-0`, `pmm-ha-1`, `pmm-ha-2` |
+| **[PMM-14704](https://perconadev.atlassian.net/browse/PMM-14704)**: PostgreSQL nodes in dropdown | Node selector still shows the PostgreSQL database instance nodes as monitoring delegates | Don't select them - they're dedicated to PMM's own storage. The PMM Server nodes (`pmm-ha-0`, `pmm-ha-1`, `pmm-ha-2`) are no longer selectable either; [connect a separate PMM Client](#connect-monitoring-clients) instead |
 | **[PMM-14705](https://perconadev.atlassian.net/browse/PMM-14705)**: CLI-added services show no metrics | Services from `pmm-admin` appear as UNSPECIFIED, dashboards empty (QAN works) | Add services via PMM UI instead |
 | **[PMM-14706](https://perconadev.atlassian.net/browse/PMM-14706)**: Extra 'pmm-' prefix | PostgreSQL nodes show as `pmm-pmm-ha-pg-...` | Cosmetic only - no action needed |
 | **[PMM-14707](https://perconadev.atlassian.net/browse/PMM-14707)**: Wrong PostgreSQL status | Inventory shows FAILED/UNSPECIFIED despite working metrics | Check dashboards to verify metrics flow |


### PR DESCRIPTION
Ticket number: PMM-14665

Feature build: not applicable — documentation-only change.

## Summary

In an HA deployment, PMM Server's own nodes (`pmm-ha-0/1/2`) are no longer offered when adding a service, and are now rejected via the API/pmm-admin too. This PR corrects two existing "Known issues" entries that documented the old, buggy behavior — one of them (the workaround for PMM-14704) now actively points users at a node selection that will fail with the new rejection error. It intentionally does **not** document the rest of the ticket's brief: about half of it (the PostgreSQL-node exclusion and the new pre-provisioned `pmmClient.*` Helm values) has not reached the released Helm chart yet — see Divergences.

## Changes

- [documentation/docs/install-pmm/HA-clustered.md](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/documentation/docs/install-pmm/HA-clustered.md#L148) — update the PMM-14665 "Known issues" bullet: PMM HA server nodes are now excluded (fixed in PMM 3.10.0); PostgreSQL instance nodes still aren't
- [documentation/docs/install-pmm/install-HA-clustered.md](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/documentation/docs/install-pmm/install-HA-clustered.md#L1100) — correct the PMM-14704 "Known issues" table row: its workaround ("select nodes named `pmm-ha-0/1/2`") is now wrong since those nodes are rejected too; points instead at the existing "Connect monitoring clients" section

## Evidence

| Claim | Source |
|---|---|
| PMM HA server nodes excluded from delegation, keyed off existing HA-enabled/`is_pmm_server_node` state — no chart change needed | [service.go#L114-L115](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/services/management/service.go#L114-L115), [#L148-L149](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/services/management/service.go#L148-L149), [#L175](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/services/management/service.go#L175) |
| Azure Database now honors the caller's `pmm_agent_id` | [azure_database.go#L199](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/services/management/azure_database.go#L199), [#L203](https://github.com/percona/pmm/blob/d5e48ce337abe78e104621f335a1d251f6758316/managed/services/management/azure_database.go#L203) |
| PostgreSQL-node exclusion + `pmmClient.*` Helm values merged only into `PMM-HA-GA`, not `main`; `main`'s `values.yaml`/`statefulset.yaml` have neither | [percona-helm-charts#913](https://github.com/percona/percona-helm-charts/pull/913) (base `PMM-HA-GA`) · still gated on open [percona-helm-charts#927](https://github.com/percona/percona-helm-charts/pull/927) |
| Source PR (percona/pmm) | [percona/pmm#5704](https://github.com/percona/pmm/pull/5704) |
| Grafana-side change, merged to `main` | [percona/grafana#919](https://github.com/percona/grafana/pull/919) |

## Analysis depth

- Analysed from a checkout: `percona/pmm` @ `d5e48ce33`
- Read over the GitHub API (shallower): `percona/grafana` (PR #919 state/base), `percona/percona-helm-charts` (PR #913 state/base/files, `main` contents to confirm what's actually shipped)
- Excluded: `Percona-Lab/pmm-submodules#4498` — feature-build submodule pointer, no product change

## Verification

- [x] Diff confined to `documentation/`, no binaries
- [x] Nav updated for new pages — or: no new pages
- [x] Relative links resolve (added link is a same-page anchor, `#connect-monitoring-clients`, matching the existing `### Connect monitoring clients` heading)
- [ ] `make doc-build` — not run: neither local mkdocs nor Docker available in this environment

## Not covered

- `documentation/api/` (`is_pmm_internal_node`, `pmm_agent_id` on `AddAzureDatabase`) — out of scope per this workflow's guardrails
- Release notes — owned by the release-notes PR; both the node-exclusion fix and the Azure fix are natural 3.10.0 lines, and the ticket itself flags the Azure one as a silent-behavior-fix users may have worked around
- `connect-database/azure.md` — the Azure agent-selection fix is real and shipped, but the page doesn't currently describe an Agent/Node selection step, and I couldn't confirm the exact UI field label to cite (no dedicated Azure component found under `ui/apps/pmm/src`, suggesting this form may still be older/Grafana-based). Deferred rather than guessing a UI string.
- `install-HA-clustered.md`'s "Connect monitoring clients" / "Review Helm parameters reference" sections and any `pmmClient.*` value docs — not added; not on the released Helm chart yet (see Divergences)

## Divergences

The ticket's "How to document" brief describes PMM-node exclusion, PostgreSQL-node exclusion, and the new `pmmClient.*` Helm values as one shipped unit for PMM 3.10.0. Code shows it split across two repos that did not land together: `percona/pmm` (backend + Grafana fork) is merged to `main` and shipped; `percona/percona-helm-charts` PR #913 merged only into the `PMM-HA-GA` staging branch, and the PR that would fold that branch into `main` (#927) is still open. Documenting the `pmmClient.*` values now would describe something no user can get from the released chart today.

## Assumptions

- Whether `percona-helm-charts#927` (the `PMM-HA-GA` → `main` stack) is expected to land before or shortly after PMM 3.10.0 ships is unconfirmed. If it lands in time, the `pmmClient.*` documentation and the remaining half of both corrected known-issues entries should follow in a fast follow-up doc PR — worth a release-sequencing check.

- [ ] API Docs updated — not applicable this run, noted above as a gap